### PR TITLE
fix(cmake): Fix empty build type cause MSVC build error

### DIFF
--- a/cmake/ThirdPartyDep.cmake
+++ b/cmake/ThirdPartyDep.cmake
@@ -82,7 +82,7 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT ANDROID AND NOT CMAKE_SYSTEM
   target_link_directories(skity PRIVATE ${CMAKE_BINARY_DIR}/third_party/zlib/lib)
   if (WIN32)
     # FIXME: zlib in msvc output a different name
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
       target_link_libraries(skity PRIVATE zlibstaticd)
     else()
       target_link_libraries(skity PRIVATE zlibstatic)

--- a/module/codec/CMakeLists.txt
+++ b/module/codec/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_directories(skity-codec PUBLIC ${CMAKE_BINARY_DIR}/third_party/libpn
 if (WIN32)
   target_link_directories(skity-codec PUBLIC ${CMAKE_BINARY_DIR}/third_party/zlib/lib)
   # FIXME: msvc generate different library name
-  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_libraries(skity-codec PRIVATE libpng16_staticd zlibstaticd)
   else()
     target_link_libraries(skity-codec PRIVATE libpng16_static zlibstatic)


### PR DESCRIPTION
The libz and libpng has different output name on windows based on cmake build type.
The default build type aka emtpy in `CMAKE_BUILD_TYPE` means Debug build type, and needs to change the link library name when using MSVC in windows.