### PR TITLE
fix(webgpu): fix text rendering not working in WebGPU

### DIFF
--- a/src/gpu/web/gpu_texture_web.hpp
+++ b/src/gpu/web/gpu_texture_web.hpp
@@ -21,6 +21,8 @@ class GPUTextureWEB : public GPUTexture {
 
   WGPUTextureView GetTextureView();
 
+  WGPUTexture GetTexture() const { return texture_; }
+
   static std::shared_ptr<GPUTexture> Create(WGPUDevice device,
                                             const GPUTextureDescriptor& desc);
 

--- a/src/render/hw/draw/fragment/wgsl_text_fragment.hpp
+++ b/src/render/hw/draw/fragment/wgsl_text_fragment.hpp
@@ -35,16 +35,21 @@ class WGSLTextFragment : public HWWGSLFragment {
        var texture_uv        : vec2<f32> = vec2<f32>(uv.x / f32(texture_dimension.x),
                                                      uv.y / f32(texture_dimension.y));
 
+        var color1 : vec4<f32> = textureSample(uFontTexture0, uSampler, texture_uv);
+        var color2 : vec4<f32> = textureSample(uFontTexture1, uSampler, texture_uv);
+        var color3 : vec4<f32> = textureSample(uFontTexture2, uSampler, texture_uv);
+        var color4 : vec4<f32> = textureSample(uFontTexture3, uSampler, texture_uv);
+
        if font_index == 0 {
-         return textureSample(uFontTexture0, uSampler, texture_uv);
+         return color1;
        } else if font_index == 1 {
-         return textureSample(uFontTexture1, uSampler, texture_uv);
+         return color2;
        } else if font_index == 2 {
-         return textureSample(uFontTexture2, uSampler, texture_uv);
+         return color3;
        } else if font_index == 3 {
-         return textureSample(uFontTexture3, uSampler, texture_uv);
+         return color4;
        } else {
-         return textureSample(uFontTexture0, uSampler, texture_uv);
+         return color1;
        }
     }
   )";

--- a/src/render/text/atlas/atlas_texture.cc
+++ b/src/render/text/atlas/atlas_texture.cc
@@ -49,7 +49,8 @@ void AtlasTexture::InitTexture() {
       break;
   }
   descriptor.usage =
-      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding) |
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopyDst);
   descriptor.storage_mode = GPUTextureStorageMode::kPrivate;
   texture_ = gpu_device_->CreateTexture(descriptor);
   valid_texture_ = true;


### PR DESCRIPTION
* support copy buffer to texture in GPUBlitpassWEB
* fix shader compile error in pure WGSL environment
* add CopyDst flag in atlas texture for glyph cache