### PR TITLE
fix(webgpu): fix validation error caused by texture upload

### DIFF
--- a/src/gpu/texture_manager.cc
+++ b/src/gpu/texture_manager.cc
@@ -93,7 +93,8 @@ void TextureManager::UploadTextureImage(const TextureImpl& texture,
         descriptor.height = pixmap->Height();
         descriptor.format = static_cast<GPUTextureFormat>(format);
         descriptor.usage =
-            static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
+            static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding) |
+            static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopyDst);
         descriptor.storage_mode = GPUTextureStorageMode::kHostVisible;
         auto gpu_texture = device->CreateTexture(descriptor);
         gpu_texture->UploadData(0, 0, pixmap->Width(), pixmap->Height(),


### PR DESCRIPTION
WebGPU spec requires the the width of buffer must be 256 bytes aligned.

And the texture must contains GPUTextureUsage.COPY_DST in it's usage flags.