### PR TITLE
feat(gpu): Add new API to disable render target cache

### DIFF
--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -243,6 +243,25 @@ class SKITY_API GPUContext {
     return enable_simple_shape_pipeline_;
   }
 
+  /**
+   * Used to enable or disable render target cache during a frame.
+   * When enabled, Skity will try to reuse the render target created in the same
+   * frame when the descriptor matches. This can reduce the render target
+   * creation overhead, and save GPU memory.
+   *
+   * @note This API is not stable, and may changed in the future.
+   *
+   * @param enable whether to enable render target cache, the default value is
+   * true.
+   */
+  void EnableRenderTargetCache(bool enable) {
+    enable_render_target_cache_ = enable;
+  }
+
+  bool IsRenderTargetCacheEnabled() const {
+    return enable_render_target_cache_;
+  }
+
  private:
   GPUErrorCallback error_callback_ = nullptr;
   void* error_callback_user_data_ = nullptr;
@@ -252,6 +271,7 @@ class SKITY_API GPUContext {
   bool enable_text_linear_filter_ = false;
   bool enable_gpu_tessellation_ = true;
   bool enable_simple_shape_pipeline_ = false;
+  bool enable_render_target_cache_ = true;
 };
 
 }  // namespace skity

--- a/src/gpu/gpu_context_impl.hpp
+++ b/src/gpu/gpu_context_impl.hpp
@@ -40,6 +40,7 @@ class GPUContextImpl : public GPUContext {
   GPUDevice* GetGPUDevice() const { return gpu_device_.get(); }
 
   HWRenderTargetCache* GetRenderTargetCache() const {
+    render_target_cache_->SetDisableCache(!IsRenderTargetCacheEnabled());
     return render_target_cache_.get();
   }
 

--- a/src/render/hw/hw_resource_cache.hpp
+++ b/src/render/hw/hw_resource_cache.hpp
@@ -57,29 +57,38 @@ class HWResourceCache {
 
   std::shared_ptr<HWResource<K, V>> ObtainResource(K key,
                                                    Pool* pool = nullptr) {
-    auto range = purgeable_map_.equal_range(key);
-    if (range.first != range.second) {
-      auto list_it = range.first->second;
-      auto resource = *list_it;
-      purgeable_list_.erase(list_it);
-      purgeable_map_.erase(range.first);
-      purgeable_bytes_ -= resource->GetBytes();
-      if (pool) {
-        pool->PutResource(resource);
+    if (!disable_cache_) {
+      auto range = purgeable_map_.equal_range(key);
+      if (range.first != range.second) {
+        auto list_it = range.first->second;
+        auto resource = *list_it;
+        purgeable_list_.erase(list_it);
+        purgeable_map_.erase(range.first);
+        purgeable_bytes_ -= resource->GetBytes();
+        if (pool) {
+          pool->PutResource(resource);
+        }
+        return resource;
       }
-      return resource;
     }
 
     std::shared_ptr<HWResource<K, V>> resource =
         allocator_->AllocateResource(key);
-    total_resource_bytes_ += resource->GetBytes();
+
     if (pool) {
       pool->PutResource(resource);
+    }
+
+    if (!disable_cache_) {
+      total_resource_bytes_ += resource->GetBytes();
     }
     return resource;
   }
 
   void StoreResource(std::shared_ptr<HWResource<K, V>> resource) {
+    if (disable_cache_) {
+      return;
+    }
     purgeable_list_.push_front(resource);
     purgeable_map_.insert({resource->GetKey(), purgeable_list_.begin()});
     purgeable_bytes_ += resource->GetBytes();
@@ -108,6 +117,8 @@ class HWResourceCache {
     PurgeAsNeeded();
   }
 
+  void SetDisableCache(bool disable_cache) { disable_cache_ = disable_cache; }
+
   size_t GetTotalResourceBytes() const { return total_resource_bytes_; }
   size_t GetPurgableBytes() const { return purgeable_bytes_; }
   size_t GetMaxbytes() const { return max_bytes_; }
@@ -117,6 +128,7 @@ class HWResourceCache {
   size_t purgeable_bytes_ = 0;
   std::unique_ptr<HWResourceAllocator<K, V>> allocator_;
   size_t max_bytes_;
+  bool disable_cache_ = false;
 
   std::list<std::shared_ptr<HWResource<K, V>>> purgeable_list_;
   std::multimap<K, decltype(purgeable_list_.begin()), Compare> purgeable_map_;

--- a/test/ut/render/resource_cache_test.cc
+++ b/test/ut/render/resource_cache_test.cc
@@ -237,3 +237,34 @@ TEST(ResourceCache, PurgeResourcesByOrder) {
   EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
   EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
 }
+
+TEST(ResourceCache, DisableCache) {
+  skity::testing::TestResourceCache cache(
+      std::make_unique<skity::testing::TestResourceAllocator>(), 1000);
+  cache.SetDisableCache(true);
+
+  EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
+  EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
+
+  skity::testing::TestResourceKey key1{100};
+  auto resource1 = cache.ObtainResource(key1);
+  EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
+  EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
+
+  auto resource2 = cache.ObtainResource(key1);
+  EXPECT_NE(resource1.get(), resource2.get());
+  EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
+  EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
+
+  {
+    auto pool =
+        std::make_unique<skity::testing::TestResourceCache::Pool>((&cache));
+    auto resource3 = cache.ObtainResource(key1, pool.get());
+    EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
+    EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
+    EXPECT_NE(resource2.get(), resource3.get());
+  }
+
+  EXPECT_EQ(cache.GetTotalResourceBytes(), static_cast<size_t>(0));
+  EXPECT_EQ(cache.GetPurgableBytes(), static_cast<size_t>(0));
+}


### PR DESCRIPTION
Add new property and function to disable the in-frame render target cache. The cache will be refactor in the future.