### PR TITLE
fix(codec): fix io suspend cause gif decode error

### DIFF
--- a/module/codec/src/codec/wuffs/wuffs_codec.cc
+++ b/module/codec/src/codec/wuffs/wuffs_codec.cc
@@ -253,7 +253,7 @@ const char* WuffsDecoder::DecodeFrameConfig(
     auto status = decoder_->decode_frame_config(frame_config, &buffer_.buffer);
 
     if ((status.repr == wuffs_base__suspension__short_read) &&
-        (!buffer_.FillBuffer(stream_.get()))) {
+        buffer_.FillBuffer(stream_.get())) {
       continue;
     }
 


### PR DESCRIPTION
When the IO buffer is finished reading, new content needs to be load for further decoding.

Related: #74 