### PR TITLE
[test]Add option to controle if generate coverage information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,16 @@ jobs:
           - name: Compile Code
             run: |
                 export PATH=$PWD/buildtools/llvm/bin:$PATH
-                cmake -B out/cmake_host_build -DSKITY_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
+                cmake -B out/cmake_host_build -DSKITY_TEST=ON -DSKITY_TEST_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
                 cmake --build out/cmake_host_build --target skity_unit_test
           - name: Test and Generate Coverage Report
+            continue-on-error: true
             run: |
                 cd out/cmake_host_build/test/ut/
-                ctest --output-junit test.xml
+                ctest --output-junit test.xml --output-on-failure
                 cd ../../
                 lcov --capture --directory . --output-file coverage.info
-                lcov --remove coverage.info '/usr/**/*' 'test/**/*' 'third_party/**/*' 'Library/*' '**/clipper2/*' --output-file coverage.filtered.info
+                lcov --remove coverage.info '/usr/**/*' 'test/ut/**/*' 'third_party/**/*' 'Library/*' '**/clipper2/*' --output-file coverage.filtered.info
           - name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v5
             env:

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -30,6 +30,16 @@ option(SKITY_EXAMPLE "option for building example" OFF)
 #  The golden test code can only run on APPLE platform
 option(SKITY_TEST "option for building test" OFF)
 
+# option for generate code coverage report
+# Note:
+#  We only support generate code coverage report by GNU or Clang compiler
+cmake_dependent_option(
+  SKITY_TEST_COVERAGE "option for generate test code coverage report"
+  OFF
+  [[SKITY_TEST]]
+  OFF
+)
+
 option(SKITY_LOG "option for logging" OFF)
 option(SKITY_CT_FONT "option for open CoreText font backend on Darwin" OFF)
 

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -37,16 +37,13 @@ target_link_libraries(skity_unit_test
     gmock_main
 )
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if (${SKITY_TEST_COVERAGE} AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     # Coverage flags
     target_compile_options(skity PRIVATE --coverage -O0 -g)
     target_link_options(skity PRIVATE --coverage)
 
     target_compile_options(wgsl-cross PRIVATE --coverage -O0 -g)
     target_link_options(wgsl-cross PRIVATE --coverage)
-
-    target_compile_options(skity_unit_test PRIVATE --coverage -O0 -g)
-    target_link_options(skity_unit_test PRIVATE --coverage)
 endif()
 
 target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)


### PR DESCRIPTION
Add a cmake option to turn off generating coverage information, which is useful in local development to speed up testing