### PR TITLE
feat(codec): remove the optional image format macro definition in codec

### DIFF
--- a/.github/actions/sync-deps/action.yml
+++ b/.github/actions/sync-deps/action.yml
@@ -8,4 +8,4 @@ runs:
     - name: run habitat sync
       shell: bash
       run: |
-        tools/hab sync . --target dev,ci
+        tools/hab sync . --target dev,module,ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             uses: actions/checkout@v4.2.2
           - name: Sync Dependencies
             run: |
-                powershell -File "./tools/hab.ps1" sync -f --target dev,ci
+                powershell -File "./tools/hab.ps1" sync -f --target dev,module,ci
           - name: Run Build
             run: |
                 ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON
@@ -135,7 +135,7 @@ jobs:
             uses: actions/checkout@v4.2.2
           - name: Sync Dependencies
             run: |
-                ./tools/hab sync -f --target dev
+                ./tools/hab sync -f --target dev,module
           - name: Setup cmake
             run: |
                 brew install cmake

--- a/.habitat
+++ b/.habitat
@@ -4,6 +4,7 @@ solutions = [{
     'target_deps_files': {
         'dev': 'hab/DEPS.dev',
         'ci': 'hab/DEPS.ci',
+        'module': 'hab/DEPS.module',
     },
     'url': 'git@github.com:lynx-family/skity.git'
 }]

--- a/hab/DEPS.dev
+++ b/hab/DEPS.dev
@@ -17,16 +17,4 @@ deps = {
         "ignore_in_git": True,
         "commit": "7b6aead9fb88b3623e3b3725ebb42670cbe4c579",
     },
-    "third_party/libpng": {
-        "type": "git",
-        "url": "https://github.com/pnggroup/libpng.git",
-        "ignore_in_git": True,
-        "commit": "f5e92d76973a7a53f517579bc95d61483bf108c0",
-    },
-    "third_party/libjpeg-turbo": {
-        "type": "git",
-        "url": "https://github.com/libjpeg-turbo/libjpeg-turbo.git",
-        "ignore_in_git": True,
-        "commit": "f29eda648547b36aa594c4116c7764a6c8a079b9",
-    },
 }

--- a/hab/DEPS.module
+++ b/hab/DEPS.module
@@ -1,0 +1,15 @@
+
+deps = {
+    "third_party/libpng": {
+        "type": "git",
+        "url": "https://github.com/pnggroup/libpng.git",
+        "ignore_in_git": True,
+        "commit": "f5e92d76973a7a53f517579bc95d61483bf108c0",
+    },
+    "third_party/libjpeg-turbo": {
+        "type": "git",
+        "url": "https://github.com/libjpeg-turbo/libjpeg-turbo.git",
+        "ignore_in_git": True,
+        "commit": "f29eda648547b36aa594c4116c7764a6c8a079b9",
+    },
+}

--- a/module/codec/CMakeLists.txt
+++ b/module/codec/CMakeLists.txt
@@ -68,8 +68,6 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/src/codec/png_codec.hpp
 )
 
-target_compile_definitions(skity-codec PUBLIC -DSKITY_HAS_PNG=1)
-
 add_dependencies(libpng skity)
 add_dependencies(skity-codec libpng)
 
@@ -110,6 +108,3 @@ if (WIN32)
 else()
   target_link_libraries(skity-codec PRIVATE turbojpeg)
 endif()
-
-target_compile_definitions(skity-codec PUBLIC -DSKITY_HAS_JPEG=1)
-

