### PR TITLE
fix(webgpu): fallback to use copy buffer when direct update texture

### DIFF
--- a/src/gpu/web/gpu_context_impl_web.cc
+++ b/src/gpu/web/gpu_context_impl_web.cc
@@ -84,7 +84,9 @@ std::shared_ptr<GPUTexture> GPUContextImplWEB::OnWrapTexture(
   // add ref for the texture
   wgpuTextureAddRef(web_info->texture);
 
-  auto texture = std::make_shared<GPUTextureWEB>(descriptor, web_info->texture);
+  auto texture = std::make_shared<GPUTextureWEB>(
+      descriptor, dynamic_cast<GPUDeviceWEB *>(this->GetGPUDevice()),
+      web_info->texture);
 
   texture->SetRelease(callback, user_data);
 

--- a/src/gpu/web/gpu_device_web.cc
+++ b/src/gpu/web/gpu_device_web.cc
@@ -86,7 +86,7 @@ std::shared_ptr<GPUSampler> GPUDeviceWEB::CreateSampler(
 
 std::shared_ptr<GPUTexture> GPUDeviceWEB::CreateTexture(
     const GPUTextureDescriptor& desc) {
-  return GPUTextureWEB::Create(device_, desc);
+  return GPUTextureWEB::Create(this, desc);
 }
 
 std::shared_ptr<GPUShaderModule> GPUDeviceWEB::CreateShaderModule(

--- a/src/gpu/web/gpu_device_web.hpp
+++ b/src/gpu/web/gpu_device_web.hpp
@@ -50,6 +50,8 @@ class GPUDeviceWEB : public GPUDevice {
   std::shared_ptr<GPUShaderModule> CreateShaderModule(
       const GPUShaderModuleDescriptor& desc) override;
 
+  WGPUDevice GetDevice() const { return device_; }
+
  private:
   WGPUDevice device_;
   WGPUQueue queue_;

--- a/src/gpu/web/gpu_texture_web.hpp
+++ b/src/gpu/web/gpu_texture_web.hpp
@@ -11,25 +11,30 @@
 
 namespace skity {
 
-class GPUTextureWEB : public GPUTexture {
+class GPUDeviceWEB;
+
+class GPUTextureWEB : public GPUTexture,
+                      public std::enable_shared_from_this<GPUTextureWEB> {
  public:
-  GPUTextureWEB(const GPUTextureDescriptor& descriptor, WGPUTexture texture);
+  GPUTextureWEB(const GPUTextureDescriptor& descriptor, GPUDeviceWEB* device,
+                WGPUTexture texture);
 
   ~GPUTextureWEB() override;
 
   size_t GetBytes() const override;
 
   void UploadData(uint32_t offset_x, uint32_t offset_y, uint32_t width,
-                  uint32_t height, void* data) override {}
+                  uint32_t height, void* data) override;
 
   WGPUTextureView GetTextureView();
 
   WGPUTexture GetTexture() const { return texture_; }
 
-  static std::shared_ptr<GPUTexture> Create(WGPUDevice device,
+  static std::shared_ptr<GPUTexture> Create(GPUDeviceWEB* device,
                                             const GPUTextureDescriptor& desc);
 
  private:
+  GPUDeviceWEB* device_ = nullptr;
   WGPUTexture texture_ = nullptr;
   WGPUTextureView texture_view_ = nullptr;
 };

--- a/src/render/hw/web/web_root_layer.cc
+++ b/src/render/hw/web/web_root_layer.cc
@@ -37,7 +37,7 @@ void WebRootLayer::PrepareAttachments(HWDrawContext *context) {
 
   wgpuTextureAddRef(
       texture_);  // release will be called when GPUTextureWEB delete
-  color_attachment_ = std::make_shared<GPUTextureWEB>(desc, texture_);
+  color_attachment_ = std::make_shared<GPUTextureWEB>(desc, nullptr, texture_);
 }
 
 void WebRootLayer::PrepareRenderPassDesc(HWDrawContext *context) {


### PR DESCRIPTION
WebGPU does not support direct upload texture content from CPU.
So fallback to use command queue and copy buffer in UploadData function