### PR TITLE
[test] generate coverage report during unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@ jobs:
     unittest_test:
         runs-on: lynx-ubuntu-22.04-medium
         timeout-minutes: 30
+        permissions:
+          issues: write
         steps:
+          - name: Install dependencies
+            run: |
+                sudo apt update
+                sudo apt install -y lcov
           - name: Python Setup
             uses: actions/setup-python@v5
             with:
@@ -29,9 +35,22 @@ jobs:
           - name: Compile Code
             run: |
                 export PATH=$PWD/buildtools/llvm/bin:$PATH
-                cmake -B out/cmake_host_build -DSKITY_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-fPIC"
+                cmake -B out/cmake_host_build -DSKITY_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
                 cmake --build out/cmake_host_build --target skity_unit_test
-                ./out/cmake_host_build/test/ut/skity_unit_test
+          - name: Test and Generate Coverage Report
+            run: |
+                cd out/cmake_host_build/test/ut/
+                ctest
+                cd ../../
+                lcov --capture --directory . --output-file coverage.info
+                lcov --remove coverage.info '/usr/**/*' 'test/**/*' 'third_party/**/*' 'Library/*' '**/clipper2/*' --output-file coverage.filtered.info
+          - name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v5
+            env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            with:
+              token: ${{ secrets.CODECOV_TOKEN }}
+              files: out/cmake_host_build/coverage.filtered.info
     android_build_check:
         runs-on: lynx-ubuntu-22.04-medium
         timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Skity
 
