### PR TITLE
Fix compilation errors under MSVC

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -6,14 +6,11 @@ if(EMSCRIPTEN)
   # Build Skity with emsdk
   add_definitions(-DSKITY_WASM)
 elseif(WIN32)
-  add_definitions(-DSKITY_WIN)
-
   # Fixme to solve NIM MAX macro defined in windows.h
   add_definitions(-DNOMINMAX)
-  set(BUILD_SHARED_LIBS TRUE)
-
   # specify dll outpu directory
   set(SKITY_DLL_DIR ${CMAKE_CURRENT_BINARY_DIR})
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SKITY_DLL_DIR})
   target_compile_options(
     skity
     PUBLIC

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,7 +13,11 @@ add_definitions(-DDISABLE_SKITY_EXPERIMENTAL_WARNINGS)
 add_subdirectory(common)
 
 # align output directory
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/example/case)
+if (MSVC)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+else()
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/example/case)
+endif()
 
 add_subdirectory(case/basic)
 add_subdirectory(case/blend)

--- a/example/case/image/image_gl.cc
+++ b/example/case/image/image_gl.cc
@@ -2,11 +2,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <functional>
+#include <mutex>
 #include <skity/gpu/gpu_context_gl.hpp>
 
 #include "common/window.hpp"
 
 namespace skity::example::image {
+
+PFNGLGENTEXTURESPROC f_glGenTextures = nullptr;
+PFNGLBINDTEXTUREPROC f_glBindTexture = nullptr;
+PFNGLTEXPARAMETERIPROC f_glTexParameteri = nullptr;
+PFNGLTEXIMAGE2DPROC f_glTexImage2D = nullptr;
 
 std::shared_ptr<skity::Image> MakeImageGL(
     const std::shared_ptr<skity::Pixmap> &pixmap,
@@ -15,15 +22,25 @@ std::shared_ptr<skity::Image> MakeImageGL(
     return {};
   }
 
+  static std::once_flag _init_flag;
+
+  std::call_once(_init_flag, []() {
+    f_glGenTextures = (PFNGLGENTEXTURESPROC)glfwGetProcAddress("glGenTextures");
+    f_glBindTexture = (PFNGLBINDTEXTUREPROC)glfwGetProcAddress("glBindTexture");
+    f_glTexParameteri =
+        (PFNGLTEXPARAMETERIPROC)glfwGetProcAddress("glTexParameteri");
+    f_glTexImage2D = (PFNGLTEXIMAGE2DPROC)glfwGetProcAddress("glTexImage2D");
+  });
+
   GLuint tex;
-  glGenTextures(1, &tex);
-  glBindTexture(GL_TEXTURE_2D, tex);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixmap->Width(), pixmap->Height(), 0,
-               GL_RGBA, GL_UNSIGNED_BYTE, pixmap->Addr());
+  f_glGenTextures(1, &tex);
+  f_glBindTexture(GL_TEXTURE_2D, tex);
+  f_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  f_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  f_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  f_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  f_glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixmap->Width(), pixmap->Height(),
+                 0, GL_RGBA, GL_UNSIGNED_BYTE, pixmap->Addr());
 
   skity::GPUBackendTextureInfoGL desc{};
   desc.backend = skity::GPUBackendType::kOpenGL;

--- a/example/common/CMakeLists.txt
+++ b/example/common/CMakeLists.txt
@@ -3,7 +3,7 @@
 # glfw
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/glfw third_party/glfw)
 
