### PR TITLE
fix(arena): DefaultAllocator has been refactored to avoid the singleton pattern

### DIFF
--- a/src/utils/arena_allocator.cc
+++ b/src/utils/arena_allocator.cc
@@ -15,7 +15,7 @@ Block DefaultAllocator::Alloc(size_t size) {
 void DefaultAllocator::Free(Block& block) { return std::free(block.head); }
 
 BlockCacheAllocator::BlockCacheAllocator()
-    : internal_(DefaultAllocator::GetInstance()) {}
+    : internal_(DefaultAllocator::Create()) {}
 
 BlockCacheAllocator::BlockCacheAllocator(std::shared_ptr<Allocator> internal)
     : internal_(std::move(internal)) {}
@@ -48,7 +48,7 @@ Arena::Arena(size_t block_size, std::shared_ptr<Allocator> allocator)
       end_(nullptr),
       block_size_(block_size),
       allocator_(allocator != nullptr ? allocator
-                                      : DefaultAllocator::GetInstance()) {
+                                      : DefaultAllocator::Create()) {
   DEBUG_CHECK(block_size > 0);
 }
 

--- a/src/utils/arena_allocator.hpp
+++ b/src/utils/arena_allocator.hpp
@@ -37,10 +37,8 @@ class Allocator {
 
 class DefaultAllocator : public Allocator {
  public:
-  static std::shared_ptr<Allocator> GetInstance() {
-    static std::shared_ptr<DefaultAllocator> instance =
-        std::make_shared<DefaultAllocator>();
-    return instance;
+  static std::shared_ptr<Allocator> Create() {
+    return std::make_shared<DefaultAllocator>();
   }
 
   Block Alloc(size_t size) override;
@@ -70,7 +68,7 @@ class BlockCacheAllocator : public Allocator {
 class Arena {
  public:
   Arena(size_t block_size = kDefaultBlockSize,
-        std::shared_ptr<Allocator> allocator = DefaultAllocator::GetInstance());
+        std::shared_ptr<Allocator> allocator = DefaultAllocator::Create());
   ~Arena();
 
   void Reset();
@@ -93,7 +91,7 @@ class Arena {
 class ArenaAllocator {
  public:
   explicit ArenaAllocator(
-      std::shared_ptr<Allocator> allocator = DefaultAllocator::GetInstance())
+      std::shared_ptr<Allocator> allocator = DefaultAllocator::Create())
       : arena_(kDefaultBlockSize, allocator) {}
 
   template <typename T>


### PR DESCRIPTION
We create a new instance of DefaultAllocator for each use to prevent multithreading problems.