### PR TITLE
fix(webgpu): fix memory leak in WebGPU backend

### DIFF
--- a/src/gpu/web/gpu_command_buffer_web.cc
+++ b/src/gpu/web/gpu_command_buffer_web.cc
@@ -92,6 +92,8 @@ bool GPUCommandBufferWEB::Submit() {
                   .userdata2 = nullptr,
               });
 
+  wgpuCommandBufferRelease(command_buffer);
+
   return true;
 }
 

--- a/src/gpu/web/gpu_render_pass_web.cc
+++ b/src/gpu/web/gpu_render_pass_web.cc
@@ -190,6 +190,7 @@ void GPURenderPassWEB::EncodeCommands(std::optional<GPUViewport> viewport,
   }
 
   wgpuRenderPassEncoderEnd(render_pass);
+  wgpuRenderPassEncoderRelease(render_pass);
 }
 
 WGPURenderPassEncoder GPURenderPassWEB::BeginRenderPass() {
@@ -296,6 +297,8 @@ void GPURenderPassWEB::SetupBindGroup(WGPURenderPassEncoder render_pass,
                                       nullptr);
 
     command_buffer_->RecordBindGroup(bind_group);
+
+    wgpuBindGroupLayoutRelease(layout);
   }
 }
 

--- a/src/gpu/web/gpu_surface_web.cc
+++ b/src/gpu/web/gpu_surface_web.cc
@@ -11,9 +11,7 @@ namespace skity {
 
 GPUSurfaceImplWEB::GPUSurfaceImplWEB(const GPUSurfaceDescriptor& desc,
                                      GPUContextImpl* ctx, WGPUTexture texture)
-    : GPUSurfaceImpl(desc, ctx), texture_(texture) {
-  wgpuTextureAddRef(texture_);
-}
+    : GPUSurfaceImpl(desc, ctx), texture_(texture) {}
 
 GPUSurfaceImplWEB::~GPUSurfaceImplWEB() { wgpuTextureRelease(texture_); }
 


### PR DESCRIPTION
Needs to release WGPUCommandBuffer, RenderPassEncoder and BindGroupLayout during rendering. 
These are all temporary objects