### PR TITLE
[HW] Use private storage mode for all texture

### DIFF
--- a/src/gpu/texture_manager.cc
+++ b/src/gpu/texture_manager.cc
@@ -94,7 +94,7 @@ void TextureManager::UploadTextureImage(const TextureImpl& texture,
         descriptor.format = static_cast<GPUTextureFormat>(format);
         descriptor.usage =
             static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
-        descriptor.storage_mode = GPUTextureStorageMode::kHostVisible;
+        descriptor.storage_mode = GPUTextureStorageMode::kPrivate;
         auto gpu_texture = device->CreateTexture(descriptor);
         auto cmd_buffer = device->CreateCommandBuffer();
         auto blit_pass = cmd_buffer->BeginBlitPass();

--- a/src/render/text/atlas/atlas_texture.cc
+++ b/src/render/text/atlas/atlas_texture.cc
@@ -49,7 +49,7 @@ void AtlasTexture::InitTexture() {
   }
   descriptor.usage =
       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
-  descriptor.storage_mode = GPUTextureStorageMode::kHostVisible;
+  descriptor.storage_mode = GPUTextureStorageMode::kPrivate;
   texture_ = gpu_device_->CreateTexture(descriptor);
   valid_texture_ = true;
 }


### PR DESCRIPTION
Create Texture with private storage mode and uploading data by blit copy. 
This can saves shared memory and solve some timing issues.