### PR TITLE
[text] Change Typeface ownership to shared

### DIFF
--- a/example/case/basic/example.cc
+++ b/example/case/basic/example.cc
@@ -149,9 +149,9 @@ void draw_simple_text(skity::Canvas* canvas) {
   //         skity::FontStyle(skity::FontStyle::Weight::kBlack_Weight,
   //                          skity::FontStyle::Width::kNormal_Width,
   //                          skity::FontStyle::Slant::kItalic_Slant));
-  skity::Typeface* typeface = skity::Typeface::GetDefaultTypeface();
+  auto typeface = skity::Typeface::GetDefaultTypeface();
   paint.SetTypeface(typeface);
-  skity::Typeface* typeface_cjk =
+  auto typeface_cjk =
       skity::FontManager::RefDefault()->MatchFamilyStyleCharacter(
           nullptr, skity::FontStyle(), nullptr, 0, 0X7ECF);
 

--- a/example/case/nanovg_frame/frame_example.cc
+++ b/example/case/nanovg_frame/frame_example.cc
@@ -17,14 +17,16 @@
 void render_frame_demo(
     skity::Canvas* canvas,
     std::vector<std::shared_ptr<skity::Pixmap>> const& images,
-    skity::Typeface* typeface, skity::Typeface* emoji, float mx, float my,
-    float width, float height, float t);
+    std::shared_ptr<skity::Typeface> typeface,
+    std::shared_ptr<skity::Typeface> emoji, float mx, float my, float width,
+    float height, float t);
 
 void render_frame_demo(
     skity::Canvas* canvas, skity::GPUContext* gpu_context,
     std::vector<std::shared_ptr<skity::Pixmap>> const& images,
-    skity::Typeface* typeface, skity::Typeface* emoji, float mx, float my,
-    float width, float height, float t);
+    std::shared_ptr<skity::Typeface> typeface,
+    std::shared_ptr<skity::Typeface> emoji, float mx, float my, float width,
+    float height, float t);
 
 void draw_eyes(skity::Canvas* canvas, float x, float y, float w, float h,
                float mx, float my, float t);
