### PR TITLE
fix(codec): use libwebp animation decoder for frame composition

### DIFF
--- a/module/codec/CMakeLists.txt
+++ b/module/codec/CMakeLists.txt
@@ -161,9 +161,11 @@ if (SKITY_ENABLE_CODEC_WEBP)
   if (WIN32)
     # This link config may not work if using llvm clang under minGW or msys2
     # FIXME: use -llibwebp to solve name conflict with ExternalProject_Add(libwebp ...)
-    target_link_libraries(skity-codec PRIVATE libsharpyuv -llibwebp libwebpdecoder libwebpdemux libwebpmux)
+    target_link_libraries(skity-codec PRIVATE libwebpmux libwebpdemux libwebpdecoder -llibwebp libsharpyuv)
   else()
-    target_link_libraries(skity-codec PRIVATE sharpyuv webp webpdecoder webpdemux webpmux)
+    # Keep dependency providers after dependents because these are raw library
+    # names, not imported CMake targets with transitive link metadata.
+    target_link_libraries(skity-codec PRIVATE webpmux webpdemux webpdecoder webp sharpyuv)
   endif()
 
 endif()

--- a/module/codec/src/codec/webp/webp_decoder.cc
+++ b/module/codec/src/codec/webp/webp_decoder.cc
@@ -5,11 +5,45 @@
 #include "src/codec/webp/webp_decoder.hpp"
 
 #include <cstring>
-#include <skity/graphic/bitmap.hpp>
 #include <skity/io/pixmap.hpp>
