### PR TITLE
ci: optimize cmake installation in MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,14 @@ jobs:
         steps:
           - name: Download Source
             uses: actions/checkout@v4.2.2
-          - name: Sync Dependencies
-            run: |
-                ./tools/hab sync -f
-          - name: Setup cmake
-            run: |
-                brew install cmake
+          - name: Install Common Dependencies
+            uses: ./.github/actions/sync-deps
+            with:
+              cache-backend: 'lynx-infra'
           - name: Run iOS build
             run: |
+                export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
+                echo "PATH=$PATH" >> "$GITHUB_ENV"
                 cmake -B out/cmake_ios_release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_SYSTEM_NAME=iOS -DSKITY_MTL_BACKEND=ON -DSKITY_CT_FONT=ON -DSKITY_CODEC_MODULE=OFF
                 cmake --build out/cmake_ios_release
           - name: check build xcframework
@@ -182,11 +182,9 @@ jobs:
             uses: ./.github/actions/sync-deps
             with:
               cache-backend: 'lynx-infra'
-          - name: Setup cmake
-            run: |
-                brew install cmake
           - name: Build And Test
             run: |
+                export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
                 cmake -B out/cmake_golden_test -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DSKITY_MTL_BACKEND=ON -DSKITY_TEST=ON -DSKITY_GOLDEN_GUI=OFF
                 cmake --build out/cmake_golden_test --target skity_golden_test_shape skity_golden_test_text
                 export MTL_DEBUG_LAYER=1
@@ -204,11 +202,9 @@ jobs:
             uses: ./.github/actions/sync-deps
             with:
               cache-backend: 'lynx-infra'
-          - name: Setup cmake
-            run: |
-                brew install cmake
           - name: Build And Test
             run: |
+                export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
                 cmake -B out/cmake_golden_test -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DSKITY_MTL_BACKEND=ON -DSKITY_TEST=ON -DSKITY_GOLDEN_GUI=OFF -DSKITY_CT_FONT=ON
                 cmake --build out/cmake_golden_test --target skity_golden_test_text
                 export MTL_DEBUG_LAYER=1

--- a/hab/DEPS.ci
+++ b/hab/DEPS.ci
@@ -5,6 +5,9 @@ system = platform.system().lower()
 machine = platform.machine().lower()
 machine = "x86_64" if machine == "amd64" else machine
 
+cmake_win_url = "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip"
+cmake_mac_url = "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-macos-universal.tar.gz"
+
 deps = {
    'buildtools/llvm': {
         "type": "http",
@@ -15,10 +18,10 @@ deps = {
     },
     'buildtools/cmake': {
         "type": "http",
-        "url" : "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip",
+        "url" : cmake_win_url if system == 'windows' else cmake_mac_url,
         "ignore_in_git": True,
         "decompress": True,
-        "condition": system in ['windows'],
+        "condition": system in ['windows', 'darwin'],
     },
     'buildtools/ninja': {
         "type": "http",


### PR DESCRIPTION
replace `brew install cmake` with lcm fetch to speed up the cmake installation for all tasks running on MacOS