### PR TITLE
feat(text): Hide all symbols of freetype in skity dynamic library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
             - 'module/**'
             - 'test/**'
             - 'cmake/**'
+            - 'patches/**'
             - 'CMakeLists.txt'
     push:
         branches:
@@ -22,6 +23,7 @@ on:
             - 'module/**'
             - 'test/**'
             - 'cmake/**'
+            - 'patches/**'
             - 'CMakeLists.txt'
 
 jobs:
@@ -121,7 +123,7 @@ jobs:
                 powershell -File "./tools/hab.ps1" sync -f --target dev,module,ci
           - name: Run Build
             run: |
-                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON
+                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON  -DCMAKE_POLICY_VERSION_MINIMUM='3.5'
                 ./buildtools/cmake/bin/cmake --build out/cmake_host_build --target skity_unit_test
                 cd out/cmake_host_build/Debug
                 ./skity_unit_test

--- a/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
+++ b/patches/freetype/0001-Adapt-freetype-to-the-Skity-project.patch
@@ -1,20 +1,49 @@
-From 0d14cab019d76bf28878669d216b05fc943a4ec1 Mon Sep 17 00:00:00 2001
-From: ColdPaleLight <coldpalelight@users.noreply.github.com>
-Date: Mon, 30 Jun 2025 15:43:49 +0800
-Subject: [PATCH] Adapt freetype to the Skity project
+From b102d3075b11d418c16e0d1c8399e7a4cdee005b Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Tue, 10 Sep 2024 16:26:11 +0800
+Subject: [PATCH 01/10] Copy the original configurations and rename them
 
 ---
- .gitignore                              |   1 +
- CMakeLists-Skity.txt                    |  59 ++
- include/freetype/config/public-macros.h |   4 +-
- include/skity_config/ftmodule.h         |  36 +
- include/skity_config/ftoption.h         | 870 ++++++++++++++++++++++++
- src/truetype/ttgload.c                  |   2 +
- 6 files changed, 971 insertions(+), 1 deletion(-)
+ .commit-queue-v2.yml            |  15 +
+ .gitignore                      |   1 +
+ BUILD.gn                        | 168 ++++++
+ CMakeLists-Lynx.txt             |  50 ++
+ CMakeLists-Skity.txt            |  59 ++
+ include/lynx_config/ftmodule.h  |  38 ++
+ include/lynx_config/ftoption.h  | 904 +++++++++++++++++++++++++++++
+ include/skity_config/ftmodule.h |  20 +
+ include/skity_config/ftoption.h | 977 ++++++++++++++++++++++++++++++++
+ 9 files changed, 2232 insertions(+)
+ create mode 100644 .commit-queue-v2.yml
+ create mode 100644 BUILD.gn
+ create mode 100644 CMakeLists-Lynx.txt
  create mode 100644 CMakeLists-Skity.txt
+ create mode 100644 include/lynx_config/ftmodule.h
+ create mode 100644 include/lynx_config/ftoption.h
  create mode 100644 include/skity_config/ftmodule.h
  create mode 100644 include/skity_config/ftoption.h
 
+diff --git a/.commit-queue-v2.yml b/.commit-queue-v2.yml
+new file mode 100644
+index 000000000..6d7ed4814
+--- /dev/null
++++ b/.commit-queue-v2.yml
+@@ -0,0 +1,15 @@
++integrate_to_lynx:
++  stage:
++    - periodic
++  runner:
++    type: integrator
++  params:
++    repo: lynx/template-assembler
++    branch: develop        
++    deps:
++      third_party/freetype2:  
++        type: lcm
++        path: dependencies/DEPS
++        updates:
++          commit: $SOURCE_COMMIT_SHA
++
 diff --git a/.gitignore b/.gitignore
 index e4f1510bf..a9c3e0599 100644
 --- a/.gitignore
@@ -24,13 +53,243 @@ index e4f1510bf..a9c3e0599 100644
  !subprojects/*.wrap
  /tests/data/*
 +.cache
+diff --git a/BUILD.gn b/BUILD.gn
+new file mode 100644
+index 000000000..1066dec9f
+--- /dev/null
++++ b/BUILD.gn
+@@ -0,0 +1,168 @@
++# Copyright 2017 The Fuchsia Authors. All rights reserved.
++#
++# Redistribution and use in source and binary forms, with or without
++# modification, are permitted provided that the following conditions are
++# met:
++#
++#    * Redistributions of source code must retain the above copyright
++# notice, this list of conditions and the following disclaimer.
++#    * Redistributions in binary form must reproduce the above
++# copyright notice, this list of conditions and the following disclaimer
++# in the documentation and/or other materials provided with the
++# distribution.
++#    * Neither the name of Google Inc. nor the names of its
++# contributors may be used to endorse or promote products derived from
++# this software without specific prior written permission.
++#
++# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++config("freetype_config") {
++  include_dirs = [
++    "include",
++  ]
++
++  cflags = []
++
++  if (is_clang) {
++    cflags += [
++      "-Wno-unused-function",
++      "-Wno-unused-variable",
++    ]
++  }
++}
++
++#TODO(mikejurka): Remove once we've migrated to the freetype2 target everywhere
++group("freetype") {
++  public_deps = [
++    ":freetype2",
++  ]
++}
++
++target(default_library_type, "freetype2") {
++  sources = [
++    "src/autofit/autofit.c",
++    "src/base/ftbase.c",
++    "src/base/ftbbox.c",
++    "src/base/ftbdf.c",
++    "src/base/ftbitmap.c",
++    "src/base/ftdebug.c",
++    "src/base/ftfstype.c",
++    "src/base/ftgasp.c",
++    "src/base/ftglyph.c",
++    "src/base/ftinit.c",
++    "src/base/ftmm.c",
++    "src/base/ftstroke.c",
++    "src/base/ftsystem.c",
++    "src/base/fttype1.c",
++    "src/base/ftsynth.c",
++    "src/gzip/ftgzip.c",
++    "src/lzw/ftlzw.c",
++    "src/psaux/psaux.c",
++    "src/pshinter/pshinter.c",
++    "src/psnames/psnames.c",
++    "src/sfnt/sfnt.c",
++    "src/smooth/smooth.c",
++
++    # Font Drivers. Drivers need to be enabled in ftmodule.h explicitly.
++    "src/cff/cff.c",           # OpenType, (.cff, .cef)
++    "src/truetype/truetype.c", # TrueType
++  ]
++
++  defines = [
++    "FT2_BUILD_LIBRARY",
++    "DARWIN_NO_CARBON",
++    # Long directory name to avoid accidentally using wrong headers.
++    "FT_CONFIG_OPTIONS_H=\"skity_config/ftoption.h\"",
++    "FT_CONFIG_MODULES_H=\"skity_config/ftmodule.h\"",
++    # Reduce visibility of symbols.
++    # "FT_PUBLIC_FUNCTION_ATTRIBUTE=",
++  ]
++
++  if (default_library_type == "shared_library") {
++    defines += [
++      "FT_EXPORT(x)=extern __attribute__(( visibility( \"default\" ) )) x",
++      "FT_EXPORT_DEF(x)=extern __attribute__(( visibility( \"default\" ) )) x",
++      "FT_EXPORT_VAR(x)=extern __attribute__(( visibility( \"default\" ) )) x",
++    ]
++  }
++
++  public_configs = [ ":freetype_config" ]
++
++  deps = [
++    "//third_party/libpng",
++    "//third_party/zlib",
++  ]
++}
++
++config("freetypelite_config") {
++  include_dirs = [
++    "./",
++    "include",
++    "//third_party/nanopng/include",
++  ]
++  defines = [
++    "FT2_BUILD_LIBRARY=1",
++    "FT_CONFIG_OPTIONS_H=\"skity_config/ftoption.h\"",
++    "FT_CONFIG_MODULES_H=\"skity_config/ftmodule.h\"",
++  ]
++  cflags = [
++    "-Wno-newline-eof",
++    "-Wno-sign-compare",
++  ]
++  cflags_cc = cflags
++}
++
++static_library("freetypelite") {
++  sources = [
++    "src/base/ftbase.c",
++    "src/base/ftbase.h",
++    "src/base/ftbbox.c",
++    "src/base/ftbitmap.c",
++    "src/base/ftdebug.c",
++    "src/base/ftfstype.c",
++    "src/base/ftglyph.c",
++    "src/base/ftinit.c",
++    "src/base/ftmm.c",
++    "src/base/ftstroke.c",
++    "src/base/ftsystem.c",
++    "src/base/fttype1.c",
++    "src/cff/cff.c",
++    "src/gzip/ftgzip.c",
++    "src/psaux/psaux.c",
++    "src/pshinter/pshinter.c",
++    "src/psnames/psnames.c",
++    "src/sfnt/sfnt.c",
++    "src/smooth/smooth.c",
++    "src/truetype/truetype.c",
++  ]
++
++  deps = [
++    "//third_party/nanopng",
++  ]
++
++  defines = [
++    "FREETYPE_STATIC_LIB=1",
++  ]
++
++  if (defined(use_system_zlib) && use_system_zlib) {
++    libs = [ "z" ]
++  } else {
++    deps += [
++      "//third_party/zlib",
++    ]
++  }
++
++  public_configs = [
++    ":freetypelite_config",
++  ]
++}
+diff --git a/CMakeLists-Lynx.txt b/CMakeLists-Lynx.txt
+new file mode 100644
+index 000000000..8d3279a2d
+--- /dev/null
++++ b/CMakeLists-Lynx.txt
+@@ -0,0 +1,50 @@
++cmake_minimum_required(VERSION 3.4.1)
++
++set(FREETYPE_SOURCE_DIR ${FREETYPE_DIR})
++
++include_directories(
++    ${FREETYPE_DIR}
++    ${FREETYPE_SOURCE_DIR}/include
++    ${ROOT_DIR}/third_party/nanopng/include
++)
++
++add_library(
++    freetype2
++
++    STATIC
++
++    ${FREETYPE_SOURCE_DIR}/src/base/ftsystem.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftinit.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftbase.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftbbox.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftdebug.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftglyph.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftbitmap.c
++    ${FREETYPE_SOURCE_DIR}/src/base/ftstroke.c
++    ${FREETYPE_SOURCE_DIR}/src/sfnt/sfnt.c
++    ${FREETYPE_SOURCE_DIR}/src/truetype/truetype.c
++    ${FREETYPE_SOURCE_DIR}/src/psaux/psaux.c
++    ${FREETYPE_SOURCE_DIR}/src/pshinter/pshinter.c
++    ${FREETYPE_SOURCE_DIR}/src/psnames/psnames.c
++    ${FREETYPE_SOURCE_DIR}/src/cff/cff.c
++    ${FREETYPE_SOURCE_DIR}/src/smooth/smooth.c
++    ${FREETYPE_SOURCE_DIR}/src/gzip/ftgzip.c
++)
++
++target_compile_definitions(
++    freetype2
++
++    PRIVATE
++
++    FT2_BUILD_LIBRARY=1
++    FT_CONFIG_OPTIONS_H="${FREETYPE_SOURCE_DIR}/include/lynx_config/ftoption.h"
++    FT_CONFIG_MODULES_H="${FREETYPE_SOURCE_DIR}/include/lynx_config/ftmodule.h"
++)
++
++target_compile_options(
++    freetype2
++
++    PRIVATE
++
++    -Wno-unused-variable
++)
 diff --git a/CMakeLists-Skity.txt b/CMakeLists-Skity.txt
 new file mode 100644
 index 000000000..fb9554d56
 --- /dev/null
 +++ b/CMakeLists-Skity.txt
 @@ -0,0 +1,59 @@
-+cmake_minimum_required(VERSION 3.15.0)
++cmake_minimum_required(VERSION 3.4.1)
 +
 +set(FREETYPE_SOURCE_DIR ${FREETYPE_DIR})
 +
@@ -86,37 +345,15 @@ index 000000000..fb9554d56
 +
 +    PRIVATE
 +
-+    # -Wno-unused-variable
-+    # -Wno-unused-function
++    -Wno-unused-variable
++    -Wno-unused-function
 +)
-diff --git a/include/freetype/config/public-macros.h b/include/freetype/config/public-macros.h
-index f56581a6e..5bb86b8b0 100644
---- a/include/freetype/config/public-macros.h
-+++ b/include/freetype/config/public-macros.h
-@@ -62,7 +62,8 @@ FT_BEGIN_HEADER
-    * because it is needed by `FT_EXPORT`.
-    */
- 
--  /* Visual C, mingw */
-+#if !FREETYPE_STATIC_LIB
-+/* Visual C, mingw */
- #if defined( _WIN32 )
- 
- #if defined( FT2_BUILD_LIBRARY ) && defined( DLL_EXPORT )
-@@ -81,6 +82,7 @@ FT_BEGIN_HEADER
- #define FT_PUBLIC_FUNCTION_ATTRIBUTE  __global
- #endif
- 
-+#endif  // FREETYPE_STATIC_LIB
- 
- #ifndef FT_PUBLIC_FUNCTION_ATTRIBUTE
- #define FT_PUBLIC_FUNCTION_ATTRIBUTE  /* empty */
-diff --git a/include/skity_config/ftmodule.h b/include/skity_config/ftmodule.h
+diff --git a/include/lynx_config/ftmodule.h b/include/lynx_config/ftmodule.h
 new file mode 100644
-index 000000000..d127a0497
+index 000000000..181384399
 --- /dev/null
-+++ b/include/skity_config/ftmodule.h
-@@ -0,0 +1,36 @@
++++ b/include/lynx_config/ftmodule.h
+@@ -0,0 +1,38 @@
 +/***************************************************************************/
 +/*                                                                         */
 +/*  ftmodule.h                                                             */
@@ -133,6 +370,7 @@ index 000000000..d127a0497
 +/*  understand and accept it fully.                                        */
 +/*                                                                         */
 +/***************************************************************************/
++
 +FT_USE_MODULE( FT_Module_Class, autofit_module_class )
 +FT_USE_MODULE( FT_Driver_ClassRec, tt_driver_class )
 +FT_USE_MODULE( FT_Driver_ClassRec, cff_driver_class )
@@ -141,6 +379,7 @@ index 000000000..d127a0497
 +FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
 +FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
 +FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
++
 +
 +// Outdated or bitmap-based font format unsupported by Flutter.
 +// FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
@@ -153,12 +392,12 @@ index 000000000..d127a0497
 +
 +// Flutter doesn't render non-anti-aliased text.
 +// FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
-diff --git a/include/skity_config/ftoption.h b/include/skity_config/ftoption.h
+diff --git a/include/lynx_config/ftoption.h b/include/lynx_config/ftoption.h
 new file mode 100644
-index 000000000..f77f7d4d6
+index 000000000..b3b60e022
 --- /dev/null
-+++ b/include/skity_config/ftoption.h
-@@ -0,0 +1,870 @@
++++ b/include/lynx_config/ftoption.h
+@@ -0,0 +1,904 @@
 +/***************************************************************************/
 +/*                                                                         */
 +/*  ftoption.h                                                             */
@@ -176,10 +415,13 @@ index 000000000..f77f7d4d6
 +/*                                                                         */
 +/***************************************************************************/
 +
++
 +#ifndef __FTOPTION_H__
 +#define __FTOPTION_H__
 +
++
 +#include <ft2build.h>
++
 +
 +FT_BEGIN_HEADER
 +
@@ -223,6 +465,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +  /*************************************************************************/
 +
++
 +  /*************************************************************************/
 +  /*************************************************************************/
 +  /****                                                                 ****/
@@ -230,6 +473,7 @@ index 000000000..f77f7d4d6
 +  /****                                                                 ****/
 +  /*************************************************************************/
 +  /*************************************************************************/
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -250,6 +494,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Many compilers provide a non-ANSI 64-bit data type that can be used   */
@@ -269,6 +514,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#undef FT_CONFIG_OPTION_FORCE_INT64
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* If this macro is defined, do not try to use an assembler version of   */
@@ -276,6 +522,7 @@ index 000000000..f77f7d4d6
 +  /* that to verify that the assembler function works properly, or to      */
 +  /* execute benchmark tests of the various implementations.               */
 +/* #define FT_CONFIG_OPTION_NO_ASSEMBLER */
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -287,6 +534,7 @@ index 000000000..f77f7d4d6
 +  /* to the standard and portable implementation found in `ftcalc.c'.      */
 +  /*                                                                       */
 +#define FT_CONFIG_OPTION_INLINE_MULFIX
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -302,6 +550,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define FT_CONFIG_OPTION_USE_LZW
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Gzip-compressed file support.                                         */
@@ -315,6 +564,7 @@ index 000000000..f77f7d4d6
 +  /*   the macro FT_CONFIG_OPTION_SYSTEM_ZLIB below.                       */
 +  /*                                                                       */
 +#define FT_CONFIG_OPTION_USE_ZLIB
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -336,6 +586,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_SYSTEM_ZLIB */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Bzip2-compressed file support.                                        */
@@ -351,6 +602,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_USE_BZIP2 */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define to disable the use of file stream functions and types, FILE,   */
@@ -360,6 +612,7 @@ index 000000000..f77f7d4d6
 +  /* necessary such as memory loading of font files.                       */
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT */
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -374,6 +627,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define FT_CONFIG_OPTION_USE_PNG
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* HarfBuzz support.                                                     */
@@ -385,6 +639,7 @@ index 000000000..f77f7d4d6
 +  /*   Define this macro if you want to enable this `feature'.             */
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_USE_HARFBUZZ */
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -427,6 +682,7 @@ index 000000000..f77f7d4d6
 +/* #define FT_EXPORT(x)      extern x */
 +/* #define FT_EXPORT_DEF(x)  x */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Glyph Postscript Names handling                                       */
