### PR TITLE
[cmake] Update CMake minimum version and pugixml dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,14 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.15.0)
 
 project(Skity)
+
+# Compatible for MSVC runtime library
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
 
 if(POLICY CMP0079)
   cmake_policy(SET CMP0079 NEW)
@@ -21,6 +26,15 @@ endif()
 set(SKITY_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_CXX_EXTENSIONS OFF) # disable -std=gnu++11 by default
+
+
+# options should set before define skity library
+include(cmake/Options.cmake)
+
+if (MSVC AND SKITY_TEST)
+  # MSVC needs to set export all symbols for test since UT case needs to access private symbols
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON CACHE BOOL "Force MSVC export all symbols")
+endif()
 
 # define library
 if(EMSCRIPTEN)
@@ -98,9 +112,6 @@ add_library(skity::skity ALIAS skity)
 
 # default config
 include(GNUInstallDirs)
-
-# options
-include(cmake/Options.cmake)
 
 # platform
 include(cmake/Platform.cmake)

--- a/hab/DEPS
+++ b/hab/DEPS
@@ -55,6 +55,6 @@ deps = {
         "type": "git",
         "url": "https://github.com/zeux/pugixml.git",
         "ignore_in_git": True,
-        "commit": "7a9da11d8b2b2f06c0904d397864f216bd7c1e14",
+        "commit": "ee86beb30e4973f5feffe3ce63bfa4fbadf72f38",
     },
 }

--- a/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
+++ b/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
@@ -30,7 +30,7 @@ index 000000000..fb9554d56
 --- /dev/null
 +++ b/CMakeLists-Skity.txt
 @@ -0,0 +1,59 @@
-+cmake_minimum_required(VERSION 3.4.1)
++cmake_minimum_required(VERSION 3.15.0)
 +
 +set(FREETYPE_SOURCE_DIR ${FREETYPE_DIR})
 +

--- a/test/ut/utils/array_list_test.cc
+++ b/test/ut/utils/array_list_test.cc
@@ -194,8 +194,8 @@ TEST(ArrayList, Reset) {
 }
 
 TEST(ArrayList, SetArenaAllocator) {
-  skity::ArrayList<int32_t, 4> array_list;
   skity::ArenaAllocator arena_allocator;
+  skity::ArrayList<int32_t, 4> array_list;
   array_list.SetArenaAllocator(&arena_allocator);
   array_list.push_back(1);
   array_list.push_back(2);


### PR DESCRIPTION
The latest cmake does no compatible with cmake script below version 3.5

So raised the minimum required CMake version to 3.15.0 in both the main and freetype patch CMake files for improved compatibility. Also upgrade the pugixml version to make it's cmake script version grater than 3.5