+[![codecov](https://codecov.io/github/lynx-family/skity/graph/badge.svg?token=QTK6TSRIHU)](https://codecov.io/github/lynx-family/skity)
+
 `Skity` is an open-source 2D graphics library developed in C++. 
 It focuses on GPU rendering, providing developers with efficient graphics drawing and rendering capabilities. 
 Currently, Skity supports mainstream graphics APIs such as OpenGL, OpenGL ES, and Metal. 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "header, diff, flags"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes

--- a/include/skity/graphic/path.hpp
+++ b/include/skity/graphic/path.hpp
@@ -6,6 +6,7 @@
 #define INCLUDE_SKITY_GRAPHIC_PATH_HPP
 
 #include <array>
+#include <cstdint>
 #include <skity/geometry/matrix.hpp>
 #include <skity/geometry/point.hpp>
 #include <skity/geometry/rect.hpp>

--- a/src/geometry/wangs_formula.hpp
+++ b/src/geometry/wangs_formula.hpp
@@ -7,6 +7,7 @@
 #define SRC_GEOMETRY_WANGS_FORMULA_HPP
 
 #include <algorithm>
+#include <cstdint>
 #include <skity/geometry/matrix.hpp>
 #include <skity/geometry/point.hpp>
 

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -36,6 +36,18 @@ target_link_libraries(skity_unit_test
     gmock_main
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    # Coverage flags
+    target_compile_options(skity PRIVATE --coverage -O0 -g)
+    target_link_options(skity PRIVATE --coverage)
+
+    target_compile_options(wgsl-cross PRIVATE --coverage -O0 -g)
+    target_link_options(wgsl-cross PRIVATE --coverage)
+
+    target_compile_options(skity_unit_test PRIVATE --coverage -O0 -g)
+    target_link_options(skity_unit_test PRIVATE --coverage)
+endif()
+
 target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
 
 gtest_add_tests(skity_unit_test "" AUTO)

--- a/test/ut/geometry/geometry_test.cc
+++ b/test/ut/geometry/geometry_test.cc
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
+#include <cmath>
 #include <vector>
 
 #include "src/geometry/math.hpp"
@@ -46,8 +46,7 @@ TEST(Geometry, CircleInterpolation) {
     skity::Vec2 end_unit_vec = {0, 1};
     std::vector<skity::Vec2> result =
         skity::CircleInterpolation(start_unit_vec, end_unit_vec, 2);
-    EXPECT_TRUE(
-        Vec2NearlyEqual(result[0], {std::sqrtf(2) / 2, std::sqrtf(2) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[0], {::sqrtf(2) / 2, ::sqrtf(2) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[1], {0, 1}));
   }
 
@@ -56,14 +55,14 @@ TEST(Geometry, CircleInterpolation) {
     skity::Vec2 end_unit_vec = {0, 1};
     std::vector<skity::Vec2> result =
         skity::CircleInterpolation(start_unit_vec, end_unit_vec, 3);
-    EXPECT_TRUE(Vec2NearlyEqual(result[0], {std::sqrtf(3) / 2, 0.5}));
-    EXPECT_TRUE(Vec2NearlyEqual(result[1], {0.5, std::sqrtf(3) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[0], {::sqrtf(3) / 2, 0.5}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[1], {0.5, ::sqrtf(3) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[2], {0, 1}));
 
     std::swap(start_unit_vec, end_unit_vec);
     result = skity::CircleInterpolation(start_unit_vec, end_unit_vec, 3);
-    EXPECT_TRUE(Vec2NearlyEqual(result[0], {0.5, std::sqrtf(3) / 2}));
-    EXPECT_TRUE(Vec2NearlyEqual(result[1], {std::sqrtf(3) / 2, 0.5}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[0], {0.5, ::sqrtf(3) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[1], {::sqrtf(3) / 2, 0.5}));
     EXPECT_TRUE(Vec2NearlyEqual(result[2], {1, 0}));
   }
 
@@ -72,27 +71,23 @@ TEST(Geometry, CircleInterpolation) {
     skity::Vec2 end_unit_vec = {-1, 0};
     std::vector<skity::Vec2> result =
         skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);
-    EXPECT_TRUE(
-        Vec2NearlyEqual(result[0], {std::sqrtf(2) / 2, std::sqrtf(2) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[0], {::sqrtf(2) / 2, ::sqrtf(2) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[1], {0, 1}));
-    EXPECT_TRUE(
-        Vec2NearlyEqual(result[2], {-std::sqrtf(2) / 2, std::sqrtf(2) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[2], {-::sqrtf(2) / 2, ::sqrtf(2) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[3], {-1, 0}));
 
     std::swap(start_unit_vec, end_unit_vec);
     result = skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);
-    EXPECT_TRUE(
-        Vec2NearlyEqual(result[0], {-std::sqrtf(2) / 2, -std::sqrtf(2) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[0], {-::sqrtf(2) / 2, -::sqrtf(2) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[1], {0, -1}));
-    EXPECT_TRUE(
-        Vec2NearlyEqual(result[2], {std::sqrtf(2) / 2, -std::sqrtf(2) / 2}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[2], {::sqrtf(2) / 2, -::sqrtf(2) / 2}));
     EXPECT_TRUE(Vec2NearlyEqual(result[3], {1, 0}));
   }
 
   {
     skity::Vec2 start_unit_vec = {1, 0};
     float x = 0.996;
-    skity::Vec2 end_unit_vec = {x, std::sqrtf(1 - x * x)};
+    skity::Vec2 end_unit_vec = {x, ::sqrtf(1 - x * x)};
     std::vector<skity::Vec2> result =
         skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);
     const auto cos01 = skity::CrossProduct(start_unit_vec, result[0]);
@@ -102,7 +97,7 @@ TEST(Geometry, CircleInterpolation) {
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos12));
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos23));
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos34));
-    EXPECT_TRUE(Vec2NearlyEqual(result[3], {x, std::sqrtf(1 - x * x)}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[3], {x, ::sqrtf(1 - x * x)}));
 
     std::swap(start_unit_vec, end_unit_vec);
     result = skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);
@@ -119,7 +114,7 @@ TEST(Geometry, CircleInterpolation) {
   {
     skity::Vec2 start_unit_vec = {1, 0};
     float x = -0.996;
-    skity::Vec2 end_unit_vec = {x, std::sqrtf(1 - x * x)};
+    skity::Vec2 end_unit_vec = {x, ::sqrtf(1 - x * x)};
     std::vector<skity::Vec2> result =
         skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);
     const auto cos01 = skity::CrossProduct(start_unit_vec, result[0]);
@@ -129,7 +124,7 @@ TEST(Geometry, CircleInterpolation) {
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos12));
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos23));
     EXPECT_TRUE(skity::FloatNearlyZero(cos01 - cos34));
-    EXPECT_TRUE(Vec2NearlyEqual(result[3], {x, std::sqrtf(1 - x * x)}));
+    EXPECT_TRUE(Vec2NearlyEqual(result[3], {x, ::sqrtf(1 - x * x)}));
 
     std::swap(start_unit_vec, end_unit_vec);
     result = skity::CircleInterpolation(start_unit_vec, end_unit_vec, 4);


### PR DESCRIPTION
* Append coverage flags if open `SKITY_TEST` flags and the compiler is GCC or Clang
* use `lcov` to trace and generate code coverage report

related to #23 