### PR TITLE
[cmake] support pack xcframework for apple platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.15.0)
 
-project(Skity)
+project(Skity VERSION 1.0.0)
 
 # Compatible for MSVC runtime library
 if(POLICY CMP0091)
@@ -100,12 +100,6 @@ endif()
 target_include_directories(skity PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(skity PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 set_property(TARGET skity PROPERTY CXX_STANDARD 17)
-
-if (NOT SKITY_NO_PREBUILD_SHADER)
-  # shaders gen header
-  target_include_directories(skity PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shaders/gen)
-  target_include_directories(skity PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shaders/bindings)
-endif()
 
 target_include_directories(
   skity
@@ -233,3 +227,8 @@ install(
   NAMESPACE skity::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/skity
 )
+
+# build frameowrk for iOS and macOS
+if(${SKITY_GENERATE_FRAMEWORK})
+  add_subdirectory(platform/darwin)
+endif()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -53,3 +53,13 @@ cmake_dependent_option(
   [[CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"]]
   OFF
 )
+
+
+# option for generate skity framework
+# This is only valid on APPLE platform
+cmake_dependent_option(
+  SKITY_GENERATE_FRAMEWORK "option for generate skity framework"
+  OFF
+  [[APPLE]]
+  OFF
+)

--- a/module/wgx/CMakeLists.txt
+++ b/module/wgx/CMakeLists.txt
@@ -6,59 +6,59 @@ option(WGX_GLSL_BACKEND "Generate GLSL shader" ON)
 option(WGX_MSL_BACKEND "Generate MSL shader" ON)
 
 add_library(wgsl-cross STATIC
-    include/wgsl_cross.h
-    wgsl/ast/attribute.cpp
-    wgsl/ast/attribute.h
-    wgsl/ast/expression.cpp
-    wgsl/ast/expression.h
-    wgsl/ast/function.cpp
-    wgsl/ast/function.h
-    wgsl/ast/identifier.cpp
-    wgsl/ast/identifier.h
-    wgsl/ast/module.cpp
-    wgsl/ast/module.h
-    wgsl/ast/node.h
-    wgsl/ast/pipeline_stage.h
-    wgsl/ast/statement.cpp
-    wgsl/ast/statement.h
-    wgsl/ast/type.cpp
-    wgsl/ast/type.h
-    wgsl/ast/type_decl.cpp
-    wgsl/ast/type_decl.h
-    wgsl/ast/variable.cpp
-    wgsl/ast/variable.h
-    wgsl/ast/visitor.h
-    wgsl/bind_group.cpp
-    wgsl/function.cpp
-    wgsl/function.h
-    wgsl/parser.cpp
-    wgsl/parser.h
-    wgsl/program.cpp
-    wgsl/scanner.cpp
-    wgsl/scanner.h
-    wgsl/token.cpp
-    wgsl/token.h
-    wgsl/type_definition.cpp
-    wgsl/type_definition.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/wgsl_cross.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/attribute.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/attribute.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/expression.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/expression.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/function.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/function.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/identifier.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/identifier.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/module.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/module.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/node.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/pipeline_stage.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/statement.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/statement.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/type.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/type.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/type_decl.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/type_decl.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/variable.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/variable.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/visitor.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/bind_group.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/function.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/function.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/parser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/parser.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/program.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/scanner.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/scanner.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/token.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/token.h
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/type_definition.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wgsl/type_definition.h
 )
 
 if (WGX_GLSL_BACKEND)
     target_compile_definitions(wgsl-cross PRIVATE -DWGX_GLSL=1)
     target_sources(wgsl-cross PRIVATE
-        glsl/ast_printer.cpp
-        glsl/ast_printer.h
+        ${CMAKE_CURRENT_LIST_DIR}/glsl/ast_printer.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/glsl/ast_printer.h
     )
 endif()
 
 if (WGX_MSL_BACKEND)
     target_compile_definitions(wgsl-cross PRIVATE -DWGX_MSL=1)
     target_sources(wgsl-cross PRIVATE
-        msl/ast_printer.cpp
-        msl/ast_printer.h
-        msl/attribute.cpp
-        msl/attribute.h
-        msl/uniform_capture.cpp
-        msl/uniform_capture.h
+        ${CMAKE_CURRENT_LIST_DIR}/msl/ast_printer.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/msl/ast_printer.h
+        ${CMAKE_CURRENT_LIST_DIR}/msl/attribute.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/msl/attribute.h
+        ${CMAKE_CURRENT_LIST_DIR}/msl/uniform_capture.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/msl/uniform_capture.h
     )
 endif()
 

--- a/platform/darwin/CMakeLists.txt
+++ b/platform/darwin/CMakeLists.txt
@@ -1,0 +1,191 @@
+
+# We use static library to prevent code sign at build time
+add_library(skity_framework STATIC)
+
+set(FM_VERSION_STRING "${CMAKE_PROJECT_VERSION}${SKITY_BUNDLE_SUFFIX}")
+
+configure_file(
+  ${CMAKE_CURRENT_LIST_DIR}/Info.plist.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+  @ONLY
+)
+
+# set all source file from skity to skity_framework
+get_target_property(skity_lib_sources skity SOURCES)
+
+if (skity_lib_sources STREQUAL "skity_lib_sources-NOTFOUND")
+  message(FATAL_ERROR "skity_lib_sources is not found")
+endif()
+
+target_sources(skity_framework PRIVATE ${skity_lib_sources})
+
+# set all include directory from skity to skity_framework
+get_target_property(skity_include_dirs skity INCLUDE_DIRECTORIES)
+
+if (skity_include_dirs STREQUAL "skity_include_dirs-NOTFOUND")
+  message(FATAL_ERROR "skity_include_dirs is not found")
+endif()
+
+message("skity_include_dirs: ${skity_include_dirs}")
+
+target_include_directories(skity_framework PRIVATE ${skity_include_dirs})
+
+# set all compile option from skity to skity_framework
+get_target_property(skity_compile_options skity COMPILE_OPTIONS)
+
+if (skity_compile_options STREQUAL "skity_compile_options-NOTFOUND")
+  message(FATAL_ERROR "skity_compile_options is not found")
+endif()
+
+message("skity_compile_options: ${skity_compile_options}")
+
+target_compile_options(skity_framework PRIVATE ${skity_compile_options})
+
+
+# set all compile definition from skity to skity_framework
+get_target_property(skity_compile_definitions skity COMPILE_DEFINITIONS)
+
+if (skity_compile_definitions STREQUAL "skity_compile_definitions-NOTFOUND")
+  message(FATAL_ERROR "skity_compile_definitions is not found")
+endif()
+
+message("skity_compile_definitions: ${skity_compile_definitions}")
+
+target_compile_definitions(skity_framework PRIVATE ${skity_compile_definitions})
+
+# set all link library from skity to skity_framework
+get_target_property(skity_link_libraries skity LINK_LIBRARIES)
+
+if (skity_link_libraries STREQUAL "skity_link_libraries-NOTFOUND")
+  message(FATAL_ERROR "skity_link_libraries is not found")
+endif()
+
+message("skity_link_libraries: ${skity_link_libraries}")
+
+target_link_libraries(skity_framework PRIVATE ${skity_link_libraries})
+
+# set all link directory from skity to skity_framework
+get_target_property(skity_link_directories skity LINK_DIRECTORIES)
+
+if (NOT skity_link_directories STREQUAL "skity_link_directories-NOTFOUND")
+  message("skity_link_directories: ${skity_link_directories}")
+  target_link_directories(skity_framework PRIVATE ${skity_link_directories})
+endif()
+
+# compile wgx into skity_framework so we not needs to use libtool
+
+get_target_property(wgx_sources wgsl-cross SOURCES)
+if (wgx_sources STREQUAL "wgx_sources-NOTFOUND")
+  message(FATAL_ERROR "wgx_sources is not found")
+endif()
+
+target_sources(skity_framework PRIVATE ${wgx_sources})
+
+# set wgx include directory
+get_target_property(wgx_include_dirs wgsl-cross INCLUDE_DIRECTORIES)
+if (wgx_include_dirs STREQUAL "wgx_include_dirs-NOTFOUND")
+  message(FATAL_ERROR "wgx_include_dirs is not found")
+endif()
+
+target_include_directories(skity_framework PRIVATE ${wgx_include_dirs})
+
+# set wgx compile definition
+get_target_property(wgx_compile_definitions wgsl-cross COMPILE_DEFINITIONS)
+if (wgx_compile_definitions STREQUAL "wgx_compile_definitions-NOTFOUND")
+  message(FATAL_ERROR "wgx_compile_definitions is not found")
+endif()
+
+target_compile_definitions(skity_framework PRIVATE ${wgx_compile_definitions})
+
+
+# set cxx standard
+set_target_properties(skity_framework PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+
+
+# set Framework property
+set_target_properties(skity_framework PROPERTIES
+    FRAMEWORK TRUE
+    PUBLIC_HEADER "public/skity.h"
+    MACOSX_FRAMEWORK_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+    OUTPUT_NAME "skity"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" # disable code sign since we only publish static library
+)
+
+# install framework
+install(
+    TARGETS skity_framework
+    FRAMEWORK
+    DESTINATION "${CMAKE_INSTALL_PREFIX}"
+    COMPONENT Runtime
+)
+
+# install public header
+install(
+    FILES "public/skity.h"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+# install c++ header manually
+install(
+    FILES "${CMAKE_SOURCE_DIR}/include/skity/macros.hpp" "${CMAKE_SOURCE_DIR}/include/skity/skity.hpp"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/effect"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/geometry"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/gpu"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/graphic"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/io"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/recorder"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/render"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/text"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/skity/utils"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+    COMPONENT Runtime
+)

--- a/platform/darwin/Info.plist.in
+++ b/platform/darwin/Info.plist.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>skity</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.lynxsdk.skity</string>
+
+    <key>CFBundleShortVersionString</key>
+    <string>@FM_VERSION_STRING@</string>
+    <key>CFBundleVersion</key>
+    <string>@PROJECT_VERSION_MAJOR@@PROJECT_VERSION_MINOR@@PROJECT_VERSION_PATCH@</string>
+
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>

--- a/platform/darwin/README.md
+++ b/platform/darwin/README.md
@@ -1,0 +1,25 @@
+# Skity Xcframework
+
+This directory contains the cmake script and other resources to build the skity xcframework.
+Note:
+1. The xcframework only contains static library. Since we do not provide code sign in this project.
+2. The xcframework contains:
+    - arm64 and x86_64 architecture for MacOS
+    - arm64 architecture for iOS
+    - x86_64 and arm64 architecture for iOS simulator
+3. The xcframework does not provide module.modulemap, which means does not provide any API for swift project.
+
+## Build Xcframework
+
+We provide a python script to build the xcframework [pack_skity_framework.py](../../tools/pack_skity_framework.py)
+Just run this script in project root directory.
+
+```bash
+
+python3 tools/pack_skity_framework.py
+
+```
+
+If everything goes well, you will get a xcframework file in `out` directory.
+The xcframework file name is `skity.xcframework`.
+

--- a/platform/darwin/public/skity.h
+++ b/platform/darwin/public/skity.h
@@ -1,0 +1,6 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+#pragma once
+
+// dummy header for Framework

--- a/tools/pack_skity_framework.py
+++ b/tools/pack_skity_framework.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 The Lynx Authors. All rights reserved.
+
+# pack skity.xcframework
+# this script will build iOS( iphoneos and iphonesimulator ) and macos( x86_64 and arm64 ) frameworks
+# and then pack them into xcframework
+# Note:
+# 1. we build static library since we do not sign this library in our repository
+# 2. iphonesimulator arm64 and x86_64 should use lipo to merge into one framework
+
+# cmake -B out/ios_framework_iphonesimulator_x64 -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_INSTALL_PREFIX=out/ios_install_simulator_x64 -DSKITY_CT_FONT=ON -DSKITY_GENERATE_FRAMEWORK=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator
+
+import os
+import subprocess
+import sys
+
+def cmake_build_and_install(out_dir: str, install_dir: str, target_version: str, arch: str, sys_root: str, version_suffix: str):
+    cmake_config_command = [
+        'cmake',
+        '-B',
+        out_dir,
+        '-G',
+        'Xcode',
+        '-DCMAKE_OSX_ARCHITECTURES={}'.format(arch),
+        '-DCMAKE_INSTALL_PREFIX={}'.format(install_dir),
+        '-DSKITY_CT_FONT=ON',
+        '-DSKITY_GENERATE_FRAMEWORK=ON',
+        '-DCMAKE_OSX_DEPLOYMENT_TARGET={}'.format(target_version),
+        '-DCMAKE_OSX_SYSROOT={}'.format(sys_root),
+    ]
+
+    # if version_suffix is not none and not empty
+    if version_suffix != '':
+        cmake_config_command.append('-DSKITY_BUNDLE_SUFFIX={}'.format(version_suffix))
+
+    print('version_suffix: {}'.format(version_suffix))
+    print('-----------------')
+    print('cmake_config_command: {}'.format(cmake_config_command))
+    print('-----------------')
+
+    # check config result
+    subprocess.check_call(cmake_config_command)
+
+    # build framework
+    cmake_build_command = [
+        'cmake',
+        '--build',
+        out_dir,
+        '--target',
+        'skity_framework',
+        '--config',
+        'Release',
+    ]
+
+    # check build result
+    subprocess.check_call(cmake_build_command)
+
+    # install framework
+    cmake_install_command = [
+        'cmake',
+        '--install',
+        out_dir,
+        '--component',
+        'Runtime',
+        '--config',
+        'Release',
+    ]
+
+    # check install result
+    subprocess.check_call(cmake_install_command)
+
+    return 1
+
+def pack_all_frameworks(version_suffix: str):
+    # pack macos framework
+    cmake_build_and_install('out/osx_framework', 'out/osx_install', '15.0', 'x86_64;arm64', 'macosx', version_suffix)
+    # pack iOS framework
+    cmake_build_and_install('out/ios_framework', 'out/ios_install', '11.0', 'arm64', 'iphoneos', version_suffix)
+    # pack iOS simulator x86_64 framework
+    cmake_build_and_install('out/ios_simulator_framework_x86_64', 'out/ios_simulator_install_x86_64', '11.0', 'x86_64', 'iphonesimulator', version_suffix)
+    # pack iOS simulator arm64 framework
+    cmake_build_and_install('out/ios_simulator_framework_arm64', 'out/ios_simulator_install_arm64', '11.0', 'arm64', 'iphonesimulator', version_suffix)
+    pass
+
+def pack_zip_bundle():
+    # delete out/skity.framework.zip if exists
+    if os.path.exists('out/skity.framework.zip'):
+        subprocess.check_call(['rm', '-rf', 'out/skity.framework.zip'])
+    # delete out/framework_pack if exists
+    if os.path.exists('out/framework_pack'):
+        subprocess.check_call(['rm', '-rf', 'out/framework_pack'])
+
+    # create out/framework_pack
+    os.makedirs('out/framework_pack')
+
+    # copy skity.xcframework to out/framework_pack
+    subprocess.check_call(['cp', '-R', 'out/skity.xcframework', 'out/framework_pack'])
+    # we also copy LICENSE to out/framework_pack
+    subprocess.check_call(['cp', 'LICENSE', 'out/framework_pack'])
+
+    # pack out/framework_pack to out/skity.framework.zip
+    subprocess.check_call(['zip', '-r', '../skity.framework.zip', 'LICENSE', 'skity.xcframework'], cwd='out/framework_pack')
+
+    # delete out/framework_pack
+    subprocess.check_call(['rm', '-rf', 'out/framework_pack'])
+    pass
+
+
+def main(version_suffix: str):
+    pack_all_frameworks(version_suffix)
+
+    # before genreate the final xcframework, we needs to merge
+    # ios_simulator_framework_x86_64 and ios_simulator_framework_arm64
+    # into one framework
+
+    # first we copy ios_simulator_framework_x86_64/skity.framework to ios_simulator_install
+
+    #check if out/ios_simulator_install, if exists, delete it
+    if os.path.exists('out/ios_simulator_install'):
+        subprocess.check_call(['rm', '-rf', 'out/ios_simulator_install'])
+    os.makedirs('out/ios_simulator_install')
+    # copy ios_simulator_framework_x86_64/skity.framework to out/ios_simulator_install
+    subprocess.check_call(['cp', '-R', 'out/ios_simulator_install_x86_64/skity.framework', 'out/ios_simulator_install'])
+
+    # delete out/ios_framework_install/skity.framework/skity first
+    subprocess.check_call(['rm', '-rf', 'out/ios_simulator_install/skity.framework/skity'])
+
+    # merge arm64 and x86_64 into out/ios_framework_install/skity.framework/skity
+    subprocess.check_call(['lipo',
+                           '-create',
+                           'out/ios_simulator_install_x86_64/skity.framework/skity',
+                           'out/ios_simulator_install_arm64/skity.framework/skity',
+                           '-output',
+                           'out/ios_simulator_install/skity.framework/skity',
+                        ])
+
+    # if out/skity.xcframework exists, delete it
+    if os.path.exists('out/skity.xcframework'):
+        subprocess.check_call(['rm', '-rf', 'out/skity.xcframework'])
+
+    # now we can create the final xcframework
+    subprocess.check_call(['xcodebuild',
+                           '-create-xcframework',
+                           '-framework', 'out/ios_install/skity.framework',
+                           '-framework', 'out/osx_install/skity.framework',
+                           '-framework', 'out/ios_simulator_install/skity.framework',
+                           '-output', 'out/skity.xcframework'])
+
+    pack_zip_bundle()
+
+
+if __name__ == '__main__':
+    version_suffix = ''
+
+    if len(sys.argv) > 1:
+        version_suffix = sys.argv[1]
+
+    main(version_suffix)


### PR DESCRIPTION
The xcframework will contains static library for MacOS, iOS and iOS simulator.

Note: the xcframework does not provide the module.modulemap file, so swift project can not use skity directly.