### PR TITLE
fix(windows): fallback to use wuffs 0.3

### DIFF
--- a/module/codec/src/codec/wuffs/wuffs_module.hpp
+++ b/module/codec/src/codec/wuffs/wuffs_module.hpp
@@ -9,7 +9,7 @@
 #include <skity/codec/codec.hpp>
 
 #define WUFFS_BASE__HAVE_UNIQUE_PTR  // use std::unique_ptr
-#include "wuffs-v0.4.c"
+#include "wuffs-v0.3.c"              // NOLINT
 
 namespace skity {
 


### PR DESCRIPTION
use stable release wuffs to prevent unexpect compile break in windows