-#include <skity/render/canvas.hpp>
 
 namespace skity {
+
+namespace {
+
+using WebPAnimDecoderPTR =
+    std::unique_ptr<WebPAnimDecoder, decltype(&WebPAnimDecoderDelete)>;
+
+WebPAnimDecoderPTR CreateAnimDecoder(const Data* data) {
+  if (data == nullptr) {
+    return {nullptr, WebPAnimDecoderDelete};
+  }
+
+  WebPAnimDecoderOptions options;
+  if (!WebPAnimDecoderOptionsInit(&options)) {
+    return {nullptr, WebPAnimDecoderDelete};
+  }
+
+  options.color_mode = MODE_RGBA;
+
+  WebPData webp_data{data->Bytes(), data->Size()};
+  return {WebPAnimDecoderNew(&webp_data, &options), WebPAnimDecoderDelete};
+}
+
+std::shared_ptr<Pixmap> PrepareOutputPixmap(std::shared_ptr<Pixmap> pixmap,
+                                            int32_t width, int32_t height) {
+  if (!pixmap || pixmap->Width() != width || pixmap->Height() != height ||
+      pixmap->GetColorType() != ColorType::kRGBA) {
+    pixmap = std::make_shared<Pixmap>(
+        width, height, AlphaType::kUnpremul_AlphaType, ColorType::kRGBA);
+  } else {
+    pixmap->SetColorInfo(AlphaType::kUnpremul_AlphaType, ColorType::kRGBA);
+  }
+
+  return pixmap;
+}
+
+}  // namespace
 
 WebpDecoder::WebpDecoder(WebPDemuxerPTR demuxer, std::shared_ptr<Data> data)
     : demuxer_(std::move(demuxer)), data_(std::move(data)) {
@@ -59,133 +93,31 @@ std::shared_ptr<Pixmap> WebpDecoder::DecodeFrame(
   }
 
   auto index = frame->GetFrameID();
-
-  WebPDecoderConfig config;
-
-  if (WebPInitDecoderConfig(&config) == 0) {
+  if (index < 0 || index >= frame_count_) {
     return nullptr;
   }
 
-  WebPDecBufferPTR dec_buffer(&config.output);
-
-  WebPIterator webp_frame;
-  WebPDIteratorPTR auto_iter(&webp_frame);
-
-  if (!WebPDemuxGetFrame(demuxer_.get(), index + 1, &webp_frame)) {
+  auto anim_decoder = CreateAnimDecoder(data_.get());
+  if (!anim_decoder) {
     return nullptr;
   }
 
-  bool independent =
-      index == 0
-          ? true
-          : (frame->GetRequiredFrame() == CodecFrameInfo::kNoFrameRequired);
-
-  CodecRect screen_rect = {0, 0, frame_width_, frame_height_};
-  auto frame_rect = frame->GetRect();
-
-  if (!screen_rect.Contains(frame_rect)) {
-    // some thing is wrong
-    return nullptr;
-  }
-
-  bool frame_is_subset = screen_rect != frame_rect;
-
-  std::shared_ptr<Pixmap> pixmap =
-      std::make_shared<Pixmap>(frame_width_, frame_height_,
-                               AlphaType::kPremul_AlphaType, ColorType::kRGBA);
-
-  std::memset(pixmap->WritableAddr8(0, 0), 0,
-              pixmap->Width() * pixmap->Height() * 4);
-
-  Bitmap temp_canvas_map(pixmap, false);
-
-  auto canvas = Canvas::MakeSoftwareCanvas(&temp_canvas_map);
-
-  bool blend_with_prev_frame =
-      !independent && webp_frame.blend_method == WEBP_MUX_BLEND;
-
-  if (blend_with_prev_frame || frame_is_subset) {
-    if (prev_pixmap == nullptr) {
-      // If needs blend with prev frame, but prev pixmap is null,
-      // then just return empty pixmap.
-      return {};
+  // WebP animation frame dependencies can skip over adjacent frames once
+  // blend/dispose rules are considered. Replaying through libwebp's animator
+  // keeps the reconstructed canvas correct for the target frame.
+  uint8_t* decoded_frame = nullptr;
+  int timestamp = 0;
+  for (int32_t i = 0; i <= index; ++i) {
+    if (!WebPAnimDecoderGetNext(anim_decoder.get(), &decoded_frame,
+                                &timestamp)) {
+      return nullptr;
     }
-
-    canvas->DrawImage(Image::MakeImage(prev_pixmap), 0, 0);
   }
 
-  std::shared_ptr<Pixmap> tmp_decode_buffer;
-
-  if (blend_with_prev_frame) {
-    // needs to decode to a temp buffer first.
-    tmp_decode_buffer = std::make_shared<Pixmap>(frame_width_, frame_height_,
-                                                 AlphaType::kUnpremul_AlphaType,
-                                                 ColorType::kRGBA);
-
-    config.output.colorspace = MODE_RGBA;  // RGBA unpremultiplied alpha
-    config.output.is_external_memory = 1;
-    config.output.u.RGBA.rgba = tmp_decode_buffer->WritableAddr8(0, 0);
-    config.output.u.RGBA.stride = tmp_decode_buffer->RowBytes();
-    config.output.u.RGBA.size =
-        tmp_decode_buffer->Width() * tmp_decode_buffer->Height() * 4;
-  } else {
-    pixmap->SetColorInfo(AlphaType::kUnpremul_AlphaType,
-                         pixmap->GetColorType());
-    config.output.colorspace = MODE_RGBA;  // RGBA unpremultiplied alpha
-    config.output.is_external_memory = 1;
-    config.output.u.RGBA.rgba =
-        pixmap->WritableAddr8(frame_rect.left, frame_rect.top);
-    config.output.u.RGBA.stride = pixmap->RowBytes();
-    config.output.u.RGBA.size = pixmap->Width() * pixmap->Height() * 4;
-  }
-
-  WebPIDecoderPTR idec(WebPIDecode(nullptr, 0, &config));
-
-  if (!idec) {
-    return nullptr;
-  }
-
-  auto status = WebPIUpdate(idec.get(), webp_frame.fragment.bytes,
-                            webp_frame.fragment.size);
-
-  bool success = false;
-  int32_t rows_decoded = 0;
-  switch (status) {
-    case VP8_STATUS_OK:
-      rows_decoded = frame_rect.Height();
-      success = true;
-      break;
-    case VP8_STATUS_SUSPENDED: {
-      if (!WebPIDecGetRGB(idec.get(), &rows_decoded, nullptr, nullptr,
-                          nullptr) ||
-          rows_decoded <= 0) {
-        success = false;
-      }
-    } break;
-    default:
-      success = false;
-      break;
-  }
-
-  if (!success) {
-    return nullptr;
-  }
-
-  if (blend_with_prev_frame) {
-    Paint paint;
-
-    if (webp_frame.blend_method != WEBP_MUX_BLEND) {
-      paint.SetBlendMode(BlendMode::kSrc);
-    }
-
-    canvas->DrawImage(Image::MakeImage(tmp_decode_buffer), frame_rect.left,
-                      frame_rect.left, SamplingOptions{}, &paint);
-  }
-
-  if (pixmap->GetAlphaType() != kUnpremul_AlphaType) {
-    pixmap->SetColorInfo(AlphaType::kUnpremul_AlphaType,
-                         pixmap->GetColorType());
-  }
+  auto pixmap =
+      PrepareOutputPixmap(std::move(prev_pixmap), frame_width_, frame_height_);
+  std::memcpy(pixmap->WritableAddr8(0, 0), decoded_frame,
+              pixmap->RowBytes() * pixmap->Height());
 
   return pixmap;
 }

--- a/test/ut/codec/webp_codec_test.cc
+++ b/test/ut/codec/webp_codec_test.cc
@@ -79,3 +79,32 @@ TEST(WebPCodecTest, Decode) {
     EXPECT_EQ(color, skity::ColorSetARGB(255, 0, 0, 255));
   }
 }
+
+TEST(WebPCodecTest, DecodeAllFrames) {
+  auto data = skity::Data::MakeFromFileName(SKITY_TEST_WEBP_FILE);
+
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec != nullptr);
+
+  codec->SetData(data);
+
+  auto multi_frame_decoder = codec->DecodeMultiFrame();
+
+  EXPECT_TRUE(multi_frame_decoder != nullptr);
+
+  std::shared_ptr<skity::Pixmap> pixmap;
+  for (int32_t i = 0; i < multi_frame_decoder->GetFrameCount(); ++i) {
+    auto frame = multi_frame_decoder->GetFrameInfo(i);
+
+    ASSERT_TRUE(frame != nullptr);
+
+    pixmap = multi_frame_decoder->DecodeFrame(frame, pixmap);
+
+    ASSERT_TRUE(pixmap != nullptr);
+    EXPECT_EQ(pixmap->Width(), multi_frame_decoder->GetWidth());
+    EXPECT_EQ(pixmap->Height(), multi_frame_decoder->GetHeight());
+    EXPECT_EQ(pixmap->GetColorType(), skity::ColorType::kRGBA);
+    EXPECT_EQ(pixmap->GetAlphaType(), skity::AlphaType::kUnpremul_AlphaType);
+  }
+}


### PR DESCRIPTION
The dependencies between frames may not be linear. To avoid frame compositing issues, the final image decoding is performed using libwebp's internal animation compositing API.