### PR TITLE
feat(canvas)!: Remove deprecated API from `Canvas`

### DIFF
--- a/include/skity/recorder/recording_canvas.hpp
+++ b/include/skity/recorder/recording_canvas.hpp
@@ -62,7 +62,6 @@ class SKITY_API RecordingCanvas : public Canvas {
   void OnFlush() override;
   uint32_t OnGetWidth() const override;
   uint32_t OnGetHeight() const override;
-  void OnUpdateViewport(uint32_t width, uint32_t height) override;
 
  private:
   void AccumulateOpBounds(const Rect& raw_bounds, const Paint* paint);

--- a/include/skity/render/canvas.hpp
+++ b/include/skity/render/canvas.hpp
@@ -346,11 +346,7 @@ class SKITY_API Canvas {
   void DrawGlyphs(int count, const GlyphID glyphs[], const float positions_x[],
                   const float positions_y[], const Font& font,
                   const Paint& paint);
-  SKITY_EXPERIMENTAL
-  inline void DrawDebugLine(bool debug) { draw_debug_line_ = debug; }
 
-  SKITY_EXPERIMENTAL
-  void UpdateViewport(uint32_t width, uint32_t height);
   uint32_t Width() const;
   uint32_t Height() const;
 
@@ -425,9 +421,6 @@ class SKITY_API Canvas {
 
   virtual bool NeedGlyphPath(Paint const& paint);
 
-  virtual void OnUpdateViewport(uint32_t width, uint32_t height) = 0;
-  inline bool IsDrawDebugLine() const { return draw_debug_line_; }
-
   virtual CanvasState* GetCanvasState() const { return canvas_state_.get(); }
 
   void CalculateGlobalClipBounds(const Rect& local_clip_bounds, ClipOp op);
@@ -442,7 +435,6 @@ class SKITY_API Canvas {
 
  private:
   int32_t save_count_ = 1;
-  bool draw_debug_line_ = false;
   std::vector<Rect> global_clip_bounds_stack_;
   bool tracing_canvas_state_ = true;
   std::unique_ptr<CanvasState> canvas_state_;

--- a/module/io/src/record/record_playback.hpp
+++ b/module/io/src/record/record_playback.hpp
@@ -86,7 +86,6 @@ class RecordPlayback : public Canvas {
   void OnFlush() override {}
   uint32_t OnGetWidth() const override { return width_; }
   uint32_t OnGetHeight() const override { return height_; }
-  void OnUpdateViewport(uint32_t width, uint32_t height) override {}
 
  private:
   bool ParseStream(ReadStream& stream, TypefaceSet* typeface_set,

--- a/src/recorder/recording_canvas.cc
+++ b/src/recorder/recording_canvas.cc
@@ -161,9 +161,6 @@ void RecordingCanvas::OnResetMatrix() { Push<ResetMatrixOp>(); }
 void RecordingCanvas::OnFlush() {}
 uint32_t RecordingCanvas::OnGetWidth() const { return 0; }
 uint32_t RecordingCanvas::OnGetHeight() const { return 0; }
-void RecordingCanvas::OnUpdateViewport(uint32_t width, uint32_t height) {
-  // Do nothing since 'Canvas::UpdateViewport' is deprecated.
-}
 
 void RecordingCanvas::AccumulateOpBounds(const Rect& raw_bounds,
                                          const Paint* paint) {

--- a/src/render/canvas.cc
+++ b/src/render/canvas.cc
@@ -387,10 +387,6 @@ void Canvas::DrawGlyphs(int count, const GlyphID *glyphs,
   this->OnDrawGlyphs(count, glyphs, position_x, position_y, font, paint);
 }
 
-void Canvas::UpdateViewport(uint32_t width, uint32_t height) {
-  this->OnUpdateViewport(width, height);
-}
-
 uint32_t Canvas::Width() const { return this->OnGetWidth(); }
 
 uint32_t Canvas::Height() const { return this->OnGetHeight(); }

--- a/src/render/hw/hw_canvas.cc
+++ b/src/render/hw/hw_canvas.cc
@@ -66,8 +66,6 @@ uint32_t HWCanvas::OnGetWidth() const { return surface_->GetWidth(); }
 
 uint32_t HWCanvas::OnGetHeight() const { return surface_->GetHeight(); }
 
-void HWCanvas::OnUpdateViewport(uint32_t width, uint32_t height) {}
-
 void HWCanvas::OnClipRect(const Rect& rect, ClipOp op) {
   SKITY_TRACE_EVENT(HWCanvas_OnClipRect);
 

--- a/src/render/hw/hw_canvas.hpp
+++ b/src/render/hw/hw_canvas.hpp
@@ -79,8 +79,6 @@ class HWCanvas : public Canvas {
 
   uint32_t OnGetHeight() const override;
 
-  void OnUpdateViewport(uint32_t width, uint32_t height) override;
-
  private:
   void Init();
 

--- a/src/render/sw/sw_canvas.cc
+++ b/src/render/sw/sw_canvas.cc
@@ -700,8 +700,6 @@ uint32_t SWCanvas::OnGetWidth() const { return bitmap_->Width(); }
 
 uint32_t SWCanvas::OnGetHeight() const { return bitmap_->Height(); }
 
-void SWCanvas::OnUpdateViewport(uint32_t, uint32_t) {}
-
 std::unique_ptr<SWSpanBrush> SWCanvas::GenerateBrush(
     std::vector<Span> const& spans, skity::Paint const& paint, bool stroke,
     Rect const& bounds) {

--- a/src/render/sw/sw_canvas.hpp
+++ b/src/render/sw/sw_canvas.hpp
@@ -103,8 +103,6 @@ class SWCanvas : public Canvas {
 
   uint32_t OnGetHeight() const override;
 
-  void OnUpdateViewport(uint32_t width, uint32_t height) override;
-
   CanvasState* GetCanvasState() const override {
     if (parent_canvas_) {
       return parent_canvas_->GetCanvasState();

--- a/test/ut/recorder/display_list_test.cc
+++ b/test/ut/recorder/display_list_test.cc
@@ -63,9 +63,6 @@ class MockCanvas : public skity::Canvas {
   MOCK_METHOD(uint32_t, OnGetWidth, (), (const, override));
 
   MOCK_METHOD(uint32_t, OnGetHeight, (), (const, override));
-
-  MOCK_METHOD(void, OnUpdateViewport, (uint32_t width, uint32_t height),
-              (override));
 };
 
 skity::Rect CalculateDisplayListBounds(


### PR DESCRIPTION
BREAKING CHANGE: The following method moved from `Canvas`
* UpdateViewport() no longer used and can be replace with combine translate and scale
* DrawDebugLine() Originally used to assist in debugging the generated GPU vertex positions no needs to put in public API