### PR TITLE
test: Add new step to run Golden test for GL backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
     osx_metal_golden_test:
         runs-on: lynx-darwin-14-medium
         timeout-minutes: 30
+        env:
+          ANGLE_DEFAULT_PLATFORM: "swiftshader"
         steps:
           - name: Download Source
             uses: actions/checkout@v4.2.2
@@ -182,6 +184,14 @@ jobs:
             uses: ./.github/actions/sync-deps
             with:
               cache-backend: 'lynx-infra'
+          - name: Set Up Environment
+            run: |
+              if [ -z "$DYLD_LIBRARY_PATH" ]; then
+                NEW_DYLD="$GITHUB_WORKSPACE/third_party/libSwAngle/lib"
+              else
+                NEW_DYLD="$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/third_party/libSwAngle/lib"
+              fi
+              echo "DYLD_LIBRARY_PATH=$NEW_DYLD" >> $GITHUB_ENV
           - name: Build And Test
             run: |
                 export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
@@ -191,10 +201,16 @@ jobs:
                 export METAL_DEBUG_ERROR_MODE=1
                 ./out/cmake_golden_test/test/golden/skity_golden_test_shape
                 ./out/cmake_golden_test/test/golden/skity_golden_test_text
+          - name: Run Experimental GL Golden Test
+            continue-on-error: true
+            run: |
+                ./out/cmake_golden_test/test/golden/skity_golden_test_shape --backend gl
 
     osx_metal_golden_test_ct:
         runs-on: lynx-darwin-14-medium
         timeout-minutes: 30
+        env:
+          ANGLE_DEFAULT_PLATFORM: "swiftshader"
         steps:
           - name: Download Source
             uses: actions/checkout@v4.2.2
@@ -202,6 +218,14 @@ jobs:
             uses: ./.github/actions/sync-deps
             with:
               cache-backend: 'lynx-infra'
+          - name: Set Up Environment
+            run: |
+              if [ -z "$DYLD_LIBRARY_PATH" ]; then
+                NEW_DYLD="$GITHUB_WORKSPACE/third_party/libSwAngle/lib"
+              else
+                NEW_DYLD="$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/third_party/libSwAngle/lib"
+              fi
+              echo "DYLD_LIBRARY_PATH=$NEW_DYLD" >> $GITHUB_ENV
           - name: Build And Test
             run: |
                 export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin

