### PR TITLE
ci(ut): Fix codecov coverage statistics inaccurate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,10 @@ coverage:
         threshold: "0%"
         informational: true
 
+ignore:
+  - "test/ut/**/*"
+  - "test/ut/common.hpp"
+
 comment:
   layout: "header, files, footer"
   require_changes: false  # if true: only post the comment if coverage changes

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -45,6 +45,9 @@ if (${SKITY_TEST_COVERAGE} AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
     target_compile_options(wgsl-cross PRIVATE --coverage -O0 -g)
     target_link_options(wgsl-cross PRIVATE --coverage)
+
+    target_compile_options(skity_unit_test PRIVATE --coverage -O0 -g)
+    target_link_options(skity_unit_test PRIVATE --coverage)
 endif()
 
 target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)


### PR DESCRIPTION
Fix codecov does not include the test code itself in the coverage statistics

Related to : #23 