### PR TITLE
fix(gl): fix uniform block size not match driver request

### DIFF
--- a/module/wgx/wgsl/type_definition.cpp
+++ b/module/wgx/wgsl/type_definition.cpp
@@ -205,7 +205,9 @@ StructDefinition::StructDefinition(const std::string_view& name,
     offset += member->type->size;
   }
 
-  this->size = round_up(this->alignment, offset);
+  // round up size to 16 bytes to make sure buffer is big enough for all GPU
+  // validations
+  this->size = round_up(16, offset);
 }
 
 bool StructDefinition::SetData(const void* data, size_t size) {


### PR DESCRIPTION
When target on GL/GLES or webgl, the struct will be wraped in a generated uniform block to prevent name conflict.
But this will cause
the final used block size may round up by 16 bytes by std140 layout rules.
To prevent generate gl error when bind uniform block, make sure all struct size is round up by 16 bytes