### PR TITLE
feat(codec): Support BGRA format in JPEG codec

### DIFF
--- a/include/skity/graphic/color.hpp
+++ b/include/skity/graphic/color.hpp
@@ -145,6 +145,8 @@ SKITY_API Color Color4fToColor(Color4f color);
 
 SKITY_API Color PMColorToColor(PMColor c);
 
+SKITY_API PMColor ColorToPMColor(Color c);
+
 namespace Colors {
 
 constexpr Color4f kTransparent = {0, 0, 0, 0};

--- a/module/codec/src/codec/codec_priv.cc
+++ b/module/codec/src/codec/codec_priv.cc
@@ -7,6 +7,24 @@
 namespace skity {
 namespace codec_priv {
 
+void CodecTransformLinePremul(uint8_t* dst, uint8_t* src, int width,
+                              int bytes_per_pixel) {
+  // currently we only support RGBA or BGRA
+  if (bytes_per_pixel != 4) {
+    return;
+  }
+
+  auto dst32 = reinterpret_cast<uint32_t*>(dst);
+  auto src32 = reinterpret_cast<uint32_t*>(src);
+  for (int x = 0; x < width; x++) {
+    auto pm_color = *src32;
+    *dst32 = ColorToPMColor(pm_color);
+
+    dst32++;
+    src32++;
+  }
+}
+
 void CodecTransformLineUnpremul(uint8_t* dst, uint8_t* src, int width,
                                 int bytes_per_pixel) {
   // currently we only support RGBA or BGRA

--- a/module/codec/src/codec/codec_priv.hpp
+++ b/module/codec/src/codec/codec_priv.hpp
@@ -23,14 +23,20 @@ static void CodecTransformLineByPass(uint8_t* dst, uint8_t* src, int width,
   }
 }
 
+void CodecTransformLinePremul(uint8_t* dst, uint8_t* src, int width,
+                              int bytes_per_pixel);
+
 void CodecTransformLineUnpremul(uint8_t* dst, uint8_t* src, int width,
                                 int bytes_per_pixel);
 
 void CodecTransformLineSwizzelRB(uint8_t* dst, uint8_t* src, int width,
                                  int bytes_per_pixel);
 
-std::function<void(uint8_t* dst, uint8_t* src, int width, int bytes_per_pixel)>
-ChooseLineTransformFunc(ColorType color_type, AlphaType alpha_type);
+using TransformLineFunc = std::function<void(uint8_t* dst, uint8_t* src,
+                                             int width, int bytes_per_pixel)>;
+
+TransformLineFunc ChooseLineTransformFunc(ColorType color_type,
+                                          AlphaType alpha_type);
 
 }  // namespace codec_priv
 }  // namespace skity

--- a/src/graphic/color_priv.cc
+++ b/src/graphic/color_priv.cc
@@ -102,4 +102,9 @@ Color PMColorToColor(PMColor c) {
                       UnPreMultiply::ApplyScale(scale, ColorGetB(c)));
 }
 
+PMColor ColorToPMColor(Color c) {
+  return PremultiplyARGBInline(ColorGetA(c), ColorGetR(c), ColorGetG(c),
+                               ColorGetB(c));
+}
+
 }  // namespace skity

--- a/src/graphic/color_priv.hpp
+++ b/src/graphic/color_priv.hpp
@@ -57,11 +57,6 @@ static inline PMColor PremultiplyARGBInline(uint32_t a, uint32_t r, uint32_t g,
   return (a << 24) | (r << 16) | (g << 8) | (b << 0);
 }
 