@@ -451,6 +707,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define FT_CONFIG_OPTION_POSTSCRIPT_NAMES
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Postscript Names to Unicode Values support                            */
@@ -468,6 +725,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +// #define FT_CONFIG_OPTION_ADOBE_GLYPH_LIST
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Support for Mac fonts                                                 */
@@ -479,6 +737,7 @@ index 000000000..f77f7d4d6
 +  /*   Note that the `FOND' resource isn't checked.                        */
 +  /*                                                                       */
 +// #define FT_CONFIG_OPTION_MAC_FONTS
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -502,6 +761,7 @@ index 000000000..f77f7d4d6
 +#define FT_CONFIG_OPTION_GUESSING_EMBEDDED_RFORK
 +#endif
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Allow the use of FT_Incremental_Interface to load typefaces that      */
@@ -512,12 +772,14 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_INCREMENTAL */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* The size in bytes of the render pool used by the scan-line converter  */
 +  /* to do all of its work.                                                */
 +  /*                                                                       */
 +#define FT_RENDER_POOL_SIZE  16384L
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -527,6 +789,7 @@ index 000000000..f77f7d4d6
 +  /*   FreeType library object.  32 is the default.                        */
 +  /*                                                                       */
 +#define FT_MAX_MODULES  32
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -547,6 +810,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_DEBUG_LEVEL_ERROR */
 +/* #define FT_DEBUG_LEVEL_TRACE */
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -582,6 +846,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_DEBUG_AUTOFIT */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Memory Debugging                                                      */
@@ -599,6 +864,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_DEBUG_MEMORY */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Module errors                                                         */
@@ -615,6 +881,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#undef FT_CONFIG_OPTION_USE_MODULE_ERRORS
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Position Independent Code                                             */
@@ -629,6 +896,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define FT_CONFIG_OPTION_PIC */
 +
++
 +  /*************************************************************************/
 +  /*************************************************************************/
 +  /****                                                                 ****/
@@ -636,6 +904,7 @@ index 000000000..f77f7d4d6
 +  /****                                                                 ****/
 +  /*************************************************************************/
 +  /*************************************************************************/
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -645,13 +914,6 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_EMBEDDED_BITMAPS
 +
-+  /**************************************************************************
-+   *
-+   * Define `TT_CONFIG_OPTION_COLOR_LAYERS` if you want to support colored
-+   * outlines (from the 'COLR'/'CPAL' tables) in all formats using the 'sfnt'
-+   * module (namely TrueType~& OpenType).
-+   */
-+#define TT_CONFIG_OPTION_COLOR_LAYERS
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -667,6 +929,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_POSTSCRIPT_NAMES
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define TT_CONFIG_OPTION_SFNT_NAMES if your applications need to       */
@@ -679,6 +942,7 @@ index 000000000..f77f7d4d6
 +  /* `ftsnames.h'.                                                         */
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_SFNT_NAMES
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -695,6 +959,7 @@ index 000000000..f77f7d4d6
 +#define TT_CONFIG_CMAP_FORMAT_12
 +#define TT_CONFIG_CMAP_FORMAT_13
 +#define TT_CONFIG_CMAP_FORMAT_14
++
 +
 +  /*************************************************************************/
 +  /*************************************************************************/
@@ -717,6 +982,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define TT_CONFIG_OPTION_SUBPIXEL_HINTING if you want to compile       */
@@ -737,6 +1003,7 @@ index 000000000..f77f7d4d6
 +  /*   defined.                                                            */
 +  /*                                                                       */
 +/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING */
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -787,6 +1054,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define TT_CONFIG_OPTION_UNPATENTED_HINTING */
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED to compile the        */
@@ -805,6 +1073,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#undef TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define TT_CONFIG_OPTION_GX_VAR_SUPPORT if you want to include         */
@@ -814,12 +1083,14 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_GX_VAR_SUPPORT
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define TT_CONFIG_OPTION_BDF if you want to include support for        */
 +  /* an embedded `BDF ' table within SFNT-based bitmap formats.            */
 +  /*                                                                       */
 +#define TT_CONFIG_OPTION_BDF
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -838,6 +1109,7 @@ index 000000000..f77f7d4d6
 +#define TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES  1000000L
 +#endif
 +
++
 +  /*************************************************************************/
 +  /*************************************************************************/
 +  /****                                                                 ****/
@@ -845,6 +1117,7 @@ index 000000000..f77f7d4d6
 +  /****                                                                 ****/
 +  /*************************************************************************/
 +  /*************************************************************************/
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -854,12 +1127,14 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define T1_MAX_DICT_DEPTH  5
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* T1_MAX_SUBRS_CALLS details the maximum number of nested sub-routine   */
 +  /* calls during glyph loading.                                           */
 +  /*                                                                       */
 +#define T1_MAX_SUBRS_CALLS  16
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -870,6 +1145,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#define T1_MAX_CHARSTRINGS_OPERANDS  256
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define this configuration macro if you want to prevent the            */
@@ -879,6 +1155,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#undef T1_CONFIG_OPTION_NO_AFM
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* Define this configuration macro if you want to prevent the            */
@@ -887,6 +1164,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +#undef T1_CONFIG_OPTION_NO_MM_SUPPORT
 +
++
 +  /*************************************************************************/
 +  /*************************************************************************/
 +  /****                                                                 ****/
@@ -894,6 +1172,7 @@ index 000000000..f77f7d4d6
 +  /****                                                                 ****/
 +  /*************************************************************************/
 +  /*************************************************************************/
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -918,6 +1197,7 @@ index 000000000..f77f7d4d6
 +#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4  2333
 +#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4     0
 +
++
 +  /*************************************************************************/
 +  /*                                                                       */
 +  /* CFF_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe CFF       */
@@ -927,6 +1207,7 @@ index 000000000..f77f7d4d6
 +  /*                                                                       */
 +/* #define CFF_CONFIG_OPTION_OLD_ENGINE */
 +
++
 +  /*************************************************************************/
 +  /*************************************************************************/
 +  /****                                                                 ****/
@@ -934,6 +1215,7 @@ index 000000000..f77f7d4d6
 +  /****                                                                 ****/
 +  /*************************************************************************/
 +  /*************************************************************************/
++
 +
 +  /*************************************************************************/
 +  /*                                                                       */
@@ -965,11 +1247,13 @@ index 000000000..f77f7d4d6
 +
 +  /* */
 +
++
 +  /*
 +   * This macro is obsolete.  Support has been removed in FreeType
 +   * version 2.5.
 +   */
 +/* #define FT_CONFIG_OPTION_OLD_INTERNALS */
++
 +
 +  /*
 +   * This macro is defined if either unpatented or native TrueType
@@ -982,19 +1266,6 @@ index 000000000..f77f7d4d6
 +#define  TT_USE_BYTECODE_INTERPRETER
 +#endif
 +
-+  /*
-+   * The TT_SUPPORT_COLRV1 macro is defined to indicate to clients that this
-+   * version of FreeType has support for 'COLR' v1 API.  This definition is
-+   * useful to FreeType clients that want to build in support for 'COLR' v1
-+   * depending on a tip-of-tree checkout before it is officially released in
-+   * FreeType, and while the feature cannot yet be tested against using
-+   * version macros.  Don't change this macro.  This may be removed once the
-+   * feature is in a FreeType release version and version macros can be used
-+   * to test for availability.
-+   */
-+#ifdef TT_CONFIG_OPTION_COLOR_LAYERS
-+#define  TT_SUPPORT_COLRV1
-+#endif
 +
 +  /*
 +   * Check CFF darkening parameters.  The checks are the same as in function
@@ -1026,9 +1297,3160 @@ index 000000000..f77f7d4d6
 +
 +FT_END_HEADER
 +
++
 +#endif /* __FTOPTION_H__ */
 +
++
 +/* END */