-add_library(skity_example_common SHARED
+add_library(skity_example_common STATIC
     ${CMAKE_CURRENT_LIST_DIR}/app.cc
     ${CMAKE_CURRENT_LIST_DIR}/app.hpp
     ${CMAKE_CURRENT_LIST_DIR}/app_utils.cc
@@ -11,10 +11,6 @@ add_library(skity_example_common SHARED
     ${CMAKE_CURRENT_LIST_DIR}/window.cc
     ${CMAKE_CURRENT_LIST_DIR}/window.hpp
 )
-
-if (APPLE)
-  target_link_libraries(skity_example_common PUBLIC "-framework OpenGL")
-endif()
 
 if (${SKITY_SW_RENDERER})
   target_compile_definitions(skity_example_common PUBLIC -DSKITY_EXAMPLE_SW_BACKEND=1)
@@ -50,6 +46,7 @@ endif()
 add_library(skity::example_common ALIAS skity_example_common)
 
 target_include_directories(skity_example_common PUBLIC ${CMAKE_SOURCE_DIR}/example)
+target_include_directories(skity_example_common PUBLIC ${CMAKE_SOURCE_DIR}/third_party/glad/include)
 
 target_link_libraries(skity_example_common PUBLIC glfw skity::skity)
 target_link_libraries(skity_example_common PUBLIC skity::codec)

--- a/example/common/window.hpp
+++ b/example/common/window.hpp
@@ -5,10 +5,11 @@
 #ifndef SKITY_EXAMPLE_COMMON_WINDOW_HPP
 #define SKITY_EXAMPLE_COMMON_WINDOW_HPP
 
-#ifndef GLFW_INCLUDE_GLEXT
-#define GLFW_INCLUDE_GLEXT
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
 #endif
 #include <GLFW/glfw3.h>
+#include <glad/gl.h>
 
 #include <memory>
 #include <skity/gpu/gpu_context.hpp>

--- a/hab/DEPS
+++ b/hab/DEPS
@@ -17,9 +17,9 @@ deps = {
     },
     "third_party/zlib": {
         "type": "git",
-        "url": "https://chromium.googlesource.com/chromium/src/third_party/zlib",
+        "url": "https://github.com/madler/zlib.git",
         "ignore_in_git": True,
-        "commit": "f5fd0ad2663e239a31184ad4c9919991dda16f46",
+        "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf",
     },
     "third_party/jsoncpp": {
         "type": "git",

--- a/include/skity/macros.hpp
+++ b/include/skity/macros.hpp
@@ -41,7 +41,7 @@
 #ifdef SKITY_DLL
 
 #if defined(SKITY_WIN)
-#define SKITY_API
+#define SKITY_API __declspec(dllexport)
 #elif defined(_MSC_VER)
 #define SKITY_API __declspec(dllexport)
 #else

--- a/include/skity/text/font_manager.hpp
+++ b/include/skity/text/font_manager.hpp
@@ -9,6 +9,7 @@
 #include <skity/macros.hpp>
 #include <skity/text/font_style.hpp>
 #include <skity/text/typeface.hpp>
+#include <string>
 #include <vector>
 
 namespace skity {

--- a/module/codec/CMakeLists.txt
+++ b/module/codec/CMakeLists.txt
@@ -40,9 +40,10 @@ ExternalProject_Add(libpng
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
   -DPNG_EXECUTABLES=OFF
   -DPNG_SHARED=ON
-  -DPNG_STATIC=OFF
+  -DPNG_STATIC=ON
   -DPNG_FRAMEWORK=OFF
   -DPNG_TESTS=OFF
+  -DZLIB_ROOT=${CMAKE_BINARY_DIR}/third_party/zlib
   -DCMAKE_INSTALL_MESSAGE=NEVER
   -DCMAKE_MESSAGE_LOG_LEVEL=ERROR
 )
@@ -69,12 +70,19 @@ target_sources(
 
 target_compile_definitions(skity-codec PUBLIC -DSKITY_HAS_PNG=1)
 
+add_dependencies(libpng skity)
 add_dependencies(skity-codec libpng)
 
 target_include_directories(skity-codec PRIVATE ${CMAKE_BINARY_DIR}/third_party/libpng/include)
 target_link_directories(skity-codec PUBLIC ${CMAKE_BINARY_DIR}/third_party/libpng/lib)
-target_link_libraries(skity-codec PRIVATE png)
 
+if (WIN32)
+  target_link_directories(skity-codec PUBLIC ${CMAKE_BINARY_DIR}/third_party/zlib/lib)
+  # FIXME: msvc generate different library name
+  target_link_libraries(skity-codec PRIVATE libpng16_staticd zlibstaticd)
+else()
+  target_link_libraries(skity-codec PRIVATE png)
+endif()
 
 target_sources(
   skity-codec
@@ -87,7 +95,12 @@ add_dependencies(skity-codec libjpeg-turbo)
 
 target_include_directories(skity-codec PRIVATE ${CMAKE_BINARY_DIR}/third_party/libjpeg-turbo/include)
 target_link_directories(skity-codec PUBLIC ${CMAKE_BINARY_DIR}/third_party/libjpeg-turbo/lib)
-target_link_libraries(skity-codec PRIVATE turbojpeg)
+
+if (WIN32)
+  target_link_libraries(skity-codec PRIVATE turbojpeg-static)
+else()
+  target_link_libraries(skity-codec PRIVATE turbojpeg)
+endif()
 
 target_compile_definitions(skity-codec PUBLIC -DSKITY_HAS_JPEG=1)
 

--- a/module/wgx/CMakeLists.txt
+++ b/module/wgx/CMakeLists.txt
@@ -64,7 +64,8 @@ endif()
 
 target_include_directories(wgsl-cross PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 target_include_directories(wgsl-cross PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-target_compile_options(wgsl-cross PRIVATE -fno-rtti -std=c++17)
+target_compile_options(wgsl-cross PRIVATE -fno-rtti)
+set_property(TARGET wgsl-cross PROPERTY CXX_STANDARD 17)
 
 # no-exceptions
 if (MSVC)

--- a/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
+++ b/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
@@ -86,8 +86,8 @@ index 000000000..fb9554d56
 +
 +    PRIVATE
 +
-+    -Wno-unused-variable
-+    -Wno-unused-function
++    # -Wno-unused-variable
++    # -Wno-unused-function
 +)
 diff --git a/include/freetype/config/public-macros.h b/include/freetype/config/public-macros.h
 index f56581a6e..5bb86b8b0 100644

--- a/patches/nanopng/0001-Adapt-nanopng-to-the-Skity-project.patch
+++ b/patches/nanopng/0001-Adapt-nanopng-to-the-Skity-project.patch
@@ -1,4 +1,4 @@
-From 2a06558fda75f1e5c4d9f8341569cc708954a473 Mon Sep 17 00:00:00 2001
+From 5ceb5dfeff1978f2fe3d78956556b0779a1ce9bb Mon Sep 17 00:00:00 2001
 From: ColdPaleLight <coldpalelight@users.noreply.github.com>
 Date: Mon, 30 Jun 2025 15:26:32 +0800
 Subject: [PATCH] Adapt nanopng to the Skity project
@@ -12,7 +12,7 @@ Subject: [PATCH] Adapt nanopng to the Skity project
  makefile              |   45 -
  src/nanopng.c         |   79 -
  src/nanopng.h         |   44 -
- src/nanopng16.cc      |  668 +++++++++
+ src/nanopng16.cc      |  689 +++++++++
  src/nanopng_chunk.c   |   86 --
  src/nanopng_chunk.h   |   28 -
  src/nanopng_decoder.c |   19 -
@@ -20,7 +20,7 @@ Subject: [PATCH] Adapt nanopng to the Skity project
  src/nanopng_source.c  |  102 --
  src/nanopng_source.h  |   39 -
  src/nanopng_structs.h |   78 -
- 16 files changed, 4785 insertions(+), 568 deletions(-)
+ 16 files changed, 4806 insertions(+), 568 deletions(-)
  create mode 100644 BUILD.gn
  delete mode 100644 include/nanopng.h
  create mode 100644 include/png.h
@@ -4397,17 +4397,23 @@ index 8a5fbdd..0000000
 -#endif /* H_NANOPNG */
 diff --git a/src/nanopng16.cc b/src/nanopng16.cc
 new file mode 100644
-index 0000000..9b9bfe3
+index 0000000..5bdfea4
 --- /dev/null
 +++ b/src/nanopng16.cc
-@@ -0,0 +1,668 @@
+@@ -0,0 +1,689 @@
 +#include "png.h"
 +#include <cstdint>
 +#include <zlib.h>
 +#include <stdlib.h>
 +#include <new>
 +#include <string.h>
++
++#if defined(_WIN32) || defined(_WIN64)
++#include <Winsock2.h>
++#pragma comment(lib, "ws2_32.lib")
++#else
 +#include <arpa/inet.h>
++#endif
 +
 +#define RGBA(r, g, b, a) uint32_t(r) | uint32_t(g) << 8 | uint32_t(b) << 16 | uint32_t(a) << 24
 +#define RGB(r, g, b) RGBA(r, g, b, 0xff)
@@ -4507,6 +4513,20 @@ index 0000000..9b9bfe3
 +    }
 +
 +    inline void read_header() {
++#if defined(_WIN32) || defined(_WIN64)
++#pragma pack(push, 1)
++
++struct Head {
++    uint32_t magic, magic2; // \x89PNG 0d0a1a0a
++    ChunkHead IHDR;
++    uint32_t width, height;
++    uint8_t bit_depth, color_type, compression_method, filter_method, interlace_method;
++    uint32_t IHDR_crc32;
++
++};
++
++#pragma pack(pop)
++#else
 +        struct __attribute__((__packed__)) Head {
 +            uint32_t magic, magic2; // \x89PNG 0d0a1a0a
 +            ChunkHead IHDR;
@@ -4515,6 +4535,7 @@ index 0000000..9b9bfe3
 +            uint32_t IHDR_crc32;
 +
 +        };
++#endif
 +        Head head = reader.read<Head>();
 +        if (error) return;
 +        // FDEBUG("read png: magic %x %x", head.magic, head.magic2);

--- a/src/base/platform/win/mapping_win.cc
+++ b/src/base/platform/win/mapping_win.cc
@@ -40,7 +40,7 @@ static bool IsExecutable(
   return false;
 }
 
-FileMapping::FileMapping(const fml::UniqueFD& fd,
+FileMapping::FileMapping(const UniqueFD& fd,
                          std::initializer_list<Protection> protections)
     : size_(0), mapping_(nullptr) {
   if (!fd.is_valid()) {

--- a/src/base/unique_object.hpp
+++ b/src/base/unique_object.hpp
@@ -8,6 +8,8 @@
 #ifndef SRC_BASE_UNIQUE_OBJECT_HPP
 #define SRC_BASE_UNIQUE_OBJECT_HPP
 
+#include <cassert>
+#include <skity/macros.hpp>
 #include <utility>
 
 #include "src/base/base_macros.hpp"

--- a/src/render/hw/draw/hw_dynamic_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_draw.cc
@@ -33,14 +33,9 @@ void HWDynamicDraw::OnGenerateCommand(HWDrawContext* context,
   SKITY_TRACE_EVENT(HWDynamicDraw_OnGenerateCommand);
 
   HWDrawStepContext ctx{
-      .context = context,
-      .state = state,
-      .transform = GetTransform(),
-      .clip_depth = GetClipValue(),
-      .scissor = GetScissorBox(),
-      .color_format = GetColorFormat(),
-      .sample_count = GetSampleCount(),
-      .blend_mode = blend_mode_,
+      context,          state,           GetTransform(),
+      GetClipValue(),   GetScissorBox(), GetColorFormat(),
+      GetSampleCount(), blend_mode_,
   };
 
   for (auto& step : steps_) {

--- a/src/render/hw/draw/hw_wgsl_geometry.hpp
+++ b/src/render/hw/draw/hw_wgsl_geometry.hpp
@@ -11,7 +11,7 @@
 
 namespace skity {
 
-class HWDrawContext;
+struct HWDrawContext;
 
 /**
  * This class represents a geometry which can generate the WGSL source code for

--- a/src/render/hw/filters/hw_blur_filter.cc
+++ b/src/render/hw/filters/hw_blur_filter.cc
@@ -47,8 +47,10 @@ HWFilterOutput HWBlurFilter::DoFilter(const HWFilterContext &context,
   render_pass->AddCommand(command);
   render_pass->EncodeCommands();
 
-  return HWFilterOutput{.texture = output_texture,
-                        .layer_bounds = layer_bounds};
+  return HWFilterOutput{
+      output_texture,
+      layer_bounds,
+  };
 }
 
 void HWBlurFilter::PrepareWGXCMD(
@@ -62,20 +64,19 @@ void HWBlurFilter::PrepareWGXCMD(
                  CoverageType::kNone};
 
   HWDrawStepContext step_context{
-      .context = context,
-      .state = {},
-      .transform = {},
-      .clip_depth = 0.1f,  // just a little bit bigger than 0
-      .scissor =
-          {
-              0,
-              0,
-              static_cast<float>(output_texture->GetDescriptor().width),
-              static_cast<float>(output_texture->GetDescriptor().height),
-          },
-      .color_format = output_texture->GetDescriptor().format,
-      .sample_count = 1,
-      .blend_mode = BlendMode::kDefault,
+      context,
+      {},
+      {},
+      0.1f,  // just a little bit bigger than 0
+      {
+          0,
+          0,
+          static_cast<float>(output_texture->GetDescriptor().width),
+          static_cast<float>(output_texture->GetDescriptor().height),
+      },
+      output_texture->GetDescriptor().format,
+      1,
+      BlendMode::kDefault,
   };
 
   step.GenerateCommand(step_context, cmd, nullptr);

--- a/src/render/hw/filters/hw_color_filter.cc
+++ b/src/render/hw/filters/hw_color_filter.cc
@@ -34,8 +34,10 @@ HWFilterOutput HWColorFilter::DoFilter(const HWFilterContext &context,
   render_pass->AddCommand(command);
   render_pass->EncodeCommands();
 
-  return HWFilterOutput{.texture = output_texture,
-                        .layer_bounds = child_output.layer_bounds};
+  return HWFilterOutput{
+      output_texture,
+      child_output.layer_bounds,
+  };
 }
 
 void HWColorFilter::PrepareCMD(
@@ -59,20 +61,19 @@ void HWColorFilter::InternalPrepareCMDWGX(
   };
 
   HWDrawStepContext step_context{
-      .context = context,
-      .state = {},
-      .transform = {},
-      .clip_depth = 0.1f,  // just a little bit bigger than 0
-      .scissor =
-          {
-              0,
-              0,
-              static_cast<float>(input_texture->GetDescriptor().width),
-              static_cast<float>(input_texture->GetDescriptor().height),
-          },
-      .color_format = input_texture->GetDescriptor().format,
-      .sample_count = 1,
-      .blend_mode = BlendMode::kDefault,
+      context,
+      {},
+      {},
+      0.1f,  // just a little bit bigger than 0
+      {
+          0,
+          0,
+          static_cast<float>(input_texture->GetDescriptor().width),
+          static_cast<float>(input_texture->GetDescriptor().height),
+      },
+      input_texture->GetDescriptor().format,
+      1,
+      BlendMode::kDefault,
   };
 
   step.GenerateCommand(step_context, cmd, nullptr);

--- a/src/render/hw/filters/hw_down_sampler_filter.cc
+++ b/src/render/hw/filters/hw_down_sampler_filter.cc
@@ -49,8 +49,10 @@ HWFilterOutput HWDownSamplerFilter::DoFilter(const HWFilterContext &context,
   render_pass->AddCommand(command);
   render_pass->EncodeCommands();
 
-  return HWFilterOutput{.texture = output_texture,
-                        .layer_bounds = child_output.layer_bounds};
+  return HWFilterOutput{
+      output_texture,
+      child_output.layer_bounds,
+  };
 }
 
 void HWDownSamplerFilter::PrepareCMDWGX(
@@ -68,20 +70,19 @@ void HWDownSamplerFilter::PrepareCMDWGX(
   };
 
   HWDrawStepContext step_context{
-      .context = context,
-      .state = {},
-      .transform = {},
-      .clip_depth = 0.1f,  // just a little bit bigger than 0
-      .scissor =
-          {
-              0,
-              0,
-              output_size.x,
-              output_size.y,
-          },
-      .color_format = input_texture->GetDescriptor().format,
-      .sample_count = 1,
-      .blend_mode = BlendMode::kDefault,
+      context,
+      {},
+      {},
+      0.1f,  // just a little bit bigger than 0
+      {
+          0,
+          0,
+          output_size.x,
+          output_size.y,
+      },
+      input_texture->GetDescriptor().format,
+      1,
+      BlendMode::kDefault,
   };
 
   step.GenerateCommand(step_context, cmd, nullptr);

--- a/src/render/hw/filters/hw_filter.cc
+++ b/src/render/hw/filters/hw_filter.cc
@@ -98,20 +98,19 @@ void HWFilter::InternalDrawChildrenOutpusWGX(
     };
 
     HWDrawStepContext step_context{
-        .context = context.draw_context,
-        .state = {},
-        .transform = {},
-        .clip_depth = 0.1f,  // just a little bit bigger than 0
-        .scissor =
-            {
-                0,
-                0,
-                output_texture_size.x,
-                output_texture_size.y,
-            },
-        .color_format = color_format,
-        .sample_count = 1,
-        .blend_mode = BlendMode::kDefault,
+        context.draw_context,
+        {},
+        {},
+        0.1f,  // just a little bit bigger than 0
+        {
+            0,
+            0,
+            output_texture_size.x,
+            output_texture_size.y,
+        },
+        color_format,
+        1,
+        BlendMode::kDefault,
     };
 
     auto cmd = context.draw_context->arena_allocator->Make<Command>();

--- a/src/render/hw/filters/hw_matrix_filter.cc
+++ b/src/render/hw/filters/hw_matrix_filter.cc
@@ -25,8 +25,10 @@ HWFilterOutput HWMatrixFilter::DoFilter(const HWFilterContext& context,
                       color_format, layer_bounds, std::vector{child_output});
 
   render_pass->EncodeCommands();
-  return HWFilterOutput{.texture = output_texture,
-                        .layer_bounds = layer_bounds};
+  return HWFilterOutput{
+      output_texture,
+      layer_bounds,
+  };
 }
 
 }  // namespace skity

--- a/src/render/hw/filters/hw_merge_filter.cc
+++ b/src/render/hw/filters/hw_merge_filter.cc
@@ -32,8 +32,10 @@ HWFilterOutput HWMergeFilter::DoFilter(const HWFilterContext& context,
   DrawChildrenOutputs(context, render_pass.get(), output_texture_size,
                       color_format, layer_bounds, children_outputs);
   render_pass->EncodeCommands();
-  return HWFilterOutput{.texture = output_texture,
-                        .layer_bounds = layer_bounds};
+  return HWFilterOutput{
+      output_texture,
+      layer_bounds,
+  };
 }
 
 }  // namespace skity

--- a/src/render/hw/layer/hw_filter_layer.cc
+++ b/src/render/hw/layer/hw_filter_layer.cc
@@ -24,17 +24,13 @@ HWDrawState HWFilterLayer::OnPrepare(HWDrawContext* context) {
       std::make_shared<GPUCommandBufferProxy>(device->CreateCommandBuffer());
 
   HWFilterOutput filter_result{
-      .texture = input_texture,
-      .layer_bounds = GetBounds(),
+      input_texture,
+      GetBounds(),
   };
 
   HWFilterContext filter_context{
-      .device = device,
-      .gpu_context = context->gpuContext,
-      .draw_context = context,
-      .source = filter_result,
-      .command_buffer = command_buffer,
-      .scale = scale_,
+      device,        context->gpuContext, context,
+      filter_result, command_buffer,      scale_,
   };
 
   filter_result = filter_->Filter(filter_context);

--- a/src/render/sw/sw_raster.cc
+++ b/src/render/sw/sw_raster.cc
@@ -33,10 +33,10 @@ void RealSpanBuilder::BuildSpan(int x, int y, int width, const uint8_t alpha) {
   }
 
   Span span{
-      .x = x,
-      .y = y,
-      .len = width,
-      .cover = alpha,
+      x,
+      y,
+      width,
+      alpha,
   };
   spans_.push_back(span);
 }

--- a/tools/hab.ps1
+++ b/tools/hab.ps1
@@ -1,0 +1,65 @@
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$__version__ = "latest"
+
+if ($null -eq $env:HABITAT_VERSION) { 
+    $HABITAT_VERSION = $__version__
+}
+else {
+    $HABITAT_VERSION = $env:HABITAT_VERSION
+}
+
+$HABITAT_RELEASE_BASE_URL = "https://github.com/lynx-family/habitat/releases"
+
+if ('latest' -eq $HABITAT_VERSION) {
+    $HABITAT_DOWNLOAD_URL = "${HABITAT_RELEASE_BASE_URL}/latest/download/hab.exe"
+    $HABITAT_VERSION = (curl.exe -sL -w '%{url_effective}' ${HABITAT_RELEASE_BASE_URL}/latest) `
+    | Select-Object -Last 1 `
+    | Select-String -Pattern '([0-9]+\.[0-9]+\.[0-9]{1,3})'
+    $HABITAT_VERSION = $HABITAT_VERSION.Matches.Value
+    Write-Debug "Using latest version: ${HABITAT_VERSION}"
+}
+else {
+    $HABITAT_DOWNLOAD_URL = "${HABITAT_RELEASE_BASE_URL}/download/$HABITAT_VERSION/hab.exe"
+}
+
+$HABITAT_CACHE_DIR = "${HOME}\.habitat\bin"
+$HABITAT_BIN = "${HABITAT_CACHE_DIR}\hab-${HABITAT_VERSION}.exe"
+
+function install() {
+    if (-Not (Test-Path -Path $HABITAT_CACHE_DIR)) {
+        New-Item -ItemType Directory -Force -Path $HABITAT_CACHE_DIR
+    }
+    if (-Not (Test-Path -Path $HABITAT_BIN)) {
+        Write-Output "Installing habitat ($HABITAT_VERSION) from url $HABITAT_DOWNLOAD_URL..."
+        curl.exe -sL -# $HABITAT_DOWNLOAD_URL -o $HABITAT_BIN
+    }
+}
+
+install
+
+$CURRENT_VERSION = (& $HABITAT_BIN -v)
+
+foreach ($arg in $args) {
+    if ($arg -eq "sync") {
+        $is_sync_command = $true
+    }
+    if (Test-Path -Path $arg) {
+        $root_dir = $arg
+    }
+}
+
+$exit_code = 0
+if ($is_sync_command) {
+    $err_msg = (& $HABITAT_BIN deps $root_dir 2>&1)
+    $exit_code = $LastExitCode
+    if ($exit_code -eq 126) {
+        $HABITAT_VERSION = (& Select-String -InputObject $err_msg -Pattern '([0-9]+\.[0-9]+\.[0-9]{1,3})$')
+        $HABITAT_VERSION = $HABITAT_VERSION.Matches.Value
+        Write-Output "required version ${HABITAT_VERSION} does not exist, try installing it first (current version is $CURRENT_VERSION)"
+        $HABITAT_BIN = "${HABITAT_CACHE_DIR}\hab-${HABITAT_VERSION}.exe"
+        install
+    }
+}
+
+& $HABITAT_BIN $args


### PR DESCRIPTION
To ensure compatibility with MSVC compilation:

1. Remove unsupported link flags in the freetype2 patches
2. Add win32 library link in the nanopng patches
3. Switch to use external project build for zlib
4. Fix some compile error caused by the code