--- a/module/codec/include/skity/codec/codec.hpp
+++ b/module/codec/include/skity/codec/codec.hpp
@@ -15,7 +15,9 @@ class Data;
 class Pixmap;
 
 /**
- * Codec interface
+ * Codec interface for encoding and decoding image data.
+ *
+ * @note This is experimental the API is unstable.
  */
 class SKITY_EXPERIMENTAL_API Codec {
  public:
@@ -24,23 +26,50 @@ class SKITY_EXPERIMENTAL_API Codec {
   Codec(const Codec&) = delete;
   Codec& operator=(const Codec&) = delete;
 
-  virtual std::shared_ptr<Pixmap> Decode() = 0;
-
+  /**
+   * Encode the raw pixmap to codec specific data.
+   *
+   * @param pixmap The raw pixmap to encode. Must not be null.
+   *
+   * @return The encoded data. nullptr if encode failed.
+   */
   virtual std::shared_ptr<Data> Encode(const Pixmap* pixmap) = 0;
 
+  /**
+   * Recognize the file type from header.
+   *
+   * @param header The header of the file.
+   * @param size   The size of the header data.
+   * @return true if the file type is supported by this codec.
+   */
   virtual bool RecognizeFileType(const char* header, size_t size) = 0;
 
+  /**
+   * Set the data to be decoded or encoded.
+   *
+   * @param data The data to be decoded. Must not be null.
+   */
   void SetData(std::shared_ptr<Data> data) { data_ = std::move(data); }
 
+  /**
+   * Decode the data to pixmap.
+   *
+   * @return The decoded pixmap. nullptr if decode failed.
+   */
+  virtual std::shared_ptr<Pixmap> Decode() = 0;
+
+  /**
+   * Create a codec from data. Will try to recognize the file type and create
+   * the corresponding codec.
+   *
+   * @param data The data to be decoded.
+   * @return The codec. nullptr if create failed or file type is not supported.
+   */
   static std::shared_ptr<Codec> MakeFromData(std::shared_ptr<Data> const& data);
 
-#ifdef SKITY_HAS_PNG
   static std::shared_ptr<Codec> MakePngCodec();
-#endif
 
-#ifdef SKITY_HAS_JPEG
   static std::shared_ptr<Codec> MakeJPEGCodec();
-#endif
 
  protected:
   std::shared_ptr<Data> data_;

--- a/module/codec/src/codec/codec.cc
+++ b/module/codec/src/codec/codec.cc
@@ -6,12 +6,8 @@
 #include <skity/io/data.hpp>
 #include <vector>
 
-#ifdef SKITY_HAS_PNG
-#include "src/codec/png_codec.hpp"
-#endif
-#ifdef SKITY_HAS_JPEG
 #include "src/codec/jpeg_codec.hpp"
-#endif
+#include "src/codec/png_codec.hpp"
 
 namespace skity {
 
@@ -20,12 +16,8 @@ static std::vector<std::shared_ptr<Codec>> codec_list = {};
 void Codec::SetupCodecs() {
   codec_list.clear();
 
-#ifdef SKITY_HAS_PNG
   codec_list.emplace_back(std::make_shared<PNGCodec>());
-#endif
-#ifdef SKITY_HAS_JPEG
   codec_list.emplace_back(std::make_shared<JPEGCodec>());
-#endif  // SKITY_HAS_JPEG
 }
 
 std::shared_ptr<Codec> Codec::MakeFromData(const std::shared_ptr<Data>& data) {
@@ -48,16 +40,12 @@ std::shared_ptr<Codec> Codec::MakeFromData(const std::shared_ptr<Data>& data) {
   return nullptr;
 }
 
-#ifdef SKITY_HAS_PNG
 std::shared_ptr<Codec> Codec::MakePngCodec() {
   return std::make_shared<PNGCodec>();
 }
-#endif
 
-#ifdef SKITY_HAS_JPEG
 std::shared_ptr<Codec> Codec::MakeJPEGCodec() {
   return std::make_shared<JPEGCodec>();
 }
-#endif
 
 }  // namespace skity

--- a/module/codec/src/codec/jpeg_codec.hpp
+++ b/module/codec/src/codec/jpeg_codec.hpp
@@ -5,8 +5,6 @@
 #ifndef MODULE_CODEC_SRC_CODEC_JPEG_CODEC_HPP
 #define MODULE_CODEC_SRC_CODEC_JPEG_CODEC_HPP
 
-#ifdef SKITY_HAS_JPEG
-
 #include <skity/codec/codec.hpp>
 
 namespace skity {
@@ -24,7 +22,5 @@ class JPEGCodec : public Codec {
 };
 
 }  // namespace skity
-
-#endif  // SKITY_HAS_JPEG
 
 #endif  // MODULE_CODEC_SRC_CODEC_JPEG_CODEC_HPP

--- a/module/codec/src/codec/png_codec.cc
+++ b/module/codec/src/codec/png_codec.cc
@@ -12,8 +12,6 @@
 
 namespace skity {
 
-#ifdef SKITY_HAS_PNG
-
 #define PNG_BYTES_TO_CHECK 4
 
 static void png_write_callback(png_structp png_ptr, png_bytep data,
@@ -117,7 +115,5 @@ bool skity::PNGCodec::RecognizeFileType(const char* header, size_t size) {
   return !png_sig_cmp((png_const_bytep)header, (png_size_t)0,
                       PNG_BYTES_TO_CHECK);
 }
-
-#endif  // SKITY_HAS_PNG
 
 }  // namespace skity

--- a/module/codec/src/codec/png_codec.hpp
+++ b/module/codec/src/codec/png_codec.hpp
@@ -5,10 +5,9 @@
 #ifndef MODULE_CODEC_SRC_CODEC_PNG_CODEC_HPP
 #define MODULE_CODEC_SRC_CODEC_PNG_CODEC_HPP
 
-#include <skity/codec/codec.hpp>
-
-#ifdef SKITY_HAS_PNG
 #include <png.h>
+
+#include <skity/codec/codec.hpp>
 
 namespace skity {
 
@@ -26,7 +25,5 @@ class PNGCodec : public Codec {
 };
 
 }  // namespace skity
-
-#endif  // SKITY_HAS_PNG
 
 #endif  // MODULE_CODEC_SRC_CODEC_PNG_CODEC_HPP


### PR DESCRIPTION
We plan to promote the codec module to a formal extension feature and support common image formats by default. so there is no need to disable some image formats through compile-time options.

Also move the libpng and libjpeg-turbo dependencies from DEPS.dev to DEPS.module to make the dependencies clearer.

Related: #74 