### PR TITLE
[Arena] Change the container of steps from 'std::vector' to 'ArrayList'

### DIFF
--- a/src/render/hw/draw/hw_dynamic_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_draw.cc
@@ -11,6 +11,7 @@ namespace skity {
 HWDrawState HWDynamicDraw::OnPrepare(HWDrawContext* context) {
   SKITY_TRACE_EVENT(HWDynamicDraw_OnPrepare);
 
+  steps_.SetArenaAllocator(context->arena_allocator);
   OnGenerateDrawStep(steps_, context);
 
   HWDrawState state = HWDrawState::kDrawStateNone;

--- a/src/render/hw/draw/hw_dynamic_draw.hpp
+++ b/src/render/hw/draw/hw_dynamic_draw.hpp
@@ -16,9 +16,7 @@ namespace skity {
 class HWDynamicDraw : public HWDraw {
  public:
   HWDynamicDraw(Matrix transform, BlendMode blend_mode)
-      : HWDraw(transform), blend_mode_(blend_mode), steps_(), commands_() {
-    steps_.reserve(2);
-  }
+      : HWDraw(transform), blend_mode_(blend_mode), steps_(), commands_() {}
 
   ~HWDynamicDraw() override = default;
 
@@ -33,12 +31,12 @@ class HWDynamicDraw : public HWDraw {
 
   void OnGenerateCommand(HWDrawContext* context, HWDrawState state) override;
 
-  virtual void OnGenerateDrawStep(std::vector<HWDrawStep*>& steps,
+  virtual void OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
                                   HWDrawContext* context) = 0;
 
  private:
   BlendMode blend_mode_;
-  std::vector<HWDrawStep*> steps_;
+  ArrayList<HWDrawStep*, 2> steps_;
   ArrayList<Command*, 32> commands_;
 };
 

--- a/src/render/hw/draw/hw_dynamic_path_clip.cc
+++ b/src/render/hw/draw/hw_dynamic_path_clip.cc
@@ -20,7 +20,7 @@ HWDynamicPathClip::HWDynamicPathClip(Matrix transform, Path path,
   bounds_.AddRect(bounds);
 }
 
-void HWDynamicPathClip::OnGenerateDrawStep(std::vector<HWDrawStep *> &steps,
+void HWDynamicPathClip::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                                            HWDrawContext *context) {
   auto arena_allocator = context->arena_allocator;
   // clip always use stencil first

--- a/src/render/hw/draw/hw_dynamic_path_clip.hpp
+++ b/src/render/hw/draw/hw_dynamic_path_clip.hpp
@@ -20,7 +20,7 @@ class HWDynamicPathClip : public HWDynamicDraw {
   ~HWDynamicPathClip() override = default;
 
  protected:
-  void OnGenerateDrawStep(std::vector<HWDrawStep *> &steps,
+  void OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                           HWDrawContext *context) override;
 
  private:

--- a/src/render/hw/draw/hw_dynamic_path_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_path_draw.cc
@@ -26,7 +26,7 @@ HWDynamicPathDraw::HWDynamicPathDraw(Matrix transform, Path path, Paint paint,
       paint_(std::move(paint)),
       is_stroke_(is_stroke) {}
 
-void HWDynamicPathDraw::OnGenerateDrawStep(std::vector<HWDrawStep *> &steps,
+void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                                            HWDrawContext *context) {
   bool single_pass = !is_stroke_ && path_.IsConvex() && !paint_.IsAntiAlias();
 

--- a/src/render/hw/draw/hw_dynamic_path_draw.hpp
+++ b/src/render/hw/draw/hw_dynamic_path_draw.hpp
@@ -19,7 +19,7 @@ class HWDynamicPathDraw : public HWDynamicDraw {
   ~HWDynamicPathDraw() override = default;
 
  protected:
-  void OnGenerateDrawStep(std::vector<HWDrawStep *> &steps,
+  void OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                           HWDrawContext *context) override;
 
  private:

--- a/src/render/hw/draw/hw_dynamic_text_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_text_draw.cc
@@ -9,7 +9,7 @@
 
 namespace skity {
 
-void HWDynamicTextDraw::OnGenerateDrawStep(std::vector<HWDrawStep*>& steps,
+void HWDynamicTextDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
                                            HWDrawContext* context) {
   if (geometry_ == nullptr || fragment_ == nullptr) {
     return;
@@ -40,7 +40,7 @@ Matrix HWDynamicTextDraw::CalcTransform(const Matrix& canvas_transform,
   return Matrix{};
 }
 
-void HWDynamicSdfTextDraw::OnGenerateDrawStep(std::vector<HWDrawStep*>& steps,
+void HWDynamicSdfTextDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
                                               HWDrawContext* context) {
   if (geometry_ == nullptr || fragment_ == nullptr) {
     return;

--- a/src/render/hw/draw/hw_dynamic_text_draw.hpp
+++ b/src/render/hw/draw/hw_dynamic_text_draw.hpp
@@ -24,7 +24,7 @@ class HWDynamicTextDraw : public HWDynamicDraw {
   ~HWDynamicTextDraw() override = default;
 
  protected:
-  void OnGenerateDrawStep(std::vector<HWDrawStep*>& steps,
+  void OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
                           HWDrawContext* context) override;
 
  private:
@@ -47,7 +47,7 @@ class HWDynamicSdfTextDraw : public HWDynamicDraw {
   ~HWDynamicSdfTextDraw() override = default;
 
  protected:
-  void OnGenerateDrawStep(std::vector<HWDrawStep*>& steps,
+  void OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
                           HWDrawContext* context) override;
 
  private:


### PR DESCRIPTION
Since there are 1 to 2 steps in each draw, using 'ArrayList<HWDrawStep*, 2>' as a container can reduce the number of malloc method calls.