### PR TITLE
fix(geometry): Use start point of conic to initialize parameter

### DIFF
--- a/src/geometry/conic.cc
+++ b/src/geometry/conic.cc
@@ -298,6 +298,7 @@ void Conic::ChopAt(float t1, float t2, Conic* dst) const {
 }
 
 uint32_t Conic::ChopIntoQuadsPOW2(Point* p_pts, uint32_t pow2) {
+  *p_pts = pts[0];
   if (pow2 == kMaxConicToQuadPOW2) {
     std::array<Conic, 2> dst = {};
     this->Chop(dst.data());


### PR DESCRIPTION
In the ChopIntoQuadsPOW2 method, a given conic is split into two quads, which produces five points from three. The first point is not used and should be a start point, while the remaining four points represent the two quads. At the end of the method, validation should only apply to the last four points. If we validate all five points under the current logic, the first point must be initialized as a start point.