+diff --git a/include/skity_config/ftmodule.h b/include/skity_config/ftmodule.h
+new file mode 100644
+index 000000000..d25bed15e
+--- /dev/null
++++ b/include/skity_config/ftmodule.h
+@@ -0,0 +1,20 @@
++FT_USE_MODULE( FT_Driver_ClassRec, tt_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
++FT_USE_MODULE( FT_Driver_ClassRec, cff_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, t1cid_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, pfr_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, t42_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, winfnt_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, pcf_driver_class )
++// FT_USE_MODULE( FT_Driver_ClassRec, bdf_driver_class )
++
++// FT_USE_MODULE( FT_Module_Class, autofit_module_class )
++FT_USE_MODULE( FT_Module_Class, psaux_module_class )
++FT_USE_MODULE( FT_Module_Class, psnames_module_class )
++FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
++FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
++
++// FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
++FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
++// FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcd_renderer_class )
++// FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcdv_renderer_class )
+diff --git a/include/skity_config/ftoption.h b/include/skity_config/ftoption.h
+new file mode 100644
+index 000000000..60fe91cc6
+--- /dev/null
++++ b/include/skity_config/ftoption.h
+@@ -0,0 +1,977 @@
++/***************************************************************************/
++/*                                                                         */
++/*  ftoption.h                                                             */
++/*                                                                         */
++/*    User-selectable configuration macros (specification only).           */
++/*                                                                         */
++/*  Copyright 1996-2018 by                                                 */
++/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
++/*                                                                         */
++/*  This file is part of the FreeType project, and may only be used,       */
++/*  modified, and distributed under the terms of the FreeType project      */
++/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
++/*  this file you indicate that you have read the license and              */
++/*  understand and accept it fully.                                        */
++/*                                                                         */
++/***************************************************************************/
++
++
++#ifndef FTOPTION_H_
++#define FTOPTION_H_
++
++
++#include <ft2build.h>
++
++
++FT_BEGIN_HEADER
++
++  /*************************************************************************/
++  /*                                                                       */
++  /*                 USER-SELECTABLE CONFIGURATION MACROS                  */
++  /*                                                                       */
++  /* This file contains the default configuration macro definitions for    */
++  /* a standard build of the FreeType library.  There are three ways to    */
++  /* use this file to build project-specific versions of the library:      */
++  /*                                                                       */
++  /*  - You can modify this file by hand, but this is not recommended in   */
++  /*    cases where you would like to build several versions of the        */
++  /*    library from a single source directory.                            */
++  /*                                                                       */
++  /*  - You can put a copy of this file in your build directory, more      */
++  /*    precisely in `$BUILD/freetype/config/ftoption.h', where `$BUILD'   */
++  /*    is the name of a directory that is included _before_ the FreeType  */
++  /*    include path during compilation.                                   */
++  /*                                                                       */
++  /*    The default FreeType Makefiles and Jamfiles use the build          */
++  /*    directory `builds/<system>' by default, but you can easily change  */
++  /*    that for your own projects.                                        */
++  /*                                                                       */
++  /*  - Copy the file <ft2build.h> to `$BUILD/ft2build.h' and modify it    */
++  /*    slightly to pre-define the macro FT_CONFIG_OPTIONS_H used to       */
++  /*    locate this file during the build.  For example,                   */
++  /*                                                                       */
++  /*      #define FT_CONFIG_OPTIONS_H  <myftoptions.h>                     */
++  /*      #include <freetype/config/ftheader.h>                            */
++  /*                                                                       */
++  /*    will use `$BUILD/myftoptions.h' instead of this file for macro     */
++  /*    definitions.                                                       */
++  /*                                                                       */
++  /*    Note also that you can similarly pre-define the macro              */
++  /*    FT_CONFIG_MODULES_H used to locate the file listing of the modules */
++  /*    that are statically linked to the library at compile time.  By     */
++  /*    default, this file is <freetype/config/ftmodule.h>.                */
++  /*                                                                       */
++  /* We highly recommend using the third method whenever possible.         */
++  /*                                                                       */
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /**** G E N E R A L   F R E E T Y P E   2   C O N F I G U R A T I O N ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*#***********************************************************************/
++  /*                                                                       */
++  /* If you enable this configuration option, FreeType recognizes an       */
++  /* environment variable called `FREETYPE_PROPERTIES', which can be used  */
++  /* to control the various font drivers and modules.  The controllable    */
++  /* properties are listed in the section @properties.                     */
++  /*                                                                       */
++  /* You have to undefine this configuration option on platforms that lack */
++  /* the concept of environment variables (and thus don't have the         */
++  /* `getenv' function), for example Windows CE.                           */
++  /*                                                                       */
++  /* `FREETYPE_PROPERTIES' has the following syntax form (broken here into */
++  /* multiple lines for better readability).                               */
++  /*                                                                       */
++  /* {                                                                     */
++  /*   <optional whitespace>                                               */
++  /*   <module-name1> ':'                                                  */
++  /*   <property-name1> '=' <property-value1>                              */
++  /*   <whitespace>                                                        */
++  /*   <module-name2> ':'                                                  */
++  /*   <property-name2> '=' <property-value2>                              */
++  /*   ...                                                                 */
++  /* }                                                                     */
++  /*                                                                       */
++  /* Example:                                                              */
++  /*                                                                       */
++  /*   FREETYPE_PROPERTIES=truetype:interpreter-version=35 \               */
++  /*                       cff:no-stem-darkening=1 \                       */
++  /*                       autofitter:warping=1                            */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_ENVIRONMENT_PROPERTIES
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Uncomment the line below if you want to activate LCD rendering        */
++  /* technology similar to ClearType in this build of the library.  This   */
++  /* technology triples the resolution in the direction color subpixels.   */
++  /* To mitigate color fringes inherent to this technology, you also need  */
++  /* to explicitly set up LCD filtering.                                   */
++  /*                                                                       */
++  /* Note that this feature is covered by several Microsoft patents        */
++  /* and should not be activated in any default build of the library.      */
++  /* When this macro is not defined, FreeType offers alternative LCD       */
++  /* rendering technology that produces excellent output without LCD       */
++  /* filtering.                                                            */
++  /*                                                                       */
++/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Many compilers provide a non-ANSI 64-bit data type that can be used   */
++  /* by FreeType to speed up some computations.  However, this will create */
++  /* some problems when compiling the library in strict ANSI mode.         */
++  /*                                                                       */
++  /* For this reason, the use of 64-bit integers is normally disabled when */
++  /* the __STDC__ macro is defined.  You can however disable this by       */
++  /* defining the macro FT_CONFIG_OPTION_FORCE_INT64 here.                 */
++  /*                                                                       */
++  /* For most compilers, this will only create compilation warnings when   */
++  /* building the library.                                                 */
++  /*                                                                       */
++  /* ObNote: The compiler-specific 64-bit integers are detected in the     */
++  /*         file `ftconfig.h' either statically or through the            */
++  /*         `configure' script on supported platforms.                    */
++  /*                                                                       */
++#undef FT_CONFIG_OPTION_FORCE_INT64
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* If this macro is defined, do not try to use an assembler version of   */
++  /* performance-critical functions (e.g. FT_MulFix).  You should only do  */
++  /* that to verify that the assembler function works properly, or to      */
++  /* execute benchmark tests of the various implementations.               */
++/* #define FT_CONFIG_OPTION_NO_ASSEMBLER */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* If this macro is defined, try to use an inlined assembler version of  */
++  /* the `FT_MulFix' function, which is a `hotspot' when loading and       */
++  /* hinting glyphs, and which should be executed as fast as possible.     */
++  /*                                                                       */
++  /* Note that if your compiler or CPU is not supported, this will default */
++  /* to the standard and portable implementation found in `ftcalc.c'.      */
++  /*                                                                       */
++#define FT_CONFIG_OPTION_INLINE_MULFIX
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* LZW-compressed file support.                                          */
++  /*                                                                       */
++  /*   FreeType now handles font files that have been compressed with the  */
++  /*   `compress' program.  This is mostly used to parse many of the PCF   */
++  /*   files that come with various X11 distributions.  The implementation */
++  /*   uses NetBSD's `zopen' to partially uncompress the file on the fly   */
++  /*   (see src/lzw/ftgzip.c).                                             */
++  /*                                                                       */
++  /*   Define this macro if you want to enable this `feature'.             */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_USE_LZW
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Gzip-compressed file support.                                         */
++  /*                                                                       */
++  /*   FreeType now handles font files that have been compressed with the  */
++  /*   `gzip' program.  This is mostly used to parse many of the PCF files */
++  /*   that come with XFree86.  The implementation uses `zlib' to          */
++  /*   partially uncompress the file on the fly (see src/gzip/ftgzip.c).   */
++  /*                                                                       */
++  /*   Define this macro if you want to enable this `feature'.  See also   */
++  /*   the macro FT_CONFIG_OPTION_SYSTEM_ZLIB below.                       */
++  /*                                                                       */
++ #define FT_CONFIG_OPTION_USE_ZLIB
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* ZLib library selection                                                */
++  /*                                                                       */
++  /*   This macro is only used when FT_CONFIG_OPTION_USE_ZLIB is defined.  */
++  /*   It allows FreeType's `ftgzip' component to link to the system's     */
++  /*   installation of the ZLib library.  This is useful on systems like   */
++  /*   Unix or VMS where it generally is already available.                */
++  /*                                                                       */
++  /*   If you let it undefined, the component will use its own copy        */
++  /*   of the zlib sources instead.  These have been modified to be        */
++  /*   included directly within the component and *not* export external    */
++  /*   function names.  This allows you to link any program with FreeType  */
++  /*   _and_ ZLib without linking conflicts.                               */
++  /*                                                                       */
++  /*   Do not #undef this macro here since the build system might define   */
++  /*   it for certain configurations only.                                 */
++  /*                                                                       */
++  /*   If you use a build system like cmake or the `configure' script,     */
++  /*   options set by those programs have precendence, overwriting the     */
++  /*   value here with the configured one.                                 */
++  /*                                                                       */
++  #define FT_CONFIG_OPTION_SYSTEM_ZLIB
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Bzip2-compressed file support.                                        */
++  /*                                                                       */
++  /*   FreeType now handles font files that have been compressed with the  */
++  /*   `bzip2' program.  This is mostly used to parse many of the PCF      */
++  /*   files that come with XFree86.  The implementation uses `libbz2' to  */
++  /*   partially uncompress the file on the fly (see src/bzip2/ftbzip2.c). */
++  /*   Contrary to gzip, bzip2 currently is not included and need to use   */
++  /*   the system available bzip2 implementation.                          */
++  /*                                                                       */
++  /*   Define this macro if you want to enable this `feature'.             */
++  /*                                                                       */
++  /*   If you use a build system like cmake or the `configure' script,     */
++  /*   options set by those programs have precendence, overwriting the     */
++  /*   value here with the configured one.                                 */
++  /*                                                                       */
++/* #define FT_CONFIG_OPTION_USE_BZIP2 */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define to disable the use of file stream functions and types, FILE,   */
++  /* fopen() etc.  Enables the use of smaller system libraries on embedded */
++  /* systems that have multiple system libraries, some with or without     */
++  /* file stream support, in the cases where file stream support is not    */
++  /* necessary such as memory loading of font files.                       */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* PNG bitmap support.                                                   */
++  /*                                                                       */
++  /*   FreeType now handles loading color bitmap glyphs in the PNG format. */
++  /*   This requires help from the external libpng library.  Uncompressed  */
++  /*   color bitmaps do not need any external libraries and will be        */
++  /*   supported regardless of this configuration.                         */
++  /*                                                                       */
++  /*   Define this macro if you want to enable this `feature'.             */
++  /*                                                                       */
++  /*   If you use a build system like cmake or the `configure' script,     */
++  /*   options set by those programs have precendence, overwriting the     */
++  /*   value here with the configured one.                                 */
++  /*                                                                       */
++#define FT_CONFIG_OPTION_USE_PNG
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* HarfBuzz support.                                                     */
++  /*                                                                       */
++  /*   FreeType uses the HarfBuzz library to improve auto-hinting of       */
++  /*   OpenType fonts.  If available, many glyphs not directly addressable */
++  /*   by a font's character map will be hinted also.                      */
++  /*                                                                       */
++  /*   Define this macro if you want to enable this `feature'.             */
++  /*                                                                       */
++  /*   If you use a build system like cmake or the `configure' script,     */
++  /*   options set by those programs have precendence, overwriting the     */
++  /*   value here with the configured one.                                 */
++  /*                                                                       */
++/* #define FT_CONFIG_OPTION_USE_HARFBUZZ */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Glyph Postscript Names handling                                       */
++  /*                                                                       */
++  /*   By default, FreeType 2 is compiled with the `psnames' module.  This */
++  /*   module is in charge of converting a glyph name string into a        */
++  /*   Unicode value, or return a Macintosh standard glyph name for the    */
++  /*   use with the TrueType `post' table.                                 */
++  /*                                                                       */
++  /*   Undefine this macro if you do not want `psnames' compiled in your   */
++  /*   build of FreeType.  This has the following effects:                 */
++  /*                                                                       */
++  /*   - The TrueType driver will provide its own set of glyph names,      */
++  /*     if you build it to support postscript names in the TrueType       */
++  /*     `post' table, but will not synthesize a missing Unicode charmap.  */
++  /*                                                                       */
++  /*   - The Type 1 driver will not be able to synthesize a Unicode        */
++  /*     charmap out of the glyphs found in the fonts.                     */
++  /*                                                                       */
++  /*   You would normally undefine this configuration macro when building  */
++  /*   a version of FreeType that doesn't contain a Type 1 or CFF driver.  */
++  /*                                                                       */
++#define FT_CONFIG_OPTION_POSTSCRIPT_NAMES
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Postscript Names to Unicode Values support                            */
++  /*                                                                       */
++  /*   By default, FreeType 2 is built with the `PSNames' module compiled  */
++  /*   in.  Among other things, the module is used to convert a glyph name */
++  /*   into a Unicode value.  This is especially useful in order to        */
++  /*   synthesize on the fly a Unicode charmap from the CFF/Type 1 driver  */
++  /*   through a big table named the `Adobe Glyph List' (AGL).             */
++  /*                                                                       */
++  /*   Undefine this macro if you do not want the Adobe Glyph List         */
++  /*   compiled in your `PSNames' module.  The Type 1 driver will not be   */
++  /*   able to synthesize a Unicode charmap out of the glyphs found in the */
++  /*   fonts.                                                              */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_ADOBE_GLYPH_LIST
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Support for Mac fonts                                                 */
++  /*                                                                       */
++  /*   Define this macro if you want support for outline fonts in Mac      */
++  /*   format (mac dfont, mac resource, macbinary containing a mac         */
++  /*   resource) on non-Mac platforms.                                     */
++  /*                                                                       */
++  /*   Note that the `FOND' resource isn't checked.                        */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_MAC_FONTS
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Guessing methods to access embedded resource forks                    */
++  /*                                                                       */
++  /*   Enable extra Mac fonts support on non-Mac platforms (e.g.           */
++  /*   GNU/Linux).                                                         */
++  /*                                                                       */
++  /*   Resource forks which include fonts data are stored sometimes in     */
++  /*   locations which users or developers don't expected.  In some cases, */
++  /*   resource forks start with some offset from the head of a file.  In  */
++  /*   other cases, the actual resource fork is stored in file different   */
++  /*   from what the user specifies.  If this option is activated,         */
++  /*   FreeType tries to guess whether such offsets or different file      */
++  /*   names must be used.                                                 */
++  /*                                                                       */
++  /*   Note that normal, direct access of resource forks is controlled via */
++  /*   the FT_CONFIG_OPTION_MAC_FONTS option.                              */
++  /*                                                                       */
++#ifdef FT_CONFIG_OPTION_MAC_FONTS
++#define FT_CONFIG_OPTION_GUESSING_EMBEDDED_RFORK
++#endif
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Allow the use of FT_Incremental_Interface to load typefaces that      */
++  /* contain no glyph data, but supply it via a callback function.         */
++  /* This is required by clients supporting document formats which         */
++  /* supply font data incrementally as the document is parsed, such        */
++  /* as the Ghostscript interpreter for the PostScript language.           */
++  /*                                                                       */
++// #define FT_CONFIG_OPTION_INCREMENTAL
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* The size in bytes of the render pool used by the scan-line converter  */
++  /* to do all of its work.                                                */
++  /*                                                                       */
++#define FT_RENDER_POOL_SIZE  16384L
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* FT_MAX_MODULES                                                        */
++  /*                                                                       */
++  /*   The maximum number of modules that can be registered in a single    */
++  /*   FreeType library object.  32 is the default.                        */
++  /*                                                                       */
++#define FT_MAX_MODULES  16
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Debug level                                                           */
++  /*                                                                       */
++  /*   FreeType can be compiled in debug or trace mode.  In debug mode,    */
++  /*   errors are reported through the `ftdebug' component.  In trace      */
++  /*   mode, additional messages are sent to the standard output during    */
++  /*   execution.                                                          */
++  /*                                                                       */
++  /*   Define FT_DEBUG_LEVEL_ERROR to build the library in debug mode.     */
++  /*   Define FT_DEBUG_LEVEL_TRACE to build it in trace mode.              */
++  /*                                                                       */
++  /*   Don't define any of these macros to compile in `release' mode!      */
++  /*                                                                       */
++  /*   Do not #undef these macros here since the build system might define */
++  /*   them for certain configurations only.                               */
++  /*                                                                       */
++/* #define FT_DEBUG_LEVEL_ERROR */
++/* #define FT_DEBUG_LEVEL_TRACE */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Autofitter debugging                                                  */
++  /*                                                                       */
++  /*   If FT_DEBUG_AUTOFIT is defined, FreeType provides some means to     */
++  /*   control the autofitter behaviour for debugging purposes with global */
++  /*   boolean variables (consequently, you should *never* enable this     */
++  /*   while compiling in `release' mode):                                 */
++  /*                                                                       */
++  /*     _af_debug_disable_horz_hints                                      */
++  /*     _af_debug_disable_vert_hints                                      */
++  /*     _af_debug_disable_blue_hints                                      */
++  /*                                                                       */
++  /*   Additionally, the following functions provide dumps of various      */
++  /*   internal autofit structures to stdout (using `printf'):             */
++  /*                                                                       */
++  /*     af_glyph_hints_dump_points                                        */
++  /*     af_glyph_hints_dump_segments                                      */
++  /*     af_glyph_hints_dump_edges                                         */
++  /*     af_glyph_hints_get_num_segments                                   */
++  /*     af_glyph_hints_get_segment_offset                                 */
++  /*                                                                       */
++  /*   As an argument, they use another global variable:                   */
++  /*                                                                       */
++  /*     _af_debug_hints                                                   */
++  /*                                                                       */
++  /*   Please have a look at the `ftgrid' demo program to see how those    */
++  /*   variables and macros should be used.                                */
++  /*                                                                       */
++  /*   Do not #undef these macros here since the build system might define */
++  /*   them for certain configurations only.                               */
++  /*                                                                       */
++/* #define FT_DEBUG_AUTOFIT */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Memory Debugging                                                      */
++  /*                                                                       */
++  /*   FreeType now comes with an integrated memory debugger that is       */
++  /*   capable of detecting simple errors like memory leaks or double      */
++  /*   deletes.  To compile it within your build of the library, you       */
++  /*   should define FT_DEBUG_MEMORY here.                                 */
++  /*                                                                       */
++  /*   Note that the memory debugger is only activated at runtime when     */
++  /*   when the _environment_ variable `FT2_DEBUG_MEMORY' is defined also! */
++  /*                                                                       */
++  /*   Do not #undef this macro here since the build system might define   */
++  /*   it for certain configurations only.                                 */
++  /*                                                                       */
++/* #define FT_DEBUG_MEMORY */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Module errors                                                         */
++  /*                                                                       */
++  /*   If this macro is set (which is _not_ the default), the higher byte  */
++  /*   of an error code gives the module in which the error has occurred,  */
++  /*   while the lower byte is the real error code.                        */
++  /*                                                                       */
++  /*   Setting this macro makes sense for debugging purposes only, since   */
++  /*   it would break source compatibility of certain programs that use    */
++  /*   FreeType 2.                                                         */
++  /*                                                                       */
++  /*   More details can be found in the files ftmoderr.h and fterrors.h.   */
++  /*                                                                       */
++#undef FT_CONFIG_OPTION_USE_MODULE_ERRORS
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Position Independent Code                                             */
++  /*                                                                       */
++  /*   If this macro is set (which is _not_ the default), FreeType2 will   */
++  /*   avoid creating constants that require address fixups.  Instead the  */
++  /*   constants will be moved into a struct and additional intialization  */
++  /*   code will be used.                                                  */
++  /*                                                                       */
++  /*   Setting this macro is needed for systems that prohibit address      */
++  /*   fixups, such as BREW.  [Note that standard compilers like gcc or    */
++  /*   clang handle PIC generation automatically; you don't have to set    */
++  /*   FT_CONFIG_OPTION_PIC, which is only necessary for very special      */
++  /*   compilers.]                                                         */
++  /*                                                                       */
++  /*   Note that FT_CONFIG_OPTION_PIC support is not available for all     */
++  /*   modules (see `modules.cfg' for a complete list).  For building with */
++  /*   FT_CONFIG_OPTION_PIC support, do the following.                     */
++  /*                                                                       */
++  /*     0. Clone the repository.                                          */
++  /*     1. Define FT_CONFIG_OPTION_PIC.                                   */
++  /*     2. Remove all subdirectories in `src' that don't have             */
++  /*        FT_CONFIG_OPTION_PIC support.                                  */
++  /*     3. Comment out the corresponding modules in `modules.cfg'.        */
++  /*     4. Compile.                                                       */
++  /*                                                                       */
++/* #define FT_CONFIG_OPTION_PIC */
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****        S F N T   D R I V E R    C O N F I G U R A T I O N       ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_EMBEDDED_BITMAPS if you want to support       */
++  /* embedded bitmaps in all formats using the SFNT module (namely         */
++  /* TrueType & OpenType).                                                 */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_EMBEDDED_BITMAPS
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_POSTSCRIPT_NAMES if you want to be able to    */
++  /* load and enumerate the glyph Postscript names in a TrueType or        */
++  /* OpenType file.                                                        */
++  /*                                                                       */
++  /* Note that when you do not compile the `PSNames' module by undefining  */
++  /* the above FT_CONFIG_OPTION_POSTSCRIPT_NAMES, the `sfnt' module will   */
++  /* contain additional code used to read the PS Names table from a font.  */
++  /*                                                                       */
++  /* (By default, the module uses `PSNames' to extract glyph names.)       */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_POSTSCRIPT_NAMES
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_SFNT_NAMES if your applications need to       */
++  /* access the internal name table in a SFNT-based format like TrueType   */
++  /* or OpenType.  The name table contains various strings used to         */
++  /* describe the font, like family name, copyright, version, etc.  It     */
++  /* does not contain any glyph name though.                               */
++  /*                                                                       */
++  /* Accessing SFNT names is done through the functions declared in        */
++  /* `ftsnames.h'.                                                         */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_SFNT_NAMES
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* TrueType CMap support                                                 */
++  /*                                                                       */
++  /*   Here you can fine-tune which TrueType CMap table format shall be    */
++  /*   supported.                                                          */
++#define TT_CONFIG_CMAP_FORMAT_0
++#define TT_CONFIG_CMAP_FORMAT_2
++#define TT_CONFIG_CMAP_FORMAT_4
++#define TT_CONFIG_CMAP_FORMAT_6
++#define TT_CONFIG_CMAP_FORMAT_8
++#define TT_CONFIG_CMAP_FORMAT_10
++#define TT_CONFIG_CMAP_FORMAT_12
++#define TT_CONFIG_CMAP_FORMAT_13
++#define TT_CONFIG_CMAP_FORMAT_14
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****    T R U E T Y P E   D R I V E R    C O N F I G U R A T I O N   ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_BYTECODE_INTERPRETER if you want to compile   */
++  /* a bytecode interpreter in the TrueType driver.                        */
++  /*                                                                       */
++  /* By undefining this, you will only compile the code necessary to load  */
++  /* TrueType glyphs without hinting.                                      */
++  /*                                                                       */
++  /*   Do not #undef this macro here, since the build system might         */
++  /*   define it for certain configurations only.                          */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_SUBPIXEL_HINTING if you want to compile       */
++  /* subpixel hinting support into the TrueType driver.  This modifies the */
++  /* TrueType hinting mechanism when anything but FT_RENDER_MODE_MONO is   */
++  /* requested.                                                            */
++  /*                                                                       */
++  /* In particular, it modifies the bytecode interpreter to interpret (or  */
++  /* not) instructions in a certain way so that all TrueType fonts look    */
++  /* like they do in a Windows ClearType (DirectWrite) environment.  See   */
++  /* [1] for a technical overview on what this means.  See `ttinterp.h'    */
++  /* for more details on the LEAN option.                                  */
++  /*                                                                       */
++  /* There are three possible values.                                      */
++  /*                                                                       */
++  /* Value 1:                                                              */
++  /*    This value is associated with the `Infinality' moniker,            */
++  /*    contributed by an individual nicknamed Infinality with the goal of */
++  /*    making TrueType fonts render better than on Windows.  A high       */
++  /*    amount of configurability and flexibility, down to rules for       */
++  /*    single glyphs in fonts, but also very slow.  Its experimental and  */
++  /*    slow nature and the original developer losing interest meant that  */
++  /*    this option was never enabled in default builds.                   */
++  /*                                                                       */
++  /*    The corresponding interpreter version is v38.                      */
++  /*                                                                       */
++  /* Value 2:                                                              */
++  /*    The new default mode for the TrueType driver.  The Infinality code */
++  /*    base was stripped to the bare minimum and all configurability      */
++  /*    removed in the name of speed and simplicity.  The configurability  */
++  /*    was mainly aimed at legacy fonts like Arial, Times New Roman, or   */
++  /*    Courier.  Legacy fonts are fonts that modify vertical stems to     */
++  /*    achieve clean black-and-white bitmaps.  The new mode focuses on    */
++  /*    applying a minimal set of rules to all fonts indiscriminately so   */
++  /*    that modern and web fonts render well while legacy fonts render    */
++  /*    okay.                                                              */
++  /*                                                                       */
++  /*    The corresponding interpreter version is v40.                      */
++  /*                                                                       */
++  /* Value 3:                                                              */
++  /*    Compile both, making both v38 and v40 available (the latter is the */
++  /*    default).                                                          */
++  /*                                                                       */
++  /* By undefining these, you get rendering behavior like on Windows       */
++  /* without ClearType, i.e., Windows XP without ClearType enabled and     */
++  /* Win9x (interpreter version v35).  Or not, depending on how much       */
++  /* hinting blood and testing tears the font designer put into a given    */
++  /* font.  If you define one or both subpixel hinting options, you can    */
++  /* switch between between v35 and the ones you define (using             */
++  /* `FT_Property_Set').                                                   */
++  /*                                                                       */
++  /* This option requires TT_CONFIG_OPTION_BYTECODE_INTERPRETER to be      */
++  /* defined.                                                              */
++  /*                                                                       */
++  /* [1] https://www.microsoft.com/typography/cleartype/truetypecleartype.aspx */
++  /*                                                                       */
++/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  1         */
++//#define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2
++/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  ( 1 | 2 ) */
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED to compile the        */
++  /* TrueType glyph loader to use Apple's definition of how to handle      */
++  /* component offsets in composite glyphs.                                */
++  /*                                                                       */
++  /* Apple and MS disagree on the default behavior of component offsets    */
++  /* in composites.  Apple says that they should be scaled by the scaling  */
++  /* factors in the transformation matrix (roughly, it's more complex)     */
++  /* while MS says they should not.  OpenType defines two bits in the      */
++  /* composite flags array which can be used to disambiguate, but old      */
++  /* fonts will not have them.                                             */
++  /*                                                                       */
++  /*   https://www.microsoft.com/typography/otspec/glyf.htm                */
++  /*   https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html */
++  /*                                                                       */
++#undef TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_GX_VAR_SUPPORT if you want to include         */
++  /* support for Apple's distortable font technology (fvar, gvar, cvar,    */
++  /* and avar tables).  This has many similarities to Type 1 Multiple      */
++  /* Masters support.                                                      */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_GX_VAR_SUPPORT
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define TT_CONFIG_OPTION_BDF if you want to include support for        */
++  /* an embedded `BDF ' table within SFNT-based bitmap formats.            */
++  /*                                                                       */
++#define TT_CONFIG_OPTION_BDF
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Option TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES controls the maximum     */
++  /* number of bytecode instructions executed for a single run of the      */
++  /* bytecode interpreter, needed to prevent infinite loops.  You don't    */
++  /* want to change this except for very special situations (e.g., making  */
++  /* a library fuzzer spend less time to handle broken fonts).             */
++  /*                                                                       */
++  /* It is not expected that this value is ever modified by a configuring  */
++  /* script; instead, it gets surrounded with #ifndef ... #endif so that   */
++  /* the value can be set as a preprocessor option on the compiler's       */
++  /* command line.                                                         */
++  /*                                                                       */
++#ifndef TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES
++#define TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES  1000000L
++#endif
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****      T Y P E 1   D R I V E R    C O N F I G U R A T I O N       ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* T1_MAX_DICT_DEPTH is the maximum depth of nest dictionaries and       */
++  /* arrays in the Type 1 stream (see t1load.c).  A minimum of 4 is        */
++  /* required.                                                             */
++  /*                                                                       */
++#define T1_MAX_DICT_DEPTH  5
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* T1_MAX_SUBRS_CALLS details the maximum number of nested sub-routine   */
++  /* calls during glyph loading.                                           */
++  /*                                                                       */
++#define T1_MAX_SUBRS_CALLS  16
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* T1_MAX_CHARSTRING_OPERANDS is the charstring stack's capacity.  A     */
++  /* minimum of 16 is required.                                            */
++  /*                                                                       */
++  /* The Chinese font MingTiEG-Medium (CNS 11643 character set) needs 256. */
++  /*                                                                       */
++#define T1_MAX_CHARSTRINGS_OPERANDS  256
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define this configuration macro if you want to prevent the            */
++  /* compilation of `t1afm', which is in charge of reading Type 1 AFM      */
++  /* files into an existing face.  Note that if set, the T1 driver will be */
++  /* unable to produce kerning distances.                                  */
++  /*                                                                       */
++#undef T1_CONFIG_OPTION_NO_AFM
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Define this configuration macro if you want to prevent the            */
++  /* compilation of the Multiple Masters font support in the Type 1        */
++  /* driver.                                                               */
++  /*                                                                       */
++#undef T1_CONFIG_OPTION_NO_MM_SUPPORT
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* T1_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe Type 1     */
++  /* engine gets compiled into FreeType.  If defined, it is possible to    */
++  /* switch between the two engines using the `hinting-engine' property of */
++  /* the type1 driver module.                                              */
++  /*                                                                       */
++/* #define T1_CONFIG_OPTION_OLD_ENGINE */
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****         C F F   D R I V E R    C O N F I G U R A T I O N        ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Using CFF_CONFIG_OPTION_DARKENING_PARAMETER_{X,Y}{1,2,3,4} it is      */
++  /* possible to set up the default values of the four control points that */
++  /* define the stem darkening behaviour of the (new) CFF engine.  For     */
++  /* more details please read the documentation of the                     */
++  /* `darkening-parameters' property (file `ftdriver.h'), which allows the */
++  /* control at run-time.                                                  */
++  /*                                                                       */
++  /* Do *not* undefine these macros!                                       */
++  /*                                                                       */
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1   500
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1   400
++
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2  1000
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y2   275
++
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3  1667
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y3   275
++
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4  2333
++#define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4     0
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* CFF_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe CFF       */
++  /* engine gets compiled into FreeType.  If defined, it is possible to    */
++  /* switch between the two engines using the `hinting-engine' property of */
++  /* the cff driver module.                                                */
++  /*                                                                       */
++/* #define CFF_CONFIG_OPTION_OLD_ENGINE */
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****         P C F   D R I V E R    C O N F I G U R A T I O N        ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* There are many PCF fonts just called `Fixed' which look completely    */
++  /* different, and which have nothing to do with each other.  When        */
++  /* selecting `Fixed' in KDE or Gnome one gets results that appear rather */
++  /* random, the style changes often if one changes the size and one       */
++  /* cannot select some fonts at all.  This option makes the PCF module    */
++  /* prepend the foundry name (plus a space) to the family name.           */
++  /*                                                                       */
++  /* We also check whether we have `wide' characters; all put together, we */
++  /* get family names like `Sony Fixed' or `Misc Fixed Wide'.              */
++  /*                                                                       */
++  /* If this option is activated, it can be controlled with the            */
++  /* `no-long-family-names' property of the pcf driver module.             */
++  /*                                                                       */
++/* #define PCF_CONFIG_OPTION_LONG_FAMILY_NAMES */
++
++
++  /*************************************************************************/
++  /*************************************************************************/
++  /****                                                                 ****/
++  /****    A U T O F I T   M O D U L E    C O N F I G U R A T I O N     ****/
++  /****                                                                 ****/
++  /*************************************************************************/
++  /*************************************************************************/
++
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Compile autofit module with CJK (Chinese, Japanese, Korean) script    */
++  /* support.                                                              */
++  /*                                                                       */
++#define AF_CONFIG_OPTION_CJK
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Compile autofit module with fallback Indic script support, covering   */
++  /* some scripts that the `latin' submodule of the autofit module doesn't */
++  /* (yet) handle.                                                         */
++  /*                                                                       */
++#define AF_CONFIG_OPTION_INDIC
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Compile autofit module with warp hinting.  The idea of the warping    */
++  /* code is to slightly scale and shift a glyph within a single dimension */
++  /* so that as much of its segments are aligned (more or less) on the     */
++  /* grid.  To find out the optimal scaling and shifting value, various    */
++  /* parameter combinations are tried and scored.                          */
++  /*                                                                       */
++  /* This experimental option is active only if the rendering mode is      */
++  /* FT_RENDER_MODE_LIGHT; you can switch warping on and off with the      */
++  /* `warping' property of the auto-hinter (see file `ftdriver.h' for more */
++  /* information; by default it is switched off).                          */
++  /*                                                                       */
++#define AF_CONFIG_OPTION_USE_WARPER
++
++  /*************************************************************************/
++  /*                                                                       */
++  /* Use TrueType-like size metrics for `light' auto-hinting.              */
++  /*                                                                       */
++  /* It is strongly recommended to avoid this option, which exists only to */
++  /* help some legacy applications retain its appearance and behaviour     */
++  /* with respect to auto-hinted TrueType fonts.                           */
++  /*                                                                       */
++  /* The very reason this option exists at all are GNU/Linux distributions */
++  /* like Fedora that did not un-patch the following change (which was     */
++  /* present in FreeType between versions 2.4.6 and 2.7.1, inclusive).     */
++  /*                                                                       */
++  /*   2011-07-16  Steven Chu  <steven.f.chu@gmail.com>                    */
++  /*                                                                       */
++  /*     [truetype] Fix metrics on size request for scalable fonts.        */
++  /*                                                                       */
++  /* This problematic commit is now reverted (more or less).               */
++  /*                                                                       */
++/* #define AF_CONFIG_OPTION_TT_SIZE_METRICS */
++
++  /* */
++
++
++  /*
++   * This macro is obsolete.  Support has been removed in FreeType
++   * version 2.5.
++   */
++/* #define FT_CONFIG_OPTION_OLD_INTERNALS */
++
++
++  /*
++   * This macro is defined if native TrueType hinting is requested by the
++   * definitions above.
++   */
++#ifdef TT_CONFIG_OPTION_BYTECODE_INTERPRETER
++#define  TT_USE_BYTECODE_INTERPRETER
++
++#ifdef TT_CONFIG_OPTION_SUBPIXEL_HINTING
++#if TT_CONFIG_OPTION_SUBPIXEL_HINTING & 1
++#define  TT_SUPPORT_SUBPIXEL_HINTING_INFINALITY
++#endif
++
++#if TT_CONFIG_OPTION_SUBPIXEL_HINTING & 2
++#define  TT_SUPPORT_SUBPIXEL_HINTING_MINIMAL
++#endif
++#endif
++#endif
++
++
++  /*
++   * Check CFF darkening parameters.  The checks are the same as in function
++   * `cff_property_set' in file `cffdrivr.c'.
++   */
++#if CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4 < 0   || \
++                                                      \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y2 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y3 < 0   || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4 < 0   || \
++                                                      \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1 >        \
++      CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2     || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2 >        \
++      CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3     || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3 >        \
++      CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4     || \
++                                                      \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1 > 500 || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y2 > 500 || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y3 > 500 || \
++    CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4 > 500
++#error "Invalid CFF darkening parameters!"
++#endif
++
++FT_END_HEADER
++
++
++#endif /* FTOPTION_H_ */
++
++
++/* END */
+-- 
+2.50.1 (Apple Git-155)
+
+
+From 5043f4e4f5b838c0afba10515afb380fa2fe3658 Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Fri, 13 Sep 2024 17:12:43 +0800
+Subject: [PATCH 02/10] Skity uses latest config from flutter to enable color
+ table
+
+---
+ include/skity_config/ftmodule.h |  36 ++-
+ include/skity_config/ftoption.h | 500 +++++++++++---------------------
+ 2 files changed, 188 insertions(+), 348 deletions(-)
+
+diff --git a/include/skity_config/ftmodule.h b/include/skity_config/ftmodule.h
+index d25bed15e..30323400a 100644
+--- a/include/skity_config/ftmodule.h
++++ b/include/skity_config/ftmodule.h
+@@ -1,20 +1,34 @@
++/***************************************************************************/
++/*                                                                         */
++/*  ftmodule.h                                                             */
++/*                                                                         */
++/*    User-selectable module macros.                                       */
++/*                                                                         */
++/*  Copyright 1996-2015 by                                                 */
++/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
++/*                                                                         */
++/*  This file is part of the FreeType project, and may only be used,       */
++/*  modified, and distributed under the terms of the FreeType project      */
++/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
++/*  this file you indicate that you have read the license and              */
++/*  understand and accept it fully.                                        */
++/*                                                                         */
++/***************************************************************************/
++FT_USE_MODULE( FT_Module_Class, autofit_module_class )
+ FT_USE_MODULE( FT_Driver_ClassRec, tt_driver_class )
+-// FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
+ FT_USE_MODULE( FT_Driver_ClassRec, cff_driver_class )
++FT_USE_MODULE( FT_Module_Class, psaux_module_class )
++FT_USE_MODULE( FT_Module_Class, psnames_module_class )
++FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
++FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
++FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
++// Outdated or bitmap-based font format unsupported by Flutter.
++// FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, t1cid_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, pfr_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, t42_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, winfnt_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, pcf_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, bdf_driver_class )
+-
+-// FT_USE_MODULE( FT_Module_Class, autofit_module_class )
+-FT_USE_MODULE( FT_Module_Class, psaux_module_class )
+-FT_USE_MODULE( FT_Module_Class, psnames_module_class )
+-FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
+-FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
+-
++// Flutter doesn't render non-anti-aliased text.
+ // FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
+-FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
+-// FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcd_renderer_class )
+-// FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcdv_renderer_class )
+diff --git a/include/skity_config/ftoption.h b/include/skity_config/ftoption.h
+index 60fe91cc6..0ac91defc 100644
+--- a/include/skity_config/ftoption.h
++++ b/include/skity_config/ftoption.h
+@@ -4,7 +4,7 @@
+ /*                                                                         */
+ /*    User-selectable configuration macros (specification only).           */
+ /*                                                                         */
+-/*  Copyright 1996-2018 by                                                 */
++/*  Copyright 1996-2015 by                                                 */
+ /*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+ /*                                                                         */
+ /*  This file is part of the FreeType project, and may only be used,       */
+@@ -14,17 +14,10 @@
+ /*  understand and accept it fully.                                        */
+ /*                                                                         */
+ /***************************************************************************/
+-
+-
+-#ifndef FTOPTION_H_
+-#define FTOPTION_H_
+-
+-
++#ifndef __FTOPTION_H__
++#define __FTOPTION_H__
+ #include <ft2build.h>
+-
+-
+ FT_BEGIN_HEADER
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /*                 USER-SELECTABLE CONFIGURATION MACROS                  */
+@@ -38,9 +31,9 @@ FT_BEGIN_HEADER
+   /*    library from a single source directory.                            */
+   /*                                                                       */
+   /*  - You can put a copy of this file in your build directory, more      */
+-  /*    precisely in `$BUILD/freetype/config/ftoption.h', where `$BUILD'   */
+-  /*    is the name of a directory that is included _before_ the FreeType  */
+-  /*    include path during compilation.                                   */
++  /*    precisely in `$BUILD/config/ftoption.h', where `$BUILD' is the     */
++  /*    name of a directory that is included _before_ the FreeType include */
++  /*    path during compilation.                                           */
+   /*                                                                       */
+   /*    The default FreeType Makefiles and Jamfiles use the build          */
+   /*    directory `builds/<system>' by default, but you can easily change  */
+@@ -51,7 +44,7 @@ FT_BEGIN_HEADER
+   /*    locate this file during the build.  For example,                   */
+   /*                                                                       */
+   /*      #define FT_CONFIG_OPTIONS_H  <myftoptions.h>                     */
+-  /*      #include <freetype/config/ftheader.h>                            */
++  /*      #include <config/ftheader.h>                                     */
+   /*                                                                       */
+   /*    will use `$BUILD/myftoptions.h' instead of this file for macro     */
+   /*    definitions.                                                       */
+@@ -59,13 +52,11 @@ FT_BEGIN_HEADER
+   /*    Note also that you can similarly pre-define the macro              */
+   /*    FT_CONFIG_MODULES_H used to locate the file listing of the modules */
+   /*    that are statically linked to the library at compile time.  By     */
+-  /*    default, this file is <freetype/config/ftmodule.h>.                */
++  /*    default, this file is <config/ftmodule.h>.                         */
+   /*                                                                       */
+   /* We highly recommend using the third method whenever possible.         */
+   /*                                                                       */
+   /*************************************************************************/
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -73,58 +64,24 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+-
+-  /*#***********************************************************************/
+-  /*                                                                       */
+-  /* If you enable this configuration option, FreeType recognizes an       */
+-  /* environment variable called `FREETYPE_PROPERTIES', which can be used  */
+-  /* to control the various font drivers and modules.  The controllable    */
+-  /* properties are listed in the section @properties.                     */
+-  /*                                                                       */
+-  /* You have to undefine this configuration option on platforms that lack */
+-  /* the concept of environment variables (and thus don't have the         */
+-  /* `getenv' function), for example Windows CE.                           */
+-  /*                                                                       */
+-  /* `FREETYPE_PROPERTIES' has the following syntax form (broken here into */
+-  /* multiple lines for better readability).                               */
+-  /*                                                                       */
+-  /* {                                                                     */
+-  /*   <optional whitespace>                                               */
+-  /*   <module-name1> ':'                                                  */
+-  /*   <property-name1> '=' <property-value1>                              */
+-  /*   <whitespace>                                                        */
+-  /*   <module-name2> ':'                                                  */
+-  /*   <property-name2> '=' <property-value2>                              */
+-  /*   ...                                                                 */
+-  /* }                                                                     */
+-  /*                                                                       */
+-  /* Example:                                                              */
+-  /*                                                                       */
+-  /*   FREETYPE_PROPERTIES=truetype:interpreter-version=35 \               */
+-  /*                       cff:no-stem-darkening=1 \                       */
+-  /*                       autofitter:warping=1                            */
+-  /*                                                                       */
+-// #define FT_CONFIG_OPTION_ENVIRONMENT_PROPERTIES
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+-  /* Uncomment the line below if you want to activate LCD rendering        */
+-  /* technology similar to ClearType in this build of the library.  This   */
+-  /* technology triples the resolution in the direction color subpixels.   */
+-  /* To mitigate color fringes inherent to this technology, you also need  */
+-  /* to explicitly set up LCD filtering.                                   */
++  /* Uncomment the line below if you want to activate sub-pixel rendering  */
++  /* (a.k.a. LCD rendering, or ClearType) in this build of the library.    */
+   /*                                                                       */
+   /* Note that this feature is covered by several Microsoft patents        */
+   /* and should not be activated in any default build of the library.      */
+-  /* When this macro is not defined, FreeType offers alternative LCD       */
+-  /* rendering technology that produces excellent output without LCD       */
+-  /* filtering.                                                            */
++  /*                                                                       */
++  /* This macro has no impact on the FreeType API, only on its             */
++  /* _implementation_.  For example, using FT_RENDER_MODE_LCD when calling */
++  /* FT_Render_Glyph still generates a bitmap that is 3 times wider than   */
++  /* the original size in case this macro isn't defined; however, each     */
++  /* triplet of subpixels has R=G=B.                                       */
++  /*                                                                       */
++  /* This is done to allow FreeType clients to run unmodified, forcing     */
++  /* them to display normal gray-level anti-aliased glyphs.                */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Many compilers provide a non-ANSI 64-bit data type that can be used   */
+@@ -143,8 +100,6 @@ FT_BEGIN_HEADER
+   /*         `configure' script on supported platforms.                    */
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_FORCE_INT64
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, do not try to use an assembler version of   */
+@@ -152,8 +107,6 @@ FT_BEGIN_HEADER
+   /* that to verify that the assembler function works properly, or to      */
+   /* execute benchmark tests of the various implementations.               */
+ /* #define FT_CONFIG_OPTION_NO_ASSEMBLER */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, try to use an inlined assembler version of  */
+@@ -164,8 +117,6 @@ FT_BEGIN_HEADER
+   /* to the standard and portable implementation found in `ftcalc.c'.      */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_INLINE_MULFIX
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* LZW-compressed file support.                                          */
+@@ -178,9 +129,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+-// #define FT_CONFIG_OPTION_USE_LZW
+-
+-
++#define FT_CONFIG_OPTION_USE_LZW
+   /*************************************************************************/
+   /*                                                                       */
+   /* Gzip-compressed file support.                                         */
+@@ -193,9 +142,7 @@ FT_BEGIN_HEADER
+   /*   Define this macro if you want to enable this `feature'.  See also   */
+   /*   the macro FT_CONFIG_OPTION_SYSTEM_ZLIB below.                       */
+   /*                                                                       */
+- #define FT_CONFIG_OPTION_USE_ZLIB
+-
+-
++#define FT_CONFIG_OPTION_USE_ZLIB
+   /*************************************************************************/
+   /*                                                                       */
+   /* ZLib library selection                                                */
+@@ -214,13 +161,7 @@ FT_BEGIN_HEADER
+   /*   Do not #undef this macro here since the build system might define   */
+   /*   it for certain configurations only.                                 */
+   /*                                                                       */
+-  /*   If you use a build system like cmake or the `configure' script,     */
+-  /*   options set by those programs have precendence, overwriting the     */
+-  /*   value here with the configured one.                                 */
+-  /*                                                                       */
+-  #define FT_CONFIG_OPTION_SYSTEM_ZLIB
+-
+-
++/* #define FT_CONFIG_OPTION_SYSTEM_ZLIB */
+   /*************************************************************************/
+   /*                                                                       */
+   /* Bzip2-compressed file support.                                        */
+@@ -234,13 +175,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+-  /*   If you use a build system like cmake or the `configure' script,     */
+-  /*   options set by those programs have precendence, overwriting the     */
+-  /*   value here with the configured one.                                 */
+-  /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_BZIP2 */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define to disable the use of file stream functions and types, FILE,   */
+@@ -249,9 +184,7 @@ FT_BEGIN_HEADER
+   /* file stream support, in the cases where file stream support is not    */
+   /* necessary such as memory loading of font files.                       */
+   /*                                                                       */
+-// #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT
+-
+-
++/* #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT */
+   /*************************************************************************/
+   /*                                                                       */
+   /* PNG bitmap support.                                                   */
+@@ -263,13 +196,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+-  /*   If you use a build system like cmake or the `configure' script,     */
+-  /*   options set by those programs have precendence, overwriting the     */
+-  /*   value here with the configured one.                                 */
+-  /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_PNG
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* HarfBuzz support.                                                     */
+@@ -280,13 +207,47 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+-  /*   If you use a build system like cmake or the `configure' script,     */
+-  /*   options set by those programs have precendence, overwriting the     */
+-  /*   value here with the configured one.                                 */
+-  /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_HARFBUZZ */
+-
+-
++  /*************************************************************************/
++  /*                                                                       */
++  /* DLL export compilation                                                */
++  /*                                                                       */
++  /*   When compiling FreeType as a DLL, some systems/compilers need a     */
++  /*   special keyword in front OR after the return type of function       */
++  /*   declarations.                                                       */
++  /*                                                                       */
++  /*   Two macros are used within the FreeType source code to define       */
++  /*   exported library functions: FT_EXPORT and FT_EXPORT_DEF.            */
++  /*                                                                       */
++  /*     FT_EXPORT( return_type )                                          */
++  /*                                                                       */
++  /*       is used in a function declaration, as in                        */
++  /*                                                                       */
++  /*         FT_EXPORT( FT_Error )                                         */
++  /*         FT_Init_FreeType( FT_Library*  alibrary );                    */
++  /*                                                                       */
++  /*                                                                       */
++  /*     FT_EXPORT_DEF( return_type )                                      */
++  /*                                                                       */
++  /*       is used in a function definition, as in                         */
++  /*                                                                       */
++  /*         FT_EXPORT_DEF( FT_Error )                                     */
++  /*         FT_Init_FreeType( FT_Library*  alibrary )                     */
++  /*         {                                                             */
++  /*           ... some code ...                                           */
++  /*           return FT_Err_Ok;                                           */
++  /*         }                                                             */
++  /*                                                                       */
++  /*   You can provide your own implementation of FT_EXPORT and            */
++  /*   FT_EXPORT_DEF here if you want.  If you leave them undefined, they  */
++  /*   will be later automatically defined as `extern return_type' to      */
++  /*   allow normal compilation.                                           */
++  /*                                                                       */
++  /*   Do not #undef these macros here since the build system might define */
++  /*   them for certain configurations only.                               */
++  /*                                                                       */
++/* #define FT_EXPORT(x)      extern x */
++/* #define FT_EXPORT_DEF(x)  x */
+   /*************************************************************************/
+   /*                                                                       */
+   /* Glyph Postscript Names handling                                       */
+@@ -301,7 +262,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   - The TrueType driver will provide its own set of glyph names,      */
+   /*     if you build it to support postscript names in the TrueType       */
+-  /*     `post' table, but will not synthesize a missing Unicode charmap.  */
++  /*     `post' table.                                                     */
+   /*                                                                       */
+   /*   - The Type 1 driver will not be able to synthesize a Unicode        */
+   /*     charmap out of the glyphs found in the fonts.                     */
+@@ -310,8 +271,6 @@ FT_BEGIN_HEADER
+   /*   a version of FreeType that doesn't contain a Type 1 or CFF driver.  */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_POSTSCRIPT_NAMES
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Postscript Names to Unicode Values support                            */
+@@ -328,8 +287,6 @@ FT_BEGIN_HEADER
+   /*   fonts.                                                              */
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_ADOBE_GLYPH_LIST
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Support for Mac fonts                                                 */
+@@ -341,8 +298,6 @@ FT_BEGIN_HEADER
+   /*   Note that the `FOND' resource isn't checked.                        */
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_MAC_FONTS
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Guessing methods to access embedded resource forks                    */
+@@ -364,8 +319,6 @@ FT_BEGIN_HEADER
+ #ifdef FT_CONFIG_OPTION_MAC_FONTS
+ #define FT_CONFIG_OPTION_GUESSING_EMBEDDED_RFORK
+ #endif
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Allow the use of FT_Incremental_Interface to load typefaces that      */
+@@ -374,17 +327,13 @@ FT_BEGIN_HEADER
+   /* supply font data incrementally as the document is parsed, such        */
+   /* as the Ghostscript interpreter for the PostScript language.           */
+   /*                                                                       */
+-// #define FT_CONFIG_OPTION_INCREMENTAL
+-
+-
++/* #define FT_CONFIG_OPTION_INCREMENTAL */
+   /*************************************************************************/
+   /*                                                                       */
+   /* The size in bytes of the render pool used by the scan-line converter  */
+   /* to do all of its work.                                                */
+   /*                                                                       */
+ #define FT_RENDER_POOL_SIZE  16384L
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* FT_MAX_MODULES                                                        */
+@@ -392,9 +341,7 @@ FT_BEGIN_HEADER
+   /*   The maximum number of modules that can be registered in a single    */
+   /*   FreeType library object.  32 is the default.                        */
+   /*                                                                       */
+-#define FT_MAX_MODULES  16
+-
+-
++#define FT_MAX_MODULES  32
+   /*************************************************************************/
+   /*                                                                       */
+   /* Debug level                                                           */
+@@ -414,8 +361,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_DEBUG_LEVEL_ERROR */
+ /* #define FT_DEBUG_LEVEL_TRACE */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Autofitter debugging                                                  */
+@@ -449,8 +394,6 @@ FT_BEGIN_HEADER
+   /*   them for certain configurations only.                               */
+   /*                                                                       */
+ /* #define FT_DEBUG_AUTOFIT */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Memory Debugging                                                      */
+@@ -467,8 +410,6 @@ FT_BEGIN_HEADER
+   /*   it for certain configurations only.                                 */
+   /*                                                                       */
+ /* #define FT_DEBUG_MEMORY */
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Module errors                                                         */
+@@ -484,8 +425,6 @@ FT_BEGIN_HEADER
+   /*   More details can be found in the files ftmoderr.h and fterrors.h.   */
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_USE_MODULE_ERRORS
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Position Independent Code                                             */
+@@ -496,25 +435,9 @@ FT_BEGIN_HEADER
+   /*   code will be used.                                                  */
+   /*                                                                       */
+   /*   Setting this macro is needed for systems that prohibit address      */
+-  /*   fixups, such as BREW.  [Note that standard compilers like gcc or    */
+-  /*   clang handle PIC generation automatically; you don't have to set    */
+-  /*   FT_CONFIG_OPTION_PIC, which is only necessary for very special      */
+-  /*   compilers.]                                                         */
+-  /*                                                                       */
+-  /*   Note that FT_CONFIG_OPTION_PIC support is not available for all     */
+-  /*   modules (see `modules.cfg' for a complete list).  For building with */
+-  /*   FT_CONFIG_OPTION_PIC support, do the following.                     */
+-  /*                                                                       */
+-  /*     0. Clone the repository.                                          */
+-  /*     1. Define FT_CONFIG_OPTION_PIC.                                   */
+-  /*     2. Remove all subdirectories in `src' that don't have             */
+-  /*        FT_CONFIG_OPTION_PIC support.                                  */
+-  /*     3. Comment out the corresponding modules in `modules.cfg'.        */
+-  /*     4. Compile.                                                       */
++  /*   fixups, such as BREW.                                               */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_PIC */
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -522,8 +445,6 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_EMBEDDED_BITMAPS if you want to support       */
+@@ -531,8 +452,13 @@ FT_BEGIN_HEADER
+   /* TrueType & OpenType).                                                 */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_EMBEDDED_BITMAPS
+-
+-
++  /**************************************************************************
++   *
++   * Define `TT_CONFIG_OPTION_COLOR_LAYERS` if you want to support colored
++   * outlines (from the 'COLR'/'CPAL' tables) in all formats using the 'sfnt'
++   * module (namely TrueType~& OpenType).
++   */
++#define TT_CONFIG_OPTION_COLOR_LAYERS
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_POSTSCRIPT_NAMES if you want to be able to    */
+@@ -546,8 +472,6 @@ FT_BEGIN_HEADER
+   /* (By default, the module uses `PSNames' to extract glyph names.)       */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_POSTSCRIPT_NAMES
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SFNT_NAMES if your applications need to       */
+@@ -560,8 +484,6 @@ FT_BEGIN_HEADER
+   /* `ftsnames.h'.                                                         */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_SFNT_NAMES
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* TrueType CMap support                                                 */
+@@ -577,8 +499,6 @@ FT_BEGIN_HEADER
+ #define TT_CONFIG_CMAP_FORMAT_12
+ #define TT_CONFIG_CMAP_FORMAT_13
+ #define TT_CONFIG_CMAP_FORMAT_14
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -586,7 +506,6 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_BYTECODE_INTERPRETER if you want to compile   */
+@@ -599,69 +518,74 @@ FT_BEGIN_HEADER
+   /*   define it for certain configurations only.                          */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SUBPIXEL_HINTING if you want to compile       */
+-  /* subpixel hinting support into the TrueType driver.  This modifies the */
+-  /* TrueType hinting mechanism when anything but FT_RENDER_MODE_MONO is   */
+-  /* requested.                                                            */
+-  /*                                                                       */
+-  /* In particular, it modifies the bytecode interpreter to interpret (or  */
+-  /* not) instructions in a certain way so that all TrueType fonts look    */
+-  /* like they do in a Windows ClearType (DirectWrite) environment.  See   */
+-  /* [1] for a technical overview on what this means.  See `ttinterp.h'    */
+-  /* for more details on the LEAN option.                                  */
+-  /*                                                                       */
+-  /* There are three possible values.                                      */
+-  /*                                                                       */
+-  /* Value 1:                                                              */
+-  /*    This value is associated with the `Infinality' moniker,            */
+-  /*    contributed by an individual nicknamed Infinality with the goal of */
+-  /*    making TrueType fonts render better than on Windows.  A high       */
+-  /*    amount of configurability and flexibility, down to rules for       */
+-  /*    single glyphs in fonts, but also very slow.  Its experimental and  */
+-  /*    slow nature and the original developer losing interest meant that  */
+-  /*    this option was never enabled in default builds.                   */
+-  /*                                                                       */
+-  /*    The corresponding interpreter version is v38.                      */
+-  /*                                                                       */
+-  /* Value 2:                                                              */
+-  /*    The new default mode for the TrueType driver.  The Infinality code */
+-  /*    base was stripped to the bare minimum and all configurability      */
+-  /*    removed in the name of speed and simplicity.  The configurability  */
+-  /*    was mainly aimed at legacy fonts like Arial, Times New Roman, or   */
+-  /*    Courier.  Legacy fonts are fonts that modify vertical stems to     */
+-  /*    achieve clean black-and-white bitmaps.  The new mode focuses on    */
+-  /*    applying a minimal set of rules to all fonts indiscriminately so   */
+-  /*    that modern and web fonts render well while legacy fonts render    */
+-  /*    okay.                                                              */
+-  /*                                                                       */
+-  /*    The corresponding interpreter version is v40.                      */
+-  /*                                                                       */
+-  /* Value 3:                                                              */
+-  /*    Compile both, making both v38 and v40 available (the latter is the */
+-  /*    default).                                                          */
+-  /*                                                                       */
+-  /* By undefining these, you get rendering behavior like on Windows       */
+-  /* without ClearType, i.e., Windows XP without ClearType enabled and     */
+-  /* Win9x (interpreter version v35).  Or not, depending on how much       */
+-  /* hinting blood and testing tears the font designer put into a given    */
+-  /* font.  If you define one or both subpixel hinting options, you can    */
+-  /* switch between between v35 and the ones you define (using             */
+-  /* `FT_Property_Set').                                                   */
+-  /*                                                                       */
+-  /* This option requires TT_CONFIG_OPTION_BYTECODE_INTERPRETER to be      */
+-  /* defined.                                                              */
+-  /*                                                                       */
+-  /* [1] https://www.microsoft.com/typography/cleartype/truetypecleartype.aspx */
+-  /*                                                                       */
+-/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  1         */
+-//#define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2
+-/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  ( 1 | 2 ) */
+-
+-
++  /* EXPERIMENTAL subpixel hinting support into the TrueType driver.  This */
++  /* replaces the native TrueType hinting mechanism when anything but      */
++  /* FT_RENDER_MODE_MONO is requested.                                     */
++  /*                                                                       */
++  /* Enabling this causes the TrueType driver to ignore instructions under */
++  /* certain conditions.  This is done in accordance with the guide here,  */
++  /* with some minor differences:                                          */
++  /*                                                                       */
++  /*  http://www.microsoft.com/typography/cleartype/truetypecleartype.aspx */
++  /*                                                                       */
++  /* By undefining this, you only compile the code necessary to hint       */
++  /* TrueType glyphs with native TT hinting.                               */
++  /*                                                                       */
++  /*   This option requires TT_CONFIG_OPTION_BYTECODE_INTERPRETER to be    */
++  /*   defined.                                                            */
++  /*                                                                       */
++/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING */
++  /*************************************************************************/
++  /*                                                                       */
++  /* If you define TT_CONFIG_OPTION_UNPATENTED_HINTING, a special version  */
++  /* of the TrueType bytecode interpreter is used that doesn't implement   */
++  /* any of the patented opcodes and algorithms.  The patents related to   */
++  /* TrueType hinting have expired worldwide since May 2010; this option   */
++  /* is now deprecated.                                                    */
++  /*                                                                       */
++  /* Note that the TT_CONFIG_OPTION_UNPATENTED_HINTING macro is *ignored*  */
++  /* if you define TT_CONFIG_OPTION_BYTECODE_INTERPRETER; in other words,  */
++  /* either define TT_CONFIG_OPTION_BYTECODE_INTERPRETER or                */
++  /* TT_CONFIG_OPTION_UNPATENTED_HINTING but not both at the same time.    */
++  /*                                                                       */
++  /* This macro is only useful for a small number of font files (mostly    */
++  /* for Asian scripts) that require bytecode interpretation to properly   */
++  /* load glyphs.  For all other fonts, this produces unpleasant results,  */
++  /* thus the unpatented interpreter is never used to load glyphs from     */
++  /* TrueType fonts unless one of the following two options is used.       */
++  /*                                                                       */
++  /*   - The unpatented interpreter is explicitly activated by the user    */
++  /*     through the FT_PARAM_TAG_UNPATENTED_HINTING parameter tag         */
++  /*     when opening the FT_Face.                                         */
++  /*                                                                       */
++  /*   - FreeType detects that the FT_Face corresponds to one of the       */
++  /*     `trick' fonts (e.g., `Mingliu') it knows about.  The font engine  */
++  /*     contains a hard-coded list of font names and other matching       */
++  /*     parameters (see function `tt_face_init' in file                   */
++  /*     `src/truetype/ttobjs.c').                                         */
++  /*                                                                       */
++  /* Here a sample code snippet for using FT_PARAM_TAG_UNPATENTED_HINTING. */
++  /*                                                                       */
++  /*   {                                                                   */
++  /*     FT_Parameter  parameter;                                          */
++  /*     FT_Open_Args  open_args;                                          */
++  /*                                                                       */
++  /*                                                                       */
++  /*     parameter.tag = FT_PARAM_TAG_UNPATENTED_HINTING;                  */
++  /*                                                                       */
++  /*     open_args.flags      = FT_OPEN_PATHNAME | FT_OPEN_PARAMS;         */
++  /*     open_args.pathname   = my_font_pathname;                          */
++  /*     open_args.num_params = 1;                                         */
++  /*     open_args.params     = &parameter;                                */
++  /*                                                                       */
++  /*     error = FT_Open_Face( library, &open_args, index, &face );        */
++  /*     ...                                                               */
++  /*   }                                                                   */
++  /*                                                                       */
++/* #define TT_CONFIG_OPTION_UNPATENTED_HINTING */
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED to compile the        */
+@@ -675,12 +599,10 @@ FT_BEGIN_HEADER
+   /* composite flags array which can be used to disambiguate, but old      */
+   /* fonts will not have them.                                             */
+   /*                                                                       */
+-  /*   https://www.microsoft.com/typography/otspec/glyf.htm                */
++  /*   http://www.microsoft.com/typography/otspec/glyf.htm                 */
+   /*   https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html */
+   /*                                                                       */
+ #undef TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_GX_VAR_SUPPORT if you want to include         */
+@@ -689,16 +611,12 @@ FT_BEGIN_HEADER
+   /* Masters support.                                                      */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_GX_VAR_SUPPORT
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_BDF if you want to include support for        */
+   /* an embedded `BDF ' table within SFNT-based bitmap formats.            */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BDF
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Option TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES controls the maximum     */
+@@ -715,8 +633,6 @@ FT_BEGIN_HEADER
+ #ifndef TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES
+ #define TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES  1000000L
+ #endif
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -724,8 +640,6 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_DICT_DEPTH is the maximum depth of nest dictionaries and       */
+@@ -733,16 +647,12 @@ FT_BEGIN_HEADER
+   /* required.                                                             */
+   /*                                                                       */
+ #define T1_MAX_DICT_DEPTH  5
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_SUBRS_CALLS details the maximum number of nested sub-routine   */
+   /* calls during glyph loading.                                           */
+   /*                                                                       */
+ #define T1_MAX_SUBRS_CALLS  16
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_CHARSTRING_OPERANDS is the charstring stack's capacity.  A     */
+@@ -751,8 +661,6 @@ FT_BEGIN_HEADER
+   /* The Chinese font MingTiEG-Medium (CNS 11643 character set) needs 256. */
+   /*                                                                       */
+ #define T1_MAX_CHARSTRINGS_OPERANDS  256
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -761,8 +669,6 @@ FT_BEGIN_HEADER
+   /* unable to produce kerning distances.                                  */
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_AFM
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -770,18 +676,6 @@ FT_BEGIN_HEADER
+   /* driver.                                                               */
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_MM_SUPPORT
+-
+-
+-  /*************************************************************************/
+-  /*                                                                       */
+-  /* T1_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe Type 1     */
+-  /* engine gets compiled into FreeType.  If defined, it is possible to    */
+-  /* switch between the two engines using the `hinting-engine' property of */
+-  /* the type1 driver module.                                              */
+-  /*                                                                       */
+-/* #define T1_CONFIG_OPTION_OLD_ENGINE */
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -789,32 +683,25 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Using CFF_CONFIG_OPTION_DARKENING_PARAMETER_{X,Y}{1,2,3,4} it is      */
+   /* possible to set up the default values of the four control points that */
+   /* define the stem darkening behaviour of the (new) CFF engine.  For     */
+   /* more details please read the documentation of the                     */
+-  /* `darkening-parameters' property (file `ftdriver.h'), which allows the */
+-  /* control at run-time.                                                  */
++  /* `darkening-parameters' property of the cff driver module (file        */
++  /* `ftcffdrv.h'), which allows the control at run-time.                  */
+   /*                                                                       */
+   /* Do *not* undefine these macros!                                       */
+   /*                                                                       */
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1   500
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1   400
+-
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2  1000
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y2   275
+-
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3  1667
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y3   275
+-
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4  2333
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4     0
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* CFF_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe CFF       */
+@@ -823,35 +710,6 @@ FT_BEGIN_HEADER
+   /* the cff driver module.                                                */
+   /*                                                                       */
+ /* #define CFF_CONFIG_OPTION_OLD_ENGINE */
+-
+-
+-  /*************************************************************************/
+-  /*************************************************************************/
+-  /****                                                                 ****/
+-  /****         P C F   D R I V E R    C O N F I G U R A T I O N        ****/
+-  /****                                                                 ****/
+-  /*************************************************************************/
+-  /*************************************************************************/
+-
+-
+-  /*************************************************************************/
+-  /*                                                                       */
+-  /* There are many PCF fonts just called `Fixed' which look completely    */
+-  /* different, and which have nothing to do with each other.  When        */
+-  /* selecting `Fixed' in KDE or Gnome one gets results that appear rather */
+-  /* random, the style changes often if one changes the size and one       */
+-  /* cannot select some fonts at all.  This option makes the PCF module    */
+-  /* prepend the foundry name (plus a space) to the family name.           */
+-  /*                                                                       */
+-  /* We also check whether we have `wide' characters; all put together, we */
+-  /* get family names like `Sony Fixed' or `Misc Fixed Wide'.              */
+-  /*                                                                       */
+-  /* If this option is activated, it can be controlled with the            */
+-  /* `no-long-family-names' property of the pcf driver module.             */
+-  /*                                                                       */
+-/* #define PCF_CONFIG_OPTION_LONG_FAMILY_NAMES */
+-
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -859,23 +717,17 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
+-
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with CJK (Chinese, Japanese, Korean) script    */
+   /* support.                                                              */
+   /*                                                                       */
+ #define AF_CONFIG_OPTION_CJK
+-
+   /*************************************************************************/
+   /*                                                                       */
+-  /* Compile autofit module with fallback Indic script support, covering   */
+-  /* some scripts that the `latin' submodule of the autofit module doesn't */
+-  /* (yet) handle.                                                         */
++  /* Compile autofit module with Indic script support.                     */
+   /*                                                                       */
+ #define AF_CONFIG_OPTION_INDIC
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with warp hinting.  The idea of the warping    */
+@@ -886,60 +738,39 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /* This experimental option is active only if the rendering mode is      */
+   /* FT_RENDER_MODE_LIGHT; you can switch warping on and off with the      */
+-  /* `warping' property of the auto-hinter (see file `ftdriver.h' for more */
++  /* `warping' property of the auto-hinter (see file `ftautoh.h' for more  */
+   /* information; by default it is switched off).                          */
+   /*                                                                       */
+-#define AF_CONFIG_OPTION_USE_WARPER
+-
+-  /*************************************************************************/
+-  /*                                                                       */
+-  /* Use TrueType-like size metrics for `light' auto-hinting.              */
+-  /*                                                                       */
+-  /* It is strongly recommended to avoid this option, which exists only to */
+-  /* help some legacy applications retain its appearance and behaviour     */
+-  /* with respect to auto-hinted TrueType fonts.                           */
+-  /*                                                                       */
+-  /* The very reason this option exists at all are GNU/Linux distributions */
+-  /* like Fedora that did not un-patch the following change (which was     */
+-  /* present in FreeType between versions 2.4.6 and 2.7.1, inclusive).     */
+-  /*                                                                       */
+-  /*   2011-07-16  Steven Chu  <steven.f.chu@gmail.com>                    */
+-  /*                                                                       */
+-  /*     [truetype] Fix metrics on size request for scalable fonts.        */
+-  /*                                                                       */
+-  /* This problematic commit is now reverted (more or less).               */
+-  /*                                                                       */
+-/* #define AF_CONFIG_OPTION_TT_SIZE_METRICS */
+-
++/*#define AF_CONFIG_OPTION_USE_WARPER*/
+   /* */
+-
+-
+   /*
+    * This macro is obsolete.  Support has been removed in FreeType
+    * version 2.5.
+    */
+ /* #define FT_CONFIG_OPTION_OLD_INTERNALS */
+-
+-
+   /*
+-   * This macro is defined if native TrueType hinting is requested by the
+-   * definitions above.
++   * This macro is defined if either unpatented or native TrueType
++   * hinting is requested by the definitions above.
+    */
+ #ifdef TT_CONFIG_OPTION_BYTECODE_INTERPRETER
+ #define  TT_USE_BYTECODE_INTERPRETER
+-
+-#ifdef TT_CONFIG_OPTION_SUBPIXEL_HINTING
+-#if TT_CONFIG_OPTION_SUBPIXEL_HINTING & 1
+-#define  TT_SUPPORT_SUBPIXEL_HINTING_INFINALITY
+-#endif
+-
+-#if TT_CONFIG_OPTION_SUBPIXEL_HINTING & 2
+-#define  TT_SUPPORT_SUBPIXEL_HINTING_MINIMAL
+-#endif
++#undef   TT_CONFIG_OPTION_UNPATENTED_HINTING
++#elif defined TT_CONFIG_OPTION_UNPATENTED_HINTING
++#define  TT_USE_BYTECODE_INTERPRETER
+ #endif
++  /*
++   * The TT_SUPPORT_COLRV1 macro is defined to indicate to clients that this
++   * version of FreeType has support for 'COLR' v1 API.  This definition is
++   * useful to FreeType clients that want to build in support for 'COLR' v1
++   * depending on a tip-of-tree checkout before it is officially released in
++   * FreeType, and while the feature cannot yet be tested against using
++   * version macros.  Don't change this macro.  This may be removed once the
++   * feature is in a FreeType release version and version macros can be used
++   * to test for availability.
++   */
++#ifdef TT_CONFIG_OPTION_COLOR_LAYERS
++#define  TT_SUPPORT_COLRV1
+ #endif
+-
+-
+   /*
+    * Check CFF darkening parameters.  The checks are the same as in function
+    * `cff_property_set' in file `cffdrivr.c'.
+@@ -967,11 +798,6 @@ FT_BEGIN_HEADER
+     CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4 > 500
+ #error "Invalid CFF darkening parameters!"
+ #endif
+-
+ FT_END_HEADER
+-
+-
+-#endif /* FTOPTION_H_ */
+-
+-
++#endif /* __FTOPTION_H__ */
+ /* END */
+-- 
+2.50.1 (Apple Git-155)
+
+
+From fb96bfdd70708434f593d6ab2be7f1ce933c3def Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Wed, 18 Sep 2024 19:04:22 +0800
+Subject: [PATCH 03/10] Dont export symbols when build static library
+
+---
+ include/freetype/config/public-macros.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/freetype/config/public-macros.h b/include/freetype/config/public-macros.h
+index f56581a6e..5bb86b8b0 100644
+--- a/include/freetype/config/public-macros.h
++++ b/include/freetype/config/public-macros.h
+@@ -62,7 +62,8 @@ FT_BEGIN_HEADER
+    * because it is needed by `FT_EXPORT`.
+    */
+ 
+-  /* Visual C, mingw */
++#if !FREETYPE_STATIC_LIB
++/* Visual C, mingw */
+ #if defined( _WIN32 )
+ 
+ #if defined( FT2_BUILD_LIBRARY ) && defined( DLL_EXPORT )
+@@ -81,6 +82,7 @@ FT_BEGIN_HEADER
+ #define FT_PUBLIC_FUNCTION_ATTRIBUTE  __global
+ #endif
+ 
++#endif  // FREETYPE_STATIC_LIB
+ 
+ #ifndef FT_PUBLIC_FUNCTION_ATTRIBUTE
+ #define FT_PUBLIC_FUNCTION_ATTRIBUTE  /* empty */
+-- 
+2.50.1 (Apple Git-155)
+
+
+From fdaf609fdd31f5eccb065c8b21a90833ce4779af Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Thu, 19 Sep 2024 16:18:50 +0800
+Subject: [PATCH 04/10] Format codes
+
+---
+ include/skity_config/ftmodule.h |  2 +
+ include/skity_config/ftoption.h | 67 +++++++++++++++++++++++++++++++++
+ 2 files changed, 69 insertions(+)
+
+diff --git a/include/skity_config/ftmodule.h b/include/skity_config/ftmodule.h
+index 30323400a..d127a0497 100644
+--- a/include/skity_config/ftmodule.h
++++ b/include/skity_config/ftmodule.h
+@@ -22,6 +22,7 @@ FT_USE_MODULE( FT_Module_Class, psnames_module_class )
+ FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
+ FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
+ FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
++
+ // Outdated or bitmap-based font format unsupported by Flutter.
+ // FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, t1cid_driver_class )
+@@ -30,5 +31,6 @@ FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, winfnt_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, pcf_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, bdf_driver_class )
++
+ // Flutter doesn't render non-anti-aliased text.
+ // FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
+diff --git a/include/skity_config/ftoption.h b/include/skity_config/ftoption.h
+index 0ac91defc..f77f7d4d6 100644
+--- a/include/skity_config/ftoption.h
++++ b/include/skity_config/ftoption.h
+@@ -14,10 +14,14 @@
+ /*  understand and accept it fully.                                        */
+ /*                                                                         */
+ /***************************************************************************/
++
+ #ifndef __FTOPTION_H__
+ #define __FTOPTION_H__
++
+ #include <ft2build.h>
++
+ FT_BEGIN_HEADER
++
+   /*************************************************************************/
+   /*                                                                       */
+   /*                 USER-SELECTABLE CONFIGURATION MACROS                  */
+@@ -57,6 +61,7 @@ FT_BEGIN_HEADER
+   /* We highly recommend using the third method whenever possible.         */
+   /*                                                                       */
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -64,6 +69,7 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Uncomment the line below if you want to activate sub-pixel rendering  */
+@@ -82,6 +88,7 @@ FT_BEGIN_HEADER
+   /* them to display normal gray-level anti-aliased glyphs.                */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Many compilers provide a non-ANSI 64-bit data type that can be used   */
+@@ -100,6 +107,7 @@ FT_BEGIN_HEADER
+   /*         `configure' script on supported platforms.                    */
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_FORCE_INT64
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, do not try to use an assembler version of   */
+@@ -107,6 +115,7 @@ FT_BEGIN_HEADER
+   /* that to verify that the assembler function works properly, or to      */
+   /* execute benchmark tests of the various implementations.               */
+ /* #define FT_CONFIG_OPTION_NO_ASSEMBLER */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, try to use an inlined assembler version of  */
+@@ -117,6 +126,7 @@ FT_BEGIN_HEADER
+   /* to the standard and portable implementation found in `ftcalc.c'.      */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_INLINE_MULFIX
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* LZW-compressed file support.                                          */
+@@ -130,6 +140,7 @@ FT_BEGIN_HEADER
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_LZW
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Gzip-compressed file support.                                         */
+@@ -143,6 +154,7 @@ FT_BEGIN_HEADER
+   /*   the macro FT_CONFIG_OPTION_SYSTEM_ZLIB below.                       */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_ZLIB
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* ZLib library selection                                                */
+@@ -162,6 +174,7 @@ FT_BEGIN_HEADER
+   /*   it for certain configurations only.                                 */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_SYSTEM_ZLIB */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Bzip2-compressed file support.                                        */
+@@ -176,6 +189,7 @@ FT_BEGIN_HEADER
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_BZIP2 */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define to disable the use of file stream functions and types, FILE,   */
+@@ -185,6 +199,7 @@ FT_BEGIN_HEADER
+   /* necessary such as memory loading of font files.                       */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* PNG bitmap support.                                                   */
+@@ -197,6 +212,7 @@ FT_BEGIN_HEADER
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_PNG
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* HarfBuzz support.                                                     */
+@@ -208,6 +224,7 @@ FT_BEGIN_HEADER
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_HARFBUZZ */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* DLL export compilation                                                */
+@@ -248,6 +265,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_EXPORT(x)      extern x */
+ /* #define FT_EXPORT_DEF(x)  x */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Glyph Postscript Names handling                                       */
+@@ -271,6 +289,7 @@ FT_BEGIN_HEADER
+   /*   a version of FreeType that doesn't contain a Type 1 or CFF driver.  */
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_POSTSCRIPT_NAMES
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Postscript Names to Unicode Values support                            */
+@@ -287,6 +306,7 @@ FT_BEGIN_HEADER
+   /*   fonts.                                                              */
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_ADOBE_GLYPH_LIST
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Support for Mac fonts                                                 */
+@@ -298,6 +318,7 @@ FT_BEGIN_HEADER
+   /*   Note that the `FOND' resource isn't checked.                        */
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_MAC_FONTS
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Guessing methods to access embedded resource forks                    */
+@@ -319,6 +340,7 @@ FT_BEGIN_HEADER
+ #ifdef FT_CONFIG_OPTION_MAC_FONTS
+ #define FT_CONFIG_OPTION_GUESSING_EMBEDDED_RFORK
+ #endif
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Allow the use of FT_Incremental_Interface to load typefaces that      */
+@@ -328,12 +350,14 @@ FT_BEGIN_HEADER
+   /* as the Ghostscript interpreter for the PostScript language.           */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_INCREMENTAL */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* The size in bytes of the render pool used by the scan-line converter  */
+   /* to do all of its work.                                                */
+   /*                                                                       */
+ #define FT_RENDER_POOL_SIZE  16384L
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* FT_MAX_MODULES                                                        */
+@@ -342,6 +366,7 @@ FT_BEGIN_HEADER
+   /*   FreeType library object.  32 is the default.                        */
+   /*                                                                       */
+ #define FT_MAX_MODULES  32
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Debug level                                                           */
+@@ -361,6 +386,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_DEBUG_LEVEL_ERROR */
+ /* #define FT_DEBUG_LEVEL_TRACE */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Autofitter debugging                                                  */
+@@ -394,6 +420,7 @@ FT_BEGIN_HEADER
+   /*   them for certain configurations only.                               */
+   /*                                                                       */
+ /* #define FT_DEBUG_AUTOFIT */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Memory Debugging                                                      */
+@@ -410,6 +437,7 @@ FT_BEGIN_HEADER
+   /*   it for certain configurations only.                                 */
+   /*                                                                       */
+ /* #define FT_DEBUG_MEMORY */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Module errors                                                         */
+@@ -425,6 +453,7 @@ FT_BEGIN_HEADER
+   /*   More details can be found in the files ftmoderr.h and fterrors.h.   */
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_USE_MODULE_ERRORS
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Position Independent Code                                             */
+@@ -438,6 +467,7 @@ FT_BEGIN_HEADER
+   /*   fixups, such as BREW.                                               */
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_PIC */
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -445,6 +475,7 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_EMBEDDED_BITMAPS if you want to support       */
+@@ -452,6 +483,7 @@ FT_BEGIN_HEADER
+   /* TrueType & OpenType).                                                 */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_EMBEDDED_BITMAPS
++
+   /**************************************************************************
+    *
+    * Define `TT_CONFIG_OPTION_COLOR_LAYERS` if you want to support colored
+@@ -459,6 +491,7 @@ FT_BEGIN_HEADER
+    * module (namely TrueType~& OpenType).
+    */
+ #define TT_CONFIG_OPTION_COLOR_LAYERS
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_POSTSCRIPT_NAMES if you want to be able to    */
+@@ -472,6 +505,7 @@ FT_BEGIN_HEADER
+   /* (By default, the module uses `PSNames' to extract glyph names.)       */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_POSTSCRIPT_NAMES
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SFNT_NAMES if your applications need to       */
+@@ -484,6 +518,7 @@ FT_BEGIN_HEADER
+   /* `ftsnames.h'.                                                         */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_SFNT_NAMES
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* TrueType CMap support                                                 */
+@@ -499,6 +534,7 @@ FT_BEGIN_HEADER
+ #define TT_CONFIG_CMAP_FORMAT_12
+ #define TT_CONFIG_CMAP_FORMAT_13
+ #define TT_CONFIG_CMAP_FORMAT_14
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -506,6 +542,7 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_BYTECODE_INTERPRETER if you want to compile   */
+@@ -518,6 +555,7 @@ FT_BEGIN_HEADER
+   /*   define it for certain configurations only.                          */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SUBPIXEL_HINTING if you want to compile       */
+@@ -538,6 +576,7 @@ FT_BEGIN_HEADER
+   /*   defined.                                                            */
+   /*                                                                       */
+ /* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* If you define TT_CONFIG_OPTION_UNPATENTED_HINTING, a special version  */
+@@ -586,6 +625,7 @@ FT_BEGIN_HEADER
+   /*   }                                                                   */
+   /*                                                                       */
+ /* #define TT_CONFIG_OPTION_UNPATENTED_HINTING */
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED to compile the        */
+@@ -603,6 +643,7 @@ FT_BEGIN_HEADER
+   /*   https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html */
+   /*                                                                       */
+ #undef TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_GX_VAR_SUPPORT if you want to include         */
+@@ -611,12 +652,14 @@ FT_BEGIN_HEADER
+   /* Masters support.                                                      */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_GX_VAR_SUPPORT
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_BDF if you want to include support for        */
+   /* an embedded `BDF ' table within SFNT-based bitmap formats.            */
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BDF
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Option TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES controls the maximum     */
+@@ -633,6 +676,7 @@ FT_BEGIN_HEADER
+ #ifndef TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES
+ #define TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES  1000000L
+ #endif
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -640,6 +684,7 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_DICT_DEPTH is the maximum depth of nest dictionaries and       */
+@@ -647,12 +692,14 @@ FT_BEGIN_HEADER
+   /* required.                                                             */
+   /*                                                                       */
+ #define T1_MAX_DICT_DEPTH  5
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_SUBRS_CALLS details the maximum number of nested sub-routine   */
+   /* calls during glyph loading.                                           */
+   /*                                                                       */
+ #define T1_MAX_SUBRS_CALLS  16
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_CHARSTRING_OPERANDS is the charstring stack's capacity.  A     */
+@@ -661,6 +708,7 @@ FT_BEGIN_HEADER
+   /* The Chinese font MingTiEG-Medium (CNS 11643 character set) needs 256. */
+   /*                                                                       */
+ #define T1_MAX_CHARSTRINGS_OPERANDS  256
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -669,6 +717,7 @@ FT_BEGIN_HEADER
+   /* unable to produce kerning distances.                                  */
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_AFM
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -676,6 +725,7 @@ FT_BEGIN_HEADER
+   /* driver.                                                               */
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_MM_SUPPORT
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -683,6 +733,7 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Using CFF_CONFIG_OPTION_DARKENING_PARAMETER_{X,Y}{1,2,3,4} it is      */
+@@ -696,12 +747,16 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X1   500
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y1   400
++
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X2  1000
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y2   275
++
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X3  1667
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y3   275
++
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4  2333
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4     0
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* CFF_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe CFF       */
+@@ -710,6 +765,7 @@ FT_BEGIN_HEADER
+   /* the cff driver module.                                                */
+   /*                                                                       */
+ /* #define CFF_CONFIG_OPTION_OLD_ENGINE */
++
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -717,17 +773,20 @@ FT_BEGIN_HEADER
+   /****                                                                 ****/
+   /*************************************************************************/
+   /*************************************************************************/
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with CJK (Chinese, Japanese, Korean) script    */
+   /* support.                                                              */
+   /*                                                                       */
+ #define AF_CONFIG_OPTION_CJK
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with Indic script support.                     */
+   /*                                                                       */
+ #define AF_CONFIG_OPTION_INDIC
++
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with warp hinting.  The idea of the warping    */
+@@ -742,12 +801,15 @@ FT_BEGIN_HEADER
+   /* information; by default it is switched off).                          */
+   /*                                                                       */
+ /*#define AF_CONFIG_OPTION_USE_WARPER*/
++
+   /* */
++
+   /*
+    * This macro is obsolete.  Support has been removed in FreeType
+    * version 2.5.
+    */
+ /* #define FT_CONFIG_OPTION_OLD_INTERNALS */
++
+   /*
+    * This macro is defined if either unpatented or native TrueType
+    * hinting is requested by the definitions above.
+@@ -758,6 +820,7 @@ FT_BEGIN_HEADER
+ #elif defined TT_CONFIG_OPTION_UNPATENTED_HINTING
+ #define  TT_USE_BYTECODE_INTERPRETER
+ #endif
++
+   /*
+    * The TT_SUPPORT_COLRV1 macro is defined to indicate to clients that this
+    * version of FreeType has support for 'COLR' v1 API.  This definition is
+@@ -771,6 +834,7 @@ FT_BEGIN_HEADER
+ #ifdef TT_CONFIG_OPTION_COLOR_LAYERS
+ #define  TT_SUPPORT_COLRV1
+ #endif
++
+   /*
+    * Check CFF darkening parameters.  The checks are the same as in function
+    * `cff_property_set' in file `cffdrivr.c'.
+@@ -798,6 +862,9 @@ FT_BEGIN_HEADER
+     CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4 > 500
+ #error "Invalid CFF darkening parameters!"
+ #endif
++
+ FT_END_HEADER
++
+ #endif /* __FTOPTION_H__ */
++
+ /* END */
+-- 
+2.50.1 (Apple Git-155)
+
+
+From 6724b66c070daab720ec0c98904d1aa221f4d8f2 Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Thu, 19 Sep 2024 15:18:44 +0800
+Subject: [PATCH 05/10] Fix compile error in clay
+
+---
+ BUILD.gn                       |  4 +-
+ include/lynx_config/ftmodule.h |  5 +--
+ include/lynx_config/ftoption.h | 78 ++++++++++------------------------
+ 3 files changed, 26 insertions(+), 61 deletions(-)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 1066dec9f..ce89080f1 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -112,8 +112,8 @@ config("freetypelite_config") {
+   ]
+   defines = [
+     "FT2_BUILD_LIBRARY=1",
+-    "FT_CONFIG_OPTIONS_H=\"skity_config/ftoption.h\"",
+-    "FT_CONFIG_MODULES_H=\"skity_config/ftmodule.h\"",
++    "FT_CONFIG_OPTIONS_H=\"lynx_config/ftoption.h\"",
++    "FT_CONFIG_MODULES_H=\"lynx_config/ftmodule.h\"",
+   ]
+   cflags = [
+     "-Wno-newline-eof",
+diff --git a/include/lynx_config/ftmodule.h b/include/lynx_config/ftmodule.h
+index 181384399..b470e2bee 100644
+--- a/include/lynx_config/ftmodule.h
++++ b/include/lynx_config/ftmodule.h
+@@ -14,8 +14,7 @@
+ /*  understand and accept it fully.                                        */
+ /*                                                                         */
+ /***************************************************************************/
+-
+-FT_USE_MODULE( FT_Module_Class, autofit_module_class )
++//FT_USE_MODULE( FT_Module_Class, autofit_module_class )
+ FT_USE_MODULE( FT_Driver_ClassRec, tt_driver_class )
+ FT_USE_MODULE( FT_Driver_ClassRec, cff_driver_class )
+ FT_USE_MODULE( FT_Module_Class, psaux_module_class )
+@@ -24,7 +23,6 @@ FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
+ FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
+ FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
+ 
+-
+ // Outdated or bitmap-based font format unsupported by Flutter.
+ // FT_USE_MODULE( FT_Driver_ClassRec, t1_driver_class )
+ // FT_USE_MODULE( FT_Driver_ClassRec, t1cid_driver_class )
+@@ -36,3 +34,4 @@ FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
+ 
+ // Flutter doesn't render non-anti-aliased text.
+ // FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
++
+diff --git a/include/lynx_config/ftoption.h b/include/lynx_config/ftoption.h
+index b3b60e022..afe06c03f 100644
+--- a/include/lynx_config/ftoption.h
++++ b/include/lynx_config/ftoption.h
+@@ -15,14 +15,11 @@
+ /*                                                                         */
+ /***************************************************************************/
+ 
+-
+ #ifndef __FTOPTION_H__
+ #define __FTOPTION_H__
+ 
+-
+ #include <ft2build.h>
+ 
+-
+ FT_BEGIN_HEADER
+ 
+   /*************************************************************************/
+@@ -65,7 +62,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -74,7 +70,6 @@ FT_BEGIN_HEADER
+   /*************************************************************************/
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Uncomment the line below if you want to activate sub-pixel rendering  */
+@@ -94,7 +89,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Many compilers provide a non-ANSI 64-bit data type that can be used   */
+@@ -114,7 +108,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_FORCE_INT64
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, do not try to use an assembler version of   */
+@@ -123,7 +116,6 @@ FT_BEGIN_HEADER
+   /* execute benchmark tests of the various implementations.               */
+ /* #define FT_CONFIG_OPTION_NO_ASSEMBLER */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* If this macro is defined, try to use an inlined assembler version of  */
+@@ -135,7 +127,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_INLINE_MULFIX
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* LZW-compressed file support.                                          */
+@@ -148,8 +139,7 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+   /*   Define this macro if you want to enable this `feature'.             */
+   /*                                                                       */
+-#define FT_CONFIG_OPTION_USE_LZW
+-
++//#define FT_CONFIG_OPTION_USE_LZW
+ 
+   /*************************************************************************/
+   /*                                                                       */
+@@ -165,7 +155,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_ZLIB
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* ZLib library selection                                                */
+@@ -184,8 +173,7 @@ FT_BEGIN_HEADER
+   /*   Do not #undef this macro here since the build system might define   */
+   /*   it for certain configurations only.                                 */
+   /*                                                                       */
+-/* #define FT_CONFIG_OPTION_SYSTEM_ZLIB */
+-
++#define FT_CONFIG_OPTION_SYSTEM_ZLIB
+ 
+   /*************************************************************************/
+   /*                                                                       */
+@@ -202,7 +190,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_BZIP2 */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define to disable the use of file stream functions and types, FILE,   */
+@@ -213,7 +200,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_DISABLE_STREAM_SUPPORT */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* PNG bitmap support.                                                   */
+@@ -227,7 +213,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_USE_PNG
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* HarfBuzz support.                                                     */
+@@ -240,7 +225,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_USE_HARFBUZZ */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* DLL export compilation                                                */
+@@ -282,7 +266,6 @@ FT_BEGIN_HEADER
+ /* #define FT_EXPORT(x)      extern x */
+ /* #define FT_EXPORT_DEF(x)  x */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Glyph Postscript Names handling                                       */
+@@ -307,7 +290,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_CONFIG_OPTION_POSTSCRIPT_NAMES
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Postscript Names to Unicode Values support                            */
+@@ -325,7 +307,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_ADOBE_GLYPH_LIST
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Support for Mac fonts                                                 */
+@@ -338,7 +319,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ // #define FT_CONFIG_OPTION_MAC_FONTS
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Guessing methods to access embedded resource forks                    */
+@@ -361,7 +341,6 @@ FT_BEGIN_HEADER
+ #define FT_CONFIG_OPTION_GUESSING_EMBEDDED_RFORK
+ #endif
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Allow the use of FT_Incremental_Interface to load typefaces that      */
+@@ -372,7 +351,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_INCREMENTAL */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* The size in bytes of the render pool used by the scan-line converter  */
+@@ -380,7 +358,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_RENDER_POOL_SIZE  16384L
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* FT_MAX_MODULES                                                        */
+@@ -390,7 +367,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define FT_MAX_MODULES  32
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Debug level                                                           */
+@@ -411,7 +387,6 @@ FT_BEGIN_HEADER
+ /* #define FT_DEBUG_LEVEL_ERROR */
+ /* #define FT_DEBUG_LEVEL_TRACE */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Autofitter debugging                                                  */
+@@ -446,7 +421,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_DEBUG_AUTOFIT */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Memory Debugging                                                      */
+@@ -464,7 +438,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_DEBUG_MEMORY */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Module errors                                                         */
+@@ -481,7 +454,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #undef FT_CONFIG_OPTION_USE_MODULE_ERRORS
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Position Independent Code                                             */
+@@ -496,7 +468,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define FT_CONFIG_OPTION_PIC */
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -505,7 +476,6 @@ FT_BEGIN_HEADER
+   /*************************************************************************/
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_EMBEDDED_BITMAPS if you want to support       */
+@@ -514,6 +484,13 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_EMBEDDED_BITMAPS
+ 
++  /**************************************************************************
++   *
++   * Define `TT_CONFIG_OPTION_COLOR_LAYERS` if you want to support colored
++   * outlines (from the 'COLR'/'CPAL' tables) in all formats using the 'sfnt'
++   * module (namely TrueType~& OpenType).
++   */
++#define TT_CONFIG_OPTION_COLOR_LAYERS
+ 
+   /*************************************************************************/
+   /*                                                                       */
+@@ -529,7 +506,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_POSTSCRIPT_NAMES
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SFNT_NAMES if your applications need to       */
+@@ -543,7 +519,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_SFNT_NAMES
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* TrueType CMap support                                                 */
+@@ -560,7 +535,6 @@ FT_BEGIN_HEADER
+ #define TT_CONFIG_CMAP_FORMAT_13
+ #define TT_CONFIG_CMAP_FORMAT_14
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -582,7 +556,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_SUBPIXEL_HINTING if you want to compile       */
+@@ -604,7 +577,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* If you define TT_CONFIG_OPTION_UNPATENTED_HINTING, a special version  */
+@@ -654,7 +626,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define TT_CONFIG_OPTION_UNPATENTED_HINTING */
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED to compile the        */
+@@ -673,7 +644,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #undef TT_CONFIG_OPTION_COMPONENT_OFFSET_SCALED
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_GX_VAR_SUPPORT if you want to include         */
+@@ -683,7 +653,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_GX_VAR_SUPPORT
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define TT_CONFIG_OPTION_BDF if you want to include support for        */
+@@ -691,7 +660,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define TT_CONFIG_OPTION_BDF
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Option TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES controls the maximum     */
+@@ -709,7 +677,6 @@ FT_BEGIN_HEADER
+ #define TT_CONFIG_OPTION_MAX_RUNNABLE_OPCODES  1000000L
+ #endif
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -718,7 +685,6 @@ FT_BEGIN_HEADER
+   /*************************************************************************/
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_DICT_DEPTH is the maximum depth of nest dictionaries and       */
+@@ -727,7 +693,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define T1_MAX_DICT_DEPTH  5
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_SUBRS_CALLS details the maximum number of nested sub-routine   */
+@@ -735,7 +700,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define T1_MAX_SUBRS_CALLS  16
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* T1_MAX_CHARSTRING_OPERANDS is the charstring stack's capacity.  A     */
+@@ -745,7 +709,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #define T1_MAX_CHARSTRINGS_OPERANDS  256
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -755,7 +718,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_AFM
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Define this configuration macro if you want to prevent the            */
+@@ -764,7 +726,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ #undef T1_CONFIG_OPTION_NO_MM_SUPPORT
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -773,7 +734,6 @@ FT_BEGIN_HEADER
+   /*************************************************************************/
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Using CFF_CONFIG_OPTION_DARKENING_PARAMETER_{X,Y}{1,2,3,4} it is      */
+@@ -797,7 +757,6 @@ FT_BEGIN_HEADER
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_X4  2333
+ #define CFF_CONFIG_OPTION_DARKENING_PARAMETER_Y4     0
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* CFF_CONFIG_OPTION_OLD_ENGINE controls whether the pre-Adobe CFF       */
+@@ -807,7 +766,6 @@ FT_BEGIN_HEADER
+   /*                                                                       */
+ /* #define CFF_CONFIG_OPTION_OLD_ENGINE */
+ 
+-
+   /*************************************************************************/
+   /*************************************************************************/
+   /****                                                                 ****/
+@@ -816,7 +774,6 @@ FT_BEGIN_HEADER
+   /*************************************************************************/
+   /*************************************************************************/
+ 
+-
+   /*************************************************************************/
+   /*                                                                       */
+   /* Compile autofit module with CJK (Chinese, Japanese, Korean) script    */
+@@ -847,14 +804,12 @@ FT_BEGIN_HEADER
+ 
+   /* */
+ 
+-
+   /*
+    * This macro is obsolete.  Support has been removed in FreeType
+    * version 2.5.
+    */
+ /* #define FT_CONFIG_OPTION_OLD_INTERNALS */
+ 
+-
+   /*
+    * This macro is defined if either unpatented or native TrueType
+    * hinting is requested by the definitions above.
+@@ -866,6 +821,19 @@ FT_BEGIN_HEADER
+ #define  TT_USE_BYTECODE_INTERPRETER
+ #endif
+ 
++  /*
++   * The TT_SUPPORT_COLRV1 macro is defined to indicate to clients that this
++   * version of FreeType has support for 'COLR' v1 API.  This definition is
++   * useful to FreeType clients that want to build in support for 'COLR' v1
++   * depending on a tip-of-tree checkout before it is officially released in
++   * FreeType, and while the feature cannot yet be tested against using
++   * version macros.  Don't change this macro.  This may be removed once the
++   * feature is in a FreeType release version and version macros can be used
++   * to test for availability.
++   */
++#ifdef TT_CONFIG_OPTION_COLOR_LAYERS
++#define  TT_SUPPORT_COLRV1
++#endif
+ 
+   /*
+    * Check CFF darkening parameters.  The checks are the same as in function
+@@ -897,8 +865,6 @@ FT_BEGIN_HEADER
+ 
+ FT_END_HEADER
+ 
+-
+ #endif /* __FTOPTION_H__ */
+ 
+-
+ /* END */
+-- 
+2.50.1 (Apple Git-155)
+
+
+From dfeda3dae0de46c21abc54c40f5b7647c075d718 Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Thu, 19 Sep 2024 17:34:19 +0800
+Subject: [PATCH 06/10] Fix build error
+
+---
+ BUILD.gn | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index ce89080f1..759cddfd2 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -100,7 +100,6 @@ target(default_library_type, "freetype2") {
+ 
+   deps = [
+     "//third_party/libpng",
+-    "//third_party/zlib",
+   ]
+ }
+ 
+-- 
+2.50.1 (Apple Git-155)
+
+
+From f5d7703d7b74fcad81b45021273783b4781a3817 Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Thu, 19 Sep 2024 21:07:46 +0800
+Subject: [PATCH 07/10] [Optimize] Add a switch to enable/disable capability of
+ drawing font variants in freetyp2 lite
+
+---
+ BUILD.gn                       | 8 ++++++++
+ include/lynx_config/ftoption.h | 4 ++++
+ src/truetype/ttgload.c         | 2 ++
+ 3 files changed, 14 insertions(+)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 759cddfd2..2d7174b99 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -26,6 +26,8 @@
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
++import("//config.gni")
++
+ config("freetype_config") {
+   include_dirs = [
+     "include",
+@@ -161,6 +163,12 @@ static_library("freetypelite") {
+     ]
+   }
+ 
++  if (defined(freetype2_lite_enable_font_variant) && freetype2_lite_enable_font_variant) {
++    defines += [
++      "FREETYPE_LITE_ENABLE_FONT_VARIANT=1",
++    ]
++  }
++
+   public_configs = [
+     ":freetypelite_config",
+   ]
+diff --git a/include/lynx_config/ftoption.h b/include/lynx_config/ftoption.h
+index afe06c03f..d9966e9b2 100644
+--- a/include/lynx_config/ftoption.h
++++ b/include/lynx_config/ftoption.h
+@@ -554,7 +554,9 @@ FT_BEGIN_HEADER
+   /*   Do not #undef this macro here, since the build system might         */
+   /*   define it for certain configurations only.                          */
+   /*                                                                       */
++#if FREETYPE_LITE_ENABLE_FONT_VARIANT
+ #define TT_CONFIG_OPTION_BYTECODE_INTERPRETER
++#endif
+ 
+   /*************************************************************************/
+   /*                                                                       */
+@@ -651,7 +653,9 @@ FT_BEGIN_HEADER
+   /* and avar tables).  This has many similarities to Type 1 Multiple      */
+   /* Masters support.                                                      */
+   /*                                                                       */
++#if FREETYPE_LITE_ENABLE_FONT_VARIANT
+ #define TT_CONFIG_OPTION_GX_VAR_SUPPORT
++#endif
+ 
+   /*************************************************************************/
+   /*                                                                       */
 diff --git a/src/truetype/ttgload.c b/src/truetype/ttgload.c
 index b656ccf04..53455f490 100644
 --- a/src/truetype/ttgload.c
@@ -1045,5 +4467,179 @@ index b656ccf04..53455f490 100644
  
  
 -- 
-2.49.0
+2.50.1 (Apple Git-155)
+
+
+From 56a9388194a1b0c1e4dcde18454c3f68424ba44e Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Mon, 23 Sep 2024 10:07:55 +0800
+Subject: [PATCH 08/10] Add a new target for skity to enable font variants
+
+---
+ BUILD.gn | 46 ++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 46 insertions(+)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 2d7174b99..4008e31a9 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -173,3 +173,49 @@ static_library("freetypelite") {
+     ":freetypelite_config",
+   ]
+ }
++
++static_library("freetypelite_variants") {
++  sources = [
++    "src/base/ftbase.c",
++    "src/base/ftbase.h",
++    "src/base/ftbbox.c",
++    "src/base/ftbitmap.c",
++    "src/base/ftdebug.c",
++    "src/base/ftfstype.c",
++    "src/base/ftglyph.c",
++    "src/base/ftinit.c",
++    "src/base/ftmm.c",
++    "src/base/ftstroke.c",
++    "src/base/ftsystem.c",
++    "src/base/fttype1.c",
++    "src/cff/cff.c",
++    "src/gzip/ftgzip.c",
++    "src/psaux/psaux.c",
++    "src/pshinter/pshinter.c",
++    "src/psnames/psnames.c",
++    "src/sfnt/sfnt.c",
++    "src/smooth/smooth.c",
++    "src/truetype/truetype.c",
++  ]
++
++  deps = [
++    "//third_party/nanopng",
++  ]
++
++  defines = [
++    "FREETYPE_STATIC_LIB=1",
++    "FREETYPE_LITE_ENABLE_FONT_VARIANT=1",
++  ]
++
++  if (defined(use_system_zlib) && use_system_zlib) {
++    libs = [ "z" ]
++  } else {
++    deps += [
++      "//third_party/zlib",
++    ]
++  }
++
++  public_configs = [
++    ":freetypelite_config",
++  ]
++}
+-- 
+2.50.1 (Apple Git-155)
+
+
+From 0b889529eddf431193eb5242daad898b911c20f6 Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Wed, 27 Aug 2025 21:07:42 +0800
+Subject: [PATCH 09/10] [infra] Add compile options for msvc
+
+---
+ CMakeLists-Skity.txt | 23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists-Skity.txt b/CMakeLists-Skity.txt
+index fb9554d56..0ee8b5eee 100644
+--- a/CMakeLists-Skity.txt
++++ b/CMakeLists-Skity.txt
+@@ -49,11 +49,22 @@ target_compile_definitions(
+     DARWIN_NO_CARBON=1
+ )
+ 
+-target_compile_options(
+-    freetype2
++if (MSVC)
++    target_compile_options(
++        freetype2
+ 
+-    PRIVATE
++        PRIVATE
+ 
+-    -Wno-unused-variable
+-    -Wno-unused-function
+-)
++        /wd4101
++        /wd4189
++    )
++else()
++    target_compile_options(
++        freetype2
++
++        PRIVATE
++
++        -Wno-unused-variable
++        -Wno-unused-function
++    )
++endif()
+-- 
+2.50.1 (Apple Git-155)
+
+
+From 632b5c51dd6342bbfac8102eb5fff7e745d8532f Mon Sep 17 00:00:00 2001
+From: patch <patch@skity.com>
+Date: Sun, 28 Sep 2025 17:01:48 +0800
+Subject: [PATCH 10/10] Hide all symbols when build for skity
+
+---
+ CMakeLists-Skity.txt                    |  2 ++
+ include/freetype/config/public-macros.h | 16 ++++++++++++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/CMakeLists-Skity.txt b/CMakeLists-Skity.txt
+index 0ee8b5eee..321be0842 100644
+--- a/CMakeLists-Skity.txt
++++ b/CMakeLists-Skity.txt
+@@ -44,6 +44,8 @@ target_compile_definitions(
+     PUBLIC
+ 
+     FT2_BUILD_LIBRARY=1
++    FREETYPE_STATIC_LIB=1
++
+     FT_CONFIG_OPTIONS_H="${FREETYPE_SOURCE_DIR}/include/skity_config/ftoption.h"
+     FT_CONFIG_MODULES_H="${FREETYPE_SOURCE_DIR}/include/skity_config/ftmodule.h"
+     DARWIN_NO_CARBON=1
+diff --git a/include/freetype/config/public-macros.h b/include/freetype/config/public-macros.h
+index 5bb86b8b0..66ad5e066 100644
+--- a/include/freetype/config/public-macros.h
++++ b/include/freetype/config/public-macros.h
+@@ -63,6 +63,7 @@ FT_BEGIN_HEADER
+    */
+ 
+ #if !FREETYPE_STATIC_LIB
++aaa
+ /* Visual C, mingw */
+ #if defined( _WIN32 )
+ 
+@@ -82,6 +83,21 @@ FT_BEGIN_HEADER
+ #define FT_PUBLIC_FUNCTION_ATTRIBUTE  __global
+ #endif
+ 
++#else  // FREETYPE_STATIC_LIB
++  /* Visual C, mingw */
++  #if defined( _WIN32 )
++  #define FT_PUBLIC_FUNCTION_ATTRIBUTE  /* empty */
++
++    /* gcc, clang */
++  #elif ( defined( __GNUC__ ) && __GNUC__ >= 4 ) || defined( __clang__ )
++  #define FT_PUBLIC_FUNCTION_ATTRIBUTE  \
++            __attribute__(( visibility( "hidden" ) ))
++
++    /* Sun */
++  #elif defined( __SUNPRO_C ) && __SUNPRO_C >= 0x550
++  #define FT_PUBLIC_FUNCTION_ATTRIBUTE  __hidden
++  #endif
++
+ #endif  // FREETYPE_STATIC_LIB
+ 
+ #ifndef FT_PUBLIC_FUNCTION_ATTRIBUTE
+-- 
+2.50.1 (Apple Git-155)
 


### PR DESCRIPTION
When statically compiling FreeType into Skity, its symbols should not be exposed; otherwise, conflicts may occur if other dynamic libraries also expose FreeType symbols globally.