@@ -82,15 +84,17 @@ void draw_thumbnails(skity::Canvas* canvas, skity::GPUContext* gpu_context,
 
 void draw_spinner(skity::Canvas* canvas, float cx, float cy, float r, float t);
 
-void draw_paragraph(skity::Canvas* canvas, skity::Typeface* typeface,
-                    skity::Typeface* emoji, float x, float y, float width,
-                    float height);
+void draw_paragraph(skity::Canvas* canvas,
+                    std::shared_ptr<skity::Typeface> typeface,
+                    std::shared_ptr<skity::Typeface> emoji, float x, float y,
+                    float width, float height);
 
 void render_frame_demo(
     skity::Canvas* canvas, skity::GPUContext* gpu_context,
     std::vector<std::shared_ptr<skity::Pixmap>> const& images,
-    skity::Typeface* typeface, skity::Typeface* emoji, float mx, float my,
-    float width, float height, float t) {
+    std::shared_ptr<skity::Typeface> typeface,
+    std::shared_ptr<skity::Typeface> emoji, float mx, float my, float width,
+    float height, float t) {
   float x, y, popy;
 
   draw_eyes(canvas, width - 250, 50, 150, 100, mx, my, t);
@@ -150,8 +154,9 @@ void render_frame_demo(
 void render_frame_demo(
     skity::Canvas* canvas,
     std::vector<std::shared_ptr<skity::Pixmap>> const& images,
-    skity::Typeface* typeface, skity::Typeface* emoji, float mx, float my,
-    float width, float height, float t) {
+    std::shared_ptr<skity::Typeface> typeface,
+    std::shared_ptr<skity::Typeface> emoji, float mx, float my, float width,
+    float height, float t) {
   render_frame_demo(canvas, nullptr, images, typeface, emoji, mx, my, width,
                     height, t);
 }
@@ -1225,8 +1230,10 @@ void draw_spinner(skity::Canvas* canvas, float cx, float cy, float r, float t) {
   canvas->DrawPath(path, paint);
 }
 
-void draw_paragraph(skity::Canvas* canvas, skity::Typeface* typeface,
-                    skity::Typeface* emoji, float x, float y, float, float) {
+void draw_paragraph(skity::Canvas* canvas,
+                    std::shared_ptr<skity::Typeface> typeface,
+                    std::shared_ptr<skity::Typeface> emoji, float x, float y,
+                    float, float) {
   skity::Paint paint;
   paint.SetStyle(skity::Paint::kFill_Style);
   paint.SetTextSize(15.f);

--- a/example/case/nanovg_frame/main.cc
+++ b/example/case/nanovg_frame/main.cc
@@ -15,8 +15,9 @@ void load_images(std::vector<std::shared_ptr<skity::Pixmap>>& images);
 void render_frame_demo(
     skity::Canvas* canvas, skity::GPUContext* gpu_context,
     std::vector<std::shared_ptr<skity::Pixmap>> const& images,
-    skity::Typeface* typeface, skity::Typeface* emoji, float mx, float my,
-    float width, float height, float t);
+    std::shared_ptr<skity::Typeface> typeface,
+    std::shared_ptr<skity::Typeface> emoji, float mx, float my, float width,
+    float height, float t);
 
 class FrameExample : public skity::example::WindowClient {
  public:
@@ -32,8 +33,8 @@ class FrameExample : public skity::example::WindowClient {
     typeface_ = skity::Typeface::MakeFromFile(
         EXAMPLE_IMAGE_ROOT "/RobotoMonoNerdFont-Regular.ttf");
 
-    emoji_typeface_ =
-        skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT "/NotoColorEmoji.ttf");
+    emoji_typeface_ = skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT
+                                                    "/NotoEmoji-Regular.ttf");
 
     time_ = prev_time_ = glfwGetTime();
   }
@@ -64,8 +65,8 @@ class FrameExample : public skity::example::WindowClient {
 
  private:
   std::vector<std::shared_ptr<skity::Pixmap>> images_ = {};
-  skity::Typeface* typeface_ = {};
-  skity::Typeface* emoji_typeface_ = {};
+  std::shared_ptr<skity::Typeface> typeface_ = {};
+  std::shared_ptr<skity::Typeface> emoji_typeface_ = {};
   double time_ = 0;
   double prev_time_ = 0;
   double cpu_time_ = 0;

--- a/example/case/text/text_example.cc
+++ b/example/case/text/text_example.cc
@@ -20,7 +20,7 @@ void draw_text_with_emoji(skity::Canvas* canvas) {
   const char* emoji_font_path = EXAMPLE_IMAGE_ROOT "/NotoColorEmoji.ttf";
   auto emoji_typeface = skity::Typeface::MakeFromFile(emoji_font_path);
 
-  std::vector<Typeface*> typefaces;
+  std::vector<std::shared_ptr<Typeface>> typefaces;
   if (emoji_typeface) {
     typefaces.push_back(emoji_typeface);
   }

--- a/include/skity/graphic/paint.hpp
+++ b/include/skity/graphic/paint.hpp
@@ -234,9 +234,11 @@ class SKITY_API Paint {
   }
   const std::shared_ptr<Shader>& GetShader() const { return shader_; }
 
-  void SetTypeface(Typeface* typeface) { typeface_ = typeface; }
+  void SetTypeface(std::shared_ptr<Typeface> typeface) {
+    typeface_ = std::move(typeface);
+  }
 
-  Typeface* GetTypeface() const { return typeface_; }
+  std::shared_ptr<Typeface> GetTypeface() const { return typeface_; }
 
   void SetColorFilter(std::shared_ptr<ColorFilter> colorFilter) {
     color_filter_ = std::move(colorFilter);
@@ -283,7 +285,7 @@ class SKITY_API Paint {
   BlendMode blend_mode_ = BlendMode::kDefault;
   std::shared_ptr<PathEffect> path_effect_;
   std::shared_ptr<Shader> shader_;
-  Typeface* typeface_ = nullptr;
+  std::shared_ptr<Typeface> typeface_ = nullptr;
   std::shared_ptr<ColorFilter> color_filter_;
   std::shared_ptr<ImageFilter> image_filter_;
   std::shared_ptr<MaskFilter> mask_filter_;

--- a/include/skity/text/font.hpp
+++ b/include/skity/text/font.hpp
@@ -39,11 +39,12 @@ class SKITY_API Font {
 
   Font();
 
-  Font(Typeface* typeface, float size);
+  Font(std::shared_ptr<Typeface> typeface, float size);
 
-  explicit Font(Typeface* typeface);
+  explicit Font(std::shared_ptr<Typeface> typeface);
 
-  Font(Typeface* typeface, float size, float scaleX, float skewX);
+  Font(std::shared_ptr<Typeface> typeface, float size, float scaleX,
+       float skewX);
 
   bool IsForceAutoHinting() const {
     return ToBool(flags_ & kForceAutoHinting_PrivFlag);
@@ -90,9 +91,9 @@ class SKITY_API Font {
 
   Font MakeWithSize(float size) const;
 
-  void SetTypeface(Typeface* tf) { typeface_ = tf; }
-  Typeface* GetTypeface() const { return typeface_; }
-  Typeface* GetTypefaceOrDefault() const;
+  void SetTypeface(std::shared_ptr<Typeface> tf) { typeface_ = std::move(tf); }
+  std::shared_ptr<Typeface> GetTypeface() const { return typeface_; }
+  std::shared_ptr<Typeface> GetTypefaceOrDefault() const;
 
   void GetWidths(const GlyphID glyphs[], int count, float widths[],
                  Rect bounds[]) const {
@@ -124,7 +125,7 @@ class SKITY_API Font {
   uint16_t GetFixedSize() const;
 
  private:
-  mutable Typeface* typeface_;
+  mutable std::shared_ptr<Typeface> typeface_;
   float size_;
   float scale_x_;
   float skew_x_;

--- a/include/skity/text/font_manager.hpp
+++ b/include/skity/text/font_manager.hpp
@@ -23,13 +23,13 @@ class SKITY_API FontStyleSet {
 
   virtual int Count() = 0;
   virtual void GetStyle(int index, FontStyle*, std::string*) = 0;
-  virtual Typeface* CreateTypeface(int index) = 0;
-  virtual Typeface* MatchStyle(const FontStyle& pattern) = 0;
+  virtual std::shared_ptr<Typeface> CreateTypeface(int index) = 0;
+  virtual std::shared_ptr<Typeface> MatchStyle(const FontStyle& pattern) = 0;
 
-  static FontStyleSet* CreateEmpty();
+  static std::shared_ptr<FontStyleSet> CreateEmpty();
 
  protected:
-  Typeface* MatchStyleCSS3(const FontStyle& pattern);
+  std::shared_ptr<Typeface> MatchStyleCSS3(const FontStyle& pattern);
 };
 
 class SKITY_API FontManager {
@@ -41,22 +41,26 @@ class SKITY_API FontManager {
   int CountFamilies() const;
   std::string GetFamilyName(int index) const;
 
-  FontStyleSet* CreateStyleSet(int index) const;
-  FontStyleSet* MatchFamily(const char familyName[]) const;
+  std::shared_ptr<FontStyleSet> CreateStyleSet(int index) const;
+  std::shared_ptr<FontStyleSet> MatchFamily(const char familyName[]) const;
 
-  Typeface* MatchFamilyStyle(const char familyName[], const FontStyle&);
-  Typeface* MatchFamilyStyleCharacter(const char familyName[], const FontStyle&,
-                                      const char* bcp47[], int bcp47Count,
-                                      Unichar character);
+  std::shared_ptr<Typeface> MatchFamilyStyle(const char familyName[],
+                                             const FontStyle&);
+  std::shared_ptr<Typeface> MatchFamilyStyleCharacter(const char familyName[],
+                                                      const FontStyle&,
+                                                      const char* bcp47[],
+                                                      int bcp47Count,
+                                                      Unichar character);
 
-  Typeface* MakeFromData(std::shared_ptr<Data> const& data, int ttcIndex = 0);
-  Typeface* MakeFromFile(const char* path, int ttcIndex = 0);
+  std::shared_ptr<Typeface> MakeFromData(std::shared_ptr<Data> const& data,
+                                         int ttcIndex = 0);
+  std::shared_ptr<Typeface> MakeFromFile(const char* path, int ttcIndex = 0);
 
-  Typeface* GetDefaultTypeface(FontStyle font_style) const;
+  std::shared_ptr<Typeface> GetDefaultTypeface(FontStyle font_style) const;
 
   // TODO(jingle): We will remove this after implementing PC portable font
   // manager
-  virtual void SetDefaultTypeface(Typeface*) {}
+  virtual void SetDefaultTypeface(std::shared_ptr<Typeface>) {}
 
   /** Return the default fontmgr. */
   static std::shared_ptr<FontManager> RefDefault();
@@ -66,28 +70,28 @@ class SKITY_API FontManager {
   virtual int OnCountFamilies() const = 0;
   virtual std::string OnGetFamilyName(int index) const = 0;
 
-  virtual FontStyleSet* OnCreateStyleSet(int index) const = 0;
+  virtual std::shared_ptr<FontStyleSet> OnCreateStyleSet(int index) const = 0;
   /** May return NULL if the name is not found. */
-  virtual FontStyleSet* OnMatchFamily(const char familyName[]) const = 0;
+  virtual std::shared_ptr<FontStyleSet> OnMatchFamily(
+      const char familyName[]) const = 0;
 
-  virtual Typeface* OnMatchFamilyStyle(const char familyName[],
-                                       const FontStyle&) const = 0;
-  virtual Typeface* OnMatchFamilyStyleCharacter(const char familyName[],
-                                                const FontStyle&,
-                                                const char* bcp47[],
-                                                int bcp47Count,
-                                                Unichar character) const = 0;
+  virtual std::shared_ptr<Typeface> OnMatchFamilyStyle(
+      const char familyName[], const FontStyle&) const = 0;
+  virtual std::shared_ptr<Typeface> OnMatchFamilyStyleCharacter(
+      const char familyName[], const FontStyle&, const char* bcp47[],
+      int bcp47Count, Unichar character) const = 0;
 
-  virtual std::unique_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
+  virtual std::shared_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
                                                    int ttcIndex) const = 0;
 
-  virtual std::unique_ptr<Typeface> OnMakeFromFile(const char path[],
+  virtual std::shared_ptr<Typeface> OnMakeFromFile(const char path[],
                                                    int ttcIndex) const = 0;
 
-  virtual Typeface* OnGetDefaultTypeface(FontStyle const& font_style) const = 0;
+  virtual std::shared_ptr<Typeface> OnGetDefaultTypeface(
+      FontStyle const& font_style) const = 0;
 
  protected:
-  std::vector<std::unique_ptr<Typeface>> font_lst_;
+  std::vector<std::shared_ptr<Typeface>> font_lst_;
 };
 
 }  // namespace skity

--- a/include/skity/text/ports/typeface_ct.hpp
+++ b/include/skity/text/ports/typeface_ct.hpp
@@ -14,8 +14,9 @@ namespace skity {
 
 class SKITY_API TypefaceCT {
  public:
-  static CTFontRef CTFontFromTypeface(const Typeface* typeface);
-  static Typeface* TypefaceFromCTFont(CTFontRef ct_font);
+  static CTFontRef CTFontFromTypeface(
+      const std::shared_ptr<Typeface>& typeface);
+  static std::shared_ptr<Typeface> TypefaceFromCTFont(CTFontRef ct_font);
 };
 
 }  // namespace skity

--- a/include/skity/text/text_blob.hpp
+++ b/include/skity/text/text_blob.hpp
@@ -45,12 +45,13 @@ class SKITY_API TypefaceDelegate {
   TypefaceDelegate(const TypefaceDelegate&) = delete;
   TypefaceDelegate& operator=(const TypefaceDelegate&) = delete;
 
-  virtual Typeface* Fallback(Unichar code_point, Paint const& text_paint) = 0;
+  virtual std::shared_ptr<Typeface> Fallback(Unichar code_point,
+                                             Paint const& text_paint) = 0;
 
   virtual std::vector<std::vector<Unichar>> BreakTextRun(const char* text) = 0;
 
   static std::unique_ptr<TypefaceDelegate> CreateSimpleFallbackDelegate(
-      const std::vector<Typeface*>& typefaces);
+      const std::vector<std::shared_ptr<Typeface>>& typefaces);
 };
 
 class SKITY_API TextBlobBuilder final {
@@ -77,11 +78,13 @@ class SKITY_API TextBlobBuilder final {
       TypefaceDelegate* delegate);
 
   std::vector<TextRun> GenerateTextRuns(std::vector<Unichar> const& code_points,
-                                        Typeface* typeface, Paint const& paint,
+                                        std::shared_ptr<Typeface> typeface,
+                                        Paint const& paint,
                                         TypefaceDelegate* delegate);
 
   TextRun GenerateTextRun(std::vector<Unichar> const& code_points,
-                          Typeface* typeface, float font_size, bool need_path);
+                          std::shared_ptr<Typeface> typeface, float font_size,
+                          bool need_path);
 };
 }  // namespace skity
 

--- a/include/skity/text/text_run.hpp
+++ b/include/skity/text/text_run.hpp
@@ -23,15 +23,6 @@ class Typeface;
  */
 class SKITY_API TextRun final {
  public:
-  /*
-   * Deprecated, use font parameter instead.
-   */
-  TextRun(Typeface* typeface, std::vector<GlyphID> info, float font_size);
-  TextRun(Typeface* typeface, std::vector<GlyphID> info,
-          std::vector<float> pos_x, float font_size);
-  TextRun(Typeface* typeface, std::vector<GlyphID> info,
-          std::vector<float> pos_x, std::vector<float> pos_y, float font_size);
-
   TextRun(const Font& font, std::vector<GlyphID> info);
   TextRun(const Font& font, std::vector<GlyphID> info,
           std::vector<float> pos_x);
@@ -50,7 +41,7 @@ class SKITY_API TextRun final {
 
   std::vector<float> const& GetPosY() const;
 
-  Typeface* LockTypeface() const { return font_.GetTypeface(); }
+  std::shared_ptr<Typeface> LockTypeface() const { return font_.GetTypeface(); }
 
   float GetFontSize() const { return font_.GetSize(); }
 

--- a/include/skity/text/typeface.hpp
+++ b/include/skity/text/typeface.hpp
@@ -33,7 +33,7 @@ using TypefaceID = uint32_t;
 class ScalerContext;
 class ScalerContextDesc;
 class Descriptor;
-class SKITY_API Typeface {
+class SKITY_API Typeface : public std::enable_shared_from_this<Typeface> {
  public:
   virtual ~Typeface() = default;
 
@@ -94,11 +94,12 @@ class SKITY_API Typeface {
 
   Data* GetData() { return this->OnGetData(); }
 
-  static Typeface* MakeFromData(std::shared_ptr<Data> const& data);
-  static Typeface* MakeFromFile(const char* path);
+  static std::shared_ptr<Typeface> MakeFromData(
+      std::shared_ptr<Data> const& data);
+  static std::shared_ptr<Typeface> MakeFromFile(const char* path);
 
   /** Returns the default normal typeface, which is never nullptr. */
-  static Typeface* GetDefaultTypeface(
+  static std::shared_ptr<Typeface> GetDefaultTypeface(
       class FontStyle font_style = skity::FontStyle());
 
   bool ContainGlyph(Unichar code_point) const;
@@ -120,7 +121,7 @@ class SKITY_API Typeface {
   VariationPosition GetVariationDesignPosition() const;
   std::vector<VariationAxis> GetVariationDesignParameters() const;
 
-  Typeface* MakeVariation(const FontArguments& args) const;
+  std::shared_ptr<Typeface> MakeVariation(const FontArguments& args) const;
 
  protected:
   explicit Typeface(const FontStyle& style)
@@ -144,7 +145,8 @@ class SKITY_API Typeface {
   virtual VariationPosition OnGetVariationDesignPosition() const = 0;
   virtual std::vector<VariationAxis> OnGetVariationDesignParameters() const = 0;
 
-  virtual Typeface* OnMakeVariation(const FontArguments& args) const = 0;
+  virtual std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments& args) const = 0;
 
   TypefaceID typeface_id_;
   class FontStyle font_style_;

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -66,7 +66,7 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
                                   const Paint& paint, bool load_sdf,
                                   float context_scale,
                                   const Matrix& transform) {
-  Typeface* typeface = font.GetTypeface();
+  auto typeface = font.GetTypeface();
   float font_size = font.GetSize();
   float sdf_scale = 1.0f;
   // TODO(jingle) consider transform for sdf text

--- a/src/render/text/text_render_control.cc
+++ b/src/render/text/text_render_control.cc
@@ -15,7 +15,7 @@ TextRenderControl::TextRenderControl(bool disallow_sdf, float min_sdf_size,
       max_sdf_size_(max_sdf_size) {}
 
 bool TextRenderControl::CanUseSDF(float text_size, const Paint& paint,
-                                  const Typeface* typeface) {
+                                  const std::shared_ptr<Typeface>& typeface) {
   float min_sdf_size = paint.IsSDFForSmallText()
                            ? kDefaultMinDistanceFieldFontSize
                            : min_sdf_size_;
@@ -24,9 +24,9 @@ bool TextRenderControl::CanUseSDF(float text_size, const Paint& paint,
          text_size < paint.GetFontThreshold();
 }
 
-bool TextRenderControl::CanUseDirect(float text_size, const Matrix& transform,
-                                     const Paint& paint,
-                                     const Typeface* typeface) {
+bool TextRenderControl::CanUseDirect(
+    float text_size, const Matrix& transform, const Paint& paint,
+    const std::shared_ptr<Typeface>& typeface) {
   return !CanUseSDF(text_size, paint, typeface) && !transform.HasPersp() &&
          text_size < paint.GetFontThreshold();
 }

--- a/src/render/text/text_render_control.hpp
+++ b/src/render/text/text_render_control.hpp
@@ -29,9 +29,11 @@ class TextRenderControl {
                     float min_sdf_size = kLargeDFFontSize,
                     float max_sdf_size = kDefaultMaxDistanceFieldFontSize);
 
-  bool CanUseSDF(float text_size, const Paint& paint, const Typeface* typeface);
+  bool CanUseSDF(float text_size, const Paint& paint,
+                 const std::shared_ptr<Typeface>& typeface);
   bool CanUseDirect(float text_size, const Matrix& transform,
-                    const Paint& paint, const Typeface* typeface);
+                    const Paint& paint,
+                    const std::shared_ptr<Typeface>& typeface);
 
  private:
   bool disallow_sdf_;

--- a/src/text/font.cc
+++ b/src/text/font.cc
@@ -23,12 +23,18 @@ static inline float ValidSize(float size) { return std::max<float>(0, size); }
 
 Font::Font() : Font(nullptr) {}
 
-Font::Font(Typeface* typeface, float size) : Font(typeface, size, 1, 0) {}
+Font::Font(std::shared_ptr<Typeface> typeface, float size)
+    : Font(std::move(typeface), size, 1, 0) {}
 
-Font::Font(Typeface* typeface) : Font(typeface, DEFAULT_SIZE) {}
+Font::Font(std::shared_ptr<Typeface> typeface)
+    : Font(std::move(typeface), DEFAULT_SIZE) {}
 
-Font::Font(Typeface* typeface, float size, float scaleX, float skewX)
-    : typeface_(typeface), size_(size), scale_x_(scaleX), skew_x_(skewX) {}
+Font::Font(std::shared_ptr<Typeface> typeface, float size, float scaleX,
+           float skewX)
+    : typeface_(std::move(typeface)),
+      size_(size),
+      scale_x_(scaleX),
+      skew_x_(skewX) {}
 
 void Font::SetForceAutoHinting(bool predicate) {
   flags_ = SetClearMask(flags_, predicate, kForceAutoHinting_PrivFlag);
@@ -62,7 +68,7 @@ Font Font::MakeWithSize(float size) const {
   return font;
 }
 
-Typeface* Font::GetTypefaceOrDefault() const {
+std::shared_ptr<Typeface> Font::GetTypefaceOrDefault() const {
   if (!typeface_) {
     typeface_ = Typeface::GetDefaultTypeface();
   }

--- a/src/text/font_manager.cc
+++ b/src/text/font_manager.cc
@@ -24,17 +24,22 @@ class EmptyFontStyleSet : public FontStyleSet {
     LOGE("SkFontStyleSet::getStyle called on empty set");
   }
 
-  Typeface* CreateTypeface(int) override {
+  std::shared_ptr<Typeface> CreateTypeface(int) override {
     LOGE("SkFontStyleSet::createTypeface called on empty set");
     return nullptr;
   }
 
-  Typeface* MatchStyle(const FontStyle&) override { return nullptr; }
+  std::shared_ptr<Typeface> MatchStyle(const FontStyle&) override {
+    return nullptr;
+  }
 };
 
-FontStyleSet* FontStyleSet::CreateEmpty() { return new EmptyFontStyleSet; }
+std::shared_ptr<FontStyleSet> FontStyleSet::CreateEmpty() {
+  return std::make_shared<EmptyFontStyleSet>();
+}
 
-Typeface* FontStyleSet::MatchStyleCSS3(const FontStyle& pattern) {
+std::shared_ptr<Typeface> FontStyleSet::MatchStyleCSS3(
+    const FontStyle& pattern) {
   int count = this->Count();
   if (0 == count) {
     return nullptr;
@@ -135,7 +140,8 @@ Typeface* FontStyleSet::MatchStyleCSS3(const FontStyle& pattern) {
   return this->CreateTypeface(maxScore.index);
 }
 
-static FontStyleSet* emptyOnNull(FontStyleSet* fsset) {
+static std::shared_ptr<FontStyleSet> emptyOnNull(
+    std::shared_ptr<FontStyleSet> fsset) {
   if (nullptr == fsset) {
     fsset = FontStyleSet::CreateEmpty();
   }
@@ -148,30 +154,29 @@ std::string FontManager::GetFamilyName(int index) const {
   return this->OnGetFamilyName(index);
 }
 
-FontStyleSet* FontManager::CreateStyleSet(int index) const {
+std::shared_ptr<FontStyleSet> FontManager::CreateStyleSet(int index) const {
   return emptyOnNull(this->OnCreateStyleSet(index));
 }
 
-FontStyleSet* FontManager::MatchFamily(const char familyName[]) const {
+std::shared_ptr<FontStyleSet> FontManager::MatchFamily(
+    const char familyName[]) const {
   return emptyOnNull(this->OnMatchFamily(familyName));
 }
 
-Typeface* FontManager::MatchFamilyStyle(const char familyName[],
-                                        const FontStyle& fs) {
+std::shared_ptr<Typeface> FontManager::MatchFamilyStyle(const char familyName[],
+                                                        const FontStyle& fs) {
   return this->OnMatchFamilyStyle(familyName, fs);
 }
 
-Typeface* FontManager::MatchFamilyStyleCharacter(const char familyName[],
-                                                 const FontStyle& style,
-                                                 const char* bcp47[],
-                                                 int bcp47Count,
-                                                 Unichar character) {
+std::shared_ptr<Typeface> FontManager::MatchFamilyStyleCharacter(
+    const char familyName[], const FontStyle& style, const char* bcp47[],
+    int bcp47Count, Unichar character) {
   return this->OnMatchFamilyStyleCharacter(familyName, style, bcp47, bcp47Count,
                                            character);
 }
 
-Typeface* FontManager::MakeFromData(std::shared_ptr<Data> const& data,
-                                    int ttcIndex) {
+std::shared_ptr<Typeface> FontManager::MakeFromData(
+    std::shared_ptr<Data> const& data, int ttcIndex) {
   if (nullptr == data) {
     return nullptr;
   }
@@ -180,10 +185,11 @@ Typeface* FontManager::MakeFromData(std::shared_ptr<Data> const& data,
     return nullptr;
   }
   font_lst_.push_back(std::move(typeface));
-  return font_lst_.back().get();
+  return font_lst_.back();
 }
 
-Typeface* FontManager::MakeFromFile(const char* path, int ttcIndex) {
+std::shared_ptr<Typeface> FontManager::MakeFromFile(const char* path,
+                                                    int ttcIndex) {
   if (nullptr == path) {
     return nullptr;
   }
@@ -192,10 +198,11 @@ Typeface* FontManager::MakeFromFile(const char* path, int ttcIndex) {
     return nullptr;
   }
   font_lst_.push_back(std::move(typeface));
-  return font_lst_.back().get();
+  return font_lst_.back();
 }
 
-Typeface* FontManager::GetDefaultTypeface(FontStyle font_style) const {
+std::shared_ptr<Typeface> FontManager::GetDefaultTypeface(
+    FontStyle font_style) const {
   return this->OnGetDefaultTypeface(font_style);
 }
 

--- a/src/text/ports/darwin/font_manager_darwin.hpp
+++ b/src/text/ports/darwin/font_manager_darwin.hpp
@@ -30,9 +30,9 @@ class FontStyleSetDarwin : public FontStyleSet {
 
   void GetStyle(int index, FontStyle*, std::string*) override;
 
-  Typeface* CreateTypeface(int index) override;
+  std::shared_ptr<Typeface> CreateTypeface(int index) override;
 
-  Typeface* MatchStyle(const FontStyle& pattern) override;
+  std::shared_ptr<Typeface> MatchStyle(const FontStyle& pattern) override;
 
   CTFontDescriptorRef GetCTFontDescriptor() const;
 
@@ -42,7 +42,7 @@ class FontStyleSetDarwin : public FontStyleSet {
  private:
   UniqueCFRef<CTFontDescriptorRef> cf_desc;
   UniqueCFRef<CFArrayRef> mached_desc_;
-  std::vector<TypefaceDarwin*> typefaces_;
+  std::vector<std::shared_ptr<TypefaceDarwin>> typefaces_;
 };
 
 class FontManagerDarwin : public FontManager {
@@ -50,8 +50,8 @@ class FontManagerDarwin : public FontManager {
   FontManagerDarwin();
   ~FontManagerDarwin() override = default;
 
-  void SetDefaultTypeface(Typeface* typeface) override {
-    default_typeface_ = typeface;
+  void SetDefaultTypeface(std::shared_ptr<Typeface> typeface) override {
+    default_typeface_ = std::move(typeface);
   }
 
  protected:
@@ -59,43 +59,44 @@ class FontManagerDarwin : public FontManager {
 
   std::string OnGetFamilyName(int index) const override;
 
-  FontStyleSet* OnCreateStyleSet(int index) const override;
+  std::shared_ptr<FontStyleSet> OnCreateStyleSet(int index) const override;
 
-  FontStyleSet* OnMatchFamily(const char* family_name) const override;
+  std::shared_ptr<FontStyleSet> OnMatchFamily(
+      const char* family_name) const override;
 
-  Typeface* OnMatchFamilyStyle(const char* family_name,
-                               const FontStyle& style) const override;
+  std::shared_ptr<Typeface> OnMatchFamilyStyle(
+      const char* family_name, const FontStyle& style) const override;
 
-  Typeface* OnMatchFamilyStyleCharacter(const char* family_name,
-                                        const FontStyle& style,
-                                        const char* bcp47[], int bcp47Count,
-                                        Unichar character) const override;
+  std::shared_ptr<Typeface> OnMatchFamilyStyleCharacter(
+      const char* family_name, const FontStyle& style, const char* bcp47[],
+      int bcp47Count, Unichar character) const override;
 
-  std::unique_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
+  std::shared_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
                                            int ttcIndex) const override;
 
-  std::unique_ptr<Typeface> OnMakeFromFile(const char path[],
+  std::shared_ptr<Typeface> OnMakeFromFile(const char path[],
                                            int ttcIndex) const override;
 
-  Typeface* OnGetDefaultTypeface(FontStyle const& font_style) const override;
+  std::shared_ptr<Typeface> OnGetDefaultTypeface(
+      FontStyle const& font_style) const override;
 
  private:
   void InitSystemFamily();
 
   int32_t GetIndexByFamilyName(const char* family_name) const;
 
-  FontStyleSetDarwin* MatchFamilyByIndex(int32_t index) const;
+  std::shared_ptr<FontStyleSetDarwin> MatchFamilyByIndex(int32_t index) const;
 
-  TypefaceDarwin* SavedFallbackTypeface(UniqueCFRef<CTFontRef> ct_font,
-                                        FontStyle const& style) const;
+  std::shared_ptr<TypefaceDarwin> SavedFallbackTypeface(
+      UniqueCFRef<CTFontRef> ct_font, FontStyle const& style) const;
 
  private:
   UniqueCFRef<CFArrayRef> cf_family_names_;
   std::vector<std::string> sys_family_names_;
   int default_name_index_ = -1;
-  mutable std::vector<std::unique_ptr<FontStyleSetDarwin>> sys_style_sets_;
-  mutable std::vector<TypefaceDarwin*> sys_fallbacked_;
-  Typeface* default_typeface_ = nullptr;
+  mutable std::vector<std::shared_ptr<FontStyleSetDarwin>> sys_style_sets_;
+  mutable std::vector<std::shared_ptr<TypefaceDarwin>> sys_fallbacked_;
+  std::shared_ptr<Typeface> default_typeface_ = nullptr;
 };
 
 }  // namespace skity

--- a/src/text/ports/darwin/scaler_context_darwin.cc
+++ b/src/text/ports/darwin/scaler_context_darwin.cc
@@ -117,8 +117,8 @@ UniqueCTFontRef ct_font_copy_with_size(CTFontRef base, CGFloat text_size) {
       CTFontCreateCopyWithAttributes(base, text_size, nullptr, desc.get()));
 }
 
-ScalerContextDarwin::ScalerContextDarwin(TypefaceDarwin *typeface,
-                                         const ScalerContextDesc *desc)
+ScalerContextDarwin::ScalerContextDarwin(
+    std::shared_ptr<TypefaceDarwin> typeface, const ScalerContextDesc *desc)
     : ScalerContext(typeface, desc), os_context_() {
   float scaled_size;
   Matrix22 transform;

--- a/src/text/ports/darwin/scaler_context_darwin.hpp
+++ b/src/text/ports/darwin/scaler_context_darwin.hpp
@@ -41,7 +41,8 @@ class OffScreenContext final {
 
 class ScalerContextDarwin : public ScalerContext {
  public:
-  ScalerContextDarwin(TypefaceDarwin *typeface, const ScalerContextDesc *desc);
+  ScalerContextDarwin(std::shared_ptr<TypefaceDarwin> typeface,
+                      const ScalerContextDesc *desc);
   ~ScalerContextDarwin() override;
 
  protected:

--- a/src/text/ports/darwin/typeface_darwin.hpp
+++ b/src/text/ports/darwin/typeface_darwin.hpp
@@ -20,8 +20,9 @@ namespace skity {
 
 class TypefaceDarwin : public Typeface {
  public:
-  static TypefaceDarwin *Make(const FontStyle &style, UniqueCTFontRef ct_font);
-  static std::unique_ptr<TypefaceDarwin> MakeWithoutCache(
+  static std::shared_ptr<TypefaceDarwin> Make(const FontStyle &style,
+                                              UniqueCTFontRef ct_font);
+  static std::shared_ptr<TypefaceDarwin> MakeWithoutCache(
       const FontStyle &style, UniqueCTFontRef ct_font);
 
   ~TypefaceDarwin() override;
@@ -51,7 +52,8 @@ class TypefaceDarwin : public Typeface {
   VariationPosition OnGetVariationDesignPosition() const override;
   std::vector<VariationAxis> OnGetVariationDesignParameters() const override;
 
-  Typeface *OnMakeVariation(const FontArguments &args) const override;
+  std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments &args) const override;
 
  private:
   UniqueCTFontRef ct_font_;

--- a/src/text/ports/font_manager_empty.cc
+++ b/src/text/ports/font_manager_empty.cc
@@ -20,35 +20,37 @@ class FontManagerEmpty : public FontManager {
     return "";
   }
 
-  FontStyleSet* OnCreateStyleSet(int) const override {
+  std::shared_ptr<FontStyleSet> OnCreateStyleSet(int) const override {
     LOGE("onCreateStyleSet called with bad index");
     return nullptr;
   }
 
-  FontStyleSet* OnMatchFamily(const char[]) const override {
+  std::shared_ptr<FontStyleSet> OnMatchFamily(const char[]) const override {
     return FontStyleSet::CreateEmpty();
   }
 
-  Typeface* OnMatchFamilyStyle(const char[], const FontStyle&) const override {
+  std::shared_ptr<Typeface> OnMatchFamilyStyle(
+      const char[], const FontStyle&) const override {
     return nullptr;
   }
 
-  Typeface* OnMatchFamilyStyleCharacter(const char[], const FontStyle&,
-                                        const char*[], int,
-                                        Unichar) const override {
+  std::shared_ptr<Typeface> OnMatchFamilyStyleCharacter(
+      const char[], const FontStyle&, const char*[], int,
+      Unichar) const override {
     return nullptr;
   }
 
-  std::unique_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
+  std::shared_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const&,
                                            int) const override {
     return std::make_unique<TypefaceEmpty>();
   }
 
-  std::unique_ptr<Typeface> OnMakeFromFile(const char[], int) const override {
+  std::shared_ptr<Typeface> OnMakeFromFile(const char[], int) const override {
     return std::make_unique<TypefaceEmpty>();
   }
 
-  Typeface* OnGetDefaultTypeface(FontStyle const&) const override {
+  std::shared_ptr<Typeface> OnGetDefaultTypeface(
+      FontStyle const&) const override {
     return nullptr;
   }
 };

--- a/src/text/ports/font_manager_freetype.cc
+++ b/src/text/ports/font_manager_freetype.cc
@@ -13,7 +13,7 @@ namespace skity {
 
 class FontManagerFreetype : public FontManager {
  public:
-  void SetDefaultTypeface(Typeface* typeface) override {
+  void SetDefaultTypeface(std::shared_ptr<Typeface> typeface) override {
     default_typeface_ = typeface;
   }
 
@@ -25,43 +25,45 @@ class FontManagerFreetype : public FontManager {
     return "";
   }
 
-  FontStyleSet* OnCreateStyleSet(int) const override {
+  std::shared_ptr<FontStyleSet> OnCreateStyleSet(int) const override {
     LOGE("onCreateStyleSet called with bad index");
     return nullptr;
   }
 
-  FontStyleSet* OnMatchFamily(const char[]) const override {
+  std::shared_ptr<FontStyleSet> OnMatchFamily(const char[]) const override {
     return FontStyleSet::CreateEmpty();
   }
 
-  Typeface* OnMatchFamilyStyle(const char[], const FontStyle&) const override {
+  std::shared_ptr<Typeface> OnMatchFamilyStyle(
+      const char[], const FontStyle&) const override {
     return nullptr;
   }
 
-  Typeface* OnMatchFamilyStyleCharacter(const char[], const FontStyle&,
-                                        const char*[], int,
-                                        Unichar) const override {
+  std::shared_ptr<Typeface> OnMatchFamilyStyleCharacter(
+      const char[], const FontStyle&, const char*[], int,
+      Unichar) const override {
     return nullptr;
   }
 
-  std::unique_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const& data,
+  std::shared_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const& data,
                                            int ttcIndex) const override {
     return TypefaceFreeType::Make(data,
                                   FontArguments().SetCollectionIndex(ttcIndex));
   }
 
-  std::unique_ptr<Typeface> OnMakeFromFile(const char path[],
+  std::shared_ptr<Typeface> OnMakeFromFile(const char path[],
                                            int ttcIndex) const override {
     auto data = Data::MakeFromFileMapping(path);
     return this->OnMakeFromData(data, ttcIndex);
   }
 
-  Typeface* OnGetDefaultTypeface(FontStyle const&) const override {
+  std::shared_ptr<Typeface> OnGetDefaultTypeface(
+      FontStyle const&) const override {
     return default_typeface_;
   }
 
  private:
-  Typeface* default_typeface_;
+  std::shared_ptr<Typeface> default_typeface_;
 };
 
 std::shared_ptr<FontManager> FontManager::RefDefault() {

--- a/src/text/ports/scaler_context_freetype.cc
+++ b/src/text/ports/scaler_context_freetype.cc
@@ -69,8 +69,8 @@ static FT_Int ChooseBitmapStrike(FT_Face face, FT_F26Dot6 scaleY) {
   return chosenStrikeIndex;
 }
 
-ScalerContextFreetype::ScalerContextFreetype(TypefaceFreeType* typeface,
-                                             const ScalerContextDesc* desc)
+ScalerContextFreetype::ScalerContextFreetype(
+    std::shared_ptr<TypefaceFreeType> typeface, const ScalerContextDesc* desc)
     : ScalerContext(typeface, desc),
       strike_index_(-1),
       path_utils_(std::make_unique<PathFreeType>()),

--- a/src/text/ports/scaler_context_freetype.hpp
+++ b/src/text/ports/scaler_context_freetype.hpp
@@ -20,7 +20,7 @@
 namespace skity {
 class ScalerContextFreetype : public ScalerContext {
  public:
-  ScalerContextFreetype(TypefaceFreeType *typeface,
+  ScalerContextFreetype(std::shared_ptr<TypefaceFreeType> typeface,
                         const ScalerContextDesc *desc);
   ~ScalerContextFreetype() override;
 

--- a/src/text/ports/typeface_empty.cc
+++ b/src/text/ports/typeface_empty.cc
@@ -38,7 +38,8 @@ std::vector<VariationAxis> TypefaceEmpty::OnGetVariationDesignParameters()
   return {};
 }
 
-Typeface *TypefaceEmpty::OnMakeVariation(const FontArguments &args) const {
+std::shared_ptr<Typeface> TypefaceEmpty::OnMakeVariation(
+    const FontArguments &args) const {
   return nullptr;
 }
 

--- a/src/text/ports/typeface_empty.hpp
+++ b/src/text/ports/typeface_empty.hpp
@@ -31,7 +31,8 @@ class TypefaceEmpty : public Typeface {
   VariationPosition OnGetVariationDesignPosition() const override;
   std::vector<VariationAxis> OnGetVariationDesignParameters() const override;
 
-  Typeface *OnMakeVariation(const FontArguments &args) const override;
+  std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments &args) const override;
 };
 
 }  // namespace skity

--- a/src/text/ports/typeface_freetype.hpp
+++ b/src/text/ports/typeface_freetype.hpp
@@ -55,7 +55,7 @@ class TypefaceFreeType : public Typeface {
   friend AutoFTAccess;
 
  public:
-  static std::unique_ptr<TypefaceFreeType> Make(std::shared_ptr<Data> stream,
+  static std::shared_ptr<TypefaceFreeType> Make(std::shared_ptr<Data> stream,
                                                 const FontArguments& font_args);
 
   explicit TypefaceFreeType(const FontStyle& style);
@@ -88,7 +88,8 @@ class TypefaceFreeType : public Typeface {
   VariationPosition OnGetVariationDesignPosition() const override;
   std::vector<VariationAxis> OnGetVariationDesignParameters() const override;
 
-  Typeface* OnMakeVariation(const FontArguments& args) const override;
+  std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments& args) const override;
 
   virtual FaceData OnGetFaceData() const = 0;
 
@@ -97,7 +98,6 @@ class TypefaceFreeType : public Typeface {
   mutable std::unique_ptr<FreetypeFaceHolder> freetype_face_holder_;
   mutable std::mutex C2GCacheMutex_;
   mutable std::unordered_map<Unichar, GlyphID> C2GCache_;
-  mutable std::vector<std::unique_ptr<TypefaceFreeType>> variant_faces_;
 };
 
 class TypefaceFreeTypeData : public TypefaceFreeType {

--- a/src/text/scaler_context.cc
+++ b/src/text/scaler_context.cc
@@ -6,8 +6,9 @@
 
 namespace skity {
 
-ScalerContext::ScalerContext(Typeface* typeface, const ScalerContextDesc* desc)
-    : typeface_(typeface), desc_(*desc) {}
+ScalerContext::ScalerContext(std::shared_ptr<Typeface> typeface,
+                             const ScalerContextDesc* desc)
+    : typeface_(std::move(typeface)), desc_(*desc) {}
 
 void ScalerContext::MakeGlyph(GlyphData* glyph_data) {
   this->GenerateMetrics(glyph_data);

--- a/src/text/scaler_context.hpp
+++ b/src/text/scaler_context.hpp
@@ -69,12 +69,13 @@ class Descriptor {
 
 class ScalerContext {
  public:
-  ScalerContext(Typeface* typeface, const ScalerContextDesc* desc);
+  ScalerContext(std::shared_ptr<Typeface> typeface,
+                const ScalerContextDesc* desc);
   virtual ~ScalerContext() = default;
 
  public:
   const ScalerContextDesc& GetDesc() const { return desc_; }
-  Typeface* GetTypeface() { return typeface_; }
+  std::shared_ptr<Typeface> GetTypeface() { return typeface_; }
   void MakeGlyph(GlyphData* glyph_data);
   void GetImage(GlyphData* glyph, const StrokeDesc& stroke_desc);
   void GetImageInfo(GlyphData* glyph, const StrokeDesc& stroke_desc);
@@ -96,7 +97,7 @@ class ScalerContext {
   virtual uint16_t OnGetFixedSize() = 0;
 
  protected:
-  Typeface* typeface_;
+  std::shared_ptr<Typeface> typeface_;
   ScalerContextDesc desc_;
 };
 }  // namespace skity

--- a/src/text/scaler_context_cache.cc
+++ b/src/text/scaler_context_cache.cc
@@ -18,8 +18,8 @@ ScalerContextCache* ScalerContextCache::GlobalScalerContextCache() {
 ScalerContextCache::ScalerContextCache() : cache_(kMaxCacheSize) {}
 
 std::shared_ptr<ScalerContextContainer>
-ScalerContextCache::FindOrCreateScalerContext(const ScalerContextDesc& desc,
-                                              Typeface* typeface) {
+ScalerContextCache::FindOrCreateScalerContext(
+    const ScalerContextDesc& desc, const std::shared_ptr<Typeface>& typeface) {
   std::unique_lock<std::mutex> lock(mutex_);
   auto p_scaler_context = cache_.find(desc);
   if (p_scaler_context) {
@@ -32,7 +32,7 @@ ScalerContextCache::FindOrCreateScalerContext(const ScalerContextDesc& desc,
 }
 
 std::shared_ptr<ScalerContextContainer> ScalerContextCache::CreateScalerContext(
-    const ScalerContextDesc& desc, Typeface* typeface) {
+    const ScalerContextDesc& desc, const std::shared_ptr<Typeface>& typeface) {
   auto scaler_context = typeface->CreateScalerContext(&desc);
   return std::make_shared<ScalerContextContainer>(std::move(scaler_context));
 }

--- a/src/text/scaler_context_cache.hpp
+++ b/src/text/scaler_context_cache.hpp
@@ -25,11 +25,11 @@ class ScalerContextCache final {
   ~ScalerContextCache() = default;
 
   std::shared_ptr<ScalerContextContainer> FindOrCreateScalerContext(
-      const ScalerContextDesc& desc, Typeface* typeface);
+      const ScalerContextDesc& desc, const std::shared_ptr<Typeface>& typeface);
 
  private:
   std::shared_ptr<ScalerContextContainer> CreateScalerContext(
-      const ScalerContextDesc& desc, Typeface* typeface);
+      const ScalerContextDesc& desc, const std::shared_ptr<Typeface>& typeface);
 
   LRUCache<ScalerContextDesc, std::shared_ptr<ScalerContextContainer>> cache_;
   std::mutex mutex_;

--- a/src/text/text_run.cc
+++ b/src/text/text_run.cc
@@ -7,23 +7,6 @@
 
 namespace skity {
 
-TextRun::TextRun(Typeface* typeface, std::vector<GlyphID> info, float font_size)
-    : font_(typeface, font_size), glyph_info_(std::move(info)) {}
-
-TextRun::TextRun(Typeface* typeface, std::vector<GlyphID> info,
-                 std::vector<float> pos_x, float font_size)
-    : font_(typeface, font_size),
-      glyph_info_(std::move(info)),
-      pos_x_(std::move(pos_x)) {}
-
-TextRun::TextRun(Typeface* typeface, std::vector<GlyphID> info,
-                 std::vector<float> pos_x, std::vector<float> pos_y,
-                 float font_size)
-    : font_(typeface, font_size),
-      glyph_info_(std::move(info)),
-      pos_x_(std::move(pos_x)),
-      pos_y_(std::move(pos_y)) {}
-
 TextRun::TextRun(const Font& font, std::vector<GlyphID> info)
     : font_(font), glyph_info_(std::move(info)) {}
 

--- a/src/text/typeface.cc
+++ b/src/text/typeface.cc
@@ -17,18 +17,20 @@
 
 namespace skity {
 
-Typeface* Typeface::GetDefaultTypeface(class FontStyle font_style) {
+std::shared_ptr<Typeface> Typeface::GetDefaultTypeface(
+    class FontStyle font_style) {
   return FontManager::RefDefault()->GetDefaultTypeface(font_style);
 }
 
-Typeface* Typeface::MakeFromData(const std::shared_ptr<Data>& data) {
+std::shared_ptr<Typeface> Typeface::MakeFromData(
+    const std::shared_ptr<Data>& data) {
   if (!data) {
     return nullptr;
   }
   return FontManager::RefDefault()->MakeFromData(data);
 }
 
-Typeface* Typeface::MakeFromFile(const char* path) {
+std::shared_ptr<Typeface> Typeface::MakeFromFile(const char* path) {
   return FontManager::RefDefault()->MakeFromFile(path);
 }
 
@@ -71,9 +73,7 @@ bool Typeface::ContainsColorTable() const {
 
 std::unique_ptr<ScalerContext> Typeface::CreateScalerContext(
     const ScalerContextDesc* desc) const {
-  std::unique_ptr<ScalerContext> scaler_context =
-      this->OnCreateScalerContext(desc);
-  return scaler_context;
+  return this->OnCreateScalerContext(desc);
 }
 
 VariationPosition Typeface::GetVariationDesignPosition() const {
@@ -83,7 +83,8 @@ std::vector<VariationAxis> Typeface::GetVariationDesignParameters() const {
   return OnGetVariationDesignParameters();
 }
 
-Typeface* Typeface::MakeVariation(const FontArguments& args) const {
+std::shared_ptr<Typeface> Typeface::MakeVariation(
+    const FontArguments& args) const {
   return OnMakeVariation(args);
 }
 

--- a/test/ut/text/text_test.cc
+++ b/test/ut/text/text_test.cc
@@ -44,7 +44,8 @@ class ColorfulTypeface : public Typeface {
   VariationPosition OnGetVariationDesignPosition() const override;
   std::vector<VariationAxis> OnGetVariationDesignParameters() const override;
 
-  Typeface *OnMakeVariation(const FontArguments &args) const override;
+  std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments &args) const override;
 
  private:
   bool colorful_ = false;
@@ -75,7 +76,8 @@ std::vector<VariationAxis> ColorfulTypeface::OnGetVariationDesignParameters()
   return {};
 }
 
-Typeface *ColorfulTypeface::OnMakeVariation(const FontArguments &args) const {
+std::shared_ptr<Typeface> ColorfulTypeface::OnMakeVariation(
+    const FontArguments &args) const {
   return nullptr;
 }
 
@@ -86,29 +88,27 @@ TEST(TextRenderControl, disallow_sdf_test) {
   skity::Paint paint;
 
   {
-    skity::ColorfulTypeface typeface(false);
-    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, &typeface));
-    EXPECT_TRUE(
-        controller.CanUseDirect(163, skity::Matrix{}, paint, &typeface));
+    auto typeface = std::make_shared<skity::ColorfulTypeface>(false);
+    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, typeface));
+    EXPECT_TRUE(controller.CanUseDirect(163, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(256, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(256, skity::Matrix{}, paint, typeface));
 
-    EXPECT_FALSE(controller.CanUseSDF(14, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(163, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(256, paint, &typeface));
+    EXPECT_FALSE(controller.CanUseSDF(14, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(163, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(256, paint, typeface));
   }
 
   {
-    skity::ColorfulTypeface typeface(true);
-    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, &typeface));
-    EXPECT_TRUE(
-        controller.CanUseDirect(163, skity::Matrix{}, paint, &typeface));
+    auto typeface = std::make_shared<skity::ColorfulTypeface>(true);
+    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, typeface));
+    EXPECT_TRUE(controller.CanUseDirect(163, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(256, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(256, skity::Matrix{}, paint, typeface));
 
-    EXPECT_FALSE(controller.CanUseSDF(14, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(163, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(256, paint, &typeface));
+    EXPECT_FALSE(controller.CanUseSDF(14, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(163, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(256, paint, typeface));
   }
 }
 
@@ -117,46 +117,44 @@ TEST(TextRenderControl, allow_sdf_test) {
   skity::Paint paint;
 
   {
-    skity::ColorfulTypeface typeface(false);
-    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, &typeface));
+    auto typeface = std::make_shared<skity::ColorfulTypeface>(false);
+    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(163, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(163, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(256, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(256, skity::Matrix{}, paint, typeface));
 
-    EXPECT_FALSE(controller.CanUseSDF(14, paint, &typeface));
-    EXPECT_TRUE(controller.CanUseSDF(163, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(256, paint, &typeface));
+    EXPECT_FALSE(controller.CanUseSDF(14, paint, typeface));
+    EXPECT_TRUE(controller.CanUseSDF(163, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(256, paint, typeface));
   }
 
   {
-    skity::ColorfulTypeface typeface(true);
-    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, &typeface));
-    EXPECT_TRUE(
-        controller.CanUseDirect(163, skity::Matrix{}, paint, &typeface));
+    auto typeface = std::make_shared<skity::ColorfulTypeface>(true);
+    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, typeface));
+    EXPECT_TRUE(controller.CanUseDirect(163, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(256, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(256, skity::Matrix{}, paint, typeface));
 
-    EXPECT_FALSE(controller.CanUseSDF(14, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(163, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(256, paint, &typeface));
+    EXPECT_FALSE(controller.CanUseSDF(14, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(163, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(256, paint, typeface));
   }
 
   paint.SetSDFForSmallText(true);
   {
-    skity::ColorfulTypeface typeface(false);
-    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, &typeface));
+    auto typeface = std::make_shared<skity::ColorfulTypeface>(false);
+    EXPECT_TRUE(controller.CanUseDirect(14, skity::Matrix{}, paint, typeface));
+    EXPECT_FALSE(controller.CanUseDirect(18, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(18, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(163, skity::Matrix{}, paint, typeface));
     EXPECT_FALSE(
-        controller.CanUseDirect(163, skity::Matrix{}, paint, &typeface));
-    EXPECT_FALSE(
-        controller.CanUseDirect(256, skity::Matrix{}, paint, &typeface));
+        controller.CanUseDirect(256, skity::Matrix{}, paint, typeface));
 
-    EXPECT_FALSE(controller.CanUseSDF(14, paint, &typeface));
-    EXPECT_TRUE(controller.CanUseSDF(18, paint, &typeface));
-    EXPECT_TRUE(controller.CanUseSDF(163, paint, &typeface));
-    EXPECT_FALSE(controller.CanUseSDF(256, paint, &typeface));
+    EXPECT_FALSE(controller.CanUseSDF(14, paint, typeface));
+    EXPECT_TRUE(controller.CanUseSDF(18, paint, typeface));
+    EXPECT_TRUE(controller.CanUseSDF(163, paint, typeface));
+    EXPECT_FALSE(controller.CanUseSDF(256, paint, typeface));
   }
 }
 


### PR DESCRIPTION
Changed the ownership model of Typeface to shared ownership to ensure that custom fonts can be properly released by the caller. This allows safe and explicit control over the lifetime of user-defined typefaces.