### PR TITLE
[cmake] Remove public install config for GLM

### DIFF
--- a/cmake/ThirdPartyDep.cmake
+++ b/cmake/ThirdPartyDep.cmake
@@ -3,13 +3,10 @@
 # LICENSE file in the root directory of this source tree.
 
 # glm
-set(GLM_BUILD_INSTALL ON CACHE BOOL "enable GLM_BUILD_INSTALL" FORCE)
+set(GLM_BUILD_LIBRARY OFF CACHE BOOL "enable GLM_BUILD_LIBRARY")
+set(GLM_BUILD_INSTALL OFF CACHE BOOL "enable GLM_BUILD_INSTALL")
 add_subdirectory(third_party/glm)
-if (WIN32)
-  target_link_libraries(skity PRIVATE glm::glm-header-only)
-else()
-  target_link_libraries(skity PRIVATE glm::glm)
-endif()
+target_link_libraries(skity PRIVATE glm::glm-header-only)
 
 # pugixml
 set(PUGIXML_NO_EXCEPTIONS ON CACHE BOOL "enable PUGIXML_NO_EXCEPTIONS")

--- a/example/case/fake_3d/CMakeLists.txt
+++ b/example/case/fake_3d/CMakeLists.txt
@@ -9,8 +9,4 @@ add_executable(fake_3d_example
 )
 
 target_link_libraries(fake_3d_example PUBLIC skity::example_common)
-if (WIN32)
-  target_link_libraries(fake_3d_example PRIVATE glm::glm-header-only)
-else()
-  target_link_libraries(fake_3d_example PRIVATE glm::glm)
-endif()
+target_link_libraries(fake_3d_example PRIVATE glm::glm-header-only)

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -22,8 +22,4 @@ target_link_libraries(skity_benchmarks
     skity::skity
     benchmark::benchmark
 )
-if (WIN32)
-  target_link_libraries(skity_benchmarks PRIVATE glm::glm-header-only)
-else()
-  target_link_libraries(skity_benchmarks PRIVATE glm::glm)
-endif()
+target_link_libraries(skity_benchmarks PRIVATE glm::glm-header-only)

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -36,10 +36,6 @@ target_link_libraries(skity_unit_test
     gmock_main
 )
 
-if (WIN32)
-  target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
-else()
-  target_link_libraries(skity_unit_test PRIVATE glm::glm)
-endif()
+target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
 
 gtest_add_tests(skity_unit_test "" AUTO)


### PR DESCRIPTION
Since all public API no longer uses GLM, switch to use header only glm dependency, and disable GLM install in CMake script file.