### PR TITLE
feat(wgx/glsl): support texture binding slot mapping in GLSL backend

### DIFF
--- a/module/wgx/glsl/ast_printer.cpp
+++ b/module/wgx/glsl/ast_printer.cpp
@@ -586,8 +586,13 @@ void AstPrinter::Visit(ast::Variable* variable) {
 
       if (var->type.expr->ident->name == "texture_2d") {
         RegisterBindGroupEntry(var);
-        texture_index_++;
+
+        if (CanUseSlotBinding()) {
+          // if GLSL supports slot binding for texture, write the layout binding
+          ss_ << "layout ( binding = " << texture_index_ << ") ";
+        }
         ss_ << "uniform ";
+        texture_index_++;
       }
 
       WriteType(var->type);
@@ -905,7 +910,7 @@ void AstPrinter::WriteUniformVariable(ast::Var* var) {
   }
 
   ss_ << "layout ( ";
-  if (CanUseUboSlotBinding()) {
+  if (CanUseSlotBinding()) {
     ss_ << "binding = " << ubo_index_++ << ", ";
   } else {
     ubo_index_++;  // for reflaction
@@ -1188,7 +1193,7 @@ void AstPrinter::WriteMainFunc() {
   ss_ << "}" << std::endl;
 }
 
-bool AstPrinter::CanUseUboSlotBinding() const {
+bool AstPrinter::CanUseSlotBinding() const {
   if (options_.standard == GlslOptions::Standard::kDesktop) {
     return options_.major_version >= 4 && options_.minor_version >= 2;
   } else {

--- a/module/wgx/glsl/ast_printer.h
+++ b/module/wgx/glsl/ast_printer.h
@@ -102,7 +102,7 @@ class AstPrinter : public ast::AstVisitor {
 
   void WriteMainFunc();
 
-  bool CanUseUboSlotBinding() const;
+  bool CanUseSlotBinding() const;
 
   ast::BuiltinAttribute* GetBuiltinAttribute(
       const std::vector<ast::Attribute*>& attrs, const std::string_view& name);

--- a/src/gpu/gl/gpu_render_pass_gl.cc
+++ b/src/gpu/gl/gpu_render_pass_gl.cc
@@ -146,7 +146,7 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
 
     // Bind uniforms
     for (auto& binding : command->uniform_bindings) {
-      if (!pipeline->SupportUBOSlotInShader()) {
+      if (!pipeline->SupportBindingSlotInShader()) {
         GL_CALL(UniformBlockBinding, pipeline->GetProgramId(),
                 pipeline->GetProgram()->GetUniformBlockIndex(binding.name),
                 binding.index);
@@ -187,9 +187,12 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
       track_texture_unit(binding.index);
       texture->Bind();
 
-      GL_CALL(Uniform1i,
-              pipeline->GetProgram()->GetUniformLocation(binding.name),
-              binding.index);
+      if (!pipeline->SupportBindingSlotInShader()) {
+        // only query uniform location if ubo slot binding is not supported
+        GL_CALL(Uniform1i,
+                pipeline->GetProgram()->GetUniformLocation(binding.name),
+                binding.index);
+      }
     }
 
     for (auto& binding : command->sampler_bindings) {

--- a/src/gpu/gl/gpu_render_pipeline_gl.cc
+++ b/src/gpu/gl/gpu_render_pipeline_gl.cc
@@ -69,19 +69,19 @@ GPURenderPipelineGL::GPURenderPipelineGL(
       static_cast<GPUShaderFunctionGL*>(desc.vertex_function.get())
           ->GetGLVersionMinor();
 
-  bool ubo_slot_in_shader = false;
+  bool slot_in_shader = false;
 
   // In OpenGL 4.2 the shader can specify the binding point for the uniform
   // buffer in shader
   // In OpenGL 3.1 the shader can specify the binding point for the
   // uniform buffer in shader
   if (is_gles) {
-    ubo_slot_in_shader = gl_version_major == 3 && gl_version_minor >= 1;
+    slot_in_shader = gl_version_major == 3 && gl_version_minor >= 1;
   } else {
-    ubo_slot_in_shader = gl_version_major == 4 && gl_version_minor >= 2;
+    slot_in_shader = gl_version_major == 4 && gl_version_minor >= 2;
   }
 
-  program_ = std::make_shared<GLProgram>(program, ubo_slot_in_shader);
+  program_ = std::make_shared<GLProgram>(program, slot_in_shader);
 }
 
 GPURenderPipelineGL::GPURenderPipelineGL(

--- a/src/gpu/gl/gpu_render_pipeline_gl.hpp
+++ b/src/gpu/gl/gpu_render_pipeline_gl.hpp
@@ -16,7 +16,7 @@ namespace skity {
 class GLProgram {
  public:
   explicit GLProgram(GLuint program, bool ubo_slot_in_shader)
-      : program_(program), support_ubo_slot_in_shader_(ubo_slot_in_shader) {}
+      : program_(program), support_slot_in_shader_(ubo_slot_in_shader) {}
 
   ~GLProgram();
 
@@ -26,13 +26,13 @@ class GLProgram {
 
   GLuint GetUniformBlockIndex(const std::string name);
 
-  bool SupportUBOSlotInShader() const { return support_ubo_slot_in_shader_; }
+  bool SupportBindingSlotInShader() const { return support_slot_in_shader_; }
 
  private:
   std::unordered_map<std::string, GLuint> uniform_block_indices_;
   std::unordered_map<std::string, GLint> uniform_locations_;
   GLuint program_;
-  bool support_ubo_slot_in_shader_ = false;
+  bool support_slot_in_shader_ = false;
 };
 
 class GPURenderPipelineGL : public GPURenderPipeline {
@@ -52,12 +52,12 @@ class GPURenderPipelineGL : public GPURenderPipeline {
     return GPURenderPipeline::IsValid() && program_->GetProgram() != 0;
   }
 
-  bool SupportUBOSlotInShader() const {
+  bool SupportBindingSlotInShader() const {
     if (program_ == nullptr) {
       return false;
     }
 
-    return program_->SupportUBOSlotInShader();
+    return program_->SupportBindingSlotInShader();
   }
 
  private:

--- a/test/ut/wgx/wgx_backend_name_resolution_test.cc
+++ b/test/ut/wgx/wgx_backend_name_resolution_test.cc
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <wgsl_cross.h>
 
+#include <algorithm>
+
 namespace {
 
 TEST(WgxBackendNameResolutionTest, RewritesGlslConflictingVariableNames) {
@@ -242,6 +244,85 @@ fn fs_main(@location(0) value: vec2<f32>) -> @location(0) vec4<f32> {
   auto fs_glsl = program->WriteToGlsl("fs_main", glsl_options);
   ASSERT_TRUE(fs_glsl.success);
   EXPECT_NE(fs_glsl.content.find("in vec2 wgx_varying_0;"), std::string::npos);
+}
+
+TEST(WgxBackendNameResolutionTest, UsesTextureSlotBindingInGlsl420) {
+  auto program = wgx::Program::Parse(R"(
+@group(0) @binding(1) var tex: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+
+@fragment
+fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+  return textureSample(tex, samp, uv);
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_options.major_version = 4;
+  glsl_options.minor_version = 2;
+
+  auto glsl_result = program->WriteToGlsl("fs_main", glsl_options);
+  ASSERT_TRUE(glsl_result.success);
+  EXPECT_NE(glsl_result.content.find("layout ( binding = 0) uniform sampler2D"),
+            std::string::npos);
+
+  ASSERT_EQ(glsl_result.bind_groups.size(), 1u);
+  auto* group = &glsl_result.bind_groups[0];
+  auto* texture_entry = group->GetEntry(1);
+  auto* sampler_entry = group->GetEntry(2);
+  ASSERT_NE(texture_entry, nullptr);
+  ASSERT_NE(sampler_entry, nullptr);
+  EXPECT_EQ(texture_entry->index, 0u);
+  ASSERT_TRUE(sampler_entry->units.has_value());
+  ASSERT_EQ(sampler_entry->units->size(), 1u);
+  EXPECT_EQ((*sampler_entry->units)[0], 0u);
+}
+
+TEST(WgxBackendNameResolutionTest,
+     CollectsSamplerUnitsWithoutTextureSlotBinding) {
+  auto program = wgx::Program::Parse(R"(
+@group(0) @binding(1) var tex_a: texture_2d<f32>;
+@group(0) @binding(3) var tex_b: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+
+@fragment
+fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+  return textureSample(tex_a, samp, uv) + textureSample(tex_b, samp, uv);
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_options.major_version = 3;
+  glsl_options.minor_version = 3;
+
+  auto glsl_result = program->WriteToGlsl("fs_main", glsl_options);
+  ASSERT_TRUE(glsl_result.success);
+  EXPECT_EQ(glsl_result.content.find("layout ( binding = "), std::string::npos);
+
+  ASSERT_EQ(glsl_result.bind_groups.size(), 1u);
+  auto* group = &glsl_result.bind_groups[0];
+  auto* tex_a_entry = group->GetEntry(1);
+  auto* tex_b_entry = group->GetEntry(3);
+  auto* sampler_entry = group->GetEntry(2);
+  ASSERT_NE(tex_a_entry, nullptr);
+  ASSERT_NE(tex_b_entry, nullptr);
+  ASSERT_NE(sampler_entry, nullptr);
+  EXPECT_EQ(tex_a_entry->index, 0u);
+  EXPECT_EQ(tex_b_entry->index, 1u);
+
+  ASSERT_TRUE(sampler_entry->units.has_value());
+  const auto& units = *sampler_entry->units;
+  EXPECT_EQ(units.size(), 2u);
+  EXPECT_NE(std::find(units.begin(), units.end(), 0u), units.end());
+  EXPECT_NE(std::find(units.begin(), units.end(), 1u), units.end());
 }
 
 }  // namespace


### PR DESCRIPTION
- emit  for texture uniforms when GLSL version supports slot binding

- keep fallback behavior for GLSL versions without slot binding support

- map sampler reflection units from  texture binding indices

- add unit tests covering slot-binding and fallback paths in GLSL backend