--- a/hab/DEPS.dev
+++ b/hab/DEPS.dev
@@ -1,3 +1,7 @@
+import platform
+system = platform.system().lower()
+
+
 deps = {
     "third_party/google_benchmark": {
         "type": "git",
@@ -29,4 +33,11 @@ deps = {
         "ignore_in_git": True,
         "decompress": True,
     },
+    'third_party/libSwAngle': {
+        "type": "http",
+        "url": "https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/skity/libSwAngle_90fb0a.zip",
+        "ignore_in_git": True,
+        "decompress": True,
+        "condition": system in ["darwin"]
+    }
 }

--- a/test/golden/CMakeLists.txt
+++ b/test/golden/CMakeLists.txt
@@ -27,11 +27,26 @@ add_library(skity_golden_test OBJECT
   ${CMAKE_CURRENT_LIST_DIR}/common/mtl/golden_test_env_mtl.mm
   ${CMAKE_CURRENT_LIST_DIR}/common/mtl/golden_texture_mtl.h
   ${CMAKE_CURRENT_LIST_DIR}/common/mtl/golden_texture_mtl.mm
+
+  # GL backend code
+  ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_test_env_gl.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_test_env_gl.cc
+  ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_texture_gl.hpp
 )
 
 target_include_directories(skity_golden_test
   PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_include_directories(skity_golden_test
+  PRIVATE
+  ${CMAKE_SOURCE_DIR}/third_party/libSwAngle/include
+)
+
+target_link_directories(skity_golden_test
+  PUBLIC
+  ${CMAKE_SOURCE_DIR}/third_party/libSwAngle/lib
 )
 
 target_link_libraries(skity_golden_test
@@ -43,6 +58,8 @@ target_link_libraries(skity_golden_test
   "-framework CoreGraphics"
   "-framework ImageIO"
   "-framework CoreServices"
+  EGL
+  GLESv2
 )
 
 target_compile_definitions(skity_golden_test PUBLIC -DDISABLE_SKITY_EXPERIMENTAL_WARNINGS)

--- a/test/golden/README.md
+++ b/test/golden/README.md
@@ -28,10 +28,34 @@ The window provides the following features:
 
 If you want to disable the GUI, you can pass `-DSKITY_GOLDEN_GUI=OFF` to cmake.
 
-After compile, you can run the golden test code by the following command:
+The recommended way to run golden tests is via `tools/test-runner.py`.
+For golden suites, the runner will automatically:
+- set `ANGLE_DEFAULT_PLATFORM=swiftshader`
+- append `<source directory>/third_party/libSwAngle/lib` to `DYLD_LIBRARY_PATH`
+- pass `--backend gl` to the golden executable when `--backend=gl` is specified
+
+```bash
+python3 tools/test-runner.py --suite=golden-shape --build-dir <build directory>
+python3 tools/test-runner.py --suite=golden-text --build-dir <build directory>
+
+# Run the shape golden test with OpenGLES backend
+python3 tools/test-runner.py --suite=golden-shape --backend=gl --build-dir <build directory>
+```
+
+If you want to run the golden executables directly, you still need to set the environment variable `DYLD_LIBRARY_PATH` to the path of the libSwAngle library and the environment variable `ANGLE_DEFAULT_PLATFORM` to `swiftshader` for Angle backend even if running the test case with Metal backend.
+
+```bash
+export ANGLE_DEFAULT_PLATFORM=swiftshader
+export DYLD_LIBRARY_PATH=<source directory>/third_party/libSwAngle/lib
+```
+
+After compile, you can run the golden test executable directly by the following command:
 
 ```bash
 ./<build directory>/test/golden/skity_golden_test_shape
+
+# Run the test case with GL backend
+./<build directory>/test/golden/skity_golden_test_shape --backend gl
 ```
 or
 ```bash

--- a/test/golden/common/gl/golden_test_env_gl.cc
+++ b/test/golden/common/gl/golden_test_env_gl.cc
@@ -1,0 +1,170 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "common/gl/golden_test_env_gl.hpp"
+
+#define EGL_EGLEXT_PROTOTYPES
+#include <EGL/eglext.h>
+#include <GLES3/gl3.h>
+
+#include <skity/gpu/gpu_context_gl.hpp>
+
+#include "common/gl/golden_texture_gl.hpp"
+
+namespace skity {
+namespace testing {
+
+GoldenTestEnvGL::GoldenTestEnvGL() {}
+
+void GoldenTestEnvGL::SetUp() {
+  const EGLint displayAttribs[] = {
+      EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
+      EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE,
+      EGL_PLATFORM_ANGLE_DEVICE_TYPE_SWIFTSHADER_ANGLE, EGL_NONE};
+
+  display_ = eglGetPlatformDisplayEXT(
+      EGL_PLATFORM_ANGLE_ANGLE, (void*)EGL_DEFAULT_DISPLAY, displayAttribs);
+
+  EGLint major, minor;
+  eglInitialize(display_, &major, &minor);
+
+  const EGLint configAttribs[] = {EGL_SURFACE_TYPE,
+                                  EGL_PBUFFER_BIT,
+                                  EGL_RENDERABLE_TYPE,
+                                  EGL_OPENGL_ES3_BIT,
+                                  EGL_RED_SIZE,
+                                  8,
+                                  EGL_GREEN_SIZE,
+                                  8,
+                                  EGL_BLUE_SIZE,
+                                  8,
+                                  EGL_ALPHA_SIZE,
+                                  8,
+                                  EGL_NONE};
+  EGLConfig config;
+  EGLint numConfigs;
+  eglChooseConfig(display_, configAttribs, &config, 1, &numConfigs);
+
+  const EGLint pbufferAttribs[] = {EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE};
+  surface_ = eglCreatePbufferSurface(display_, config, pbufferAttribs);
+
+  const EGLint contextAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+  context_ = eglCreateContext(display_, config, EGL_NO_CONTEXT, contextAttribs);
+  eglMakeCurrent(display_, surface_, surface_, context_);
+
+  GoldenTestEnv::SetUp();
+}
+
+void GoldenTestEnvGL::TearDown() {
+  GoldenTestEnv::TearDown();
+
+  eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  eglDestroySurface(display_, surface_);
+  eglDestroyContext(display_, context_);
+}
+
+std::shared_ptr<GoldenTexture> GoldenTestEnvGL::DisplayListToTexture(
+    DisplayList* dl, uint32_t width, uint32_t height) {
+  eglMakeCurrent(display_, surface_, surface_, context_);
+  // create off screen fbo and texture
+  GLuint fbo = 0;
+  GLuint texture = 0;
+  glGenFramebuffers(1, &fbo);
+  glGenTextures(1, &texture);
+
+  if (fbo == 0 || texture == 0) {
+    auto egl_error = eglGetError();
+    std::cerr << "eglCreatePbufferSurface failed, error: " << std::hex
+              << egl_error << std::endl;
+
+    auto gl_error = glGetError();
+    std::cerr << "glGenFramebuffers failed, error: " << std::hex << gl_error
+              << std::endl;
+
+    return {};
+  }
+
+  glBindTexture(GL_TEXTURE_2D, texture);
+
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         texture, 0);
+
+  auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    std::cerr << "glCheckFramebufferStatus failed, error: " << std::hex
+              << status << std::endl;
+    return {};
+  }
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  GPUSurfaceDescriptorGL surface_desc;
+  surface_desc.backend = GPUBackendType::kOpenGL;
+  surface_desc.width = width;
+  surface_desc.height = height;
+  surface_desc.sample_count = 4;
+  surface_desc.surface_type = GLSurfaceType::kFramebuffer;
+  surface_desc.gl_id = fbo;
+  surface_desc.has_stencil_attachment = false;
+
+  auto surface = GetGPUContext()->CreateSurface(&surface_desc);
+
+  if (!surface) {
+    return {};
+  }
+
+  auto canvas = surface->LockCanvas();
+
+  dl->Draw(canvas);
+
+  canvas->Flush();
+  surface->Flush();
+
+  glFinish();
+
+  auto err = glGetError();
+
+  // read pixels from fbo
+  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  std::vector<uint8_t> pixels(width * height * 4);
+  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  glDeleteFramebuffers(1, &fbo);
+  glDeleteTextures(1, &texture);
+
+  // flip Y in-place
+  std::vector<uint8_t> rowTmpVec(width * 4);
+  for (int y = 0; y < height / 2; y++) {
+    unsigned char* rowA = pixels.data() + y * width * 4;
+    unsigned char* rowB = pixels.data() + (height - 1 - y) * width * 4;
+    std::memcpy(rowTmpVec.data(), rowA, width * 4);
+    std::memcpy(rowA, rowB, width * 4);
+    std::memcpy(rowB, rowTmpVec.data(), width * 4);
+  }
+
+  auto data = Data::MakeWithCopy(pixels.data(), pixels.size());
+
+  auto pixmap = std::make_shared<Pixmap>(std::move(data), width, height,
+                                         AlphaType::kPremul_AlphaType);
+
+  auto image = skity::Image::MakeImage(pixmap, nullptr);
+
+  return std::make_shared<GoldenTextureGL>(std::move(image), std::move(pixmap));
+}
+
+std::unique_ptr<skity::GPUContext> GoldenTestEnvGL::CreateGPUContext() {
+  return GLContextCreate((void*)eglGetProcAddress);
+}
+
+GoldenTestEnv* CreateGoldenTestEnvGL() { return new GoldenTestEnvGL(); }
+
+}  // namespace testing
+}  // namespace skity

--- a/test/golden/common/gl/golden_test_env_gl.hpp
+++ b/test/golden/common/gl/golden_test_env_gl.hpp
@@ -4,35 +4,36 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
+#include <EGL/egl.h>
 
 #include "common/golden_test_env.hpp"
 
 namespace skity {
 namespace testing {
 
-class GoldenTestEnvMTL : public GoldenTestEnv {
+class GoldenTestEnvGL : public GoldenTestEnv {
  public:
-  GoldenTestEnvMTL();
+  GoldenTestEnvGL();
 
-  ~GoldenTestEnvMTL() override = default;
+  ~GoldenTestEnvGL() override = default;
 
-  Backend GetBackend() const override { return Backend::kMetal; }
+  Backend GetBackend() const override { return Backend::kGL; }
+
+  void SetUp() override;
+
+  void TearDown() override;
 
   std::shared_ptr<GoldenTexture> DisplayListToTexture(DisplayList* dl,
                                                       uint32_t width,
                                                       uint32_t height) override;
 
-  id<MTLDevice> GetDevice() const { return device_; }
-
-  id<MTLCommandQueue> GetCommandQueue() const { return command_queue_; }
-
  protected:
   std::unique_ptr<skity::GPUContext> CreateGPUContext() override;
 
  private:
-  id<MTLDevice> device_ = nullptr;
-  id<MTLCommandQueue> command_queue_ = nullptr;
+  EGLDisplay display_ = EGL_NO_DISPLAY;
+  EGLSurface surface_ = EGL_NO_SURFACE;
+  EGLContext context_ = EGL_NO_CONTEXT;
 };
 
 }  // namespace testing

--- a/test/golden/common/gl/golden_texture_gl.hpp
+++ b/test/golden/common/gl/golden_texture_gl.hpp
@@ -1,0 +1,25 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "common/golden_texture.hpp"
+
+namespace skity {
+namespace testing {
+
+class GoldenTextureGL : public GoldenTexture {
+ public:
+  GoldenTextureGL(std::shared_ptr<Image> image, std::shared_ptr<Pixmap> pixmap)
+      : GoldenTexture(std::move(image)), pixmap_(std::move(pixmap)) {}
+  ~GoldenTextureGL() override = default;
+
+  std::shared_ptr<skity::Pixmap> ReadPixels() override { return pixmap_; }
+
+ private:
+  std::shared_ptr<Pixmap> pixmap_;
+};
+
+}  // namespace testing
+}  // namespace skity

--- a/test/golden/common/golden_test_env.cc
+++ b/test/golden/common/golden_test_env.cc
@@ -4,24 +4,59 @@
 
 #include "common/golden_test_env.hpp"
 
+#ifdef SKITY_GOLDEN_GUI
+
+#include <GLFW/glfw3.h>
+
+#endif
+
 namespace skity {
 namespace testing {
 
 GoldenTestEnv* CreateGoldenTestEnvMTL();
+GoldenTestEnv* CreateGoldenTestEnvGL();
 
 GoldenTestEnv* g_golden_test_env = nullptr;
 
-GoldenTestEnv* GoldenTestEnv::GetInstance() {
-  if (g_golden_test_env == nullptr) {
-    g_golden_test_env = CreateGoldenTestEnvMTL();
+GoldenTestEnv* GoldenTestEnv::CreateInstance(Backend backend) {
+  switch (backend) {
+    case Backend::kGL:
+      g_golden_test_env = CreateGoldenTestEnvGL();
+      break;
+    case Backend::kVulkan:
+      break;
+    case Backend::kMetal:
+      g_golden_test_env = CreateGoldenTestEnvMTL();
+      break;
+    default:
+      return nullptr;
   }
 
   return g_golden_test_env;
 }
 
-void GoldenTestEnv::SetUp() { gpu_context_ = CreateGPUContext(); }
+GoldenTestEnv* GoldenTestEnv::GetInstance() { return g_golden_test_env; }
 
-void GoldenTestEnv::TearDown() { gpu_context_.reset(); }
+void GoldenTestEnv::SetUp() {
+#ifdef SKITY_GOLDEN_GUI
+  // Init glfw for all testing case
+  glfwInit();
+  // Metal does not needs GL client api
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+#endif
+
+  gpu_context_ = CreateGPUContext();
+}
+
+void GoldenTestEnv::TearDown() {
+  gpu_context_.reset();
+
+#ifdef SKITY_GOLDEN_GUI
+
+  glfwTerminate();
+
+#endif
+}
 
 }  // namespace testing
 }  // namespace skity

--- a/test/golden/common/golden_test_env.hpp
+++ b/test/golden/common/golden_test_env.hpp
@@ -15,6 +15,12 @@
 namespace skity {
 namespace testing {
 
+enum class Backend {
+  kGL,
+  kVulkan,
+  kMetal,
+};
+
 class GoldenTestEnv : public ::testing::Environment {
  public:
   ~GoldenTestEnv() override = default;
@@ -23,11 +29,14 @@ class GoldenTestEnv : public ::testing::Environment {
 
   void TearDown() override;
 
+  virtual Backend GetBackend() const = 0;
+
   virtual std::shared_ptr<GoldenTexture> DisplayListToTexture(
       DisplayList* dl, uint32_t width, uint32_t height) = 0;
 
-  virtual bool SaveGoldenImage(std::shared_ptr<Pixmap> image,
-                               const char* path) = 0;
+  bool SaveGoldenImage(std::shared_ptr<Pixmap> image, const char* path);
+
+  static GoldenTestEnv* CreateInstance(Backend backend);
 
   static GoldenTestEnv* GetInstance();
 

--- a/test/golden/common/golden_texture.hpp
+++ b/test/golden/common/golden_texture.hpp
@@ -17,7 +17,7 @@ class GoldenTexture {
 
   const std::shared_ptr<Image>& GetImage() const { return image_; }
 
-  std::shared_ptr<skity::Pixmap> ReadPixels();
+  virtual std::shared_ptr<skity::Pixmap> ReadPixels();
 
  private:
   std::shared_ptr<Image> image_;

--- a/test/golden/common/mtl/golden_test_env_mtl.mm
+++ b/test/golden/common/mtl/golden_test_env_mtl.mm
@@ -9,110 +9,10 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <ImageIO/ImageIO.h>
 
-#ifdef SKITY_GOLDEN_GUI
-
-#include <GLFW/glfw3.h>
-
-#endif
-
 #include <iostream>
 
 namespace skity {
 namespace testing {
-
-const char* diff_shader_source = R"(
-  #include <metal_stdlib>
-  #include <simd/simd.h>
-
-  using namespace metal;
-
-  kernel void diff_image(texture2d<float, access::read> source_image    [[texture(0)]],
-                         texture2d<float, access::read> target_image    [[texture(1)]],
-                         texture2d<float, access::write> isolate_image  [[texture(2)]],
-                         texture2d<float, access::write> diff_image     [[texture(3)]],
-                         uint2 gid                                      [[thread_position_in_grid]])
-  {
-    if (gid.x >= source_image.get_width() || gid.y >= source_image.get_height()) {
-      return;
-    }
-
-    float4 source_color = source_image.read(gid);
-    float4 target_color = target_image.read(gid);
-
-    if (source_color.a > 0.001) {
-      source_color.rgb /= source_color.a;
-    }
-
-    float4 diff = abs(source_color - target_color);
-
-    if (diff.x > 0.001 || diff.y > 0.001 || diff.z > 0.001 || diff.w > 0.001) {
-      float4 diff_image_color = float4(abs(float3(1.0, 1.0, 1.0) - target_color.rgb), 1.0);
-
-      isolate_image.write(diff_image_color, gid);
-      diff_image.write(diff_image_color, gid);
-    } else {
-      isolate_image.write(float4(0.0, 0.0, 0.0, 0.0), gid);
-
-      diff_image.write(target_color, gid);
-    }
-  }
-)";
-
-void GoldenTestEnvMTL::SetUp() {
-  GoldenTestEnv::SetUp();
-
-  NSString* diff_shader_source_string = [NSString stringWithUTF8String:diff_shader_source];
-
-  MTLCompileOptions* compileOptions = [MTLCompileOptions new];
-  if (@available(macOS 10.13, iOS 11.0, *)) {
-    compileOptions.languageVersion = MTLLanguageVersion2_0;
-  }
-
-  NSError* error = nil;
-
-  id<MTLLibrary> library = [device_ newLibraryWithSource:diff_shader_source_string
-                                                 options:compileOptions
-                                                   error:&error];
-
-  if (error != nil) {
-    std::cerr << "diff shader compile error: " << error.localizedDescription.UTF8String
-              << std::endl;
-  }
-
-  if (library == nil) {
-    return;
-  }
-
-  diff_pipeline_state_ =
-      [device_ newComputePipelineStateWithFunction:[library newFunctionWithName:@"diff_image"]
-                                             error:&error];
-  if (error != nil) {
-    std::cerr << "diff pipeline state create error: " << error.localizedDescription.UTF8String
-              << std::endl;
-  }
-
-  if (diff_pipeline_state_ == nil) {
-    std::cerr << "Failed create diff pipeline" << std::endl;
-  }
-
-#ifdef SKITY_GOLDEN_GUI
-  // Init glfw for all testing case
-  glfwInit();
-  // Metal does not needs GL client api
-  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-#endif
-}
-
-void GoldenTestEnvMTL::TearDown() {
-  GoldenTestEnv::TearDown();
-  diff_pipeline_state_ = nil;
-
-#ifdef SKITY_GOLDEN_GUI
-
-  glfwTerminate();
-
-#endif
-}
 
 GoldenTestEnv* CreateGoldenTestEnvMTL() { return new GoldenTestEnvMTL(); }
 
@@ -178,7 +78,7 @@ std::shared_ptr<GoldenTexture> GoldenTestEnvMTL::DisplayListToTexture(DisplayLis
   return std::make_shared<GoldenTextureMTL>(std::move(image), texture);
 }
 
-bool GoldenTestEnvMTL::SaveGoldenImage(std::shared_ptr<Pixmap> image, const char* path) {
+bool GoldenTestEnv::SaveGoldenImage(std::shared_ptr<Pixmap> image, const char* path) {
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
   CGContextRef context =
       CGBitmapContextCreate((void*)image->Addr(), image->Width(), image->Height(), 8,

--- a/test/golden/golden_test.cc
+++ b/test/golden/golden_test.cc
@@ -6,11 +6,55 @@
 
 #include "common/golden_test_env.hpp"
 
-int main(int argc, char *argv[]) {
+#ifdef SKITY_GOLDEN_GUI
+namespace skity {
+namespace testing {
+
+::testing::Environment* CreateDiffEnv();
+
+}
+}  // namespace skity
+
+#endif
+
+int main(int argc, char* argv[]) {
+  /**
+   * If --backend="gl/vulkan/metal" is provided, then create the test env for
+   * that backend. Otherwise, create the test env for Metal as the default
+   * backend.
+   */
+
+  skity::testing::Backend backend = skity::testing::Backend::kMetal;
+
+  if (argc > 1) {
+    // find the backend in the command line arguments
+    for (int i = 1; i < argc; ++i) {
+      if (strcmp(argv[i], "--backend") == 0) {
+        if (strcmp(argv[i + 1], "gl") == 0) {
+          backend = skity::testing::Backend::kGL;
+          break;
+        } else if (strcmp(argv[i + 1], "vulkan") == 0) {
+          backend = skity::testing::Backend::kVulkan;
+          break;
+        } else if (strcmp(argv[i + 1], "metal") == 0) {
+          backend = skity::testing::Backend::kMetal;
+          break;
+        }
+        break;
+      }
+    }
+  }
+
   testing::InitGoogleTest(&argc, argv);
 
   testing::AddGlobalTestEnvironment(
-      skity::testing::GoldenTestEnv::GetInstance());
+      skity::testing::GoldenTestEnv::CreateInstance(backend));
+
+#ifdef SKITY_GOLDEN_GUI
+  // GUI needs Metal compute pipeline to generate diff images
+  // Create a seperate test env to hold the compute pipeline for GUI
+  testing::AddGlobalTestEnvironment(skity::testing::CreateDiffEnv());
+#endif
 
   return RUN_ALL_TESTS();
 }

--- a/test/golden/playground/CMakeLists.txt
+++ b/test/golden/playground/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(skity_golden_test
   ${CMAKE_CURRENT_LIST_DIR}/window.hpp
 
   # Metal backend
+  ${CMAKE_CURRENT_LIST_DIR}/mtl/diff_env_mtl.h
+  ${CMAKE_CURRENT_LIST_DIR}/mtl/diff_env_mtl.mm
   ${CMAKE_CURRENT_LIST_DIR}/mtl/window_mtl.h
   ${CMAKE_CURRENT_LIST_DIR}/mtl/window_mtl.mm
 )

--- a/test/golden/playground/mtl/diff_env_mtl.h
+++ b/test/golden/playground/mtl/diff_env_mtl.h
@@ -1,0 +1,45 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <Metal/Metal.h>
+#include <gtest/gtest.h>
+
+#include <skity/gpu/gpu_context.hpp>
+
+namespace skity {
+namespace testing {
+
+class DiffEnvMtlTest : public ::testing::Environment {
+ public:
+  DiffEnvMtlTest(id<MTLDevice> device, id<MTLCommandQueue> command_queue)
+      : device_(device), command_queue_(command_queue) {}
+
+  ~DiffEnvMtlTest() = default;
+
+  static DiffEnvMtlTest* GetInstance();
+
+  void SetUp() override;
+  void TearDown() override;
+
+  id<MTLDevice> GetDevice() const { return device_; }
+  id<MTLCommandQueue> GetCommandQueue() const { return command_queue_; }
+
+  id<MTLComputePipelineState> GetComputePipelineState() const {
+    return diff_pipeline_state_;
+  }
+
+  GPUContext* GetGPUContext() const { return gpu_context_.get(); }
+
+ private:
+  id<MTLDevice> device_ = nullptr;
+  id<MTLCommandQueue> command_queue_ = nullptr;
+  id<MTLComputePipelineState> diff_pipeline_state_ = nullptr;
+
+  std::unique_ptr<GPUContext> gpu_context_;
+};
+
+}  // namespace testing
+}  // namespace skity

--- a/test/golden/playground/mtl/diff_env_mtl.mm
+++ b/test/golden/playground/mtl/diff_env_mtl.mm
@@ -1,0 +1,120 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "playground/mtl/diff_env_mtl.h"
+
+#include <skity/gpu/gpu_context_mtl.h>
+#include "common/mtl/golden_test_env_mtl.h"
+
+namespace skity {
+namespace testing {
+
+DiffEnvMtlTest* g_diff_env_mtl_test = nullptr;
+
+DiffEnvMtlTest* DiffEnvMtlTest::GetInstance() { return g_diff_env_mtl_test; }
+
+::testing::Environment* CreateDiffEnv() {
+  auto env = GoldenTestEnv::GetInstance();
+
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> command_queue = nil;
+
+  if (env->GetBackend() == Backend::kMetal) {
+    auto env_mtl = static_cast<GoldenTestEnvMTL*>(env);
+
+    device = env_mtl->GetDevice();
+    command_queue = env_mtl->GetCommandQueue();
+  } else {
+    device = MTLCreateSystemDefaultDevice();
+
+    command_queue = [device newCommandQueue];
+  }
+
+  g_diff_env_mtl_test = new DiffEnvMtlTest(device, command_queue);
+
+  return g_diff_env_mtl_test;
+}
+
+void DiffEnvMtlTest::SetUp() {
+  const char* diff_shader_source = R"(
+  #include <metal_stdlib>
+  #include <simd/simd.h>
+
+  using namespace metal;
+
+  kernel void diff_image(texture2d<float, access::read> source_image    [[texture(0)]],
+                         texture2d<float, access::read> target_image    [[texture(1)]],
+                         texture2d<float, access::write> isolate_image  [[texture(2)]],
+                         texture2d<float, access::write> diff_image     [[texture(3)]],
+                         uint2 gid                                      [[thread_position_in_grid]])
+  {
+    if (gid.x >= source_image.get_width() || gid.y >= source_image.get_height()) {
+      return;
+    }
+
+    float4 source_color = source_image.read(gid);
+    float4 target_color = target_image.read(gid);
+
+    if (source_color.a > 0.001) {
+      source_color.rgb /= source_color.a;
+    }
+
+    float4 diff = abs(source_color - target_color);
+
+    if (diff.x > 0.001 || diff.y > 0.001 || diff.z > 0.001 || diff.w > 0.001) {
+      float4 diff_image_color = float4(abs(float3(1.0, 1.0, 1.0) - target_color.rgb), 1.0);
+
+      isolate_image.write(diff_image_color, gid);
+      diff_image.write(diff_image_color, gid);
+    } else {
+      isolate_image.write(float4(0.0, 0.0, 0.0, 0.0), gid);
+
+      diff_image.write(target_color, gid);
+    }
+  }
+)";
+
+  NSString* diff_shader_source_string = [NSString stringWithUTF8String:diff_shader_source];
+
+  MTLCompileOptions* compileOptions = [MTLCompileOptions new];
+  if (@available(macOS 10.13, iOS 11.0, *)) {
+    compileOptions.languageVersion = MTLLanguageVersion2_0;
+  }
+
+  NSError* error = nil;
+
+  id<MTLLibrary> library = [device_ newLibraryWithSource:diff_shader_source_string
+                                                 options:compileOptions
+                                                   error:&error];
+
+  if (error != nil) {
+    std::cerr << "diff shader compile error: " << error.localizedDescription.UTF8String
+              << std::endl;
+  }
+
+  if (library == nil) {
+    return;
+  }
+
+  diff_pipeline_state_ =
+      [device_ newComputePipelineStateWithFunction:[library newFunctionWithName:@"diff_image"]
+                                             error:&error];
+  if (error != nil) {
+    std::cerr << "diff pipeline state create error: " << error.localizedDescription.UTF8String
+              << std::endl;
+  }
+
+  if (diff_pipeline_state_ == nil) {
+    std::cerr << "Failed create diff pipeline" << std::endl;
+  }
+
+  if (GoldenTestEnv::GetInstance()->GetBackend() != Backend::kMetal) {
+    gpu_context_ = MTLContextCreate(device_, command_queue_);
+  }
+}
+
+void DiffEnvMtlTest::TearDown() { diff_pipeline_state_ = nil; }
+
+}  // namespace testing
+}  // namespace skity

--- a/test/golden/playground/mtl/window_mtl.h
+++ b/test/golden/playground/mtl/window_mtl.h
@@ -35,7 +35,9 @@ class WindowMTL : public Window {
   void DrawImageInCenter(skity::Canvas* canvas,
                          const std::shared_ptr<Image>& image, Rect rect);
 
- private:
+  id<MTLTexture> GetTextureFromGolden(
+      const std::shared_ptr<GoldenTexture>& texture);
+
   CAMetalLayer* metal_layer_ = nil;
 
   id<MTLDevice> device_ = nil;

--- a/test/golden/playground/mtl/window_mtl.mm
+++ b/test/golden/playground/mtl/window_mtl.mm
@@ -13,6 +13,7 @@
 
 #include "common/mtl/golden_test_env_mtl.h"
 #include "common/mtl/golden_texture_mtl.h"
+#include "playground/mtl/diff_env_mtl.h"
 
 namespace skity {
 namespace testing {
@@ -36,8 +37,10 @@ GLFWwindow* WindowMTL::InitWindow() {
 
   CAMetalLayer* metal_layer = [CAMetalLayer layer];
 
-  device_ = static_cast<GoldenTestEnvMTL*>(GoldenTestEnv::GetInstance())->GetDevice();
-  command_queue_ = static_cast<GoldenTestEnvMTL*>(GoldenTestEnv::GetInstance())->GetCommandQueue();
+  auto diff_env = DiffEnvMtlTest::GetInstance();
+
+  device_ = diff_env->GetDevice();
+  command_queue_ = diff_env->GetCommandQueue();
 
   metal_layer.device = device_;
   metal_layer.opaque = YES;
@@ -50,7 +53,11 @@ GLFWwindow* WindowMTL::InitWindow() {
 
   metal_layer_ = metal_layer;
 
-  gpu_context_ = GoldenTestEnv::GetInstance()->GetGPUContext();
+  if (GoldenTestEnv::GetInstance()->GetBackend() == Backend::kMetal) {
+    gpu_context_ = GoldenTestEnv::GetInstance()->GetGPUContext();
+  } else {
+    gpu_context_ = DiffEnvMtlTest::GetInstance()->GetGPUContext();
+  }
 
   return window;
 }
@@ -191,7 +198,7 @@ bool WindowMTL::InitTextures(bool passed, std::shared_ptr<GoldenTexture> source,
     }
 
     id<MTLComputePipelineState> pipeline_state =
-        static_cast<GoldenTestEnvMTL*>(GoldenTestEnv::GetInstance())->GetComputePipelineState();
+        DiffEnvMtlTest::GetInstance()->GetComputePipelineState();
 
     id<MTLCommandBuffer> command_buffer = [command_queue_ commandBuffer];
 
@@ -199,9 +206,7 @@ bool WindowMTL::InitTextures(bool passed, std::shared_ptr<GoldenTexture> source,
 
     [compute_command_encoder setComputePipelineState:pipeline_state];
 
-    [compute_command_encoder
-        setTexture:static_cast<GoldenTextureMTL*>(source.get())->GetMTLTexture()
-           atIndex:0];
+    [compute_command_encoder setTexture:GetTextureFromGolden(source) atIndex:0];
     [compute_command_encoder setTexture:target_texture atIndex:1];
     [compute_command_encoder setTexture:isolate_diff_texture atIndex:2];
     [compute_command_encoder setTexture:diff_texture atIndex:3];
@@ -256,6 +261,48 @@ void WindowMTL::DrawImageInCenter(skity::Canvas* canvas, const std::shared_ptr<I
   skity::SamplingOptions options{};
   options.filter = skity::FilterMode::kLinear;
   canvas->DrawImage(image, Rect::MakeXYWH(x, y, image_width, image_height), options);
+}
+
+id<MTLTexture> WindowMTL::GetTextureFromGolden(const std::shared_ptr<GoldenTexture>& texture) {
+  if (GoldenTestEnv::GetInstance()->GetBackend() == Backend::kMetal) {
+    return static_cast<GoldenTextureMTL*>(texture.get())->GetMTLTexture();
+  } else {
+    auto pixmap = texture->ReadPixels();
+
+    MTLTextureDescriptor* desc = [[MTLTextureDescriptor alloc] init];
+    desc.width = pixmap->Width();
+    desc.height = pixmap->Height();
+    desc.pixelFormat = MTLPixelFormatRGBA8Unorm;
+    desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
+    desc.storageMode = MTLStorageModePrivate;
+
+    id<MTLTexture> texture = [device_ newTextureWithDescriptor:desc];
+    [desc release];
+
+    // upload pixmap to texture
+    id<MTLBuffer> buffer = [device_ newBufferWithBytes:pixmap->Addr()
+                                                length:pixmap->Width() * pixmap->Height() * 4
+                                               options:MTLResourceStorageModeShared];
+
+    id<MTLCommandBuffer> command_buffer = [command_queue_ commandBuffer];
+
+    id<MTLBlitCommandEncoder> blit_command_encoder = [command_buffer blitCommandEncoder];
+    [blit_command_encoder copyFromBuffer:buffer
+                            sourceOffset:0
+                       sourceBytesPerRow:pixmap->Width() * 4
+                     sourceBytesPerImage:pixmap->Width() * pixmap->Height() * 4
+                              sourceSize:MTLSizeMake(pixmap->Width(), pixmap->Height(), 1)
+                               toTexture:texture
+                        destinationSlice:0
+                        destinationLevel:0
+                       destinationOrigin:MTLOriginMake(0, 0, 0)
+                                 options:MTLBlitOptionNone];
+
+    [blit_command_encoder endEncoding];
+    [command_buffer commit];
+
+    return texture;
+  }
 }
 
 }  // namespace testing

--- a/tools/test-runner.py
+++ b/tools/test-runner.py
@@ -25,6 +25,7 @@ class Colors:
 
 class TestRunner:
     def __init__(self, args):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
         self.build_dir = args.build_dir
         self.parallel_jobs = args.parallel
         self.test_filter = args.filter
@@ -34,6 +35,7 @@ class TestRunner:
         self.skip_configure = args.no_configure or args.run_only
         self.skip_build = args.no_build or args.run_only
         self.suite = args.suite
+        self.backend = args.backend
         self.started = time.time()
         
         os.makedirs(self.build_dir, exist_ok=True)
@@ -61,6 +63,32 @@ class TestRunner:
             return result.returncode, result.stdout, result.stderr
         except Exception as e:
             return 1, "", str(e)
+
+    def _prepend_env_path(self, env: Dict[str, str], name: str, path: str):
+        current = env.get(name, "")
+        entries = [entry for entry in current.split(os.pathsep) if entry]
+        if path in entries:
+            return
+
+        env[name] = path if not current else f"{path}{os.pathsep}{current}"
+
+    def prepare_test_environment(self) -> Tuple[Optional[Dict[str, str]], Optional[str]]:
+        env = os.environ.copy()
+        env["AGENT_OUT_DIR"] = os.path.abspath(self.golden_failures_dir)
+
+        if not self.suite.startswith("golden"):
+            return env, None
+
+        env.setdefault("ANGLE_DEFAULT_PLATFORM", "swiftshader")
+
+        angle_lib_dir = os.path.join(self.repo_root, "third_party", "libSwAngle", "lib")
+        if not os.path.isdir(angle_lib_dir):
+            return None, f"Angle runtime library directory not found: {angle_lib_dir}"
+
+        if sys.platform == "darwin":
+            self._prepend_env_path(env, "DYLD_LIBRARY_PATH", angle_lib_dir)
+
+        return env, None
 
     def clean_build_directory(self):
         if self.clean_build and os.path.exists(self.build_dir):
@@ -136,8 +164,12 @@ class TestRunner:
             os.remove(gtest_json_path)
 
         cmd = [test_executable, f"--gtest_output=json:{gtest_json_path}"]
-        env = os.environ.copy()
-        env["AGENT_OUT_DIR"] = os.path.abspath(self.golden_failures_dir)
+        env, env_error = self.prepare_test_environment()
+        if env_error:
+            return self._create_infra_error("missing_runtime_dependency", env_error)
+
+        if self.suite.startswith("golden") and self.backend != "metal":
+            cmd.extend(["--backend", self.backend])
         
         if self.test_filter:
             cmd.append(f"--gtest_filter={self.test_filter}")
@@ -242,7 +274,7 @@ class TestRunner:
                             stage = "Layer 3: Visual Regression"
                             reason_code = "pixel_mismatch"
                             oracle = "golden"
-                            backend = "metal"
+                            backend = self.backend
 
                         failure_record = {
                             "suite": self.suite,
@@ -371,6 +403,7 @@ def main():
     parser = argparse.ArgumentParser(description='Skity Test Runner with AI Agent feedback loop')
     parser.add_argument('--suite', default='unit', choices=['unit', 'golden-shape', 'golden-text'], help='Test suite to run')
     parser.add_argument('--build-dir', default='build', help='Build directory (default: build)')
+    parser.add_argument('--backend', default='metal', choices=['metal', 'gl', 'vulkan'], help='Golden test backend to run (default: metal)')
     parser.add_argument('--filter', default='', help='Run only tests matching pattern (e.g. for gtest)')
     parser.add_argument('--parallel', type=int, default=multiprocessing.cpu_count(), help='Number of parallel build jobs')
     parser.add_argument('--verbose', action='store_true', help='Verbose output')


### PR DESCRIPTION
Add new test step to run Golden Test for OpenGLES backend. This new test based on Angle + SwiftShader.

Currently the result is different from Metal in anti-alias edge. So ignore the test result for now.

Also make test-runner support running the new GoldenTest by passing backend from parameter and setup environment before running.