### PR TITLE
wrap clipper2 code into skity namespace

### DIFF
--- a/src/graphic/pathop/clipper2/core.h
+++ b/src/graphic/pathop/clipper2/core.h
@@ -23,7 +23,7 @@
 #include <iterator>
 #include <vector>
 
-namespace Clipper2Lib {
+namespace skity::Clipper2Lib {
 
 // error codes (2^n)
 constexpr int precision_error_i = 1;   // non-fatal
@@ -933,4 +933,4 @@ inline bool Path2ContainsPath1(const Path<T>& path1, const Path<T>& path2) {
   return PointInPolygon(mp1, path2) == PointInPolygonResult::IsInside;
 }
 
-}  // namespace Clipper2Lib
+}  // namespace skity::Clipper2Lib

--- a/src/graphic/pathop/clipper2/engine.cc
+++ b/src/graphic/pathop/clipper2/engine.cc
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-namespace Clipper2Lib {
+namespace skity::Clipper2Lib {
 
 static const Rect64 invalid_rect = Rect64(false);
 
@@ -2581,4 +2581,4 @@ void ClipperD::BuildTreeD(PolyPathD& polytree, PathsD& open_paths) {
   }
 }
 
-}  // namespace Clipper2Lib
+}  // namespace skity::Clipper2Lib

--- a/src/graphic/pathop/clipper2/engine.h
+++ b/src/graphic/pathop/clipper2/engine.h
@@ -23,7 +23,7 @@
 
 #include "src/graphic/pathop/clipper2/core.h"
 
-namespace Clipper2Lib {
+namespace skity::Clipper2Lib {
 
 struct Scanline;
 struct IntersectNode;
@@ -538,4 +538,4 @@ class ClipperD : public ClipperBase {
   }
 };
 
-}  // namespace Clipper2Lib
+}  // namespace skity::Clipper2Lib


### PR DESCRIPTION
The Clipper2 is an open source project, may also be used by other projects. To prevent symbol conflict, wrap the code into skity namespace.