-static inline PMColor ColorToPMColor(Color c) {
-  return PremultiplyARGBInline(ColorGetA(c), ColorGetR(c), ColorGetG(c),
-                               ColorGetB(c));
-}
-
 // When Android is compiled optimizing for size, SkAlphaMulQ doesn't get
 // inlined; forcing inlining significantly improves performance.
 static inline uint32_t AlphaMulQ(uint32_t c, unsigned scale) {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -46,10 +46,12 @@ target_link_libraries(skity_unit_test
 if (${SKITY_CODEC_MODULE})
     target_sources(skity_unit_test
         PUBLIC
+        codec/jpeg_codec_test.cc
         codec/png_codec_test.cc
     )
 
     target_compile_definitions(skity_unit_test PRIVATE -DSKITY_TEST_PNG_FILE="${CMAKE_SOURCE_DIR}/example/images/firefox_64.png")
+    target_compile_definitions(skity_unit_test PRIVATE -DSKITY_TEST_JPEG_FILE="${CMAKE_SOURCE_DIR}/example/images/image1.jpg")
 
     target_link_libraries(skity_unit_test PUBLIC skity::codec)
 endif()

--- a/test/ut/codec/jpeg_codec_test.cc
+++ b/test/ut/codec/jpeg_codec_test.cc
@@ -1,0 +1,107 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <skity/codec/codec.hpp>
+#include <skity/graphic/bitmap.hpp>
+#include <skity/graphic/color.hpp>
+#include <skity/io/data.hpp>
+#include <skity/io/pixmap.hpp>
+#include <skity/render/canvas.hpp>
+
+TEST(JPEGCodecTest, RecognizeFileType) {
+  auto png_data = skity::Data::MakeFromFileName(SKITY_TEST_PNG_FILE);
+  auto jpeg_data = skity::Data::MakeFromFileName(SKITY_TEST_JPEG_FILE);
+
+  auto codec = skity::Codec::MakeJPEGCodec();
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(jpeg_data->Bytes()), jpeg_data->Size()));
+  EXPECT_FALSE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(png_data->Bytes()), png_data->Size()));
+}
+
+TEST(JPEGCodecTest, Decode) {
+  auto jpeg_data = skity::Data::MakeFromFileName(SKITY_TEST_JPEG_FILE);
+
+  auto codec = skity::Codec::MakeFromData(jpeg_data);
+
+  codec->SetData(jpeg_data);
+
+  auto pixmap = codec->Decode();
+
+  EXPECT_TRUE(pixmap != nullptr);
+  EXPECT_EQ(pixmap->Width(), 133);
+  EXPECT_EQ(pixmap->Height(), 100);
+  EXPECT_EQ(pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(pixmap->GetAlphaType(), skity::AlphaType::kUnpremul_AlphaType);
+
+  const unsigned char empty_jpeg[] = {0xFF, 0xD8, 0xFF};
+
+  EXPECT_FALSE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(empty_jpeg), sizeof(empty_jpeg)));
+}
+
+TEST(JPEGCodecTest, Encode) {
+  skity::Bitmap bitmap(128, 128, skity::AlphaType::kUnpremul_AlphaType,
+                       skity::ColorType::kRGBA);
+
+  auto canvas = skity::Canvas::MakeSoftwareCanvas(&bitmap);
+
+  canvas->Clear(skity::Color_TRANSPARENT);
+
+  skity::Paint paint;
+  paint.SetColor(skity::Color_RED);
+  paint.SetAlphaF(0.5f);
+  paint.SetStyle(skity::Paint::kStroke_Style);
+  paint.SetStrokeWidth(5.f);
+
+  canvas->DrawCircle(64, 64, 50, paint);
+
+  auto codec = skity::Codec::MakeJPEGCodec();
+
+  auto data = codec->Encode(bitmap.GetPixmap().get());
+
+  EXPECT_TRUE(data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(data->Bytes()), data->Size()));
+}
+
+TEST(JPEGCodecTest, EncodeBGRA) {
+  skity::Pixmap pixmap(1, 1, skity::AlphaType::kUnpremul_AlphaType,
+                       skity::ColorType::kBGRA);
+
+  {
+    auto addr = reinterpret_cast<uint32_t*>(pixmap.WritableAddr());
+
+    *addr = skity::ColorSetARGB(128, 255, 0, 0);
+  }
+
+  auto codec = skity::Codec::MakeJPEGCodec();
+
+  auto jpeg_data = codec->Encode(&pixmap);
+
+  EXPECT_TRUE(jpeg_data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(jpeg_data->Bytes()), jpeg_data->Size()));
+
+  codec->SetData(jpeg_data);
+
+  auto decode_pixmap = codec->Decode();
+
+  EXPECT_TRUE(decode_pixmap != nullptr);
+  EXPECT_EQ(decode_pixmap->Width(), 1);
+  EXPECT_EQ(decode_pixmap->Height(), 1);
+  EXPECT_EQ(decode_pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(decode_pixmap->GetAlphaType(),
+            skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* decode_addr =
+      reinterpret_cast<const uint32_t*>(decode_pixmap->Addr());
+
+  EXPECT_EQ(*decode_addr, skity::ColorSetARGB(255, 0, 0, 128));
+}


### PR DESCRIPTION
Support BGRA color format in JPEG encoding

Support convert Unpremultiplied alpha type into Premultiplied alpha type in JPEG encoding.
> Note: JPEG does not support alpha channel.

Related: #74 