### PR TITLE
fix(wgx): Fix resolved symbol name cause error in uniform binding

### DIFF
--- a/module/wgx/glsl/ast_printer.cpp
+++ b/module/wgx/glsl/ast_printer.cpp
@@ -1245,6 +1245,12 @@ void AstPrinter::RegisterBindGroupEntry(ast::Var* var) {
     bind_entry->index = ubo_index_;
   } else if (var->type.expr->ident->name == "texture_2d") {
     bind_entry->index = texture_index_;
+    // If target GLSL version not support binding slot in shader, we need to use
+    // reflection name to query the uniform location at runtime. So we needs to
+    // replace the binding name with resolved symbol name.
+    // Only GL backend needs to do this.
+    bind_entry->name =
+        GetOutputName(FindDeclSymbol(var->name), var->name->name);
   }
 }
 


### PR DESCRIPTION
When the target GLSL version does not support binding location in shader source, the name of uniform variable is needed to query uniform location at runtime. So needs to replace the reflection name with resolved symbol name.