### PR TITLE
fix(hw): fix precision loss of corner index in WGSL RRect shader

### DIFF
--- a/src/render/hw/draw/geometry/wgsl_rrect_geometry.cc
+++ b/src/render/hw/draw/geometry/wgsl_rrect_geometry.cc
@@ -333,7 +333,7 @@ fn calculate_mask_alpha(v_pos: vec2<f32>, corner_idx: i32, v_region: f32, v_rect
 
 void WGSLRRectGeometry::WriteFSAlphaMask(std::stringstream& ss) const {
   ss << R"(
-  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(input.v_fs_packed.z), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
+  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(round(input.v_fs_packed.z)), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
 )";
 }
 

--- a/test/ut/render/hw/draw/hw_wgsl_shader_writer_test.cc
+++ b/test/ut/render/hw/draw/hw_wgsl_shader_writer_test.cc
@@ -1061,7 +1061,7 @@ fn fs_main(input: FSInput) -> @location(0) vec4<f32> {
   var color : vec4<f32>;
   color = vec4<f32>(input.f_color.rgb * input.f_color.a, input.f_color.a);
   var mask_alpha: f32 = 1.0;
-  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(input.v_fs_packed.z), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
+  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(round(input.v_fs_packed.z)), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
   color = color * mask_alpha;
   return color;
 }
@@ -1367,7 +1367,7 @@ fn fs_main(input: FSInput) -> @location(0) vec4<f32> {
   var color : vec4<f32>;
   color = generate_gradient_color(input.f_param_pos);
   var mask_alpha: f32 = 1.0;
-  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(input.v_fs_packed.z), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
+  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(round(input.v_fs_packed.z)), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
   color = color * mask_alpha;
   return color;
 }
@@ -1674,7 +1674,7 @@ fn fs_main(input: FSInput) -> @location(0) vec4<f32> {
 
   color *= image_color_info.global_alpha;
   var mask_alpha: f32 = 1.0;
-  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(input.v_fs_packed.z), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
+  mask_alpha = calculate_mask_alpha(input.v_fs_packed.xy, i32(round(input.v_fs_packed.z)), input.v_fs_packed.w, input.v_rect, input.v_radii, input.v_stroke, input.v_j, input.v_inv_grid);
   color = color * mask_alpha;
   return color;
 }


### PR DESCRIPTION
In the WGSL RRect fragment shader, `corner_idx` is passed as a float varying. During triangle interpolation (especially on ANGLE + Vulkan + SwiftShader backends), floating-point precision loss can cause an expected value like `1.0` to degrade to `0.9999`. Directly casting this to `i32` truncates the value to `0`, leading to incorrect corner calculations and rendering artifacts. This commit adds a `round()` call before the `i32` cast to ensure slight precision errors are correctly rounded to the nearest intended integer, fixing the golden test anomalies.