### PR TITLE
feat(gpu): add Vulkan GPU backend implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,17 @@ jobs:
             run: |
                 export PATH=$PWD/buildtools/llvm/bin:$PATH
                 cmake -B out/cmake_host_build -DSKITY_TEST=ON -DSKITY_VK_BACKEND=ON -DSKITY_TEST_COVERAGE=OFF -DSKITY_CODEC_MODULE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
-                cmake --build out/cmake_host_build --target skity_unit_test
+                cmake --build out/cmake_host_build --target skity_unit_test skity_vulkan_unit_test
           - name: Unit Test
             run: |
                 cd out/cmake_host_build/test/ut/
                 ctest --output-junit test.xml --rerun-failed --output-on-failure
+          - name: Vulkan Unit Test
+            env:
+              VK_ICD_FILENAMES: ${{ github.workspace }}/third_party/libSwiftShader/vk_swiftshader_icd.json
+            run: |
+                cd out/cmake_host_build/test/ut/
+                ctest --output-junit vk_test.xml -R skity_vulkan_unit_test --rerun-failed --output-on-failure
     unittest_coverage:
         runs-on: ubuntu-22.04
         timeout-minutes: 30
@@ -74,11 +80,14 @@ jobs:
             run: |
                 export PATH=$PWD/buildtools/llvm/bin:$PATH
                 cmake -B out/cmake_host_build -DSKITY_TEST=ON -DSKITY_VK_BACKEND=ON -DSKITY_TEST_COVERAGE=ON -DSKITY_CODEC_MODULE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
-                cmake --build out/cmake_host_build --target skity_unit_test
+                cmake --build out/cmake_host_build --target skity_unit_test skity_vulkan_unit_test
           - name: Test and Generate Coverage Report
+            env:
+              VK_ICD_FILENAMES: ${{ github.workspace }}/third_party/libSwiftShader/vk_swiftshader_icd.json
             run: |
                 cd out/cmake_host_build/test/ut/
                 ctest --output-junit test.xml --rerun-failed --output-on-failure
+                ctest --output-junit vk_test.xml -R skity_vulkan_unit_test --rerun-failed --output-on-failure
                 cd ../../
                 lcov --capture --directory . --output-file coverage.info
                 lcov --remove coverage.info '/usr/**/*' 'test/ut/**/*' 'third_party/**/*' 'Library/*' '**/clipper2/*' --output-file coverage.filtered.info
@@ -95,7 +104,7 @@ jobs:
             with:
               token: ${{ secrets.CODECOV_TOKEN }}
               directory: "out/cmake_host_build/test/ut"
-              files: out/cmake_host_build/test/ut/test.xml
+              files: out/cmake_host_build/test/ut/test.xml out/cmake_host_build/test/ut/vk_test.xml
     android_build_check:
         runs-on: lynx-ubuntu-22.04-medium
         timeout-minutes: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,9 @@ endif()
 
 if(${SKITY_VK_BACKEND})
   target_compile_definitions(skity PUBLIC -DSKITY_VULKAN)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(skity PUBLIC -DSKITY_VK_DEBUG_RUNTIME)
+  endif()
 endif()
 
 if(${SKITY_GL_BACKEND})

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -68,6 +68,9 @@ elseif(ANDROID)
   else()
     message("build without asan")
     target_compile_options(skity PRIVATE -fomit-frame-pointer -fno-sanitize=safe-stack -Werror -Wunused-variable -Wunused-function)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      target_compile_options(skity PRIVATE -Wno-nullability-completeness)
+    endif()
   endif()
 
   # arm64

--- a/cmake/ThirdPartyDep.cmake
+++ b/cmake/ThirdPartyDep.cmake
@@ -36,6 +36,23 @@ if(${SKITY_VK_BACKEND})
   # set vulkan headers
   target_include_directories(skity PRIVATE third_party/VulkanMemoryAllocator/include)
   add_subdirectory(third_party/SPIRV-Headers)
+
+  # Detect Linux display server headers for Vulkan platform extensions
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    include(CheckIncludeFile)
+    check_include_file("xcb/xcb.h" SKITY_VK_HAS_XCB)
+    check_include_file("X11/Xlib.h" SKITY_VK_HAS_XLIB)
+    check_include_file("wayland-client.h" SKITY_VK_HAS_WAYLAND)
+    if(SKITY_VK_HAS_XCB)
+      target_compile_definitions(skity PRIVATE SKITY_VK_USE_XCB)
+    endif()
+    if(SKITY_VK_HAS_XLIB)
+      target_compile_definitions(skity PRIVATE SKITY_VK_USE_XLIB)
+    endif()
+    if(SKITY_VK_HAS_WAYLAND)
+      target_compile_definitions(skity PRIVATE SKITY_VK_USE_WAYLAND)
+    endif()
+  endif()
 endif()
 
 # json parser

--- a/hab/DEPS.dev
+++ b/hab/DEPS.dev
@@ -39,5 +39,12 @@ deps = {
         "ignore_in_git": True,
         "decompress": True,
         "condition": system in ["darwin"]
+    },
+    "third_party/libSwiftShader": {
+        "type": "http",
+        "url":  "https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/skity/libSwiftShader_f9d5d49.zip",
+        "ignore_in_git": True,
+        "decompress": True,
+        "condition": system in [ 'linux' ]
     }
 }

--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <skity/geometry/rect.hpp>
 #include <skity/gpu/gpu_backend_type.hpp>
+#include <skity/gpu/gpu_presenter.hpp>
 #include <skity/gpu/gpu_render_target.hpp>
 #include <skity/gpu/gpu_surface.hpp>
 #include <skity/gpu/texture.hpp>
@@ -62,6 +63,19 @@ class SKITY_API GPUContext {
    */
   virtual std::unique_ptr<GPUSurface> CreateSurface(
       GPUSurfaceDescriptor* desc) = 0;
+
+  /**
+   * Create a GPU backend presenter for presenting the surface on screen
+   *
+   * @note This API is experimental. Might change in the future. Currently only
+   *       Vulkan backend supports this.
+   *
+   * @param desc describe the information to create the presenter
+   *             different backends may have different descriptor structures
+   * @return GPUPresenter instance or null if init failed
+   */
+  virtual std::unique_ptr<GPUPresenter> CreatePresenter(
+      GPUPresenterDescriptor* desc) = 0;
 
   /**
    * Create a Texture instance associated with current GPU context.

--- a/include/skity/gpu/gpu_context_vk.hpp
+++ b/include/skity/gpu/gpu_context_vk.hpp
@@ -1,0 +1,610 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef INCLUDE_SKITY_GPU_GPU_CONTEXT_VK_HPP
+#define INCLUDE_SKITY_GPU_GPU_CONTEXT_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/gpu_surface.hpp>
+#include <skity/gpu/texture.hpp>
+#include <skity/macros.hpp>
+
+namespace skity {
+
+/**
+ * Info struct to pass Vulkan info to create GPUContext.
+ */
+struct GPUContextInfoVK {
+  /**
+   * User provided Vulkan instance. The user is responsible for picking required
+   * extensions like `VK_KHR_surface`.
+   *
+   * @note The user is responsible for destroying the instance.
+   */
+  VkInstance instance = VK_NULL_HANDLE;
+
+  /**
+   * procedure address loader to load Vulkan instance procedures.
+   *
+   * @note can not be nullptr.
+   */
+  PFN_vkGetInstanceProcAddr get_instance_proc_addr = nullptr;
+
+  /**
+   * Enabled Vulkan instance extensions for the provided or to-be-created
+   * instance.
+   *
+   * For user provided instance, Vulkan does not expose a way to query enabled
+   * instance extensions from a live handle, so caller should provide them when
+   * this information matters to later rendering logic.
+   *
+   * For engine-created instances, this list is treated as additional requested
+   * instance extensions. Skity will merge these entries with the extensions it
+   * already enables internally for the current platform and feature set.
+   */
+  const char* const* enabled_instance_extensions = nullptr;
+
+  /**
+   * Count of `enabled_instance_extensions`.
+   */
+  uint32_t enabled_instance_extension_count = 0;
+
+  /**
+   * Whether `enabled_instance_extensions` fully describes the enabled
+   * extensions for the instance.
+   *
+   * This flag is only meaningful for user provided instances. Engine-created
+   * instances always derive the final enabled extension set during creation.
+   */
+  bool enabled_instance_extensions_known = false;
+
+  /**
+   * User provided Vulkan physical device.
+   *
+   * If nullptr, the engine will use the first physical device if available.
+   */
+  VkPhysicalDevice physical_device = VK_NULL_HANDLE;
+
+  /**
+   * User provided Vulkan logical device.
+   * If user provides logical device, needs to load some useful extensions
+   * `VK_KHR_timeline_semaphore` or `VK_KHR_external_memory`.
+   *
+   * If nullptr, the engine will create a logical device and load required
+   * extensions.
+   *
+   * @note The user is responsible for destroying the device.
+   */
+  VkDevice logical_device = VK_NULL_HANDLE;
+
+  /**
+   * procedure address loader to load Vulkan logical device procedures.
+   *
+   * @note can not be nullptr.
+   */
+  PFN_vkGetDeviceProcAddr get_device_proc_addr = nullptr;
+
+  /**
+   * Enabled Vulkan device extensions for the provided or to-be-created device.
+   *
+   * For user provided logical device, Vulkan does not expose a way to query
+   * enabled device extensions from a live handle, so caller should provide
+   * them when this information matters to later rendering logic.
+   *
+   * @note if some advance extensions are in this list, the engine assumed that
+   * the corresponding feature was already enabled when the device was created.
+   * For example, `VK_KHR_synchronization2` needs to put
+   * VkPhysicalDeviceSynchronization2Features in device create info.
+   */
+  const char* const* enabled_device_extensions = nullptr;
+
+  /**
+   * Count of `enabled_device_extensions`.
+   */
+  uint32_t enabled_device_extension_count = 0;
+
+  /**
+   * Whether `enabled_device_extensions` fully describes the enabled
+   * extensions for the device.
+   */
+  bool enabled_device_extensions_known = false;
+
+  /**
+   * User provided Vulkan graphics queue.
+   *
+   * If nullptr, the engine will use the first graphics queue if available.
+   */
+  VkQueue graphics_queue = VK_NULL_HANDLE;
+
+  /**
+   * User provided Vulkan graphics queue family index.
+   *
+   * If -1, the engine will use the first graphics queue family index.
+   */
+  int32_t graphics_queue_family_index = -1;
+
+  /**
+   * User provided Vulkan compute queue.
+   *
+   * If nullptr, the engine will use the first compute queue if available.
+   */
+  VkQueue compute_queue = VK_NULL_HANDLE;
+
+  /**
+   * User provided Vulkan compute queue family index.
+   *
+   * If -1, the engine will use the first compute queue family index.
+   */
+  int32_t compute_queue_family_index = -1;
+
+  /**
+   * User provided Vulkan transfer queue.
+   *
+   * If nullptr, the engine will use the first transfer queue if available.
+   */
+  VkQueue transfer_queue = VK_NULL_HANDLE;
+
+  /**
+   * User provided Vulkan transfer queue family index.
+   *
+   * If -1, the engine will use the first transfer queue family index.
+   */
+  int32_t transfer_queue_family_index = -1;
+
+  /**
+   * Enable Vulkan debug runtime features for engine-created instances.
+   *
+   * When enabled in a Debug build, the engine will try to enable
+   * `VK_EXT_debug_utils` and `VK_LAYER_KHRONOS_validation` independently.
+   *
+   * If the validation layer is unavailable but `VK_EXT_debug_utils` is
+   * available, the engine will still enable `VK_EXT_debug_utils` so debug
+   * labels and related utilities can still be used.
+   *
+   * In non-Debug builds this hint is compiled out and has no effect.
+   *
+   * When false, skity will not request Vulkan debug runtime layers or
+   * extensions for owned instances, even in Debug builds.
+   *
+   * This flag is ignored for user provided Vulkan instances because those
+   * layers and extensions must already be chosen during instance creation.
+   */
+  bool enable_debug_runtime = false;
+};
+
+/**
+ * @enum VKSurfaceType indicates which Vulkan target a GPUSurface is backed by.
+ */
+enum class VKSurfaceType {
+  /**
+   * empty type, default value
+   */
+  kInvalid,
+  /**
+   * Indicate the Surface targets a user provided Vulkan image.
+   *
+   * @note The image must be renderable with the supplied format and image view.
+   */
+  kTexture,
+  /**
+   * Indicate the Surface targets a swapchain image acquired for the current
+   * frame.
+   *
+   * @note Presentation and swapchain lifecycle should be managed by a higher
+   * level Vulkan presenter rather than the Surface itself.
+   */
+  kSwapchainImage,
+};
+
+struct GPUSurfaceSyncInfoVK {
+  /**
+   * Optional semaphore that must be signaled before the engine starts
+   * rendering to this Surface.
+   */
+  VkSemaphore wait_semaphore = VK_NULL_HANDLE;
+
+  /**
+   * The earliest pipeline stage that waits on `wait_semaphore`.
+   */
+  VkPipelineStageFlags wait_dst_stage_mask =
+      VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+  /**
+   * Optional semaphore signaled after the engine finishes rendering to this
+   * Surface.
+   */
+  VkSemaphore signal_semaphore = VK_NULL_HANDLE;
+
+  /**
+   * Optional fence signaled after the engine finishes rendering to this
+   * Surface.
+   */
+  VkFence signal_fence = VK_NULL_HANDLE;
+};
+
+struct GPUSurfaceDescriptorVK : public GPUSurfaceDescriptor {
+  VKSurfaceType surface_type = VKSurfaceType::kInvalid;
+
+  /**
+   * User provided Vulkan image used as the render target for this Surface.
+   *
+   * @note If `surface_type` is `VKSurfaceType::kSwapchainImage`, this should be
+   * the image acquired for the current frame.
+   */
+  VkImage image = VK_NULL_HANDLE;
+
+  /**
+   * User provided image view matching `image`.
+   *
+   * @note The image view should be compatible with `format`.
+   */
+  VkImageView image_view = VK_NULL_HANDLE;
+
+  /**
+   * Vulkan format of the render target image.
+   */
+  VkFormat format = VK_FORMAT_UNDEFINED;
+
+  /**
+   * Optional pre-transform for the current frame target.
+   *
+   * This is especially useful when `image` comes from a swapchain image whose
+   * physical orientation differs from the logical surface coordinate system.
+   */
+  VkSurfaceTransformFlagBitsKHR pre_transform =
+      VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+
+  /**
+   * Current image layout when the engine begins rendering to this Surface.
+   */
+  VkImageLayout initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  /**
+   * Image layout should transition to after rendering finishes.
+   */
+  VkImageLayout final_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+  /**
+   * Whether the engine owns `image` and should destroy it when the Surface is
+   * released.
+   */
+  bool owns_image = false;
+
+  /**
+   * Whether the engine owns `image_view` and should destroy it when the Surface
+   * is released.
+   */
+  bool owns_image_view = false;
+
+  /**
+   * Optional Vulkan synchronization information for this one-shot Surface.
+   *
+   * The pointed synchronization object is not owned by the engine and must
+   * outlive the create/flush sequence that consumes it.
+   */
+  const GPUSurfaceSyncInfoVK* sync_info = nullptr;
+};
+
+struct GPUPresenterDescriptorVK : public GPUPresenterDescriptor {
+  /**
+   * Vulkan presentation surface used to create the swapchain.
+   */
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+
+  /**
+   * Optional Vulkan present queue. If null, the engine will pick a preferred
+   * queue.
+   */
+  VkQueue present_queue = VK_NULL_HANDLE;
+
+  /**
+   * Queue family index matching `present_queue`. If -1, the engine will pick a
+   * preferred queue family.
+   */
+  int32_t present_queue_family_index = -1;
+
+  /**
+   * Requested minimum swapchain image count.
+   */
+  uint32_t min_image_count = 2;
+
+  /**
+   * Preferred swapchain image format.
+   */
+  VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
+
+  /**
+   * Preferred swapchain color space.
+   */
+  VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+
+  /**
+   * Preferred swapchain present mode.
+   */
+  VkPresentModeKHR present_mode = VK_PRESENT_MODE_FIFO_KHR;
+
+  /**
+   * Composite alpha mode for the swapchain.
+   */
+  VkCompositeAlphaFlagBitsKHR composite_alpha =
+      VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+
+  /**
+   * Preferred swapchain transform for presented images.
+   */
+  VkSurfaceTransformFlagBitsKHR pre_transform =
+      VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+
+  /**
+   * Whether obscured pixels may be discarded by presentation.
+   */
+  bool clipped = true;
+
+  /**
+   * Previous swapchain to enable smooth retirement on resize.
+   * Pass the old swapchain when recreating to avoid
+   * VK_ERROR_NATIVE_WINDOW_IN_USE_KHR on some platforms.
+   * Set to VK_NULL_HANDLE for initial creation.
+   */
+  VkSwapchainKHR old_swapchain = VK_NULL_HANDLE;
+};
+
+/**
+ * @enum VKNativeWindowType indicates how `VKNativeWindowInfo` should be
+ * interpreted when creating a Vulkan presentation surface.
+ */
+enum class VKNativeWindowType {
+  /**
+   * Empty value. Surface creation will fail when this type is used.
+   */
+  kInvalid,
+  /**
+   * Win32 `HWND` + optional `HINSTANCE`.
+   */
+  kWin32,
+  /**
+   * Android `ANativeWindow*`.
+   */
+  kAndroid,
+  /**
+   * Apple `CAMetalLayer*` used with `VK_EXT_metal_surface`.
+   */
+  kMetalLayer,
+  /**
+   * Wayland `wl_display*` + `wl_surface*`.
+   */
+  kWayland,
+  /**
+   * XCB `xcb_connection_t*` + `xcb_window_t`.
+   */
+  kXcb,
+  /**
+   * Xlib `Display*` + `Window`.
+   */
+  kXlib,
+};
+
+/**
+ * @brief Platform-neutral native window description for simple Vulkan setup.
+ *
+ * @details Callers only need to populate the fields required by `type`.
+ *          Unused fields should stay at their default values.
+ */
+struct VKNativeWindowInfo {
+  /**
+   * Native window backend carried by this struct.
+   */
+  VKNativeWindowType type = VKNativeWindowType::kInvalid;
+
+  /**
+   * Generic primary pointer payload.
+   *
+   * The meaning depends on `type`:
+   * - `kWin32`: `HWND`
+   * - `kAndroid`: `ANativeWindow*`
+   * - `kMetalLayer`: `CAMetalLayer*`
+   * - `kWayland`: `wl_display*`
+   * - `kXcb`: `xcb_connection_t*`
+   * - `kXlib`: `Display*`
+   */
+  void* handle = nullptr;
+
+  /**
+   * Optional secondary pointer payload.
+   *
+   * The meaning depends on `type`:
+   * - `kWin32`: `HINSTANCE`
+   * - `kMetalLayer`: optional `NSView*` fallback for `VK_MVK_macos_surface`
+   * - `kWayland`: `wl_surface*`
+   *
+   * Other window types ignore this field.
+   */
+  void* secondary_handle = nullptr;
+
+  /**
+   * Integer native window identifier used by XCB / Xlib style platforms.
+   *
+   * The meaning depends on `type`:
+   * - `kXcb`: `xcb_window_t`
+   * - `kXlib`: `Window`
+   *
+   * Other window types ignore this field.
+   */
+  uint64_t window_id = 0;
+};
+
+/**
+ * @brief Descriptor for creating a Vulkan native window presenter.
+ *
+ * @details This struct only describes window-scoped presentation state such as
+ *          native handles, drawable size, and swapchain preferences. The
+ *          Vulkan `GPUContext` is supplied separately to the creation API so a
+ *          single device context can be reused across multiple windows.
+ */
+struct GPUNativeWindowInfoVK {
+  /**
+   * Native window used to create `VkSurfaceKHR`.
+   */
+  VKNativeWindowInfo native_window = {};
+
+  /**
+   * Physical presentation width in pixels.
+   *
+   * @note This value is forwarded to the internal Vulkan presenter and should
+   *       match the current drawable size of `native_window`.
+   */
+  uint32_t width = 0;
+
+  /**
+   * Physical presentation height in pixels.
+   */
+  uint32_t height = 0;
+
+  /**
+   * Optional Vulkan present queue. If null, the engine will pick a preferred
+   * queue for presentation.
+   */
+  VkQueue present_queue = VK_NULL_HANDLE;
+
+  /**
+   * Queue family index matching `present_queue`. If -1, the engine will pick a
+   * preferred queue family.
+   */
+  int32_t present_queue_family_index = -1;
+
+  /**
+   * Requested minimum swapchain image count.
+   */
+  uint32_t min_image_count = 2;
+
+  /**
+   * Preferred swapchain image format.
+   */
+  VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
+
+  /**
+   * Preferred swapchain color space.
+   */
+  VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+
+  /**
+   * Preferred swapchain present mode.
+   */
+  VkPresentModeKHR present_mode = VK_PRESENT_MODE_FIFO_KHR;
+
+  /**
+   * Composite alpha mode for the swapchain.
+   */
+  VkCompositeAlphaFlagBitsKHR composite_alpha =
+      VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+
+  /**
+   * Preferred transform for presented images.
+   */
+  VkSurfaceTransformFlagBitsKHR pre_transform =
+      VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+
+  /**
+   * Whether obscured pixels may be discarded by presentation.
+   */
+  bool clipped = true;
+};
+
+/**
+ * @brief Vulkan native window presenter created by Skity.
+ *
+ * @details This object bundles together a caller-provided Vulkan `GPUContext`,
+ *          the presentation `VkSurfaceKHR`, and the immutable
+ *          `GPUPresenter`. A single `GPUContext` may be shared by multiple
+ *          native windows. When the window size changes, call `Resize()` to
+ *          recreate the presenter / swapchain while preserving the underlying
+ *          GPU context.
+ */
+class SKITY_API GPUNativeWindowVK {
+ public:
+  virtual ~GPUNativeWindowVK() = default;
+
+  /**
+   * Access the Vulkan GPU context used by this native window presenter.
+   */
+  virtual GPUContext* GetContext() const = 0;
+
+  /**
+   * Access the Vulkan presenter bound to the current native window size.
+   */
+  virtual GPUPresenter* GetPresenter() const = 0;
+
+  /**
+   * Current physical presentation width in pixels.
+   */
+  virtual uint32_t GetWidth() const = 0;
+
+  /**
+   * Current physical presentation height in pixels.
+   */
+  virtual uint32_t GetHeight() const = 0;
+
+  /**
+   * Recreate the presenter and swapchain for a new physical window size.
+   *
+   * @return true on success. The existing presenter is preserved when
+   *         recreation fails.
+   */
+  virtual bool Resize(uint32_t width, uint32_t height) = 0;
+};
+
+/**
+ * Create GPUContext with Vulkan info.
+ *
+ * The engine needs vulkan at least version 1.1.
+ * If user provides logical device, needs to load some useful extensions.
+ * For example:
+ * - `VK_KHR_timeline_semaphore` is required for timeline semaphore.
+ * - `VK_KHR_external_memory` for external memory.
+ * - `VK_KHR_dynamic_rendering` for simplified render-pass creation.
+ */
+std::unique_ptr<GPUContext> SKITY_API
+CreateGPUContextVK(const GPUContextInfoVK* info);
+
+/**
+ * Create GPUContext with Vulkan instance procedure address loader.
+ *
+ * When using this function, the engine will create a Vulkan instance and handle
+ * all initialization.
+ * But the instance and device are not available for outside use. Which means
+ * the engine can not be mixed with other Vulkan code.
+ */
+std::unique_ptr<GPUContext> SKITY_API
+CreateGPUContextVK(PFN_vkGetInstanceProcAddr get_instance_proc_addr);
+
+/**
+ * Create a Vulkan native window presenter from a caller-provided GPU context.
+ *
+ * This is the preferred API when the caller wants to share one Vulkan
+ * `GPUContext` across multiple windows. The supplied context must use the
+ * Vulkan backend and must outlive the returned `GPUNativeWindowVK`.
+ *
+ * The returned object owns all Vulkan presentation resources created by Skity.
+ * The native window itself is still owned by the caller and must outlive the
+ * returned `GPUNativeWindowVK`.
+ *
+ * @note On Linux, this function creates a VkSurfaceKHR internally based on
+ *       the VKNativeWindowType in GPUNativeWindowInfoVK. The available window
+ *       types depend on which display server development headers were detected
+ *       at build time by CMake:
+ *       - VKNativeWindowType::kWayland requires wayland-client headers
+ *       - VKNativeWindowType::kXcb requires xcb headers
+ *       - VKNativeWindowType::kXlib requires X11 headers
+ *       Requesting a type that was not available at build time will fail.
+ *       On Windows, Android, and macOS/iOS there is only one platform type
+ *       and no such restriction applies.
+ */
+std::unique_ptr<GPUNativeWindowVK> SKITY_API
+CreateGPUNativeWindowVK(GPUContext* context, const GPUNativeWindowInfoVK* info);
+
+}  // namespace skity
+
+#endif  // INCLUDE_SKITY_GPU_GPU_CONTEXT_VK_HPP

--- a/include/skity/gpu/gpu_presenter.hpp
+++ b/include/skity/gpu/gpu_presenter.hpp
@@ -1,0 +1,145 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef INCLUDE_SKITY_GPU_GPU_PRESENTER_HPP
+#define INCLUDE_SKITY_GPU_GPU_PRESENTER_HPP
+
+#include <cstdint>
+#include <memory>
+#include <skity/gpu/gpu_backend_type.hpp>
+#include <skity/gpu/gpu_surface.hpp>
+#include <skity/macros.hpp>
+
+namespace skity {
+
+/**
+ * @brief Descriptor for creating a GPU presenter.
+ *
+ * @details `width` and `height` describe the physical presentation size in
+ *          pixels. For swapchain-backed presenters, these values typically map
+ *          to the swapchain extent.
+ */
+struct GPUPresenterDescriptor {
+  GPUBackendType backend = GPUBackendType::kNone;
+
+  /**
+   * Physical presentation width in pixels.
+   */
+  uint32_t width = 0;
+
+  /**
+   * Physical presentation height in pixels.
+   */
+  uint32_t height = 0;
+};
+
+/**
+ * @brief Descriptor for acquiring a renderable surface from a presenter.
+ *
+ * @details The acquired surface logical size is derived from the presenter
+ *          physical size and `content_scale`:
+ *          `logical_size * content_scale == physical_size`.
+ */
+struct GPUSurfaceAcquireDescriptor {
+  /**
+   * Sample count used when rendering this acquired surface.
+   */
+  uint32_t sample_count = 1;
+
+  /**
+   * Logical-to-physical scale factor for the acquired surface.
+   */
+  float content_scale = 1.f;
+};
+
+/**
+ * @brief Result status for presenter acquire/present operations.
+ */
+enum class GPUPresenterStatus {
+  /**
+   * Operation succeeded.
+   */
+  kSuccess,
+
+  /**
+   * The current swapchain is no longer compatible with presentation and should
+   * be recreated by the caller.
+   */
+  kNeedRecreate,
+
+  /**
+   * Operation failed for a reason other than swapchain recreation.
+   */
+  kError,
+};
+
+/**
+ * @brief Result returned by `AcquireNextSurface()`.
+ */
+struct GPUSurfaceAcquireResult {
+  /**
+   * Outcome of the acquire operation.
+   */
+  GPUPresenterStatus status = GPUPresenterStatus::kError;
+
+  /**
+   * One-shot surface returned on successful acquire.
+   */
+  std::unique_ptr<GPUSurface> surface = nullptr;
+};
+
+/**
+ * @brief GPU backend presenter for presenting the surface on screen.
+ *
+ * @details The presenter is responsible for acquiring the next surface from the
+ *          GPU and presenting it on the screen.
+ *          The presenter is responsible for managing the surface lifecycle.
+ *
+ * @note This API is experimental. Might change in the future. Currently only
+ *       Vulkan backend supports this.
+ *
+ * @note The presenter is immutable. If the window size changes, the presenter
+ *       must be recreated.
+ *
+ */
+class SKITY_API GPUPresenter {
+ public:
+  virtual ~GPUPresenter() = default;
+
+  /**
+   * @brief Actual presentation mode in use.
+   *
+   * @details Backends that do not expose a meaningful presentation mode may
+   *          return 0.
+   */
+  virtual int32_t GetPresentMode() const { return 0; }
+
+  /**
+   * @brief Acquire the next surface from the GPU.
+   *
+   * @param desc describe per-surface rendering parameters such as sample count
+   *             and content scale. The acquired surface logical size is
+   *             derived from the presenter physical size and `content_scale`.
+   *
+   * @return A structured acquire result. On success, `surface` contains a
+   *         one-shot GPUSurface instance. The returned surface should be
+   *         presented or discarded before acquiring the next one from the same
+   *         presenter.
+   */
+  virtual GPUSurfaceAcquireResult AcquireNextSurface(
+      const GPUSurfaceAcquireDescriptor& desc) = 0;
+
+  /**
+   * @brief Present a surface previously acquired from this presenter.
+   *
+   * @param surface one-shot surface returned by `AcquireNextSurface()`
+   * @return Presentation status. `kNeedRecreate` indicates that the caller
+   *         should recreate the presenter and its underlying swapchain.
+   */
+  virtual GPUPresenterStatus Present(std::unique_ptr<GPUSurface> surface) = 0;
+};
+
+}  // namespace skity
+
+#endif  // INCLUDE_SKITY_GPU_GPU_PRESENTER_HPP

--- a/include/skity/gpu/gpu_surface.hpp
+++ b/include/skity/gpu/gpu_surface.hpp
@@ -35,6 +35,8 @@ class SKITY_API GPUSurface {
  public:
   virtual ~GPUSurface() = default;
 
+  virtual GPUBackendType GetBackendType() const = 0;
+
   virtual uint32_t GetWidth() const = 0;
 
   virtual uint32_t GetHeight() const = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -478,6 +478,48 @@ if(${SKITY_HW_RENDERER})
       "-framework Foundation"
     )
   endif()
+
+  # Vulkan backend
+  if(${SKITY_VK_BACKEND})
+    target_sources(
+      skity
+      PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_blit_pass_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_blit_pass_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_buffer_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_buffer_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_command_buffer_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_command_buffer_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_device_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_device_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_presenter_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_presenter_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_context_impl_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_context_impl_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_native_window_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pass_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pass_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pipeline_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pipeline_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_sampler_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_sampler_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_shader_function_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_shader_function_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_surface_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_surface_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_texture_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_texture_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_debug_runtime_state.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_render_pass_cache.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_render_pass_cache.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_pending_submission.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_pending_submission.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_platform_extensions.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_platform_extensions.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_context_state.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_context_state.hpp
+    )
+  endif()
 endif()
 
 if(${SKITY_SW_RENDERER})

--- a/src/gpu/gl/gpu_command_buffer_gl.cc
+++ b/src/gpu/gl/gpu_command_buffer_gl.cc
@@ -34,7 +34,10 @@ std::shared_ptr<GPUBlitPass> GPUCommandBufferGL::BeginBlitPass() {
   return std::make_shared<GPUBlitPassGL>();
 }
 
-bool GPUCommandBufferGL::Submit() { return true; }
+bool GPUCommandBufferGL::Submit(const GPUSubmitInfo* submit_info) {
+  (void)submit_info;
+  return true;
+}
 
 std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginDirectRenderPass(
     const skity::GPURenderPassDescriptor& desc) {

--- a/src/gpu/gl/gpu_command_buffer_gl.hpp
+++ b/src/gpu/gl/gpu_command_buffer_gl.hpp
@@ -21,7 +21,7 @@ class GPUCommandBufferGL : public GPUCommandBuffer {
 
   std::shared_ptr<GPUBlitPass> BeginBlitPass() override;
 
-  bool Submit() override;
+  bool Submit(const GPUSubmitInfo* submit_info = nullptr) override;
 
  private:
   std::shared_ptr<GPURenderPass> BeginDirectRenderPass(

--- a/src/gpu/gpu_command_buffer.hpp
+++ b/src/gpu/gpu_command_buffer.hpp
@@ -6,6 +6,7 @@
 #define SRC_GPU_GPU_COMMAND_BUFFER_HPP
 
 #include <memory>
+#include <skity/gpu/gpu_backend_type.hpp>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,15 @@
 #include "src/gpu/gpu_render_pass.hpp"
 
 namespace skity {
+
+class GPUSubmitInfo {
+ public:
+  virtual ~GPUSubmitInfo() = default;
+
+  virtual GPUBackendType GetBackendType() const {
+    return GPUBackendType::kNone;
+  }
+};
 
 class GPUCommandBuffer {
  public:
@@ -23,7 +33,9 @@ class GPUCommandBuffer {
 
   virtual std::shared_ptr<GPUBlitPass> BeginBlitPass() = 0;
 
-  virtual bool Submit() = 0;
+  virtual void HoldResource(std::shared_ptr<void> resource) { (void)resource; }
+
+  virtual bool Submit(const GPUSubmitInfo* submit_info = nullptr) = 0;
 
   void SetLabel(const std::string& label) { label_ = label; }
 

--- a/src/gpu/gpu_context_impl.cc
+++ b/src/gpu/gpu_context_impl.cc
@@ -119,4 +119,12 @@ std::shared_ptr<Data> GPUContextImpl::ReadPixels(
   return OnReadPixels(texture);
 }
 
+void GPUContextImpl::ResetOwnedResources() {
+  pipeline_lib_.reset();
+  render_target_cache_.reset();
+  atlas_manager_.reset();
+  texture_manager_.reset();
+  gpu_device_.reset();
+}
+
 }  // namespace skity

--- a/src/gpu/gpu_context_impl.hpp
+++ b/src/gpu/gpu_context_impl.hpp
@@ -24,6 +24,12 @@ class GPUContextImpl : public GPUContext {
 
   GPUBackendType GetBackendType() const override { return backend_type_; }
 
+  std::unique_ptr<GPUPresenter> CreatePresenter(
+      GPUPresenterDescriptor* desc) override {
+    (void)desc;
+    return nullptr;
+  }
+
   std::shared_ptr<Texture> CreateTexture(TextureFormat format, uint32_t width,
                                          uint32_t height,
                                          skity::AlphaType alpha_type) override;
@@ -59,6 +65,8 @@ class GPUContextImpl : public GPUContext {
   std::shared_ptr<Data> ReadPixels(const std::shared_ptr<GPUTexture>& texture);
 
  protected:
+  void ResetOwnedResources();
+
   virtual std::unique_ptr<GPUDevice> CreateGPUDevice() = 0;
 
   virtual std::shared_ptr<GPUTexture> OnWrapTexture(

--- a/src/gpu/gpu_render_pass.hpp
+++ b/src/gpu/gpu_render_pass.hpp
@@ -226,6 +226,10 @@ struct Command {
   ArrayList<TextureBinding, 4> texture_bindings;
   ArrayList<SamplerBinding, 4> sampler_bindings;
   uint32_t stencil_reference = 0u;
+  uint32_t front_stencil_compare_mask = 0xFFFFFFFFu;
+  uint32_t back_stencil_compare_mask = 0xFFFFFFFFu;
+  uint32_t front_stencil_write_mask = 0xFFFFFFFFu;
+  uint32_t back_stencil_write_mask = 0xFFFFFFFFu;
   uint32_t index_count = 0u;
   uint32_t instance_count = 0u;
 

--- a/src/gpu/gpu_surface_impl.hpp
+++ b/src/gpu/gpu_surface_impl.hpp
@@ -16,12 +16,17 @@ namespace skity {
 class HWCanvas;
 class HWRootLayer;
 class HWStageBuffer;
+class GPUCommandBuffer;
 
 class GPUSurfaceImpl : public GPUSurface {
  public:
   GPUSurfaceImpl(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx);
 
   ~GPUSurfaceImpl() override;
+
+  GPUBackendType GetBackendType() const override {
+    return ctx_ != nullptr ? ctx_->GetBackendType() : GPUBackendType::kNone;
+  }
 
   uint32_t GetWidth() const override { return width_; }
 
@@ -44,6 +49,8 @@ class GPUSurfaceImpl : public GPUSurface {
   ArenaAllocator* GetArenaAllocator() const { return arena_allocator_.get(); }
 
   virtual GPUTextureFormat GetGPUFormat() const = 0;
+
+  virtual const GPUSubmitInfo* GetSubmitInfo() const { return nullptr; }
 
  protected:
   virtual HWRootLayer* OnBeginNextFrame(bool clear) = 0;

--- a/src/gpu/mtl/gpu_command_buffer_mtl.h
+++ b/src/gpu/mtl/gpu_command_buffer_mtl.h
@@ -26,7 +26,7 @@ class GPUCommandBufferMTL : public GPUCommandBuffer {
 
   std::shared_ptr<GPUBlitPass> BeginBlitPass() override;
 
-  bool Submit() override;
+  bool Submit(const GPUSubmitInfo* submit_info = nullptr) override;
 
  private:
   id<MTLDevice> mtl_device_;

--- a/src/gpu/mtl/gpu_command_buffer_mtl.mm
+++ b/src/gpu/mtl/gpu_command_buffer_mtl.mm
@@ -27,7 +27,8 @@ std::shared_ptr<GPUBlitPass> GPUCommandBufferMTL::BeginBlitPass() {
   return std::make_shared<GPUBlitPassMTL>(mtl_device_, blit_encoder);
 }
 
-bool GPUCommandBufferMTL::Submit() {
+bool GPUCommandBufferMTL::Submit(const GPUSubmitInfo* submit_info) {
+  (void)submit_info;
   mtl_command_buffer_.label = [NSString stringWithUTF8String:GetLabel().c_str()];
   [mtl_command_buffer_ addCompletedHandler:^(id<MTLCommandBuffer> cmd) {
     if (cmd.error == nil) {

--- a/src/gpu/vk/gpu_blit_pass_vk.cc
+++ b/src/gpu/vk/gpu_blit_pass_vk.cc
@@ -1,0 +1,375 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_blit_pass_vk.hpp"
+
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+VkImageAspectFlags GetImageAspectMask(GPUTextureFormat format) {
+  switch (format) {
+    case GPUTextureFormat::kStencil8:
+      return VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kDepth24Stencil8:
+      return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kInvalid:
+      return 0;
+    default:
+      return VK_IMAGE_ASPECT_COLOR_BIT;
+  }
+}
+
+VkAccessFlags AccessMaskForLayout(VkImageLayout layout) {
+  switch (layout) {
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+      return VK_ACCESS_TRANSFER_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+      return VK_ACCESS_TRANSFER_READ_BIT;
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+      return VK_ACCESS_SHADER_READ_BIT;
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+      return VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+      return VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_GENERAL:
+      return VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT |
+             VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+    default:
+      return 0;
+  }
+}
+
+VkPipelineStageFlags StageMaskForLayout(VkImageLayout layout) {
+  switch (layout) {
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+      return VK_PIPELINE_STAGE_TRANSFER_BIT;
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+      return VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+      return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+      return VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+             VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    case VK_IMAGE_LAYOUT_GENERAL:
+      return VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    default:
+      return VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+  }
+}
+
+void TransitionImageLayout(const VulkanContextState& state,
+                           VkCommandBuffer command_buffer,
+                           GPUTextureVK& texture, VkImageLayout new_layout) {
+  const VkImageLayout old_layout = texture.GetCurrentLayout();
+  if (old_layout == new_layout) {
+    return;
+  }
+
+  VkImageMemoryBarrier barrier = {};
+  barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  barrier.oldLayout = old_layout;
+  barrier.newLayout = new_layout;
+  barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.image = texture.GetImage();
+  barrier.subresourceRange.aspectMask =
+      GetImageAspectMask(texture.GetDescriptor().format);
+  barrier.subresourceRange.baseMipLevel = 0;
+  barrier.subresourceRange.levelCount = texture.GetDescriptor().mip_level_count;
+  barrier.subresourceRange.baseArrayLayer = 0;
+  barrier.subresourceRange.layerCount = 1;
+  barrier.srcAccessMask = AccessMaskForLayout(old_layout);
+  barrier.dstAccessMask = AccessMaskForLayout(new_layout);
+
+  state.DeviceFns().vkCmdPipelineBarrier(
+      command_buffer, StageMaskForLayout(old_layout),
+      StageMaskForLayout(new_layout), 0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+  texture.SetCurrentLayout(new_layout);
+}
+
+void TransitionMipRangeLayout(const VulkanContextState& state,
+                              VkCommandBuffer command_buffer,
+                              GPUTextureVK& texture, uint32_t base_mip_level,
+                              uint32_t level_count, VkImageLayout old_layout,
+                              VkImageLayout new_layout) {
+  if (old_layout == new_layout || level_count == 0) {
+    return;
+  }
+
+  VkImageMemoryBarrier barrier = {};
+  barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  barrier.oldLayout = old_layout;
+  barrier.newLayout = new_layout;
+  barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.image = texture.GetImage();
+  barrier.subresourceRange.aspectMask =
+      GetImageAspectMask(texture.GetDescriptor().format);
+  barrier.subresourceRange.baseMipLevel = base_mip_level;
+  barrier.subresourceRange.levelCount = level_count;
+  barrier.subresourceRange.baseArrayLayer = 0;
+  barrier.subresourceRange.layerCount = 1;
+  barrier.srcAccessMask = AccessMaskForLayout(old_layout);
+  barrier.dstAccessMask = AccessMaskForLayout(new_layout);
+
+  state.DeviceFns().vkCmdPipelineBarrier(
+      command_buffer, StageMaskForLayout(old_layout),
+      StageMaskForLayout(new_layout), 0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+bool SupportsLinearBlit(const VulkanContextState& state, VkFormat format) {
+  if (format == VK_FORMAT_UNDEFINED ||
+      state.InstanceFns().vkGetPhysicalDeviceFormatProperties == nullptr) {
+    return false;
+  }
+
+  VkFormatProperties format_properties = {};
+  state.InstanceFns().vkGetPhysicalDeviceFormatProperties(
+      state.GetPhysicalDevice(), format, &format_properties);
+  return (format_properties.optimalTilingFeatures &
+          VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) != 0;
+}
+
+}  // namespace
+
+GPUBlitPassVK::GPUBlitPassVK(std::shared_ptr<const VulkanContextState> state,
+                             GPUCommandBufferVK* command_buffer)
+    : state_(std::move(state)), command_buffer_(command_buffer) {}
+
+void GPUBlitPassVK::UploadTextureData(std::shared_ptr<GPUTexture> texture,
+                                      uint32_t offset_x, uint32_t offset_y,
+                                      uint32_t width, uint32_t height,
+                                      void* data) {
+  const auto texture_ref = texture;
+  auto texture_vk = GPUTextureVK::Cast(texture.get());
+  if (texture_vk == nullptr || state_ == nullptr ||
+      command_buffer_ == nullptr || data == nullptr || width == 0 ||
+      height == 0) {
+    LOGE("Failed to upload Vulkan texture data: invalid upload state");
+    return;
+  }
+
+  if (texture_vk->GetImage() == VK_NULL_HANDLE ||
+      command_buffer_->GetCommandBuffer() == VK_NULL_HANDLE) {
+    LOGE(
+        "Failed to upload Vulkan texture data: image or command buffer is "
+        "unavailable");
+    return;
+  }
+
+  if (texture_vk->GetDescriptor().sample_count != 1) {
+    LOGW("Uploading CPU data to multisampled Vulkan textures is unsupported");
+    return;
+  }
+
+  const size_t bytes_per_pixel =
+      GetTextureFormatBytesPerPixel(texture_vk->GetDescriptor().format);
+  if (bytes_per_pixel == 0) {
+    LOGE("Failed to upload Vulkan texture data: invalid texture format");
+    return;
+  }
+
+  const size_t upload_size =
+      static_cast<size_t>(width) * height * bytes_per_pixel;
+  auto staging_buffer = std::make_unique<GPUBufferVK>(
+      0u, state_, GPUBufferVKMemoryType::kHostVisible);
+  if (!staging_buffer->UploadData(data, upload_size)) {
+    return;
+  }
+
+  TransitionImageLayout(*state_, command_buffer_->GetCommandBuffer(),
+                        *texture_vk, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+  VkBufferImageCopy copy_region = {};
+  copy_region.bufferOffset = 0;
+  copy_region.bufferRowLength = 0;
+  copy_region.bufferImageHeight = 0;
+  copy_region.imageSubresource.aspectMask =
+      GetImageAspectMask(texture_vk->GetDescriptor().format);
+  copy_region.imageSubresource.mipLevel = 0;
+  copy_region.imageSubresource.baseArrayLayer = 0;
+  copy_region.imageSubresource.layerCount = 1;
+  copy_region.imageOffset = {static_cast<int32_t>(offset_x),
+                             static_cast<int32_t>(offset_y), 0};
+  copy_region.imageExtent = {width, height, 1};
+
+  state_->DeviceFns().vkCmdCopyBufferToImage(
+      command_buffer_->GetCommandBuffer(), staging_buffer->GetBuffer(),
+      texture_vk->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
+      &copy_region);
+
+  TransitionImageLayout(*state_, command_buffer_->GetCommandBuffer(),
+                        *texture_vk, texture_vk->GetPreferredLayout());
+  command_buffer_->RecordStageBuffer(std::move(staging_buffer));
+  command_buffer_->RecordCleanupAction([texture_ref]() {});
+}
+
+void GPUBlitPassVK::UploadBufferData(GPUBuffer* buffer, void* data,
+                                     size_t size) {
+  auto* destination_buffer = static_cast<GPUBufferVK*>(buffer);
+  if (destination_buffer == nullptr || state_ == nullptr ||
+      command_buffer_ == nullptr) {
+    LOGE("Failed to upload Vulkan buffer data: invalid upload state");
+    return;
+  }
+
+  if (!destination_buffer->ResizeIfNeeded(size)) {
+    return;
+  }
+
+  auto staging_buffer = std::make_unique<GPUBufferVK>(
+      0u, state_, GPUBufferVKMemoryType::kHostVisible);
+  if (!staging_buffer->UploadData(data, size)) {
+    return;
+  }
+
+  VkBufferCopy copy_region = {};
+  copy_region.size = size;
+
+  state_->DeviceFns().vkCmdCopyBuffer(
+      command_buffer_->GetCommandBuffer(), staging_buffer->GetBuffer(),
+      destination_buffer->GetBuffer(), 1, &copy_region);
+
+  command_buffer_->RecordStageBuffer(std::move(staging_buffer));
+}
+
+void GPUBlitPassVK::GenerateMipmaps(
+    const std::shared_ptr<GPUTexture>& texture) {
+  const auto texture_ref = texture;
+  auto* texture_vk = GPUTextureVK::Cast(texture.get());
+  if (texture_vk == nullptr || state_ == nullptr ||
+      command_buffer_ == nullptr) {
+    LOGE("Failed to generate Vulkan mipmaps: invalid blit pass state");
+    return;
+  }
+
+  if (texture_vk->GetImage() == VK_NULL_HANDLE ||
+      command_buffer_->GetCommandBuffer() == VK_NULL_HANDLE) {
+    LOGE(
+        "Failed to generate Vulkan mipmaps: image or command buffer is "
+        "unavailable");
+    return;
+  }
+
+  const auto& desc = texture_vk->GetDescriptor();
+  if (desc.mip_level_count <= 1) {
+    return;
+  }
+
+  if (desc.sample_count != 1) {
+    LOGW("Skipping Vulkan mipmap generation for multisampled texture");
+    return;
+  }
+
+  if (GetImageAspectMask(desc.format) != VK_IMAGE_ASPECT_COLOR_BIT) {
+    LOGW("Skipping Vulkan mipmap generation for non-color texture format");
+    return;
+  }
+
+  if (!SupportsLinearBlit(*state_, texture_vk->GetVkFormat())) {
+    LOGW(
+        "Skipping Vulkan mipmap generation: format does not support linear "
+        "blit");
+    return;
+  }
+
+  const VkCommandBuffer command_buffer = command_buffer_->GetCommandBuffer();
+  const VkImageLayout initial_layout = texture_vk->GetCurrentLayout();
+
+  TransitionMipRangeLayout(*state_, command_buffer, *texture_vk, 0, 1,
+                           initial_layout,
+                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+  TransitionMipRangeLayout(*state_, command_buffer, *texture_vk, 1,
+                           desc.mip_level_count - 1, initial_layout,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+  int32_t mip_width = static_cast<int32_t>(desc.width);
+  int32_t mip_height = static_cast<int32_t>(desc.height);
+
+  for (uint32_t mip_level = 1; mip_level < desc.mip_level_count; ++mip_level) {
+    const int32_t next_width = std::max(1, mip_width / 2);
+    const int32_t next_height = std::max(1, mip_height / 2);
+
+    VkImageBlit blit_region = {};
+    blit_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    blit_region.srcSubresource.mipLevel = mip_level - 1;
+    blit_region.srcSubresource.baseArrayLayer = 0;
+    blit_region.srcSubresource.layerCount = 1;
+    blit_region.srcOffsets[0] = {0, 0, 0};
+    blit_region.srcOffsets[1] = {mip_width, mip_height, 1};
+    blit_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    blit_region.dstSubresource.mipLevel = mip_level;
+    blit_region.dstSubresource.baseArrayLayer = 0;
+    blit_region.dstSubresource.layerCount = 1;
+    blit_region.dstOffsets[0] = {0, 0, 0};
+    blit_region.dstOffsets[1] = {next_width, next_height, 1};
+
+    state_->DeviceFns().vkCmdBlitImage(command_buffer, texture_vk->GetImage(),
+                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                       texture_vk->GetImage(),
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
+                                       &blit_region, VK_FILTER_LINEAR);
+
+    TransitionMipRangeLayout(
+        *state_, command_buffer, *texture_vk, mip_level - 1, 1,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, texture_vk->GetPreferredLayout());
+
+    if (mip_level < desc.mip_level_count - 1) {
+      TransitionMipRangeLayout(*state_, command_buffer, *texture_vk, mip_level,
+                               1, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    } else {
+      TransitionMipRangeLayout(*state_, command_buffer, *texture_vk, mip_level,
+                               1, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               texture_vk->GetPreferredLayout());
+    }
+
+    mip_width = next_width;
+    mip_height = next_height;
+  }
+
+  texture_vk->SetCurrentLayout(texture_vk->GetPreferredLayout());
+  command_buffer_->RecordCleanupAction([texture_ref]() {});
+}
+
+void GPUBlitPassVK::End() { InsertDebugLabelIfNeeded(); }
+
+void GPUBlitPassVK::InsertDebugLabelIfNeeded() {
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  if (state_ == nullptr || command_buffer_ == nullptr ||
+      !state_->HasEnabledInstanceExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME) ||
+      state_->DeviceFns().vkCmdInsertDebugUtilsLabelEXT == nullptr) {
+    return;
+  }
+
+  std::string label = command_buffer_->GetLabel();
+  if (label.empty()) {
+    label = "BlitPass";
+  } else {
+    label += " BlitPass";
+  }
+
+  VkDebugUtilsLabelEXT debug_label = {};
+  debug_label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+  debug_label.pLabelName = label.c_str();
+
+  state_->DeviceFns().vkCmdInsertDebugUtilsLabelEXT(
+      command_buffer_->GetCommandBuffer(), &debug_label);
+#endif
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_blit_pass_vk.hpp
+++ b/src/gpu/vk/gpu_blit_pass_vk.hpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_BLIT_PASS_VK_HPP
+#define SRC_GPU_VK_GPU_BLIT_PASS_VK_HPP
+
+#include "src/gpu/gpu_blit_pass.hpp"
+
+namespace skity {
+
+class GPUCommandBufferVK;
+class VulkanContextState;
+
+class GPUBlitPassVK : public GPUBlitPass {
+ public:
+  GPUBlitPassVK(std::shared_ptr<const VulkanContextState> state,
+                GPUCommandBufferVK* command_buffer);
+
+  ~GPUBlitPassVK() override = default;
+
+  void UploadTextureData(std::shared_ptr<GPUTexture> texture, uint32_t offset_x,
+                         uint32_t offset_y, uint32_t width, uint32_t height,
+                         void* data) override;
+
+  void UploadBufferData(GPUBuffer* buffer, void* data, size_t size) override;
+
+  void GenerateMipmaps(const std::shared_ptr<GPUTexture>& texture) override;
+
+  void End() override;
+
+ private:
+  void InsertDebugLabelIfNeeded();
+
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  GPUCommandBufferVK* command_buffer_ = nullptr;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_BLIT_PASS_VK_HPP

--- a/src/gpu/vk/gpu_buffer_vk.cc
+++ b/src/gpu/vk/gpu_buffer_vk.cc
@@ -1,0 +1,147 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+VkBufferUsageFlags ConvertGPUBufferUsageMask(GPUBufferUsageMask usage) {
+  VkBufferUsageFlags flags = 0;
+
+  if ((usage & GPUBufferUsage::kVertexBuffer) != 0) {
+    flags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+  }
+
+  if ((usage & GPUBufferUsage::kUniformBuffer) != 0) {
+    flags |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+  }
+
+  if ((usage & GPUBufferUsage::kIndexBuffer) != 0) {
+    flags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+  }
+
+  return flags;
+}
+
+}  // namespace
+
+GPUBufferVK::GPUBufferVK(GPUBufferUsageMask usage,
+                         std::shared_ptr<const VulkanContextState> state,
+                         GPUBufferVKMemoryType memory_type)
+    : GPUBuffer(usage), state_(std::move(state)), memory_type_(memory_type) {}
+
+GPUBufferVK::~GPUBufferVK() { DestroyBuffer(); }
+
+bool GPUBufferVK::ResizeIfNeeded(size_t size) {
+  if (size == 0) {
+    return true;
+  }
+
+  if (size_ >= size && IsValid()) {
+    return true;
+  }
+
+  return CreateBuffer(size);
+}
+
+bool GPUBufferVK::UploadData(const void* data, size_t size) {
+  if (data == nullptr || size == 0) {
+    LOGW("Uploading data to Vulkan buffer with empty source");
+    return false;
+  }
+
+  if (!ResizeIfNeeded(size)) {
+    return false;
+  }
+
+  if (state_ == nullptr || state_->GetAllocator() == nullptr ||
+      allocation_ == nullptr) {
+    LOGE("Failed to upload Vulkan buffer data: allocator is unavailable");
+    return false;
+  }
+
+  if (memory_type_ != GPUBufferVKMemoryType::kHostVisible) {
+    LOGE(
+        "Failed to upload Vulkan buffer data: destination buffer is not "
+        "host visible");
+    return false;
+  }
+
+  const VkResult result = vmaCopyMemoryToAllocation(state_->GetAllocator(),
+                                                    data, allocation_, 0, size);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to upload {} bytes to Vulkan buffer: {}", size,
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  return true;
+}
+
+bool GPUBufferVK::CreateBuffer(VkDeviceSize size) {
+  DestroyBuffer();
+
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state_->GetAllocator() == nullptr) {
+    LOGE("Failed to create Vulkan buffer: device or allocator is unavailable");
+    return false;
+  }
+
+  VkBufferCreateInfo buffer_info = {};
+  buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+  buffer_info.size = size;
+  buffer_info.usage = ConvertGPUBufferUsageMask(GetUsage());
+  if (memory_type_ == GPUBufferVKMemoryType::kHostVisible) {
+    buffer_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+  } else {
+    buffer_info.usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+  }
+  buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  VmaAllocationCreateInfo allocation_info = {};
+  if (memory_type_ == GPUBufferVKMemoryType::kHostVisible) {
+    allocation_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+    allocation_info.flags =
+        VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+        VMA_ALLOCATION_CREATE_MAPPED_BIT;
+  } else {
+    allocation_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    allocation_info.flags = 0;
+  }
+
+  VmaAllocationInfo vma_info = {};
+  const VkResult result =
+      vmaCreateBuffer(state_->GetAllocator(), &buffer_info, &allocation_info,
+                      &buffer_, &allocation_, &vma_info);
+  if (result != VK_SUCCESS || buffer_ == VK_NULL_HANDLE ||
+      allocation_ == nullptr) {
+    LOGE("Failed to create Vulkan buffer with size {}: {}",
+         static_cast<uint64_t>(size), static_cast<int32_t>(result));
+    DestroyBuffer();
+    return false;
+  }
+
+  mapped_data_ = vma_info.pMappedData;
+  size_ = size;
+  return true;
+}
+
+void GPUBufferVK::DestroyBuffer() {
+  if (state_ != nullptr && state_->GetAllocator() != nullptr &&
+      buffer_ != VK_NULL_HANDLE && allocation_ != nullptr) {
+    vmaDestroyBuffer(state_->GetAllocator(), buffer_, allocation_);
+  }
+
+  buffer_ = VK_NULL_HANDLE;
+  allocation_ = nullptr;
+  mapped_data_ = nullptr;
+  size_ = 0;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_buffer_vk.hpp
+++ b/src/gpu/vk/gpu_buffer_vk.hpp
@@ -1,0 +1,63 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_BUFFER_VK_HPP
+#define SRC_GPU_VK_GPU_BUFFER_VK_HPP
+
+#include <vk_mem_alloc.h>
+
+#include <memory>
+
+#include "src/gpu/gpu_buffer.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+enum class GPUBufferVKMemoryType {
+  kDeviceLocal,
+  kHostVisible,
+};
+
+class GPUBufferVK : public GPUBuffer {
+ public:
+  GPUBufferVK(
+      GPUBufferUsageMask usage, std::shared_ptr<const VulkanContextState> state,
+      GPUBufferVKMemoryType memory_type = GPUBufferVKMemoryType::kDeviceLocal);
+
+  ~GPUBufferVK() override;
+
+  bool ResizeIfNeeded(size_t size);
+
+  bool UploadData(const void* data, size_t size);
+
+  bool IsValid() const {
+    return buffer_ != VK_NULL_HANDLE && allocation_ != VK_NULL_HANDLE;
+  }
+
+  VkBuffer GetBuffer() const { return buffer_; }
+
+  VmaAllocation GetAllocation() const { return allocation_; }
+
+  void* GetMappedData() const { return mapped_data_; }
+
+  VkDeviceSize GetSize() const { return size_; }
+
+  GPUBufferVKMemoryType GetMemoryType() const { return memory_type_; }
+
+ private:
+  bool CreateBuffer(VkDeviceSize size);
+  void DestroyBuffer();
+
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  GPUBufferVKMemoryType memory_type_ = GPUBufferVKMemoryType::kDeviceLocal;
+  VkBuffer buffer_ = VK_NULL_HANDLE;
+  VmaAllocation allocation_ = nullptr;
+  void* mapped_data_ = nullptr;
+  VkDeviceSize size_ = 0;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_BUFFER_VK_HPP

--- a/src/gpu/vk/gpu_command_buffer_vk.cc
+++ b/src/gpu/vk/gpu_command_buffer_vk.cc
@@ -1,0 +1,328 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+
+#include "src/gpu/vk/gpu_blit_pass_vk.hpp"
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_render_pass_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+
+void SetVkObjectDebugLabel(const VulkanContextState& state,
+                           VkObjectType object_type, uint64_t object_handle,
+                           const std::string& label) {
+  if (label.empty() || object_handle == 0 ||
+      !state.HasEnabledInstanceExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME) ||
+      state.GetLogicalDevice() == VK_NULL_HANDLE ||
+      state.DeviceFns().vkSetDebugUtilsObjectNameEXT == nullptr) {
+    return;
+  }
+
+  VkDebugUtilsObjectNameInfoEXT name_info = {};
+  name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+  name_info.objectType = object_type;
+  name_info.objectHandle = object_handle;
+  name_info.pObjectName = label.c_str();
+
+  const VkResult result = state.DeviceFns().vkSetDebugUtilsObjectNameEXT(
+      state.GetLogicalDevice(), &name_info);
+  if (result != VK_SUCCESS) {
+    LOGW("Failed to set Vulkan object debug label '{}': {}", label,
+         static_cast<int32_t>(result));
+  }
+}
+
+#else
+
+void SetVkObjectDebugLabel(const VulkanContextState& state,
+                           VkObjectType object_type, uint64_t object_handle,
+                           const std::string& label) {
+  (void)state;
+  (void)object_type;
+  (void)object_handle;
+  (void)label;
+}
+
+#endif
+
+}  // namespace
+
+VkResult SubmitCommandBuffer(const VulkanContextState& state, VkQueue queue,
+                             VkCommandBuffer command_buffer, VkFence fence,
+                             const GPUSubmitInfoVK* submit_info) {
+  const auto& device_fns = state.DeviceFns();
+  if (state.IsSynchronization2Enabled() &&
+      device_fns.vkQueueSubmit2 != nullptr) {
+    VkCommandBufferSubmitInfo command_buffer_info = {};
+    command_buffer_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO;
+    command_buffer_info.commandBuffer = command_buffer;
+    command_buffer_info.deviceMask = 0;
+
+    VkSemaphoreSubmitInfo wait_semaphore_info = {};
+    if (submit_info != nullptr &&
+        submit_info->wait_semaphore != VK_NULL_HANDLE) {
+      wait_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+      wait_semaphore_info.semaphore = submit_info->wait_semaphore;
+      wait_semaphore_info.stageMask = submit_info->wait_dst_stage_mask;
+      wait_semaphore_info.deviceIndex = 0;
+      wait_semaphore_info.value = 0;
+    }
+
+    VkSemaphoreSubmitInfo signal_semaphore_info = {};
+    if (submit_info != nullptr &&
+        submit_info->signal_semaphore != VK_NULL_HANDLE) {
+      signal_semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+      signal_semaphore_info.semaphore = submit_info->signal_semaphore;
+      signal_semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT;
+      signal_semaphore_info.deviceIndex = 0;
+      signal_semaphore_info.value = 0;
+    }
+
+    VkSubmitInfo2 vk_submit_info2 = {};
+    vk_submit_info2.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+    if (wait_semaphore_info.semaphore != VK_NULL_HANDLE) {
+      vk_submit_info2.waitSemaphoreInfoCount = 1;
+      vk_submit_info2.pWaitSemaphoreInfos = &wait_semaphore_info;
+    }
+    vk_submit_info2.commandBufferInfoCount = 1;
+    vk_submit_info2.pCommandBufferInfos = &command_buffer_info;
+    if (signal_semaphore_info.semaphore != VK_NULL_HANDLE) {
+      vk_submit_info2.signalSemaphoreInfoCount = 1;
+      vk_submit_info2.pSignalSemaphoreInfos = &signal_semaphore_info;
+    }
+
+    return device_fns.vkQueueSubmit2(queue, 1, &vk_submit_info2, fence);
+  }
+
+  VkPipelineStageFlags wait_stage_mask =
+      submit_info != nullptr ? submit_info->wait_dst_stage_mask
+                             : VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  VkSubmitInfo vk_submit_info = {};
+  vk_submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  if (submit_info != nullptr && submit_info->wait_semaphore != VK_NULL_HANDLE) {
+    vk_submit_info.waitSemaphoreCount = 1;
+    vk_submit_info.pWaitSemaphores = &submit_info->wait_semaphore;
+    vk_submit_info.pWaitDstStageMask = &wait_stage_mask;
+  }
+  vk_submit_info.commandBufferCount = 1;
+  vk_submit_info.pCommandBuffers = &command_buffer;
+  if (submit_info != nullptr &&
+      submit_info->signal_semaphore != VK_NULL_HANDLE) {
+    vk_submit_info.signalSemaphoreCount = 1;
+    vk_submit_info.pSignalSemaphores = &submit_info->signal_semaphore;
+  }
+
+  return device_fns.vkQueueSubmit(queue, 1, &vk_submit_info, fence);
+}
+
+GPUCommandBufferVK::GPUCommandBufferVK(
+    std::shared_ptr<const VulkanContextState> state)
+    : state_(std::move(state)) {}
+
+GPUCommandBufferVK::~GPUCommandBufferVK() { Reset(); }
+
+bool GPUCommandBufferVK::Init() {
+  if (state_ != nullptr) {
+    state_->CollectPendingSubmissions(false);
+  }
+
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state_->GetGraphicsQueue() == VK_NULL_HANDLE ||
+      state_->GetGraphicsQueueFamilyIndex() < 0) {
+    LOGE("Failed to initialize Vulkan command buffer: context is unavailable");
+    return false;
+  }
+
+  const auto& device_fns = state_->DeviceFns();
+  VkCommandPoolCreateInfo pool_info = {};
+  pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  pool_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+  pool_info.queueFamilyIndex =
+      static_cast<uint32_t>(state_->GetGraphicsQueueFamilyIndex());
+
+  VkResult result = device_fns.vkCreateCommandPool(
+      state_->GetLogicalDevice(), &pool_info, nullptr, &command_pool_);
+  if (result != VK_SUCCESS || command_pool_ == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan command pool: {}",
+         static_cast<int32_t>(result));
+    Reset();
+    return false;
+  }
+
+  VkCommandBufferAllocateInfo allocate_info = {};
+  allocate_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  allocate_info.commandPool = command_pool_;
+  allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  allocate_info.commandBufferCount = 1;
+
+  result = device_fns.vkAllocateCommandBuffers(
+      state_->GetLogicalDevice(), &allocate_info, &command_buffer_);
+  if (result != VK_SUCCESS || command_buffer_ == VK_NULL_HANDLE) {
+    LOGE("Failed to allocate Vulkan command buffer: {}",
+         static_cast<int32_t>(result));
+    Reset();
+    return false;
+  }
+
+  VkCommandBufferBeginInfo begin_info = {};
+  begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+  result = device_fns.vkBeginCommandBuffer(command_buffer_, &begin_info);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to begin Vulkan command buffer: {}",
+         static_cast<int32_t>(result));
+    Reset();
+    return false;
+  }
+
+  recording_ = true;
+  return true;
+}
+
+std::shared_ptr<GPURenderPass> GPUCommandBufferVK::BeginRenderPass(
+    const GPURenderPassDescriptor& desc) {
+  if (!recording_ || command_buffer_ == VK_NULL_HANDLE || state_ == nullptr) {
+    LOGE("Failed to begin Vulkan render pass: command buffer is not recording");
+    return {};
+  }
+
+  return std::make_shared<GPURenderPassVK>(state_, this, desc);
+}
+
+std::shared_ptr<GPUBlitPass> GPUCommandBufferVK::BeginBlitPass() {
+  if (!recording_ || command_buffer_ == VK_NULL_HANDLE) {
+    LOGE("Failed to begin Vulkan blit pass: command buffer is not recording");
+    return {};
+  }
+
+  return std::make_shared<GPUBlitPassVK>(state_, this);
+}
+
+void GPUCommandBufferVK::HoldResource(std::shared_ptr<void> resource) {
+  if (resource == nullptr) {
+    return;
+  }
+
+  cleanup_actions_.emplace_back([resource = std::move(resource)]() {});
+}
+
+bool GPUCommandBufferVK::Submit(const GPUSubmitInfo* submit_info) {
+  if (!recording_ || submitted_ || state_ == nullptr ||
+      command_buffer_ == VK_NULL_HANDLE) {
+    return false;
+  }
+
+  if (submit_info != nullptr &&
+      submit_info->GetBackendType() != GPUBackendType::kVulkan) {
+    LOGE("Failed to submit Vulkan command buffer: invalid submit info type");
+    return false;
+  }
+  const auto* submit_info_vk = static_cast<const GPUSubmitInfoVK*>(submit_info);
+
+  ApplyDebugLabelsIfNeeded();
+
+  const auto& device_fns = state_->DeviceFns();
+  VkFence fence =
+      submit_info_vk != nullptr ? submit_info_vk->signal_fence : VK_NULL_HANDLE;
+  bool owns_fence = false;
+
+  VkResult result = device_fns.vkEndCommandBuffer(command_buffer_);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to end Vulkan command buffer: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  recording_ = false;
+
+  if (fence == VK_NULL_HANDLE) {
+    VkFenceCreateInfo fence_info = {};
+    fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    result = device_fns.vkCreateFence(state_->GetLogicalDevice(), &fence_info,
+                                      nullptr, &fence);
+    if (result != VK_SUCCESS || fence == VK_NULL_HANDLE) {
+      LOGE("Failed to create Vulkan fence: {}", static_cast<int32_t>(result));
+      return false;
+    }
+    owns_fence = true;
+  }
+
+  result = SubmitCommandBuffer(*state_, state_->GetGraphicsQueue(),
+                               command_buffer_, fence, submit_info_vk);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to submit Vulkan command buffer: {}",
+         static_cast<int32_t>(result));
+    if (owns_fence) {
+      device_fns.vkDestroyFence(state_->GetLogicalDevice(), fence, nullptr);
+    }
+    return false;
+  }
+
+  state_->EnqueuePendingSubmission(
+      VulkanPendingSubmission(fence, command_pool_, std::move(stage_buffers_),
+                              std::move(cleanup_actions_), owns_fence));
+  state_->CollectPendingSubmissions(false);
+
+  submitted_ = true;
+  command_buffer_ = VK_NULL_HANDLE;
+  command_pool_ = VK_NULL_HANDLE;
+  return true;
+}
+
+void GPUCommandBufferVK::RecordStageBuffer(
+    std::unique_ptr<GPUBufferVK> buffer) {
+  if (buffer != nullptr) {
+    stage_buffers_.emplace_back(std::move(buffer));
+  }
+}
+
+void GPUCommandBufferVK::RecordCleanupAction(std::function<void()> action) {
+  if (action) {
+    cleanup_actions_.emplace_back(std::move(action));
+  }
+}
+
+void GPUCommandBufferVK::ApplyDebugLabelsIfNeeded() {
+  if (state_ == nullptr) {
+    return;
+  }
+
+  const std::string& label = GetLabel();
+  if (label.empty()) {
+    return;
+  }
+
+  SetVkObjectDebugLabel(*state_, VK_OBJECT_TYPE_COMMAND_POOL,
+                        reinterpret_cast<uint64_t>(command_pool_),
+                        label + " CommandPool");
+  SetVkObjectDebugLabel(*state_, VK_OBJECT_TYPE_COMMAND_BUFFER,
+                        reinterpret_cast<uint64_t>(command_buffer_), label);
+}
+
+void GPUCommandBufferVK::Reset() {
+  stage_buffers_.clear();
+  cleanup_actions_.clear();
+
+  if (state_ != nullptr && command_pool_ != VK_NULL_HANDLE &&
+      state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+      state_->DeviceFns().vkDestroyCommandPool != nullptr) {
+    state_->DeviceFns().vkDestroyCommandPool(state_->GetLogicalDevice(),
+                                             command_pool_, nullptr);
+  }
+
+  command_buffer_ = VK_NULL_HANDLE;
+  command_pool_ = VK_NULL_HANDLE;
+  recording_ = false;
+  submitted_ = false;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_command_buffer_vk.hpp
+++ b/src/gpu/vk/gpu_command_buffer_vk.hpp
@@ -1,0 +1,74 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_COMMAND_BUFFER_VK_HPP
+#define SRC_GPU_VK_GPU_COMMAND_BUFFER_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <functional>
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <vector>
+
+#include "src/gpu/gpu_command_buffer.hpp"
+
+namespace skity {
+
+class GPUBufferVK;
+class VulkanContextState;
+
+class GPUSubmitInfoVK : public GPUSubmitInfo {
+ public:
+  GPUBackendType GetBackendType() const override {
+    return GPUBackendType::kVulkan;
+  }
+
+  VkSemaphore wait_semaphore = VK_NULL_HANDLE;
+  VkPipelineStageFlags wait_dst_stage_mask =
+      VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  VkSemaphore signal_semaphore = VK_NULL_HANDLE;
+  VkFence signal_fence = VK_NULL_HANDLE;
+};
+
+class GPUCommandBufferVK : public GPUCommandBuffer {
+ public:
+  explicit GPUCommandBufferVK(std::shared_ptr<const VulkanContextState> state);
+
+  ~GPUCommandBufferVK() override;
+
+  bool Init();
+
+  std::shared_ptr<GPURenderPass> BeginRenderPass(
+      const GPURenderPassDescriptor& desc) override;
+
+  std::shared_ptr<GPUBlitPass> BeginBlitPass() override;
+
+  void HoldResource(std::shared_ptr<void> resource) override;
+
+  bool Submit(const GPUSubmitInfo* submit_info = nullptr) override;
+
+  VkCommandBuffer GetCommandBuffer() const { return command_buffer_; }
+
+  void ApplyDebugLabelsIfNeeded();
+
+  void RecordStageBuffer(std::unique_ptr<GPUBufferVK> buffer);
+
+  void RecordCleanupAction(std::function<void()> action);
+
+ private:
+  void Reset();
+
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  VkCommandPool command_pool_ = VK_NULL_HANDLE;
+  VkCommandBuffer command_buffer_ = VK_NULL_HANDLE;
+  bool recording_ = false;
+  bool submitted_ = false;
+  std::vector<std::unique_ptr<GPUBufferVK>> stage_buffers_;
+  std::vector<std::function<void()>> cleanup_actions_;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_COMMAND_BUFFER_VK_HPP

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -1,0 +1,819 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_context_impl_vk.hpp"
+
+#include <cmath>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <string>
+#include <vector>
+
+#include "src/gpu/vk/gpu_device_vk.hpp"
+#include "src/gpu/vk/gpu_presenter_vk.hpp"
+#include "src/gpu/vk/gpu_surface_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/gpu/vk/vulkan_proc_table.hpp"
+#include "src/logging.hpp"
+
+// put VMA_IMPLEMENTATION here
+#ifndef VMA_IMPLEMENTATION
+#define VMA_IMPLEMENTATION
+#endif
+#ifndef VMA_STATIC_VULKAN_FUNCTIONS
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#endif
+#ifndef VMA_DYNAMIC_VULKAN_FUNCTIONS
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#endif
+#include <vk_mem_alloc.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+namespace skity {
+
+namespace {
+
+GPUTextureFormat ToGPUTextureFormat(VkFormat format) {
+  switch (format) {
+    case VK_FORMAT_R8_UNORM:
+      return GPUTextureFormat::kR8Unorm;
+    case VK_FORMAT_R8G8B8_UNORM:
+      return GPUTextureFormat::kRGB8Unorm;
+    case VK_FORMAT_R5G6B5_UNORM_PACK16:
+      return GPUTextureFormat::kRGB565Unorm;
+    case VK_FORMAT_R8G8B8A8_UNORM:
+      return GPUTextureFormat::kRGBA8Unorm;
+    case VK_FORMAT_B8G8R8A8_UNORM:
+      return GPUTextureFormat::kBGRA8Unorm;
+    case VK_FORMAT_S8_UINT:
+      return GPUTextureFormat::kStencil8;
+    case VK_FORMAT_D24_UNORM_S8_UINT:
+    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+      return GPUTextureFormat::kDepth24Stencil8;
+    default:
+      return GPUTextureFormat::kInvalid;
+  }
+}
+
+template <typename Proc>
+Proc LoadInstanceProcByName(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                            VkInstance instance, const char* core_name,
+                            const char* extension_name = nullptr) {
+  auto proc =
+      reinterpret_cast<Proc>(get_instance_proc_addr(instance, core_name));
+  if (proc == nullptr && extension_name != nullptr) {
+    proc = reinterpret_cast<Proc>(
+        get_instance_proc_addr(instance, extension_name));
+  }
+  return proc;
+}
+
+template <typename Proc>
+Proc LoadDeviceProcByName(PFN_vkGetDeviceProcAddr get_device_proc_addr,
+                          VkDevice device, const char* core_name,
+                          const char* extension_name = nullptr) {
+  auto proc = reinterpret_cast<Proc>(get_device_proc_addr(device, core_name));
+  if (proc == nullptr && extension_name != nullptr) {
+    proc = reinterpret_cast<Proc>(get_device_proc_addr(device, extension_name));
+  }
+  return proc;
+}
+
+uint32_t ResolveInstanceApiVersion(const VulkanGlobalFns& global_fns) {
+  if (global_fns.vkEnumerateInstanceVersion == nullptr) {
+    return VK_API_VERSION_1_0;
+  }
+
+  uint32_t version = VK_API_VERSION_1_0;
+  if (global_fns.vkEnumerateInstanceVersion(&version) != VK_SUCCESS) {
+    return VK_API_VERSION_1_0;
+  }
+
+  return version;
+}
+
+bool IsAtLeastVulkan11(uint32_t version) {
+  return VK_API_VERSION_MAJOR(version) > 1 ||
+         (VK_API_VERSION_MAJOR(version) == 1 &&
+          VK_API_VERSION_MINOR(version) >= 1);
+}
+
+bool ContainsExtension(const std::vector<VkExtensionProperties>& extensions,
+                       const char* extension_name) {
+  if (extension_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& extension : extensions) {
+    if (std::string(extension.extensionName) == extension_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool ContainsExtension(const std::vector<std::string>& extensions,
+                       const char* extension_name) {
+  if (extension_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& extension : extensions) {
+    if (extension == extension_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool QueryInstanceExtensions(const VulkanGlobalFns& global_fns,
+                             std::vector<VkExtensionProperties>* extensions) {
+  if (extensions == nullptr) {
+    return false;
+  }
+
+  if (global_fns.vkEnumerateInstanceExtensionProperties == nullptr) {
+    LOGE("Failed to enumerate Vulkan instance extensions: loader is null");
+    return false;
+  }
+
+  uint32_t extension_count = 0;
+  VkResult result = global_fns.vkEnumerateInstanceExtensionProperties(
+      nullptr, &extension_count, nullptr);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to query Vulkan instance extension count: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  extensions->clear();
+  if (extension_count == 0) {
+    return true;
+  }
+
+  extensions->resize(extension_count);
+  result = global_fns.vkEnumerateInstanceExtensionProperties(
+      nullptr, &extension_count, extensions->data());
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to query Vulkan instance extensions: {}",
+         static_cast<int32_t>(result));
+    extensions->clear();
+    return false;
+  }
+
+  extensions->resize(extension_count);
+  return true;
+}
+
+void LogInstanceExtensions(
+    const std::vector<VkExtensionProperties>& extensions) {
+#ifdef SKITY_RELEASE
+  (void)extensions;
+#else
+  LOGD("Enumerated {} Vulkan instance extension(s)", extensions.size());
+  for (const auto& extension : extensions) {
+    LOGD("Vulkan instance extension: {} (spec version {})",
+         extension.extensionName, extension.specVersion);
+  }
+#endif
+}
+
+}  // namespace
+
+bool LoadVulkanGlobalFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                         VulkanGlobalFns* fns) {
+  if (get_instance_proc_addr == nullptr || fns == nullptr) {
+    LOGE("Failed to load Vulkan global procedures: invalid arguments");
+    return false;
+  }
+
+  fns->vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(
+      get_instance_proc_addr(nullptr, "vkCreateInstance"));
+  fns->vkEnumerateInstanceExtensionProperties =
+      reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
+          get_instance_proc_addr(nullptr,
+                                 "vkEnumerateInstanceExtensionProperties"));
+  fns->vkEnumerateInstanceLayerProperties =
+      reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(
+          get_instance_proc_addr(nullptr,
+                                 "vkEnumerateInstanceLayerProperties"));
+  fns->vkEnumerateInstanceVersion =
+      reinterpret_cast<PFN_vkEnumerateInstanceVersion>(
+          get_instance_proc_addr(nullptr, "vkEnumerateInstanceVersion"));
+
+  if (fns->vkCreateInstance == nullptr) {
+    LOGE("Failed to load Vulkan global procedures: vkCreateInstance is null");
+    return false;
+  }
+
+  return true;
+}
+
+bool LoadVulkanInstanceFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                           VkInstance instance, VulkanInstanceFns* fns) {
+  if (get_instance_proc_addr == nullptr || instance == VK_NULL_HANDLE ||
+      fns == nullptr) {
+    LOGE("Failed to load Vulkan instance procedures: invalid arguments");
+    return false;
+  }
+
+  fns->vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(
+      get_instance_proc_addr(instance, "vkDestroyInstance"));
+  fns->vkEnumeratePhysicalDevices =
+      reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(
+          get_instance_proc_addr(instance, "vkEnumeratePhysicalDevices"));
+  fns->vkGetPhysicalDeviceProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(
+          get_instance_proc_addr(instance, "vkGetPhysicalDeviceProperties"));
+  fns->vkGetPhysicalDeviceFormatProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkGetPhysicalDeviceFormatProperties"));
+  fns->vkGetPhysicalDeviceMemoryProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkGetPhysicalDeviceMemoryProperties"));
+  fns->vkGetPhysicalDeviceImageFormatProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkGetPhysicalDeviceImageFormatProperties"));
+  fns->vkGetPhysicalDeviceFeatures2 =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(
+          get_instance_proc_addr(instance, "vkGetPhysicalDeviceFeatures2"));
+  fns->vkGetPhysicalDeviceMemoryProperties2KHR =
+      LoadInstanceProcByName<PFN_vkGetPhysicalDeviceMemoryProperties2KHR>(
+          get_instance_proc_addr, instance,
+          "vkGetPhysicalDeviceMemoryProperties2",
+          "vkGetPhysicalDeviceMemoryProperties2KHR");
+  fns->vkEnumerateDeviceExtensionProperties =
+      reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkEnumerateDeviceExtensionProperties"));
+  fns->vkGetPhysicalDeviceQueueFamilyProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkGetPhysicalDeviceQueueFamilyProperties"));
+  fns->vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(
+      get_instance_proc_addr(instance, "vkCreateDevice"));
+  fns->vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(
+      get_instance_proc_addr(instance, "vkGetDeviceProcAddr"));
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  fns->vkCreateDebugUtilsMessengerEXT =
+      reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+          get_instance_proc_addr(instance, "vkCreateDebugUtilsMessengerEXT"));
+  fns->vkDestroyDebugUtilsMessengerEXT =
+      reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+          get_instance_proc_addr(instance, "vkDestroyDebugUtilsMessengerEXT"));
+#endif
+
+  if (fns->vkDestroyInstance == nullptr ||
+      fns->vkEnumeratePhysicalDevices == nullptr ||
+      fns->vkGetPhysicalDeviceProperties == nullptr ||
+      fns->vkGetPhysicalDeviceFormatProperties == nullptr ||
+      fns->vkGetPhysicalDeviceMemoryProperties == nullptr ||
+      fns->vkGetPhysicalDeviceImageFormatProperties == nullptr ||
+      fns->vkGetPhysicalDeviceFeatures2 == nullptr ||
+      fns->vkEnumerateDeviceExtensionProperties == nullptr ||
+      fns->vkGetPhysicalDeviceQueueFamilyProperties == nullptr ||
+      fns->vkCreateDevice == nullptr || fns->vkGetDeviceProcAddr == nullptr) {
+    LOGE("Failed to load Vulkan instance procedures for instance: {:p}",
+         reinterpret_cast<void*>(instance));
+    return false;
+  }
+
+  return true;
+}
+
+bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
+                         VkDevice device, VulkanDeviceFns* fns) {
+  if (get_device_proc_addr == nullptr || device == VK_NULL_HANDLE ||
+      fns == nullptr) {
+    LOGE("Failed to load Vulkan device procedures: invalid arguments");
+    return false;
+  }
+
+  fns->vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(
+      get_device_proc_addr(device, "vkDestroyDevice"));
+  fns->vkDeviceWaitIdle = reinterpret_cast<PFN_vkDeviceWaitIdle>(
+      get_device_proc_addr(device, "vkDeviceWaitIdle"));
+  fns->vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(
+      get_device_proc_addr(device, "vkGetDeviceQueue"));
+  fns->vkQueueSubmit = reinterpret_cast<PFN_vkQueueSubmit>(
+      get_device_proc_addr(device, "vkQueueSubmit"));
+  fns->vkQueueSubmit2 = reinterpret_cast<PFN_vkQueueSubmit2>(
+      get_device_proc_addr(device, "vkQueueSubmit2"));
+  fns->vkCreateCommandPool = reinterpret_cast<PFN_vkCreateCommandPool>(
+      get_device_proc_addr(device, "vkCreateCommandPool"));
+  fns->vkDestroyCommandPool = reinterpret_cast<PFN_vkDestroyCommandPool>(
+      get_device_proc_addr(device, "vkDestroyCommandPool"));
+  fns->vkAllocateCommandBuffers =
+      reinterpret_cast<PFN_vkAllocateCommandBuffers>(
+          get_device_proc_addr(device, "vkAllocateCommandBuffers"));
+  fns->vkBeginCommandBuffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(
+      get_device_proc_addr(device, "vkBeginCommandBuffer"));
+  fns->vkEndCommandBuffer = reinterpret_cast<PFN_vkEndCommandBuffer>(
+      get_device_proc_addr(device, "vkEndCommandBuffer"));
+  fns->vkCreateFence = reinterpret_cast<PFN_vkCreateFence>(
+      get_device_proc_addr(device, "vkCreateFence"));
+  fns->vkDestroyFence = reinterpret_cast<PFN_vkDestroyFence>(
+      get_device_proc_addr(device, "vkDestroyFence"));
+  fns->vkGetFenceStatus = reinterpret_cast<PFN_vkGetFenceStatus>(
+      get_device_proc_addr(device, "vkGetFenceStatus"));
+  fns->vkWaitForFences = reinterpret_cast<PFN_vkWaitForFences>(
+      get_device_proc_addr(device, "vkWaitForFences"));
+  fns->vkAllocateMemory = reinterpret_cast<PFN_vkAllocateMemory>(
+      get_device_proc_addr(device, "vkAllocateMemory"));
+  fns->vkFreeMemory = reinterpret_cast<PFN_vkFreeMemory>(
+      get_device_proc_addr(device, "vkFreeMemory"));
+  fns->vkMapMemory = reinterpret_cast<PFN_vkMapMemory>(
+      get_device_proc_addr(device, "vkMapMemory"));
+  fns->vkUnmapMemory = reinterpret_cast<PFN_vkUnmapMemory>(
+      get_device_proc_addr(device, "vkUnmapMemory"));
+  fns->vkFlushMappedMemoryRanges =
+      reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(
+          get_device_proc_addr(device, "vkFlushMappedMemoryRanges"));
+  fns->vkInvalidateMappedMemoryRanges =
+      reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(
+          get_device_proc_addr(device, "vkInvalidateMappedMemoryRanges"));
+  fns->vkBindBufferMemory = reinterpret_cast<PFN_vkBindBufferMemory>(
+      get_device_proc_addr(device, "vkBindBufferMemory"));
+  fns->vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(
+      get_device_proc_addr(device, "vkBindImageMemory"));
+  fns->vkGetBufferMemoryRequirements =
+      reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(
+          get_device_proc_addr(device, "vkGetBufferMemoryRequirements"));
+  fns->vkGetImageMemoryRequirements =
+      reinterpret_cast<PFN_vkGetImageMemoryRequirements>(
+          get_device_proc_addr(device, "vkGetImageMemoryRequirements"));
+  fns->vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(
+      get_device_proc_addr(device, "vkCreateBuffer"));
+  fns->vkDestroyBuffer = reinterpret_cast<PFN_vkDestroyBuffer>(
+      get_device_proc_addr(device, "vkDestroyBuffer"));
+  fns->vkCreateImage = reinterpret_cast<PFN_vkCreateImage>(
+      get_device_proc_addr(device, "vkCreateImage"));
+  fns->vkDestroyImage = reinterpret_cast<PFN_vkDestroyImage>(
+      get_device_proc_addr(device, "vkDestroyImage"));
+  fns->vkGetBufferMemoryRequirements2KHR =
+      LoadDeviceProcByName<PFN_vkGetBufferMemoryRequirements2KHR>(
+          get_device_proc_addr, device, "vkGetBufferMemoryRequirements2",
+          "vkGetBufferMemoryRequirements2KHR");
+  fns->vkGetImageMemoryRequirements2KHR =
+      LoadDeviceProcByName<PFN_vkGetImageMemoryRequirements2KHR>(
+          get_device_proc_addr, device, "vkGetImageMemoryRequirements2",
+          "vkGetImageMemoryRequirements2KHR");
+  fns->vkBindBufferMemory2KHR =
+      LoadDeviceProcByName<PFN_vkBindBufferMemory2KHR>(
+          get_device_proc_addr, device, "vkBindBufferMemory2",
+          "vkBindBufferMemory2KHR");
+  fns->vkBindImageMemory2KHR = LoadDeviceProcByName<PFN_vkBindImageMemory2KHR>(
+      get_device_proc_addr, device, "vkBindImageMemory2",
+      "vkBindImageMemory2KHR");
+  fns->vkGetDeviceBufferMemoryRequirements =
+      LoadDeviceProcByName<PFN_vkGetDeviceBufferMemoryRequirementsKHR>(
+          get_device_proc_addr, device, "vkGetDeviceBufferMemoryRequirements",
+          "vkGetDeviceBufferMemoryRequirementsKHR");
+  fns->vkGetDeviceImageMemoryRequirements =
+      LoadDeviceProcByName<PFN_vkGetDeviceImageMemoryRequirementsKHR>(
+          get_device_proc_addr, device, "vkGetDeviceImageMemoryRequirements",
+          "vkGetDeviceImageMemoryRequirementsKHR");
+  fns->vkCmdCopyBuffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(
+      get_device_proc_addr(device, "vkCmdCopyBuffer"));
+  fns->vkCreateFramebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(
+      get_device_proc_addr(device, "vkCreateFramebuffer"));
+  fns->vkDestroyFramebuffer = reinterpret_cast<PFN_vkDestroyFramebuffer>(
+      get_device_proc_addr(device, "vkDestroyFramebuffer"));
+  fns->vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(
+      get_device_proc_addr(device, "vkCreateRenderPass"));
+  fns->vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(
+      get_device_proc_addr(device, "vkDestroyRenderPass"));
+  fns->vkCreateImageView = reinterpret_cast<PFN_vkCreateImageView>(
+      get_device_proc_addr(device, "vkCreateImageView"));
+  fns->vkDestroyImageView = reinterpret_cast<PFN_vkDestroyImageView>(
+      get_device_proc_addr(device, "vkDestroyImageView"));
+  fns->vkCmdBeginRenderPass = reinterpret_cast<PFN_vkCmdBeginRenderPass>(
+      get_device_proc_addr(device, "vkCmdBeginRenderPass"));
+  fns->vkCmdEndRenderPass = reinterpret_cast<PFN_vkCmdEndRenderPass>(
+      get_device_proc_addr(device, "vkCmdEndRenderPass"));
+  fns->vkCmdBlitImage = reinterpret_cast<PFN_vkCmdBlitImage>(
+      get_device_proc_addr(device, "vkCmdBlitImage"));
+  fns->vkCmdCopyBufferToImage = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(
+      get_device_proc_addr(device, "vkCmdCopyBufferToImage"));
+  fns->vkCmdPipelineBarrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(
+      get_device_proc_addr(device, "vkCmdPipelineBarrier"));
+  fns->vkCmdBeginRendering = LoadDeviceProcByName<PFN_vkCmdBeginRendering>(
+      get_device_proc_addr, device, "vkCmdBeginRendering",
+      "vkCmdBeginRenderingKHR");
+  fns->vkCmdEndRendering = LoadDeviceProcByName<PFN_vkCmdEndRendering>(
+      get_device_proc_addr, device, "vkCmdEndRendering",
+      "vkCmdEndRenderingKHR");
+  fns->vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(
+      get_device_proc_addr(device, "vkCreateShaderModule"));
+  fns->vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(
+      get_device_proc_addr(device, "vkDestroyShaderModule"));
+  fns->vkCreateSampler = reinterpret_cast<PFN_vkCreateSampler>(
+      get_device_proc_addr(device, "vkCreateSampler"));
+  fns->vkDestroySampler = reinterpret_cast<PFN_vkDestroySampler>(
+      get_device_proc_addr(device, "vkDestroySampler"));
+  fns->vkCreateDescriptorPool = reinterpret_cast<PFN_vkCreateDescriptorPool>(
+      get_device_proc_addr(device, "vkCreateDescriptorPool"));
+  fns->vkDestroyDescriptorPool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(
+      get_device_proc_addr(device, "vkDestroyDescriptorPool"));
+  fns->vkAllocateDescriptorSets =
+      reinterpret_cast<PFN_vkAllocateDescriptorSets>(
+          get_device_proc_addr(device, "vkAllocateDescriptorSets"));
+  fns->vkUpdateDescriptorSets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(
+      get_device_proc_addr(device, "vkUpdateDescriptorSets"));
+  fns->vkCreateDescriptorSetLayout =
+      reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(
+          get_device_proc_addr(device, "vkCreateDescriptorSetLayout"));
+  fns->vkDestroyDescriptorSetLayout =
+      reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(
+          get_device_proc_addr(device, "vkDestroyDescriptorSetLayout"));
+  fns->vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(
+      get_device_proc_addr(device, "vkCreatePipelineLayout"));
+  fns->vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(
+      get_device_proc_addr(device, "vkDestroyPipelineLayout"));
+  fns->vkCreatePipelineCache = reinterpret_cast<PFN_vkCreatePipelineCache>(
+      get_device_proc_addr(device, "vkCreatePipelineCache"));
+  fns->vkDestroyPipelineCache = reinterpret_cast<PFN_vkDestroyPipelineCache>(
+      get_device_proc_addr(device, "vkDestroyPipelineCache"));
+  fns->vkCreateGraphicsPipelines =
+      reinterpret_cast<PFN_vkCreateGraphicsPipelines>(
+          get_device_proc_addr(device, "vkCreateGraphicsPipelines"));
+  fns->vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(
+      get_device_proc_addr(device, "vkDestroyPipeline"));
+  fns->vkCmdBindPipeline = reinterpret_cast<PFN_vkCmdBindPipeline>(
+      get_device_proc_addr(device, "vkCmdBindPipeline"));
+  fns->vkCmdBindDescriptorSets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(
+      get_device_proc_addr(device, "vkCmdBindDescriptorSets"));
+  fns->vkCmdBindVertexBuffers = reinterpret_cast<PFN_vkCmdBindVertexBuffers>(
+      get_device_proc_addr(device, "vkCmdBindVertexBuffers"));
+  fns->vkCmdBindIndexBuffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(
+      get_device_proc_addr(device, "vkCmdBindIndexBuffer"));
+  fns->vkCmdDrawIndexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(
+      get_device_proc_addr(device, "vkCmdDrawIndexed"));
+  fns->vkCmdSetViewport = reinterpret_cast<PFN_vkCmdSetViewport>(
+      get_device_proc_addr(device, "vkCmdSetViewport"));
+  fns->vkCmdSetScissor = reinterpret_cast<PFN_vkCmdSetScissor>(
+      get_device_proc_addr(device, "vkCmdSetScissor"));
+  fns->vkCmdSetStencilCompareMask =
+      reinterpret_cast<PFN_vkCmdSetStencilCompareMask>(
+          get_device_proc_addr(device, "vkCmdSetStencilCompareMask"));
+  fns->vkCmdSetStencilWriteMask =
+      reinterpret_cast<PFN_vkCmdSetStencilWriteMask>(
+          get_device_proc_addr(device, "vkCmdSetStencilWriteMask"));
+  fns->vkCmdSetStencilReference =
+      reinterpret_cast<PFN_vkCmdSetStencilReference>(
+          get_device_proc_addr(device, "vkCmdSetStencilReference"));
+  fns->vkSetDebugUtilsObjectNameEXT =
+      reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
+          get_device_proc_addr(device, "vkSetDebugUtilsObjectNameEXT"));
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  fns->vkCmdBeginDebugUtilsLabelEXT =
+      reinterpret_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
+          get_device_proc_addr(device, "vkCmdBeginDebugUtilsLabelEXT"));
+  fns->vkCmdEndDebugUtilsLabelEXT =
+      reinterpret_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
+          get_device_proc_addr(device, "vkCmdEndDebugUtilsLabelEXT"));
+  fns->vkCmdInsertDebugUtilsLabelEXT =
+      reinterpret_cast<PFN_vkCmdInsertDebugUtilsLabelEXT>(
+          get_device_proc_addr(device, "vkCmdInsertDebugUtilsLabelEXT"));
+#endif
+
+  if (fns->vkDestroyDevice == nullptr || fns->vkDeviceWaitIdle == nullptr ||
+      fns->vkGetDeviceQueue == nullptr || fns->vkQueueSubmit == nullptr ||
+      fns->vkCreateCommandPool == nullptr ||
+      fns->vkDestroyCommandPool == nullptr ||
+      fns->vkAllocateCommandBuffers == nullptr ||
+      fns->vkBeginCommandBuffer == nullptr ||
+      fns->vkEndCommandBuffer == nullptr || fns->vkCreateFence == nullptr ||
+      fns->vkDestroyFence == nullptr || fns->vkGetFenceStatus == nullptr ||
+      fns->vkWaitForFences == nullptr || fns->vkCmdCopyBuffer == nullptr ||
+      fns->vkAllocateMemory == nullptr || fns->vkFreeMemory == nullptr ||
+      fns->vkMapMemory == nullptr || fns->vkUnmapMemory == nullptr ||
+      fns->vkFlushMappedMemoryRanges == nullptr ||
+      fns->vkInvalidateMappedMemoryRanges == nullptr ||
+      fns->vkBindBufferMemory == nullptr || fns->vkBindImageMemory == nullptr ||
+      fns->vkGetBufferMemoryRequirements == nullptr ||
+      fns->vkGetImageMemoryRequirements == nullptr ||
+      fns->vkCreateBuffer == nullptr || fns->vkDestroyBuffer == nullptr ||
+      fns->vkCreateImage == nullptr || fns->vkDestroyImage == nullptr ||
+      fns->vkCreateFramebuffer == nullptr ||
+      fns->vkDestroyFramebuffer == nullptr ||
+      fns->vkCreateRenderPass == nullptr ||
+      fns->vkDestroyRenderPass == nullptr ||
+      fns->vkCreateImageView == nullptr || fns->vkDestroyImageView == nullptr ||
+      fns->vkCmdBeginRenderPass == nullptr ||
+      fns->vkCmdEndRenderPass == nullptr || fns->vkCmdBlitImage == nullptr ||
+      fns->vkCmdCopyBufferToImage == nullptr ||
+      fns->vkCmdPipelineBarrier == nullptr ||
+      fns->vkCreateShaderModule == nullptr ||
+      fns->vkDestroyShaderModule == nullptr ||
+      fns->vkCreateSampler == nullptr || fns->vkDestroySampler == nullptr ||
+      fns->vkCreateDescriptorPool == nullptr ||
+      fns->vkDestroyDescriptorPool == nullptr ||
+      fns->vkAllocateDescriptorSets == nullptr ||
+      fns->vkUpdateDescriptorSets == nullptr ||
+      fns->vkCreateDescriptorSetLayout == nullptr ||
+      fns->vkDestroyDescriptorSetLayout == nullptr ||
+      fns->vkCreatePipelineLayout == nullptr ||
+      fns->vkDestroyPipelineLayout == nullptr ||
+      fns->vkCreatePipelineCache == nullptr ||
+      fns->vkDestroyPipelineCache == nullptr ||
+      fns->vkCreateGraphicsPipelines == nullptr ||
+      fns->vkDestroyPipeline == nullptr || fns->vkCmdBindPipeline == nullptr ||
+      fns->vkCmdBindDescriptorSets == nullptr ||
+      fns->vkCmdBindVertexBuffers == nullptr ||
+      fns->vkCmdBindIndexBuffer == nullptr ||
+      fns->vkCmdDrawIndexed == nullptr || fns->vkCmdSetViewport == nullptr ||
+      fns->vkCmdSetScissor == nullptr ||
+      fns->vkCmdSetStencilCompareMask == nullptr ||
+      fns->vkCmdSetStencilWriteMask == nullptr ||
+      fns->vkCmdSetStencilReference == nullptr) {
+    LOGE("Failed to load Vulkan device procedures for device: {:p}",
+         reinterpret_cast<void*>(device));
+    return false;
+  }
+
+  return true;
+}
+
+void EnablePortabilityEnumerationIfAvailable(
+    const std::vector<VkExtensionProperties>& available_extensions,
+    std::vector<std::string>* enabled_extensions,
+    VkInstanceCreateFlags* instance_flags) {
+  if (enabled_extensions == nullptr || instance_flags == nullptr) {
+    return;
+  }
+
+  if (!ContainsExtension(available_extensions,
+                         VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) ||
+      ContainsExtension(*enabled_extensions,
+                        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+    return;
+  }
+
+  enabled_extensions->emplace_back(
+      VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+  *instance_flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+}
+
+bool CreateVkInstance(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                      VkInstance* instance, VulkanFunctionPointers* functions,
+                      const VkInstanceCreateInfo* create_info,
+                      const VkAllocationCallbacks* allocator) {
+  if (instance == nullptr || get_instance_proc_addr == nullptr) {
+    LOGE("Failed to create Vulkan instance: invalid arguments");
+    return false;
+  }
+
+  *instance = VK_NULL_HANDLE;
+
+  VulkanFunctionPointers local_functions = {};
+  VulkanFunctionPointers* target_functions =
+      functions == nullptr ? &local_functions : functions;
+  target_functions->get_instance_proc_addr = get_instance_proc_addr;
+
+  if (!LoadVulkanGlobalFns(get_instance_proc_addr, &target_functions->global)) {
+    return false;
+  }
+
+  std::vector<VkExtensionProperties> available_extensions;
+  if (!QueryInstanceExtensions(target_functions->global,
+                               &available_extensions)) {
+    return false;
+  }
+  LogInstanceExtensions(available_extensions);
+
+  VkApplicationInfo app_info = {};
+  VkInstanceCreateInfo instance_info = {};
+  if (create_info == nullptr) {
+    const uint32_t supported_version =
+        ResolveInstanceApiVersion(target_functions->global);
+    LOGD("Detected Vulkan instance version: {}.{}",
+         VK_API_VERSION_MAJOR(supported_version),
+         VK_API_VERSION_MINOR(supported_version));
+    if (!IsAtLeastVulkan11(supported_version)) {
+      LOGE("Vulkan 1.1 is required, but only {}.{} is available",
+           VK_API_VERSION_MAJOR(supported_version),
+           VK_API_VERSION_MINOR(supported_version));
+      return false;
+    }
+
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "skity";
+    app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = "skity";
+    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.apiVersion = supported_version;
+
+    instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_info.pApplicationInfo = &app_info;
+    create_info = &instance_info;
+  }
+
+  VkInstanceCreateInfo effective_create_info = *create_info;
+  std::vector<std::string> enabled_extensions;
+  enabled_extensions.reserve(create_info->enabledExtensionCount + 1);
+  for (uint32_t i = 0; i < create_info->enabledExtensionCount; ++i) {
+    if (create_info->ppEnabledExtensionNames[i] != nullptr) {
+      enabled_extensions.emplace_back(create_info->ppEnabledExtensionNames[i]);
+    }
+  }
+  EnablePortabilityEnumerationIfAvailable(
+      available_extensions, &enabled_extensions, &effective_create_info.flags);
+  std::vector<const char*> enabled_extension_ptrs;
+  enabled_extension_ptrs.reserve(enabled_extensions.size());
+  for (const auto& extension : enabled_extensions) {
+    enabled_extension_ptrs.push_back(extension.c_str());
+  }
+  effective_create_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_extension_ptrs.size());
+  effective_create_info.ppEnabledExtensionNames =
+      enabled_extension_ptrs.empty() ? nullptr : enabled_extension_ptrs.data();
+  create_info = &effective_create_info;
+
+  uint32_t api_version = VK_API_VERSION_1_0;
+  if (create_info->pApplicationInfo != nullptr) {
+    api_version = create_info->pApplicationInfo->apiVersion;
+  }
+  LOGD("Creating Vulkan instance, apiVersion: {}.{}",
+       VK_API_VERSION_MAJOR(api_version), VK_API_VERSION_MINOR(api_version));
+  VkResult result = target_functions->global.vkCreateInstance(
+      create_info, allocator, instance);
+  if (result != VK_SUCCESS || *instance == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan instance: result={}, instance={:p}",
+         static_cast<int32_t>(result), reinterpret_cast<void*>(*instance));
+    *instance = VK_NULL_HANDLE;
+    return false;
+  }
+
+  if (!LoadVulkanInstanceFns(get_instance_proc_addr, *instance,
+                             &target_functions->instance)) {
+    target_functions->instance.vkDestroyInstance =
+        reinterpret_cast<PFN_vkDestroyInstance>(
+            get_instance_proc_addr(*instance, "vkDestroyInstance"));
+    if (target_functions->instance.vkDestroyInstance != nullptr) {
+      target_functions->instance.vkDestroyInstance(*instance, allocator);
+    }
+    LOGE("Failed to load Vulkan instance procedures after instance creation");
+    *instance = VK_NULL_HANDLE;
+    return false;
+  }
+
+  target_functions->get_device_proc_addr =
+      target_functions->instance.vkGetDeviceProcAddr;
+  LOGD("Created Vulkan instance: {:p}", reinterpret_cast<void*>(*instance));
+  return true;
+}
+
+GPUContextVK::GPUContextVK(std::shared_ptr<VulkanContextState> state)
+    : GPUContextImpl(GPUBackendType::kVulkan), state_(std::move(state)) {}
+
+GPUContextVK::~GPUContextVK() {
+  if (state_ != nullptr) {
+    state_->CollectPendingSubmissions(true);
+  }
+  ResetOwnedResources();
+}
+
+std::unique_ptr<GPUSurface> GPUContextVK::CreateSurface(
+    GPUSurfaceDescriptor* desc) {
+  if (desc == nullptr || desc->backend != GPUBackendType::kVulkan) {
+    return nullptr;
+  }
+
+  auto* vk_desc = static_cast<GPUSurfaceDescriptorVK*>(desc);
+  if (vk_desc->surface_type != VKSurfaceType::kTexture &&
+      vk_desc->surface_type != VKSurfaceType::kSwapchainImage) {
+    LOGW(
+        "GPUContextVK::CreateSurface only supports texture-backed Vulkan "
+        "surfaces for now");
+    return nullptr;
+  }
+
+  const uint32_t target_width = static_cast<uint32_t>(
+      std::floor(static_cast<float>(vk_desc->width) * vk_desc->content_scale));
+  const uint32_t target_height = static_cast<uint32_t>(
+      std::floor(static_cast<float>(vk_desc->height) * vk_desc->content_scale));
+
+  if (vk_desc->image == VK_NULL_HANDLE ||
+      vk_desc->image_view == VK_NULL_HANDLE ||
+      vk_desc->format == VK_FORMAT_UNDEFINED || vk_desc->width == 0 ||
+      vk_desc->height == 0 || target_width == 0 || target_height == 0) {
+    LOGE("Failed to create Vulkan surface: invalid descriptor");
+    return nullptr;
+  }
+
+  GPUTextureDescriptor texture_desc = {};
+  texture_desc.width = target_width;
+  texture_desc.height = target_height;
+  texture_desc.mip_level_count = 1;
+  texture_desc.sample_count = 1;
+  texture_desc.format = ToGPUTextureFormat(vk_desc->format);
+  texture_desc.usage =
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment);
+  texture_desc.storage_mode = GPUTextureStorageMode::kPrivate;
+
+  if (texture_desc.format == GPUTextureFormat::kInvalid) {
+    LOGE("Failed to create Vulkan surface: unsupported VkFormat {}",
+         static_cast<int32_t>(vk_desc->format));
+    return nullptr;
+  }
+
+  auto texture = GPUTextureVK::Wrap(
+      state_, texture_desc, vk_desc->image, vk_desc->image_view,
+      vk_desc->initial_layout, vk_desc->final_layout, vk_desc->format,
+      vk_desc->owns_image, vk_desc->owns_image_view);
+  if (texture == nullptr) {
+    return nullptr;
+  }
+
+  return std::make_unique<GPUSurfaceVK>(
+      *desc, this, std::move(texture), texture_desc.format, vk_desc->sync_info);
+}
+
+std::unique_ptr<GPUPresenter> GPUContextVK::CreatePresenter(
+    GPUPresenterDescriptor* desc) {
+  if (desc == nullptr || desc->backend != GPUBackendType::kVulkan) {
+    return nullptr;
+  }
+
+  auto* vk_desc = static_cast<GPUPresenterDescriptorVK*>(desc);
+  auto presenter = std::make_unique<GPUPresenterVK>(this, state_, *vk_desc);
+  if (!presenter->Init()) {
+    return nullptr;
+  }
+  return presenter;
+}
+
+std::unique_ptr<GPUDevice> GPUContextVK::CreateGPUDevice() {
+  return std::make_unique<GPUDeviceVK>(state_);
+}
+
+std::shared_ptr<GPUTexture> GPUContextVK::OnWrapTexture(
+    GPUBackendTextureInfo* info, ReleaseCallback callback,
+    ReleaseUserData user_data) {
+  (void)info;
+  (void)callback;
+  (void)user_data;
+  LOGW("GPUContextVK::OnWrapTexture is not implemented yet");
+  return {};
+}
+
+std::unique_ptr<GPURenderTarget> GPUContextVK::OnCreateRenderTarget(
+    const GPURenderTargetDescriptor& desc, std::shared_ptr<Texture> texture) {
+  (void)desc;
+  (void)texture;
+  LOGW("GPUContextVK::OnCreateRenderTarget is not implemented yet");
+  return {};
+}
+
+std::shared_ptr<Data> GPUContextVK::OnReadPixels(
+    const std::shared_ptr<GPUTexture>& texture) const {
+  (void)texture;
+  LOGW("GPUContextVK::OnReadPixels is not implemented yet");
+  return {};
+}
+
+std::unique_ptr<GPUContext> CreateGPUContextVK(const GPUContextInfoVK* info) {
+  if (info == nullptr) {
+    return nullptr;
+  }
+
+  LOGD("CreateGPUContextVK called with GPUContextInfoVK: {:p}",
+       reinterpret_cast<const void*>(info));
+  auto state = std::make_shared<VulkanContextState>();
+  if (!state->Initialize(*info)) {
+    return nullptr;
+  }
+
+  auto context = std::make_unique<GPUContextVK>(std::move(state));
+  if (!context->Init()) {
+    LOGE("Failed to initialize GPUContextVK device state");
+    return nullptr;
+  }
+
+  return context;
+}
+
+std::unique_ptr<GPUContext> CreateGPUContextVK(
+    PFN_vkGetInstanceProcAddr get_instance_proc_addr) {
+  GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = get_instance_proc_addr;
+  LOGD("CreateGPUContextVK called with vkGetInstanceProcAddr: {:p}",
+       reinterpret_cast<void*>(get_instance_proc_addr));
+  return CreateGPUContextVK(&info);
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_context_impl_vk.hpp
+++ b/src/gpu/vk/gpu_context_impl_vk.hpp
@@ -1,0 +1,54 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_CONTEXT_IMPL_VK_HPP
+#define SRC_GPU_VK_GPU_CONTEXT_IMPL_VK_HPP
+
+#include <memory>
+
+#include "src/gpu/gpu_context_impl.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+class GPUContextVK : public GPUContextImpl {
+ public:
+  explicit GPUContextVK(std::shared_ptr<VulkanContextState> state);
+
+  ~GPUContextVK() override;
+
+  GPUBackendType GetBackendType() const override {
+    return GPUBackendType::kVulkan;
+  }
+
+  std::unique_ptr<GPUSurface> CreateSurface(
+      GPUSurfaceDescriptor* desc) override;
+
+  std::unique_ptr<GPUPresenter> CreatePresenter(
+      GPUPresenterDescriptor* desc) override;
+
+  const VulkanContextState* GetState() const { return state_.get(); }
+
+ protected:
+  std::unique_ptr<GPUDevice> CreateGPUDevice() override;
+
+  std::shared_ptr<GPUTexture> OnWrapTexture(GPUBackendTextureInfo* info,
+                                            ReleaseCallback callback,
+                                            ReleaseUserData user_data) override;
+
+  std::unique_ptr<GPURenderTarget> OnCreateRenderTarget(
+      const GPURenderTargetDescriptor& desc,
+      std::shared_ptr<Texture> texture) override;
+
+  std::shared_ptr<Data> OnReadPixels(
+      const std::shared_ptr<GPUTexture>& texture) const override;
+
+ private:
+  std::shared_ptr<VulkanContextState> state_;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_CONTEXT_IMPL_VK_HPP

--- a/src/gpu/vk/gpu_device_vk.cc
+++ b/src/gpu/vk/gpu_device_vk.cc
@@ -1,0 +1,919 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_device_vk.hpp"
+
+#include <algorithm>
+#include <array>
+
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_render_pipeline_vk.hpp"
+#include "src/gpu/vk/gpu_sampler_vk.hpp"
+#include "src/gpu/vk/gpu_shader_function_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+#include "src/tracing.hpp"
+
+namespace skity {
+
+namespace {
+
+VkShaderStageFlagBits ToVkShaderStage(GPUShaderStage stage) {
+  switch (stage) {
+    case GPUShaderStage::kVertex:
+      return VK_SHADER_STAGE_VERTEX_BIT;
+    case GPUShaderStage::kFragment:
+      return VK_SHADER_STAGE_FRAGMENT_BIT;
+  }
+
+  return VK_SHADER_STAGE_VERTEX_BIT;
+}
+
+VkShaderStageFlags ToVkShaderStageFlags(wgx::ShaderStage stage) {
+  VkShaderStageFlags flags = 0;
+  if ((stage & wgx::ShaderStage_kVertex) != 0) {
+    flags |= VK_SHADER_STAGE_VERTEX_BIT;
+  }
+  if ((stage & wgx::ShaderStage_kFragment) != 0) {
+    flags |= VK_SHADER_STAGE_FRAGMENT_BIT;
+  }
+  return flags;
+}
+
+VkDescriptorType ToVkDescriptorType(wgx::BindingType type) {
+  switch (type) {
+    case wgx::BindingType::kUniformBuffer:
+      return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    case wgx::BindingType::kTexture:
+      return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    case wgx::BindingType::kSampler:
+      return VK_DESCRIPTOR_TYPE_SAMPLER;
+    case wgx::BindingType::kUndefined:
+      break;
+  }
+
+  return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+}
+
+VkBlendFactor ToVkBlendFactor(GPUBlendFactor factor) {
+  switch (factor) {
+    case GPUBlendFactor::kZero:
+      return VK_BLEND_FACTOR_ZERO;
+    case GPUBlendFactor::kOne:
+      return VK_BLEND_FACTOR_ONE;
+    case GPUBlendFactor::kSrc:
+      return VK_BLEND_FACTOR_SRC_COLOR;
+    case GPUBlendFactor::kOneMinusSrc:
+      return VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+    case GPUBlendFactor::kSrcAlpha:
+      return VK_BLEND_FACTOR_SRC_ALPHA;
+    case GPUBlendFactor::kOneMinusSrcAlpha:
+      return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    case GPUBlendFactor::kDst:
+      return VK_BLEND_FACTOR_DST_COLOR;
+    case GPUBlendFactor::kOneMinusDst:
+      return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+    case GPUBlendFactor::kDstAlpha:
+      return VK_BLEND_FACTOR_DST_ALPHA;
+    case GPUBlendFactor::kOneMinusDstAlpha:
+      return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
+    case GPUBlendFactor::kSrcAlphaSaturated:
+      return VK_BLEND_FACTOR_SRC_ALPHA_SATURATE;
+  }
+
+  return VK_BLEND_FACTOR_ONE;
+}
+
+VkCompareOp ToVkCompareOp(GPUCompareFunction compare) {
+  switch (compare) {
+    case GPUCompareFunction::kNever:
+      return VK_COMPARE_OP_NEVER;
+    case GPUCompareFunction::kLess:
+      return VK_COMPARE_OP_LESS;
+    case GPUCompareFunction::kEqual:
+      return VK_COMPARE_OP_EQUAL;
+    case GPUCompareFunction::kLessEqual:
+      return VK_COMPARE_OP_LESS_OR_EQUAL;
+    case GPUCompareFunction::kGreater:
+      return VK_COMPARE_OP_GREATER;
+    case GPUCompareFunction::kNotEqual:
+      return VK_COMPARE_OP_NOT_EQUAL;
+    case GPUCompareFunction::kGreaterEqual:
+      return VK_COMPARE_OP_GREATER_OR_EQUAL;
+    case GPUCompareFunction::kAlways:
+      return VK_COMPARE_OP_ALWAYS;
+  }
+
+  return VK_COMPARE_OP_ALWAYS;
+}
+
+VkStencilOp ToVkStencilOp(GPUStencilOperation op) {
+  switch (op) {
+    case GPUStencilOperation::kKeep:
+      return VK_STENCIL_OP_KEEP;
+    case GPUStencilOperation::kZero:
+      return VK_STENCIL_OP_ZERO;
+    case GPUStencilOperation::kReplace:
+      return VK_STENCIL_OP_REPLACE;
+    case GPUStencilOperation::kInvert:
+      return VK_STENCIL_OP_INVERT;
+    case GPUStencilOperation::kIncrementClamp:
+      return VK_STENCIL_OP_INCREMENT_AND_CLAMP;
+    case GPUStencilOperation::kDecrementClamp:
+      return VK_STENCIL_OP_DECREMENT_AND_CLAMP;
+    case GPUStencilOperation::kIncrementWrap:
+      return VK_STENCIL_OP_INCREMENT_AND_WRAP;
+    case GPUStencilOperation::kDecrementWrap:
+      return VK_STENCIL_OP_DECREMENT_AND_WRAP;
+  }
+
+  return VK_STENCIL_OP_KEEP;
+}
+
+VkStencilOpState ToVkStencilOpState(const GPUStencilFaceState& state) {
+  VkStencilOpState vk_state = {};
+  vk_state.failOp = ToVkStencilOp(state.fail_op);
+  vk_state.passOp = ToVkStencilOp(state.pass_op);
+  vk_state.depthFailOp = ToVkStencilOp(state.depth_fail_op);
+  vk_state.compareOp = ToVkCompareOp(state.compare);
+  vk_state.compareMask = 0xFFFFFFFFu;
+  vk_state.writeMask = 0xFFFFFFFFu;
+  return vk_state;
+}
+
+VkVertexInputRate ToVkVertexInputRate(GPUVertexStepMode step_mode) {
+  return step_mode == GPUVertexStepMode::kInstance
+             ? VK_VERTEX_INPUT_RATE_INSTANCE
+             : VK_VERTEX_INPUT_RATE_VERTEX;
+}
+
+VkFormat ToVkVertexFormat(GPUVertexFormat format) {
+  switch (format) {
+    case GPUVertexFormat::kFloat32:
+      return VK_FORMAT_R32_SFLOAT;
+    case GPUVertexFormat::kFloat32x2:
+      return VK_FORMAT_R32G32_SFLOAT;
+    case GPUVertexFormat::kFloat32x3:
+      return VK_FORMAT_R32G32B32_SFLOAT;
+    case GPUVertexFormat::kFloat32x4:
+      return VK_FORMAT_R32G32B32A32_SFLOAT;
+  }
+
+  return VK_FORMAT_UNDEFINED;
+}
+
+VkColorComponentFlags ToVkColorWriteMask(int32_t write_mask) {
+  VkColorComponentFlags result = 0;
+  if ((write_mask & 0x1) != 0) {
+    result |= VK_COLOR_COMPONENT_R_BIT;
+  }
+  if ((write_mask & 0x2) != 0) {
+    result |= VK_COLOR_COMPONENT_G_BIT;
+  }
+  if ((write_mask & 0x4) != 0) {
+    result |= VK_COLOR_COMPONENT_B_BIT;
+  }
+  if ((write_mask & 0x8) != 0) {
+    result |= VK_COLOR_COMPONENT_A_BIT;
+  }
+  return result;
+}
+
+VkSamplerAddressMode ToVkSamplerAddressMode(GPUAddressMode mode) {
+  switch (mode) {
+    case GPUAddressMode::kRepeat:
+      return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    case GPUAddressMode::kMirrorRepeat:
+      return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+    case GPUAddressMode::kClampToEdge:
+      return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  }
+
+  return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+}
+
+VkFilter ToVkFilter(GPUFilterMode mode) {
+  switch (mode) {
+    case GPUFilterMode::kLinear:
+      return VK_FILTER_LINEAR;
+    case GPUFilterMode::kNearest:
+      return VK_FILTER_NEAREST;
+  }
+
+  return VK_FILTER_NEAREST;
+}
+
+bool HasDepthAttachmentFormat(GPUTextureFormat format) {
+  return format == GPUTextureFormat::kDepth24Stencil8;
+}
+
+bool HasStencilAttachmentFormat(GPUTextureFormat format) {
+  return format == GPUTextureFormat::kStencil8 ||
+         format == GPUTextureFormat::kDepth24Stencil8;
+}
+
+bool HasDepthStencilAttachmentFormat(GPUTextureFormat format) {
+  return HasDepthAttachmentFormat(format) || HasStencilAttachmentFormat(format);
+}
+
+bool IsAttachmentFormatSupported(const VulkanContextState& state,
+                                 VkFormat format, VkImageUsageFlags usage,
+                                 VkSampleCountFlagBits samples) {
+  if (format == VK_FORMAT_UNDEFINED ||
+      state.InstanceFns().vkGetPhysicalDeviceImageFormatProperties == nullptr) {
+    return false;
+  }
+
+  VkImageFormatProperties properties = {};
+  const VkResult result =
+      state.InstanceFns().vkGetPhysicalDeviceImageFormatProperties(
+          state.GetPhysicalDevice(), format, VK_IMAGE_TYPE_2D,
+          VK_IMAGE_TILING_OPTIMAL, usage, 0, &properties);
+  if (result != VK_SUCCESS) {
+    return false;
+  }
+
+  return (properties.sampleCounts & samples) != 0;
+}
+
+VkFormat ResolveAttachmentFormat(const VulkanContextState& state,
+                                 GPUTextureFormat format,
+                                 VkSampleCountFlagBits samples) {
+  const VkImageUsageFlags usage =
+      HasDepthStencilAttachmentFormat(format)
+          ? VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+          : VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+  const VkFormat preferred = GPUTextureVK::ToVkFormat(format);
+  if (IsAttachmentFormatSupported(state, preferred, usage, samples)) {
+    return preferred;
+  }
+
+  if (format == GPUTextureFormat::kDepth24Stencil8 &&
+      IsAttachmentFormatSupported(state, VK_FORMAT_D32_SFLOAT_S8_UINT, usage,
+                                  samples)) {
+    return VK_FORMAT_D32_SFLOAT_S8_UINT;
+  }
+
+  if (format == GPUTextureFormat::kStencil8) {
+    if (IsAttachmentFormatSupported(state, VK_FORMAT_D24_UNORM_S8_UINT, usage,
+                                    samples)) {
+      return VK_FORMAT_D24_UNORM_S8_UINT;
+    }
+
+    if (IsAttachmentFormatSupported(state, VK_FORMAT_D32_SFLOAT_S8_UINT, usage,
+                                    samples)) {
+      return VK_FORMAT_D32_SFLOAT_S8_UINT;
+    }
+  }
+
+  return VK_FORMAT_UNDEFINED;
+}
+
+VkSamplerMipmapMode ToVkSamplerMipmapMode(GPUMipmapMode mode) {
+  switch (mode) {
+    case GPUMipmapMode::kLinear:
+      return VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    case GPUMipmapMode::kNearest:
+    case GPUMipmapMode::kNone:
+      return VK_SAMPLER_MIPMAP_MODE_NEAREST;
+  }
+
+  return VK_SAMPLER_MIPMAP_MODE_NEAREST;
+}
+
+bool CreateDescriptorSetLayout(const VulkanContextState& state,
+                               const wgx::BindGroup& bind_group,
+                               VkDescriptorSetLayout* set_layout) {
+  if (set_layout == nullptr) {
+    return false;
+  }
+
+  std::vector<VkDescriptorSetLayoutBinding> bindings;
+  bindings.reserve(bind_group.entries.size());
+  for (const auto& entry : bind_group.entries) {
+    const VkDescriptorType descriptor_type = ToVkDescriptorType(entry.type);
+    if (descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM) {
+      LOGE("Unsupported Vulkan bind group entry type: {}",
+           static_cast<uint32_t>(entry.type));
+      return false;
+    }
+
+    VkDescriptorSetLayoutBinding binding = {};
+    binding.binding = entry.binding;
+    binding.descriptorType = descriptor_type;
+    binding.descriptorCount = 1;
+    binding.stageFlags = ToVkShaderStageFlags(entry.stage);
+    bindings.push_back(binding);
+  }
+
+  VkDescriptorSetLayoutCreateInfo layout_info = {};
+  layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+  layout_info.bindingCount = static_cast<uint32_t>(bindings.size());
+  layout_info.pBindings = bindings.empty() ? nullptr : bindings.data();
+
+  *set_layout = VK_NULL_HANDLE;
+  const VkResult result = state.DeviceFns().vkCreateDescriptorSetLayout(
+      state.GetLogicalDevice(), &layout_info, nullptr, set_layout);
+  if (result != VK_SUCCESS || *set_layout == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan descriptor set layout: {}",
+         static_cast<int32_t>(result));
+    *set_layout = VK_NULL_HANDLE;
+    return false;
+  }
+
+  return true;
+}
+
+VulkanContextState::LegacyRenderPassKey BuildPipelineRenderPassKey(
+    const VulkanContextState& state, const GPURenderPipelineDescriptor& desc) {
+  VulkanContextState::LegacyRenderPassKey key = {};
+  key.color_samples = static_cast<VkSampleCountFlagBits>(desc.sample_count);
+  key.color_format =
+      ResolveAttachmentFormat(state, desc.target.format, key.color_samples);
+  key.color_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  key.color_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+
+  key.has_depth = HasDepthAttachmentFormat(desc.depth_stencil.format);
+  key.has_stencil = HasStencilAttachmentFormat(desc.depth_stencil.format);
+  if (key.has_depth || key.has_stencil) {
+    key.depth_stencil_format = ResolveAttachmentFormat(
+        state, desc.depth_stencil.format, key.color_samples);
+    key.depth_stencil_samples = key.color_samples;
+    key.depth_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    key.depth_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    key.stencil_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    key.stencil_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  }
+
+  return key;
+}
+
+struct PipelineTargetInfo {
+  VkRenderPass render_pass = VK_NULL_HANDLE;
+  bool uses_dynamic_rendering = false;
+  VkPipelineRenderingCreateInfo rendering_info = {};
+  VkFormat color_format = VK_FORMAT_UNDEFINED;
+};
+
+bool BuildPipelineTargetInfo(const VulkanContextState& state,
+                             const GPURenderPipelineDescriptor& desc,
+                             PipelineTargetInfo* target_info) {
+  if (target_info == nullptr) {
+    return false;
+  }
+
+  target_info->color_format = ResolveAttachmentFormat(
+      state, desc.target.format,
+      static_cast<VkSampleCountFlagBits>(desc.sample_count));
+  if (target_info->color_format == VK_FORMAT_UNDEFINED) {
+    LOGE("Unsupported Vulkan color attachment format for render pipeline");
+    return false;
+  }
+
+  if (state.IsDynamicRenderingEnabled()) {
+    const VkFormat depth_stencil_format =
+        HasDepthStencilAttachmentFormat(desc.depth_stencil.format)
+            ? ResolveAttachmentFormat(
+                  state, desc.depth_stencil.format,
+                  static_cast<VkSampleCountFlagBits>(desc.sample_count))
+            : VK_FORMAT_UNDEFINED;
+    if (HasDepthStencilAttachmentFormat(desc.depth_stencil.format) &&
+        depth_stencil_format == VK_FORMAT_UNDEFINED) {
+      LOGE(
+          "Unsupported Vulkan depth/stencil attachment format for render "
+          "pipeline");
+      return false;
+    }
+
+    target_info->uses_dynamic_rendering = true;
+    target_info->rendering_info.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
+    target_info->rendering_info.colorAttachmentCount = 1;
+    target_info->rendering_info.pColorAttachmentFormats =
+        &target_info->color_format;
+    target_info->rendering_info.depthAttachmentFormat =
+        HasDepthAttachmentFormat(desc.depth_stencil.format)
+            ? depth_stencil_format
+            : VK_FORMAT_UNDEFINED;
+    target_info->rendering_info.stencilAttachmentFormat =
+        HasStencilAttachmentFormat(desc.depth_stencil.format)
+            ? depth_stencil_format
+            : VK_FORMAT_UNDEFINED;
+    return true;
+  }
+
+  const auto render_pass_key = BuildPipelineRenderPassKey(state, desc);
+  target_info->render_pass = state.GetOrCreateLegacyRenderPass(render_pass_key);
+  return target_info->render_pass != VK_NULL_HANDLE;
+}
+
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+
+void SetShaderModuleDebugLabel(const VulkanContextState& state,
+                               VkShaderModule shader_module,
+                               const std::string& label) {
+  if (shader_module == VK_NULL_HANDLE || label.empty() ||
+      !state.HasEnabledInstanceExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+    return;
+  }
+
+  const auto& device_fns = state.DeviceFns();
+  if (device_fns.vkSetDebugUtilsObjectNameEXT == nullptr ||
+      state.GetLogicalDevice() == VK_NULL_HANDLE) {
+    return;
+  }
+
+  VkDebugUtilsObjectNameInfoEXT name_info = {};
+  name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+  name_info.objectType = VK_OBJECT_TYPE_SHADER_MODULE;
+  name_info.objectHandle = reinterpret_cast<uint64_t>(shader_module);
+  name_info.pObjectName = label.c_str();
+
+  const VkResult result = device_fns.vkSetDebugUtilsObjectNameEXT(
+      state.GetLogicalDevice(), &name_info);
+  if (result != VK_SUCCESS) {
+    LOGW("Failed to set Vulkan shader module debug label '{}': {}", label,
+         static_cast<int32_t>(result));
+  }
+}
+
+#else
+
+void SetShaderModuleDebugLabel(const VulkanContextState& state,
+                               VkShaderModule shader_module,
+                               const std::string& label) {
+  (void)state;
+  (void)shader_module;
+  (void)label;
+}
+
+#endif
+
+}  // namespace
+
+GPUDeviceVK::GPUDeviceVK(std::shared_ptr<const VulkanContextState> state)
+    : state_(std::move(state)) {
+  auto gpu_caps = std::make_unique<GPUCaps>();
+  gpu_caps->supports_framebuffer_fetch = false;
+  InitCaps(std::move(gpu_caps));
+
+  if (state_ == nullptr || state_->GetPhysicalDevice() == VK_NULL_HANDLE ||
+      state_->InstanceFns().vkGetPhysicalDeviceProperties == nullptr) {
+    return;
+  }
+
+  VkPhysicalDeviceProperties properties = {};
+  state_->InstanceFns().vkGetPhysicalDeviceProperties(
+      state_->GetPhysicalDevice(), &properties);
+  buffer_alignment_ =
+      static_cast<uint32_t>(properties.limits.minUniformBufferOffsetAlignment);
+  if (buffer_alignment_ == 0) {
+    buffer_alignment_ = 256;
+  }
+
+  max_texture_size_ = properties.limits.maxImageDimension2D;
+}
+
+std::unique_ptr<GPUBuffer> GPUDeviceVK::CreateBuffer(GPUBufferUsageMask usage) {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state_->GetAllocator() == nullptr) {
+    LOGE("GPUDeviceVK::CreateBuffer failed: Vulkan device is unavailable");
+    return {};
+  }
+
+  return std::make_unique<GPUBufferVK>(usage, state_);
+}
+
+std::shared_ptr<GPUShaderFunction> GPUDeviceVK::CreateShaderFunction(
+    const GPUShaderFunctionDescriptor& desc) {
+  if (desc.source_type != GPUShaderSourceType::kWGX) {
+    LOGW("GPUDeviceVK only supports WGX shader sources currently");
+    return {};
+  }
+
+  return CreateShaderFunctionFromModule(desc);
+}
+
+std::unique_ptr<GPURenderPipeline> GPUDeviceVK::CreateRenderPipeline(
+    const GPURenderPipelineDescriptor& desc) {
+  return CreateRenderPipelineInternal(desc);
+}
+
+std::unique_ptr<GPURenderPipeline> GPUDeviceVK::ClonePipeline(
+    GPURenderPipeline* base, const GPURenderPipelineDescriptor& desc) {
+  if (base == nullptr) {
+    return {};
+  }
+
+  auto* vk_pipeline = GPURenderPipelineVK::Cast(base);
+  if (vk_pipeline == nullptr || !vk_pipeline->IsValid()) {
+    return {};
+  }
+
+  return CreateRenderPipelineInternal(desc);
+}
+
+std::shared_ptr<GPUCommandBuffer> GPUDeviceVK::CreateCommandBuffer() {
+  auto command_buffer = std::make_shared<GPUCommandBufferVK>(state_);
+  if (!command_buffer->Init()) {
+    return {};
+  }
+  return command_buffer;
+}
+
+std::shared_ptr<GPUSampler> GPUDeviceVK::CreateSampler(
+    const GPUSamplerDescriptor& desc) {
+  auto it = sampler_map_.find(desc);
+  if (it != sampler_map_.end()) {
+    return it->second;
+  }
+
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state_->DeviceFns().vkCreateSampler == nullptr) {
+    LOGE("GPUDeviceVK::CreateSampler failed: Vulkan device is unavailable");
+    return {};
+  }
+
+  VkSamplerCreateInfo sampler_info = {};
+  sampler_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+  sampler_info.magFilter = ToVkFilter(desc.mag_filter);
+  sampler_info.minFilter = ToVkFilter(desc.min_filter);
+  sampler_info.mipmapMode = ToVkSamplerMipmapMode(desc.mipmap_filter);
+  sampler_info.addressModeU = ToVkSamplerAddressMode(desc.address_mode_u);
+  sampler_info.addressModeV = ToVkSamplerAddressMode(desc.address_mode_v);
+  sampler_info.addressModeW = ToVkSamplerAddressMode(desc.address_mode_w);
+  sampler_info.mipLodBias = 0.f;
+  sampler_info.anisotropyEnable = VK_FALSE;
+  sampler_info.maxAnisotropy = 1.f;
+  sampler_info.compareEnable = VK_FALSE;
+  sampler_info.compareOp = VK_COMPARE_OP_ALWAYS;
+  sampler_info.minLod = 0.f;
+  sampler_info.maxLod =
+      desc.mipmap_filter == GPUMipmapMode::kNone ? 0.f : VK_LOD_CLAMP_NONE;
+  sampler_info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+  sampler_info.unnormalizedCoordinates = VK_FALSE;
+
+  VkSampler sampler = VK_NULL_HANDLE;
+  const VkResult result = state_->DeviceFns().vkCreateSampler(
+      state_->GetLogicalDevice(), &sampler_info, nullptr, &sampler);
+  if (result != VK_SUCCESS || sampler == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan sampler: {}", static_cast<int32_t>(result));
+    return {};
+  }
+
+  auto sampler_vk = std::make_shared<GPUSamplerVK>(state_, desc, sampler);
+  sampler_map_.insert({desc, sampler_vk});
+  return sampler_vk;
+}
+
+std::shared_ptr<GPUTexture> GPUDeviceVK::CreateTexture(
+    const GPUTextureDescriptor& desc) {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state_->GetAllocator() == nullptr) {
+    LOGE("GPUDeviceVK::CreateTexture failed: Vulkan device is unavailable");
+    return {};
+  }
+
+  return GPUTextureVK::Create(state_, desc);
+}
+
+std::shared_ptr<GPUShaderFunction> GPUDeviceVK::CreateShaderFunctionFromModule(
+    const GPUShaderFunctionDescriptor& desc) {
+  SKITY_TRACE_EVENT(GPUDeviceVK_CreateShaderFunctionFromModuleWGX);
+
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    return {};
+  }
+
+  auto* source = reinterpret_cast<GPUShaderSourceWGX*>(desc.shader_source);
+  if (source == nullptr || source->module == nullptr ||
+      source->module->GetProgram() == nullptr ||
+      source->entry_point == nullptr) {
+    return {};
+  }
+
+  const auto& device_fns = state_->DeviceFns();
+  if (device_fns.vkCreateShaderModule == nullptr ||
+      device_fns.vkDestroyShaderModule == nullptr) {
+    LOGE("Vulkan shader module procedures are not available");
+    return {};
+  }
+
+  wgx::SpirvOptions options = {};
+  auto wgx_result = source->module->GetProgram()->WriteToSpirv(
+      source->entry_point, options, source->context);
+
+  if (!wgx_result.success || wgx_result.spirv.empty()) {
+    if (desc.error_callback) {
+      desc.error_callback("WGX translate to SPIR-V failed");
+    }
+    return {};
+  }
+
+  VkShaderModuleCreateInfo create_info = {};
+  create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+  create_info.codeSize = wgx_result.spirv.size() * sizeof(uint32_t);
+  create_info.pCode = wgx_result.spirv.data();
+
+  VkShaderModule shader_module = VK_NULL_HANDLE;
+  VkResult result = device_fns.vkCreateShaderModule(
+      state_->GetLogicalDevice(), &create_info, nullptr, &shader_module);
+  if (result != VK_SUCCESS || shader_module == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan shader module for {}:{} result={}",
+         source->module->GetLabel(), source->entry_point,
+         static_cast<int32_t>(result));
+    if (desc.error_callback) {
+      desc.error_callback("Failed to create Vulkan shader module");
+    }
+    return {};
+  }
+
+  SetShaderModuleDebugLabel(*state_, shader_module, desc.label.ToString());
+
+  auto function = std::make_shared<GPUShaderFunctionVK>(
+      desc.label, desc.stage, source->entry_point, state_, shader_module);
+  function->SetBindGroups(
+      source->module->GetProgram()->GetWGSLBindGroups(source->entry_point));
+  function->SetWGXContext(wgx_result.context);
+
+  // pass the WGX context to caller for later pipeline compilation.
+  source->context = wgx_result.context;
+
+  return function;
+}
+
+std::unique_ptr<GPURenderPipelineVK> GPUDeviceVK::CreateRenderPipelineInternal(
+    const GPURenderPipelineDescriptor& desc) {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      desc.vertex_function == nullptr || desc.fragment_function == nullptr) {
+    return {};
+  }
+
+  auto* vertex_function = GPUShaderFunctionVK::Cast(desc.vertex_function.get());
+  auto* fragment_function =
+      GPUShaderFunctionVK::Cast(desc.fragment_function.get());
+  if (vertex_function == nullptr || fragment_function == nullptr ||
+      !vertex_function->IsValid() || !fragment_function->IsValid()) {
+    LOGE("GPUDeviceVK::CreateRenderPipeline failed: invalid shader function");
+    return {};
+  }
+
+  std::vector<VkDescriptorSetLayout> set_layouts;
+  GPURenderPipeline merged_pipeline(desc);
+  if (!merged_pipeline.IsValid()) {
+    LOGE(
+        "GPUDeviceVK::CreateRenderPipeline failed: invalid merged bind groups");
+    return {};
+  }
+
+  const auto bind_groups = merged_pipeline.GetBindGroups();
+  uint32_t max_group = 0;
+  for (const auto& bind_group : bind_groups) {
+    max_group = std::max(max_group, bind_group.group);
+  }
+  if (!bind_groups.empty()) {
+    set_layouts.resize(max_group + 1, VK_NULL_HANDLE);
+    for (const auto& bind_group : bind_groups) {
+      if (!CreateDescriptorSetLayout(*state_, bind_group,
+                                     &set_layouts[bind_group.group])) {
+        for (auto set_layout : set_layouts) {
+          if (set_layout != VK_NULL_HANDLE) {
+            state_->DeviceFns().vkDestroyDescriptorSetLayout(
+                state_->GetLogicalDevice(), set_layout, nullptr);
+          }
+        }
+        return {};
+      }
+    }
+
+    for (auto& set_layout : set_layouts) {
+      if (set_layout == VK_NULL_HANDLE &&
+          !CreateDescriptorSetLayout(*state_, wgx::BindGroup{}, &set_layout)) {
+        for (auto created_layout : set_layouts) {
+          if (created_layout != VK_NULL_HANDLE) {
+            state_->DeviceFns().vkDestroyDescriptorSetLayout(
+                state_->GetLogicalDevice(), created_layout, nullptr);
+          }
+        }
+        return {};
+      }
+    }
+  }
+
+  VkPipelineLayoutCreateInfo pipeline_layout_info = {};
+  pipeline_layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+  pipeline_layout_info.setLayoutCount =
+      static_cast<uint32_t>(set_layouts.size());
+  pipeline_layout_info.pSetLayouts =
+      set_layouts.empty() ? nullptr : set_layouts.data();
+
+  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+  VkResult result = state_->DeviceFns().vkCreatePipelineLayout(
+      state_->GetLogicalDevice(), &pipeline_layout_info, nullptr,
+      &pipeline_layout);
+  if (result != VK_SUCCESS || pipeline_layout == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan pipeline layout: {}",
+         static_cast<int32_t>(result));
+    for (auto set_layout : set_layouts) {
+      if (set_layout != VK_NULL_HANDLE) {
+        state_->DeviceFns().vkDestroyDescriptorSetLayout(
+            state_->GetLogicalDevice(), set_layout, nullptr);
+      }
+    }
+    return {};
+  }
+
+  PipelineTargetInfo target_info = {};
+  if (!BuildPipelineTargetInfo(*state_, desc, &target_info)) {
+    state_->DeviceFns().vkDestroyPipelineLayout(state_->GetLogicalDevice(),
+                                                pipeline_layout, nullptr);
+    for (auto set_layout : set_layouts) {
+      if (set_layout != VK_NULL_HANDLE) {
+        state_->DeviceFns().vkDestroyDescriptorSetLayout(
+            state_->GetLogicalDevice(), set_layout, nullptr);
+      }
+    }
+    return {};
+  }
+
+  std::array<VkPipelineShaderStageCreateInfo, 2> shader_stages = {};
+  shader_stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  shader_stages[0].stage = ToVkShaderStage(vertex_function->GetStage());
+  shader_stages[0].module = vertex_function->GetShaderModule();
+  shader_stages[0].pName = vertex_function->GetEntryPoint().c_str();
+  shader_stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  shader_stages[1].stage = ToVkShaderStage(fragment_function->GetStage());
+  shader_stages[1].module = fragment_function->GetShaderModule();
+  shader_stages[1].pName = fragment_function->GetEntryPoint().c_str();
+
+  std::vector<VkVertexInputBindingDescription> vertex_bindings;
+  std::vector<VkVertexInputAttributeDescription> vertex_attributes;
+  if (desc.buffers != nullptr) {
+    vertex_bindings.reserve(desc.buffers->size());
+    for (uint32_t i = 0; i < desc.buffers->size(); ++i) {
+      const auto& buffer = (*desc.buffers)[i];
+      VkVertexInputBindingDescription binding = {};
+      binding.binding = i;
+      binding.stride = static_cast<uint32_t>(buffer.array_stride);
+      binding.inputRate = ToVkVertexInputRate(buffer.step_mode);
+      vertex_bindings.push_back(binding);
+
+      for (const auto& attribute : buffer.attributes) {
+        VkVertexInputAttributeDescription vk_attribute = {};
+        vk_attribute.location = attribute.shader_location;
+        vk_attribute.binding = i;
+        vk_attribute.format = ToVkVertexFormat(attribute.format);
+        vk_attribute.offset = static_cast<uint32_t>(attribute.offset);
+        vertex_attributes.push_back(vk_attribute);
+      }
+    }
+  }
+
+  VkPipelineVertexInputStateCreateInfo vertex_input_state = {};
+  vertex_input_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+  vertex_input_state.vertexBindingDescriptionCount =
+      static_cast<uint32_t>(vertex_bindings.size());
+  vertex_input_state.pVertexBindingDescriptions =
+      vertex_bindings.empty() ? nullptr : vertex_bindings.data();
+  vertex_input_state.vertexAttributeDescriptionCount =
+      static_cast<uint32_t>(vertex_attributes.size());
+  vertex_input_state.pVertexAttributeDescriptions =
+      vertex_attributes.empty() ? nullptr : vertex_attributes.data();
+
+  VkPipelineInputAssemblyStateCreateInfo input_assembly_state = {};
+  input_assembly_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+  input_assembly_state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+  VkViewport viewport = {};
+  viewport.width = 1.f;
+  viewport.height = 1.f;
+  viewport.maxDepth = 1.f;
+
+  VkRect2D scissor = {};
+  scissor.extent.width = 1;
+  scissor.extent.height = 1;
+
+  VkPipelineViewportStateCreateInfo viewport_state = {};
+  viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+  viewport_state.viewportCount = 1;
+  viewport_state.pViewports = &viewport;
+  viewport_state.scissorCount = 1;
+  viewport_state.pScissors = &scissor;
+
+  std::array<VkDynamicState, 5> dynamic_states = {
+      VK_DYNAMIC_STATE_VIEWPORT,
+      VK_DYNAMIC_STATE_SCISSOR,
+      VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK,
+      VK_DYNAMIC_STATE_STENCIL_WRITE_MASK,
+      VK_DYNAMIC_STATE_STENCIL_REFERENCE,
+  };
+  VkPipelineDynamicStateCreateInfo dynamic_state = {};
+  dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+  dynamic_state.dynamicStateCount =
+      static_cast<uint32_t>(dynamic_states.size());
+  dynamic_state.pDynamicStates = dynamic_states.data();
+
+  VkPipelineRasterizationStateCreateInfo rasterization_state = {};
+  rasterization_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+  rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
+  rasterization_state.cullMode = VK_CULL_MODE_NONE;
+  rasterization_state.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+  rasterization_state.lineWidth = 1.f;
+
+  VkPipelineMultisampleStateCreateInfo multisample_state = {};
+  multisample_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+  multisample_state.rasterizationSamples =
+      static_cast<VkSampleCountFlagBits>(desc.sample_count);
+
+  VkPipelineColorBlendAttachmentState color_blend_attachment = {};
+  color_blend_attachment.blendEnable =
+      desc.target.src_blend_factor != GPUBlendFactor::kOne ||
+      desc.target.dst_blend_factor != GPUBlendFactor::kZero;
+  color_blend_attachment.srcColorBlendFactor =
+      ToVkBlendFactor(desc.target.src_blend_factor);
+  color_blend_attachment.dstColorBlendFactor =
+      ToVkBlendFactor(desc.target.dst_blend_factor);
+  color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
+  color_blend_attachment.srcAlphaBlendFactor =
+      ToVkBlendFactor(desc.target.src_blend_factor);
+  color_blend_attachment.dstAlphaBlendFactor =
+      ToVkBlendFactor(desc.target.dst_blend_factor);
+  color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
+  color_blend_attachment.colorWriteMask =
+      ToVkColorWriteMask(desc.target.write_mask);
+
+  VkPipelineColorBlendStateCreateInfo color_blend_state = {};
+  color_blend_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+  color_blend_state.attachmentCount = 1;
+  color_blend_state.pAttachments = &color_blend_attachment;
+
+  VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {};
+  depth_stencil_state.sType =
+      VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+  depth_stencil_state.depthTestEnable = desc.depth_stencil.enable_depth;
+  depth_stencil_state.depthWriteEnable =
+      desc.depth_stencil.enable_depth &&
+      desc.depth_stencil.depth_state.enableWrite;
+  depth_stencil_state.depthCompareOp =
+      ToVkCompareOp(desc.depth_stencil.depth_state.compare);
+  depth_stencil_state.stencilTestEnable = desc.depth_stencil.enable_stencil;
+  depth_stencil_state.front =
+      ToVkStencilOpState(desc.depth_stencil.stencil_state.front);
+  depth_stencil_state.back =
+      ToVkStencilOpState(desc.depth_stencil.stencil_state.back);
+
+  VkGraphicsPipelineCreateInfo pipeline_info = {};
+  pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+  if (target_info.uses_dynamic_rendering) {
+    pipeline_info.pNext = &target_info.rendering_info;
+  }
+  pipeline_info.stageCount = static_cast<uint32_t>(shader_stages.size());
+  pipeline_info.pStages = shader_stages.data();
+  pipeline_info.pVertexInputState = &vertex_input_state;
+  pipeline_info.pInputAssemblyState = &input_assembly_state;
+  pipeline_info.pViewportState = &viewport_state;
+  pipeline_info.pRasterizationState = &rasterization_state;
+  pipeline_info.pMultisampleState = &multisample_state;
+  pipeline_info.pDynamicState = &dynamic_state;
+  pipeline_info.pDepthStencilState =
+      HasDepthStencilAttachmentFormat(desc.depth_stencil.format)
+          ? &depth_stencil_state
+          : nullptr;
+  pipeline_info.pColorBlendState = &color_blend_state;
+  pipeline_info.layout = pipeline_layout;
+  pipeline_info.renderPass = target_info.render_pass;
+  pipeline_info.subpass = 0;
+
+  VkPipeline pipeline = VK_NULL_HANDLE;
+  result = state_->DeviceFns().vkCreateGraphicsPipelines(
+      state_->GetLogicalDevice(), state_->GetPipelineCache(), 1, &pipeline_info,
+      nullptr, &pipeline);
+  if (result != VK_SUCCESS || pipeline == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan graphics pipeline: {}",
+         static_cast<int32_t>(result));
+    state_->DeviceFns().vkDestroyPipelineLayout(state_->GetLogicalDevice(),
+                                                pipeline_layout, nullptr);
+    for (auto set_layout : set_layouts) {
+      if (set_layout != VK_NULL_HANDLE) {
+        state_->DeviceFns().vkDestroyDescriptorSetLayout(
+            state_->GetLogicalDevice(), set_layout, nullptr);
+      }
+    }
+    return {};
+  }
+
+  return std::make_unique<GPURenderPipelineVK>(
+      state_, pipeline, pipeline_layout, target_info.render_pass,
+      target_info.uses_dynamic_rendering, std::move(set_layouts), desc);
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_device_vk.hpp
+++ b/src/gpu/vk/gpu_device_vk.hpp
@@ -1,0 +1,61 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_DEVICE_VK_HPP
+#define SRC_GPU_VK_GPU_DEVICE_VK_HPP
+
+#include "src/gpu/gpu_device.hpp"
+
+namespace skity {
+
+class GPURenderPipelineVK;
+class VulkanContextState;
+
+class GPUDeviceVK : public GPUDevice {
+ public:
+  explicit GPUDeviceVK(std::shared_ptr<const VulkanContextState> state);
+
+  ~GPUDeviceVK() override = default;
+
+  std::unique_ptr<GPUBuffer> CreateBuffer(GPUBufferUsageMask usage) override;
+
+  std::shared_ptr<GPUShaderFunction> CreateShaderFunction(
+      const GPUShaderFunctionDescriptor& desc) override;
+
+  std::unique_ptr<GPURenderPipeline> CreateRenderPipeline(
+      const GPURenderPipelineDescriptor& desc) override;
+
+  std::unique_ptr<GPURenderPipeline> ClonePipeline(
+      GPURenderPipeline* base,
+      const GPURenderPipelineDescriptor& desc) override;
+
+  std::shared_ptr<GPUCommandBuffer> CreateCommandBuffer() override;
+
+  std::shared_ptr<GPUSampler> CreateSampler(
+      const GPUSamplerDescriptor& desc) override;
+
+  std::shared_ptr<GPUTexture> CreateTexture(
+      const GPUTextureDescriptor& desc) override;
+
+  bool CanUseMSAA() override { return true; }
+
+  uint32_t GetBufferAlignment() override { return buffer_alignment_; }
+
+  uint32_t GetMaxTextureSize() override { return max_texture_size_; }
+
+ private:
+  std::shared_ptr<GPUShaderFunction> CreateShaderFunctionFromModule(
+      const GPUShaderFunctionDescriptor& desc);
+  std::unique_ptr<GPURenderPipelineVK> CreateRenderPipelineInternal(
+      const GPURenderPipelineDescriptor& desc);
+
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  GPUSamplerMap sampler_map_ = {};
+  uint32_t buffer_alignment_ = 256;
+  uint32_t max_texture_size_ = 4096;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_DEVICE_VK_HPP

--- a/src/gpu/vk/gpu_native_window_vk.cc
+++ b/src/gpu/vk/gpu_native_window_vk.cc
@@ -1,0 +1,410 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity/macros.hpp>
+
+#if defined(SKITY_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
+#define VK_USE_PLATFORM_WIN32_KHR 1
+#endif
+
+#if defined(SKITY_ANDROID) && !defined(VK_USE_PLATFORM_ANDROID_KHR)
+#define VK_USE_PLATFORM_ANDROID_KHR 1
+#endif
+
+#if (defined(SKITY_MACOS) || defined(SKITY_IOS)) && \
+    !defined(VK_USE_PLATFORM_METAL_EXT)
+#define VK_USE_PLATFORM_METAL_EXT 1
+#endif
+
+#if (defined(SKITY_MACOS) || defined(SKITY_IOS)) && \
+    !defined(VK_USE_PLATFORM_MACOS_MVK)
+#define VK_USE_PLATFORM_MACOS_MVK 1
+#endif
+
+#if defined(SKITY_LINUX) && defined(SKITY_VK_HAS_WAYLAND) && \
+    !defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#define VK_USE_PLATFORM_WAYLAND_KHR 1
+#endif
+
+#if defined(SKITY_LINUX) && defined(SKITY_VK_HAS_XCB) && \
+    !defined(VK_USE_PLATFORM_XCB_KHR)
+#define VK_USE_PLATFORM_XCB_KHR 1
+#endif
+
+#if defined(SKITY_LINUX) && defined(SKITY_VK_HAS_XLIB) && \
+    !defined(VK_USE_PLATFORM_XLIB_KHR)
+#define VK_USE_PLATFORM_XLIB_KHR 1
+#endif
+
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+
+#include "src/gpu/vk/gpu_context_impl_vk.hpp"
+#include "src/gpu/vk/gpu_presenter_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+template <typename Proc>
+Proc LoadInstanceProc(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                      VkInstance instance, const char* proc_name) {
+  if (get_instance_proc_addr == nullptr || instance == VK_NULL_HANDLE ||
+      proc_name == nullptr) {
+    return nullptr;
+  }
+
+  return reinterpret_cast<Proc>(get_instance_proc_addr(instance, proc_name));
+}
+
+bool IsValidNativeWindowInfo(const VKNativeWindowInfo& info) {
+  switch (info.type) {
+    case VKNativeWindowType::kWin32:
+      return info.handle != nullptr;
+    case VKNativeWindowType::kAndroid:
+      return info.handle != nullptr;
+    case VKNativeWindowType::kMetalLayer:
+      return info.handle != nullptr;
+    case VKNativeWindowType::kWayland:
+      return info.handle != nullptr && info.secondary_handle != nullptr;
+    case VKNativeWindowType::kXcb:
+      return info.handle != nullptr && info.window_id != 0;
+    case VKNativeWindowType::kXlib:
+      return info.handle != nullptr && info.window_id != 0;
+    case VKNativeWindowType::kInvalid:
+    default:
+      return false;
+  }
+}
+
+bool CreateVkSurfaceForWindow(const VulkanContextState* state,
+                              const VKNativeWindowInfo& window,
+                              VkSurfaceKHR* surface) {
+  if (state == nullptr || surface == nullptr) {
+    LOGE("Failed to create Vulkan window surface: invalid arguments");
+    return false;
+  }
+
+  *surface = VK_NULL_HANDLE;
+
+  const auto get_instance_proc_addr = state->GetInstanceProcAddr();
+  const VkInstance instance = state->GetInstance();
+  if (get_instance_proc_addr == nullptr || instance == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan window surface: context has no instance");
+    return false;
+  }
+
+  if (!IsValidNativeWindowInfo(window)) {
+    LOGE("Failed to create Vulkan window surface: invalid native window info");
+    return false;
+  }
+
+  switch (window.type) {
+#if defined(SKITY_WIN) && defined(VK_USE_PLATFORM_WIN32_KHR)
+    case VKNativeWindowType::kWin32: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateWin32SurfaceKHR>(
+          get_instance_proc_addr, instance, "vkCreateWin32SurfaceKHR");
+      if (create_surface == nullptr) {
+        LOGE("Failed to load vkCreateWin32SurfaceKHR");
+        return false;
+      }
+
+      VkWin32SurfaceCreateInfoKHR create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+      create_info.hwnd = static_cast<decltype(create_info.hwnd)>(window.handle);
+      create_info.hinstance =
+          static_cast<decltype(create_info.hinstance)>(window.secondary_handle);
+      return create_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+    }
+#endif
+#if defined(SKITY_ANDROID) && defined(VK_USE_PLATFORM_ANDROID_KHR)
+    case VKNativeWindowType::kAndroid: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateAndroidSurfaceKHR>(
+          get_instance_proc_addr, instance, "vkCreateAndroidSurfaceKHR");
+      if (create_surface == nullptr) {
+        LOGE("Failed to load vkCreateAndroidSurfaceKHR");
+        return false;
+      }
+
+      VkAndroidSurfaceCreateInfoKHR create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
+      create_info.window =
+          static_cast<decltype(create_info.window)>(window.handle);
+      return create_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+    }
+#endif
+#if (defined(SKITY_MACOS) || defined(SKITY_IOS)) && \
+    defined(VK_USE_PLATFORM_METAL_EXT)
+    case VKNativeWindowType::kMetalLayer: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateMetalSurfaceEXT>(
+          get_instance_proc_addr, instance, "vkCreateMetalSurfaceEXT");
+      if (create_surface != nullptr) {
+        VkMetalSurfaceCreateInfoEXT create_info = {};
+        create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+        create_info.pLayer = window.handle;
+        if (create_surface(instance, &create_info, nullptr, surface) ==
+                VK_SUCCESS &&
+            *surface != VK_NULL_HANDLE) {
+          return true;
+        }
+      }
+
+#if defined(VK_USE_PLATFORM_MACOS_MVK)
+      auto create_macos_surface = LoadInstanceProc<PFN_vkCreateMacOSSurfaceMVK>(
+          get_instance_proc_addr, instance, "vkCreateMacOSSurfaceMVK");
+      if (create_macos_surface == nullptr) {
+        LOGE(
+            "Failed to load vkCreateMetalSurfaceEXT or "
+            "vkCreateMacOSSurfaceMVK");
+        return false;
+      }
+
+      VkMacOSSurfaceCreateInfoMVK create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
+      create_info.pView = window.secondary_handle != nullptr
+                              ? window.secondary_handle
+                              : window.handle;
+      return create_macos_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+#else
+      LOGE("Failed to load vkCreateMetalSurfaceEXT");
+      return false;
+#endif
+    }
+#endif
+#if defined(SKITY_LINUX) && defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    case VKNativeWindowType::kWayland: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateWaylandSurfaceKHR>(
+          get_instance_proc_addr, instance, "vkCreateWaylandSurfaceKHR");
+      if (create_surface == nullptr) {
+        LOGE("Failed to load vkCreateWaylandSurfaceKHR");
+        return false;
+      }
+
+      VkWaylandSurfaceCreateInfoKHR create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+      create_info.display =
+          static_cast<decltype(create_info.display)>(window.handle);
+      create_info.surface =
+          static_cast<decltype(create_info.surface)>(window.secondary_handle);
+      return create_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+    }
+#endif
+#if defined(SKITY_LINUX) && defined(VK_USE_PLATFORM_XCB_KHR)
+    case VKNativeWindowType::kXcb: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateXcbSurfaceKHR>(
+          get_instance_proc_addr, instance, "vkCreateXcbSurfaceKHR");
+      if (create_surface == nullptr) {
+        LOGE("Failed to load vkCreateXcbSurfaceKHR");
+        return false;
+      }
+
+      VkXcbSurfaceCreateInfoKHR create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+      create_info.connection =
+          static_cast<decltype(create_info.connection)>(window.handle);
+      create_info.window =
+          static_cast<decltype(create_info.window)>(window.window_id);
+      return create_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+    }
+#endif
+#if defined(SKITY_LINUX) && defined(VK_USE_PLATFORM_XLIB_KHR)
+    case VKNativeWindowType::kXlib: {
+      auto create_surface = LoadInstanceProc<PFN_vkCreateXlibSurfaceKHR>(
+          get_instance_proc_addr, instance, "vkCreateXlibSurfaceKHR");
+      if (create_surface == nullptr) {
+        LOGE("Failed to load vkCreateXlibSurfaceKHR");
+        return false;
+      }
+
+      VkXlibSurfaceCreateInfoKHR create_info = {};
+      create_info.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+      create_info.dpy = static_cast<decltype(create_info.dpy)>(window.handle);
+      create_info.window =
+          static_cast<decltype(create_info.window)>(window.window_id);
+      return create_surface(instance, &create_info, nullptr, surface) ==
+                 VK_SUCCESS &&
+             *surface != VK_NULL_HANDLE;
+    }
+#endif
+    case VKNativeWindowType::kInvalid:
+      LOGE("Failed to create Vulkan window surface: invalid window type");
+      return false;
+    default:
+      LOGE("Failed to create Vulkan window surface: unsupported platform type");
+      return false;
+  }
+}
+
+class GPUNativeWindowVKImpl final : public GPUNativeWindowVK {
+ public:
+  GPUNativeWindowVKImpl(GPUContext* context, const GPUNativeWindowInfoVK& info)
+      : info_(info), context_(context) {}
+
+  ~GPUNativeWindowVKImpl() override {
+    presenter_.reset();
+    DestroySurface();
+  }
+
+  bool Init() {
+    if (info_.width == 0 || info_.height == 0) {
+      LOGE("Failed to initialize GPUNativeWindowVK: invalid descriptor");
+      return false;
+    }
+
+    if (!ResolveContext()) {
+      return false;
+    }
+
+    auto* vk_context = static_cast<GPUContextVK*>(context_);
+    state_ = vk_context->GetState();
+    if (state_ == nullptr) {
+      LOGE("Failed to initialize GPUNativeWindowVK: missing Vulkan state");
+      return false;
+    }
+
+    destroy_surface_ = LoadInstanceProc<PFN_vkDestroySurfaceKHR>(
+        state_->GetInstanceProcAddr(), state_->GetInstance(),
+        "vkDestroySurfaceKHR");
+    if (destroy_surface_ == nullptr) {
+      LOGE("Failed to load vkDestroySurfaceKHR");
+      return false;
+    }
+
+    if (!CreateVkSurfaceForWindow(state_, info_.native_window, &surface_)) {
+      LOGE("Failed to initialize GPUNativeWindowVK: surface creation failed");
+      return false;
+    }
+
+    if (!RecreatePresenter(info_.width, info_.height)) {
+      LOGE("Failed to initialize GPUNativeWindowVK: presenter creation failed");
+      return false;
+    }
+
+    return true;
+  }
+
+  GPUContext* GetContext() const override { return context_; }
+
+  GPUPresenter* GetPresenter() const override { return presenter_.get(); }
+
+  uint32_t GetWidth() const override { return width_; }
+
+  uint32_t GetHeight() const override { return height_; }
+
+  bool Resize(uint32_t width, uint32_t height) override {
+    if (width == 0 || height == 0) {
+      LOGE("Failed to resize GPUNativeWindowVK: invalid size");
+      return false;
+    }
+
+    return RecreatePresenter(width, height);
+  }
+
+ private:
+  bool RecreatePresenter(uint32_t width, uint32_t height) {
+    if (context_ == nullptr || surface_ == VK_NULL_HANDLE) {
+      return false;
+    }
+
+    VkSwapchainKHR old_swapchain = VK_NULL_HANDLE;
+    if (presenter_ != nullptr) {
+      auto* old_vk_presenter = static_cast<GPUPresenterVK*>(presenter_.get());
+      if (old_vk_presenter != nullptr) {
+        old_swapchain = old_vk_presenter->GetSwapchain();
+      }
+    }
+
+    GPUPresenterDescriptorVK presenter_desc = {};
+    presenter_desc.backend = GPUBackendType::kVulkan;
+    presenter_desc.width = width;
+    presenter_desc.height = height;
+    presenter_desc.surface = surface_;
+    presenter_desc.present_queue = info_.present_queue;
+    presenter_desc.present_queue_family_index =
+        info_.present_queue_family_index;
+    presenter_desc.min_image_count = info_.min_image_count;
+    presenter_desc.format = info_.format;
+    presenter_desc.color_space = info_.color_space;
+    presenter_desc.present_mode = info_.present_mode;
+    presenter_desc.composite_alpha = info_.composite_alpha;
+    presenter_desc.pre_transform = info_.pre_transform;
+    presenter_desc.clipped = info_.clipped;
+    presenter_desc.old_swapchain = old_swapchain;
+
+    auto presenter = context_->CreatePresenter(&presenter_desc);
+    if (presenter == nullptr) {
+      LOGE("Failed to create Vulkan presenter for window context");
+      return false;
+    }
+
+    presenter_ = std::move(presenter);
+    width_ = width;
+    height_ = height;
+    return true;
+  }
+
+  void DestroySurface() {
+    if (destroy_surface_ == nullptr || state_ == nullptr ||
+        surface_ == VK_NULL_HANDLE) {
+      return;
+    }
+
+    destroy_surface_(state_->GetInstance(), surface_, nullptr);
+    surface_ = VK_NULL_HANDLE;
+  }
+
+  bool ResolveContext() {
+    if (context_ == nullptr) {
+      LOGE("Failed to initialize GPUNativeWindowVK: missing GPUContext");
+      return false;
+    }
+
+    if (context_->GetBackendType() != GPUBackendType::kVulkan) {
+      LOGE("Failed to initialize GPUNativeWindowVK: context is not Vulkan");
+      return false;
+    }
+
+    return true;
+  }
+
+  GPUNativeWindowInfoVK info_ = {};
+  GPUContext* context_ = nullptr;
+  std::unique_ptr<GPUPresenter> presenter_ = nullptr;
+  const VulkanContextState* state_ = nullptr;
+  PFN_vkDestroySurfaceKHR destroy_surface_ = nullptr;
+  VkSurfaceKHR surface_ = VK_NULL_HANDLE;
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+};
+
+}  // namespace
+
+std::unique_ptr<GPUNativeWindowVK> CreateGPUNativeWindowVK(
+    GPUContext* context, const GPUNativeWindowInfoVK* info) {
+  if (info == nullptr) {
+    LOGE("CreateGPUNativeWindowVK called with null info");
+    return nullptr;
+  }
+
+  auto native_window = std::make_unique<GPUNativeWindowVKImpl>(context, *info);
+  if (!native_window->Init()) {
+    return nullptr;
+  }
+
+  return native_window;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_presenter_vk.cc
+++ b/src/gpu/vk/gpu_presenter_vk.cc
@@ -1,0 +1,677 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_presenter_vk.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "src/gpu/gpu_context_impl.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+VkCompositeAlphaFlagBitsKHR ResolveCompositeAlpha(
+    VkCompositeAlphaFlagBitsKHR preferred,
+    VkCompositeAlphaFlagsKHR supported_flags) {
+  if ((supported_flags & preferred) != 0) {
+    return preferred;
+  }
+
+  constexpr VkCompositeAlphaFlagBitsKHR kFallbackOrder[] = {
+      VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+      VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
+      VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
+      VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
+  };
+
+  for (auto candidate : kFallbackOrder) {
+    if ((supported_flags & candidate) != 0) {
+      return candidate;
+    }
+  }
+
+  return preferred;
+}
+
+VkImageView CreateSwapchainImageView(const VulkanContextState& state,
+                                     VkImage image, VkFormat format) {
+  VkImageViewCreateInfo view_info = {};
+  view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  view_info.image = image;
+  view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  view_info.format = format;
+  view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  view_info.subresourceRange.baseMipLevel = 0;
+  view_info.subresourceRange.levelCount = 1;
+  view_info.subresourceRange.baseArrayLayer = 0;
+  view_info.subresourceRange.layerCount = 1;
+
+  VkImageView image_view = VK_NULL_HANDLE;
+  const VkResult result = state.DeviceFns().vkCreateImageView(
+      state.GetLogicalDevice(), &view_info, nullptr, &image_view);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to create swapchain image view: {}",
+         static_cast<int32_t>(result));
+    return VK_NULL_HANDLE;
+  }
+
+  return image_view;
+}
+
+GPUTextureFormat ToGPUTextureFormat(VkFormat format) {
+  switch (format) {
+    case VK_FORMAT_R8_UNORM:
+      return GPUTextureFormat::kR8Unorm;
+    case VK_FORMAT_R8G8B8_UNORM:
+      return GPUTextureFormat::kRGB8Unorm;
+    case VK_FORMAT_R5G6B5_UNORM_PACK16:
+      return GPUTextureFormat::kRGB565Unorm;
+    case VK_FORMAT_R8G8B8A8_UNORM:
+      return GPUTextureFormat::kRGBA8Unorm;
+    case VK_FORMAT_B8G8R8A8_UNORM:
+      return GPUTextureFormat::kBGRA8Unorm;
+    default:
+      return GPUTextureFormat::kInvalid;
+  }
+}
+
+void LogSurfaceCapabilities(const VkSurfaceCapabilitiesKHR& capabilities) {
+#ifdef SKITY_RELEASE
+  (void)capabilities;
+#else
+  LOGD(
+      "Vulkan surface capabilities: minImages={} maxImages={} "
+      "currentExtent={}x{} "
+      "minExtent={}x{} maxExtent={}x{} supportedTransforms=0x{:x} "
+      "currentTransform=0x{:x} supportedCompositeAlpha=0x{:x} "
+      "supportedUsage=0x{:x}",
+      capabilities.minImageCount, capabilities.maxImageCount,
+      capabilities.currentExtent.width, capabilities.currentExtent.height,
+      capabilities.minImageExtent.width, capabilities.minImageExtent.height,
+      capabilities.maxImageExtent.width, capabilities.maxImageExtent.height,
+      static_cast<uint32_t>(capabilities.supportedTransforms),
+      static_cast<uint32_t>(capabilities.currentTransform),
+      capabilities.supportedCompositeAlpha, capabilities.supportedUsageFlags);
+#endif
+}
+
+void LogSurfaceFormats(const std::vector<VkSurfaceFormatKHR>& formats) {
+#ifdef SKITY_RELEASE
+  (void)formats;
+#else
+  LOGD("Vulkan surface formats: {}", formats.size());
+  for (const auto& format : formats) {
+    LOGD("  - format={} colorSpace={}", static_cast<int32_t>(format.format),
+         static_cast<int32_t>(format.colorSpace));
+  }
+#endif
+}
+
+void LogPresentModes(const std::vector<VkPresentModeKHR>& present_modes) {
+#ifdef SKITY_RELEASE
+  (void)present_modes;
+#else
+  LOGD("Vulkan present modes: {}", present_modes.size());
+  for (auto present_mode : present_modes) {
+    LOGD("  - presentMode={}", static_cast<int32_t>(present_mode));
+  }
+#endif
+}
+
+}  // namespace
+
+GPUPresenterVK::GPUPresenterVK(GPUContextImpl* context,
+                               std::shared_ptr<const VulkanContextState> state,
+                               const GPUPresenterDescriptorVK& desc)
+    : context_(context), state_(std::move(state)), desc_(desc) {}
+
+GPUPresenterVK::~GPUPresenterVK() { Reset(); }
+
+bool GPUPresenterVK::Init() {
+  if (context_ == nullptr || state_ == nullptr ||
+      desc_.surface == VK_NULL_HANDLE || desc_.width == 0 ||
+      desc_.height == 0) {
+    LOGE("Failed to initialize Vulkan presenter: invalid descriptor");
+    return false;
+  }
+
+  present_queue_ = desc_.present_queue != VK_NULL_HANDLE
+                       ? desc_.present_queue
+                       : state_->GetGraphicsQueue();
+  present_queue_family_index_ = desc_.present_queue_family_index >= 0
+                                    ? desc_.present_queue_family_index
+                                    : state_->GetGraphicsQueueFamilyIndex();
+
+  if (present_queue_ == VK_NULL_HANDLE || present_queue_family_index_ < 0) {
+    LOGE("Failed to initialize Vulkan presenter: invalid present queue");
+    return false;
+  }
+
+  if (!LoadPresenterFns()) {
+    return false;
+  }
+
+  VkBool32 supported = VK_FALSE;
+  const VkResult support_result = fns_.vkGetPhysicalDeviceSurfaceSupportKHR(
+      state_->GetPhysicalDevice(),
+      static_cast<uint32_t>(present_queue_family_index_), desc_.surface,
+      &supported);
+  if (support_result != VK_SUCCESS || supported != VK_TRUE) {
+    LOGE("Failed to initialize Vulkan presenter: present queue unsupported");
+    return false;
+  }
+
+  if (!CreateSwapchain() || !CreateSwapchainImageViews() ||
+      !CreateFrameSlots()) {
+    Reset();
+    return false;
+  }
+
+  return true;
+}
+
+int32_t GPUPresenterVK::GetPresentMode() const {
+  return static_cast<int32_t>(swapchain_present_mode_);
+}
+
+GPUSurfaceAcquireResult GPUPresenterVK::AcquireNextSurface(
+    const GPUSurfaceAcquireDescriptor& acquire_desc) {
+  GPUSurfaceAcquireResult result = {};
+  if (state_ == nullptr || swapchain_ == VK_NULL_HANDLE ||
+      frame_slots_.empty() || has_outstanding_surface_) {
+    return result;
+  }
+
+  const auto& device_fns = state_->DeviceFns();
+  FrameSlot& frame_slot = frame_slots_[current_frame_];
+
+  if (device_fns.vkWaitForFences(state_->GetLogicalDevice(), 1,
+                                 &frame_slot.in_flight, VK_TRUE,
+                                 UINT64_MAX) != VK_SUCCESS) {
+    LOGE("Failed to wait for Vulkan presenter fence");
+    return result;
+  }
+
+  if (fns_.vkResetFences(state_->GetLogicalDevice(), 1,
+                         &frame_slot.in_flight) != VK_SUCCESS) {
+    LOGE("Failed to reset Vulkan presenter fence");
+    return result;
+  }
+
+  uint32_t image_index = 0;
+  const VkResult acquire_result = fns_.vkAcquireNextImageKHR(
+      state_->GetLogicalDevice(), swapchain_, UINT64_MAX,
+      frame_slot.image_available, VK_NULL_HANDLE, &image_index);
+  if (acquire_result == VK_ERROR_OUT_OF_DATE_KHR ||
+      acquire_result == VK_SUBOPTIMAL_KHR) {
+    result.status = GPUPresenterStatus::kNeedRecreate;
+    return result;
+  }
+  if (acquire_result != VK_SUCCESS) {
+    LOGE("Failed to acquire swapchain image: {}",
+         static_cast<int32_t>(acquire_result));
+    return result;
+  }
+
+  if (image_index >= swapchain_images_.size() ||
+      image_index >= swapchain_image_views_.size()) {
+    LOGE("Failed to acquire swapchain image: invalid image index {}",
+         image_index);
+    state_->DeviceFns().vkWaitForFences(state_->GetLogicalDevice(), 1,
+                                        &frame_slot.in_flight, VK_TRUE,
+                                        UINT64_MAX);
+    fns_.vkResetFences(state_->GetLogicalDevice(), 1, &frame_slot.in_flight);
+    return result;
+  }
+
+  VkFence& image_fence = image_in_flight_fences_[image_index];
+  if (image_fence != VK_NULL_HANDLE && image_fence != frame_slot.in_flight) {
+    if (device_fns.vkWaitForFences(state_->GetLogicalDevice(), 1, &image_fence,
+                                   VK_TRUE, UINT64_MAX) != VK_SUCCESS) {
+      LOGE("Failed to wait for Vulkan image fence");
+      return result;
+    }
+  }
+  image_fence = frame_slot.in_flight;
+
+  GPUSurfaceSyncInfoVK sync_info = {};
+  sync_info.wait_semaphore = frame_slot.image_available;
+  sync_info.wait_dst_stage_mask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  sync_info.signal_semaphore = frame_slot.render_finished;
+  sync_info.signal_fence = frame_slot.in_flight;
+
+  const uint32_t target_width = static_cast<uint32_t>(
+      std::floor(static_cast<float>(desc_.width) / acquire_desc.content_scale));
+  const uint32_t target_height = static_cast<uint32_t>(std::floor(
+      static_cast<float>(desc_.height) / acquire_desc.content_scale));
+  if (target_width == 0 || target_height == 0) {
+    LOGE("Failed to acquire Vulkan surface: invalid target size");
+    return result;
+  }
+
+  GPUSurfaceDescriptorVK surface_desc = {};
+  surface_desc.backend = GPUBackendType::kVulkan;
+  surface_desc.width = target_width;
+  surface_desc.height = target_height;
+  surface_desc.sample_count = acquire_desc.sample_count;
+  surface_desc.content_scale = acquire_desc.content_scale;
+  surface_desc.surface_type = VKSurfaceType::kSwapchainImage;
+  surface_desc.image = swapchain_images_[image_index];
+  surface_desc.image_view = swapchain_image_views_[image_index];
+  surface_desc.format = swapchain_format_;
+  surface_desc.pre_transform = swapchain_transform_;
+  surface_desc.initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  surface_desc.final_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  surface_desc.owns_image = false;
+  surface_desc.owns_image_view = false;
+  surface_desc.sync_info = &sync_info;
+
+  GPUTextureDescriptor texture_desc = {};
+  texture_desc.width = desc_.width;
+  texture_desc.height = desc_.height;
+  texture_desc.mip_level_count = 1;
+  texture_desc.sample_count = acquire_desc.sample_count;
+  texture_desc.format = ToGPUTextureFormat(swapchain_format_);
+  texture_desc.usage =
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment);
+  texture_desc.storage_mode = GPUTextureStorageMode::kPrivate;
+  if (texture_desc.format == GPUTextureFormat::kInvalid) {
+    LOGE("Failed to acquire Vulkan surface: unsupported swapchain format");
+    return result;
+  }
+
+  auto texture = GPUTextureVK::Wrap(
+      state_, texture_desc, surface_desc.image, surface_desc.image_view,
+      surface_desc.initial_layout, surface_desc.final_layout,
+      surface_desc.format, false, false);
+  if (texture == nullptr) {
+    return result;
+  }
+
+  auto surface = std::make_unique<GPUSurfaceVK>(
+      surface_desc, context_, std::move(texture), texture_desc.format,
+      surface_desc.sync_info);
+  GPUSurfaceVK::PresentInfo present_info = {};
+  present_info.owner = this;
+  present_info.image_index = image_index;
+  surface->SetPresentInfo(present_info);
+  has_outstanding_surface_ = true;
+  result.status = GPUPresenterStatus::kSuccess;
+  result.surface = std::move(surface);
+  return result;
+}
+
+GPUPresenterStatus GPUPresenterVK::Present(
+    std::unique_ptr<GPUSurface> surface) {
+  if (!has_outstanding_surface_ || surface == nullptr ||
+      surface->GetBackendType() != GPUBackendType::kVulkan) {
+    return GPUPresenterStatus::kError;
+  }
+
+  auto* surface_vk = static_cast<GPUSurfaceVK*>(surface.get());
+  const auto* present_info = surface_vk->GetPresentInfo();
+  const auto* submit_info =
+      static_cast<const GPUSubmitInfoVK*>(surface_vk->GetSubmitInfo());
+  if (present_info == nullptr || present_info->owner != this ||
+      submit_info == nullptr) {
+    return GPUPresenterStatus::kError;
+  }
+
+  VkSemaphore wait_semaphore = submit_info->signal_semaphore;
+  VkPresentInfoKHR present_info_vk = {};
+  present_info_vk.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+  if (wait_semaphore != VK_NULL_HANDLE) {
+    present_info_vk.waitSemaphoreCount = 1;
+    present_info_vk.pWaitSemaphores = &wait_semaphore;
+  }
+  present_info_vk.swapchainCount = 1;
+  present_info_vk.pSwapchains = &swapchain_;
+  present_info_vk.pImageIndices = &present_info->image_index;
+
+  const VkResult result =
+      fns_.vkQueuePresentKHR(present_queue_, &present_info_vk);
+  has_outstanding_surface_ = false;
+  current_frame_ = (current_frame_ + 1) % frame_slots_.size();
+  if (result == VK_SUCCESS) {
+    return GPUPresenterStatus::kSuccess;
+  }
+  if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
+    return GPUPresenterStatus::kNeedRecreate;
+  }
+  return GPUPresenterStatus::kError;
+}
+
+bool GPUPresenterVK::LoadPresenterFns() {
+  if (state_ == nullptr || state_->GetInstanceProcAddr() == nullptr ||
+      state_->GetDeviceProcAddr() == nullptr ||
+      state_->GetInstance() == VK_NULL_HANDLE ||
+      state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    LOGE("Failed to load Vulkan presenter procedures: invalid state");
+    return false;
+  }
+
+  auto load_instance = [this](const char* name) -> PFN_vkVoidFunction {
+    return state_->GetInstanceProcAddr()(state_->GetInstance(), name);
+  };
+  auto load_device = [this](const char* name) -> PFN_vkVoidFunction {
+    return state_->GetDeviceProcAddr()(state_->GetLogicalDevice(), name);
+  };
+
+  fns_.vkGetPhysicalDeviceSurfaceCapabilitiesKHR =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>(
+          load_instance("vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
+  fns_.vkGetPhysicalDeviceSurfaceFormatsKHR =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>(
+          load_instance("vkGetPhysicalDeviceSurfaceFormatsKHR"));
+  fns_.vkGetPhysicalDeviceSurfacePresentModesKHR =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModesKHR>(
+          load_instance("vkGetPhysicalDeviceSurfacePresentModesKHR"));
+  fns_.vkGetPhysicalDeviceSurfaceSupportKHR =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>(
+          load_instance("vkGetPhysicalDeviceSurfaceSupportKHR"));
+  fns_.vkCreateSwapchainKHR = reinterpret_cast<PFN_vkCreateSwapchainKHR>(
+      load_device("vkCreateSwapchainKHR"));
+  fns_.vkDestroySwapchainKHR = reinterpret_cast<PFN_vkDestroySwapchainKHR>(
+      load_device("vkDestroySwapchainKHR"));
+  fns_.vkGetSwapchainImagesKHR = reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(
+      load_device("vkGetSwapchainImagesKHR"));
+  fns_.vkAcquireNextImageKHR = reinterpret_cast<PFN_vkAcquireNextImageKHR>(
+      load_device("vkAcquireNextImageKHR"));
+  fns_.vkQueuePresentKHR =
+      reinterpret_cast<PFN_vkQueuePresentKHR>(load_device("vkQueuePresentKHR"));
+  fns_.vkCreateSemaphore =
+      reinterpret_cast<PFN_vkCreateSemaphore>(load_device("vkCreateSemaphore"));
+  fns_.vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(
+      load_device("vkDestroySemaphore"));
+  fns_.vkResetFences =
+      reinterpret_cast<PFN_vkResetFences>(load_device("vkResetFences"));
+
+  if (fns_.vkGetPhysicalDeviceSurfaceCapabilitiesKHR == nullptr ||
+      fns_.vkGetPhysicalDeviceSurfaceFormatsKHR == nullptr ||
+      fns_.vkGetPhysicalDeviceSurfacePresentModesKHR == nullptr ||
+      fns_.vkGetPhysicalDeviceSurfaceSupportKHR == nullptr ||
+      fns_.vkCreateSwapchainKHR == nullptr ||
+      fns_.vkDestroySwapchainKHR == nullptr ||
+      fns_.vkGetSwapchainImagesKHR == nullptr ||
+      fns_.vkAcquireNextImageKHR == nullptr ||
+      fns_.vkQueuePresentKHR == nullptr || fns_.vkCreateSemaphore == nullptr ||
+      fns_.vkDestroySemaphore == nullptr || fns_.vkResetFences == nullptr) {
+    LOGE("Failed to load Vulkan presenter procedures");
+    return false;
+  }
+
+  return true;
+}
+
+bool GPUPresenterVK::CreateSwapchain() {
+  VkSurfaceCapabilitiesKHR capabilities = {};
+  if (fns_.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+          state_->GetPhysicalDevice(), desc_.surface, &capabilities) !=
+      VK_SUCCESS) {
+    LOGE("Failed to query Vulkan surface capabilities");
+    return false;
+  }
+  LogSurfaceCapabilities(capabilities);
+
+  uint32_t format_count = 0;
+  if (fns_.vkGetPhysicalDeviceSurfaceFormatsKHR(state_->GetPhysicalDevice(),
+                                                desc_.surface, &format_count,
+                                                nullptr) != VK_SUCCESS ||
+      format_count == 0) {
+    LOGE("Failed to query Vulkan surface formats");
+    return false;
+  }
+  std::vector<VkSurfaceFormatKHR> formats(format_count);
+  if (fns_.vkGetPhysicalDeviceSurfaceFormatsKHR(state_->GetPhysicalDevice(),
+                                                desc_.surface, &format_count,
+                                                formats.data()) != VK_SUCCESS) {
+    LOGE("Failed to load Vulkan surface formats");
+    return false;
+  }
+  LogSurfaceFormats(formats);
+
+  uint32_t present_mode_count = 0;
+  if (fns_.vkGetPhysicalDeviceSurfacePresentModesKHR(
+          state_->GetPhysicalDevice(), desc_.surface, &present_mode_count,
+          nullptr) != VK_SUCCESS ||
+      present_mode_count == 0) {
+    LOGE("Failed to query Vulkan present modes");
+    return false;
+  }
+  std::vector<VkPresentModeKHR> present_modes(present_mode_count);
+  if (fns_.vkGetPhysicalDeviceSurfacePresentModesKHR(
+          state_->GetPhysicalDevice(), desc_.surface, &present_mode_count,
+          present_modes.data()) != VK_SUCCESS) {
+    LOGE("Failed to load Vulkan present modes");
+    return false;
+  }
+  LogPresentModes(present_modes);
+
+  VkSurfaceFormatKHR selected_format = formats.front();
+  for (const auto& surface_format : formats) {
+    if (surface_format.format == desc_.format &&
+        surface_format.colorSpace == desc_.color_space) {
+      selected_format = surface_format;
+      break;
+    }
+  }
+
+  VkPresentModeKHR selected_present_mode = VK_PRESENT_MODE_FIFO_KHR;
+  for (auto present_mode : present_modes) {
+    if (present_mode == desc_.present_mode) {
+      selected_present_mode = present_mode;
+      break;
+    }
+  }
+
+  if (capabilities.currentExtent.width != UINT32_MAX) {
+    swapchain_extent_ = capabilities.currentExtent;
+  } else {
+    swapchain_extent_.width =
+        std::clamp(desc_.width, capabilities.minImageExtent.width,
+                   capabilities.maxImageExtent.width);
+    swapchain_extent_.height =
+        std::clamp(desc_.height, capabilities.minImageExtent.height,
+                   capabilities.maxImageExtent.height);
+  }
+
+  swapchain_format_ = selected_format.format;
+  swapchain_present_mode_ = selected_present_mode;
+  swapchain_transform_ =
+      (capabilities.supportedTransforms & desc_.pre_transform) != 0
+          ? desc_.pre_transform
+          : capabilities.currentTransform;
+  const VkCompositeAlphaFlagBitsKHR composite_alpha = ResolveCompositeAlpha(
+      desc_.composite_alpha, capabilities.supportedCompositeAlpha);
+
+  uint32_t image_count =
+      std::max(desc_.min_image_count, capabilities.minImageCount);
+  if (capabilities.maxImageCount > 0) {
+    image_count = std::min(image_count, capabilities.maxImageCount);
+  }
+
+  const bool shared_present_queue =
+      present_queue_family_index_ != state_->GetGraphicsQueueFamilyIndex();
+  const uint32_t queue_family_indices[2] = {
+      static_cast<uint32_t>(state_->GetGraphicsQueueFamilyIndex()),
+      static_cast<uint32_t>(present_queue_family_index_)};
+
+  VkSwapchainCreateInfoKHR create_info = {};
+  create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+  create_info.surface = desc_.surface;
+  create_info.minImageCount = image_count;
+  create_info.imageFormat = selected_format.format;
+  create_info.imageColorSpace = selected_format.colorSpace;
+  create_info.imageExtent = swapchain_extent_;
+  create_info.imageArrayLayers = 1;
+  create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  create_info.imageSharingMode = shared_present_queue
+                                     ? VK_SHARING_MODE_CONCURRENT
+                                     : VK_SHARING_MODE_EXCLUSIVE;
+  create_info.queueFamilyIndexCount = shared_present_queue ? 2u : 0u;
+  create_info.pQueueFamilyIndices =
+      shared_present_queue ? queue_family_indices : nullptr;
+  create_info.preTransform = swapchain_transform_;
+  create_info.compositeAlpha = composite_alpha;
+  create_info.presentMode = selected_present_mode;
+  create_info.clipped = desc_.clipped ? VK_TRUE : VK_FALSE;
+  create_info.oldSwapchain =
+      desc_.old_swapchain != VK_NULL_HANDLE ? desc_.old_swapchain : swapchain_;
+  LOGD(
+      "Creating Vulkan swapchain: extent={}x{} imageCount={} format={} "
+      "colorSpace={} "
+      "presentMode={} preTransform=0x{:x} compositeAlpha=0x{:x} usage=0x{:x}",
+      create_info.imageExtent.width, create_info.imageExtent.height,
+      create_info.minImageCount, static_cast<int32_t>(create_info.imageFormat),
+      static_cast<int32_t>(create_info.imageColorSpace),
+      static_cast<int32_t>(create_info.presentMode),
+      static_cast<uint32_t>(create_info.preTransform),
+      static_cast<uint32_t>(create_info.compositeAlpha),
+      static_cast<uint32_t>(create_info.imageUsage));
+
+  const VkResult result = fns_.vkCreateSwapchainKHR(
+      state_->GetLogicalDevice(), &create_info, nullptr, &swapchain_);
+  if (result != VK_SUCCESS || swapchain_ == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan swapchain: {}", static_cast<int32_t>(result));
+    swapchain_ = VK_NULL_HANDLE;
+    return false;
+  }
+
+  uint32_t swapchain_image_count = 0;
+  if (fns_.vkGetSwapchainImagesKHR(state_->GetLogicalDevice(), swapchain_,
+                                   &swapchain_image_count,
+                                   nullptr) != VK_SUCCESS ||
+      swapchain_image_count == 0) {
+    LOGE("Failed to query Vulkan swapchain images");
+    return false;
+  }
+
+  swapchain_images_.resize(swapchain_image_count);
+  if (fns_.vkGetSwapchainImagesKHR(state_->GetLogicalDevice(), swapchain_,
+                                   &swapchain_image_count,
+                                   swapchain_images_.data()) != VK_SUCCESS) {
+    LOGE("Failed to load Vulkan swapchain images");
+    swapchain_images_.clear();
+    return false;
+  }
+  swapchain_images_.resize(swapchain_image_count);
+  image_in_flight_fences_.assign(swapchain_image_count, VK_NULL_HANDLE);
+  return true;
+}
+
+bool GPUPresenterVK::CreateSwapchainImageViews() {
+  swapchain_image_views_.reserve(swapchain_images_.size());
+  for (VkImage image : swapchain_images_) {
+    VkImageView image_view =
+        CreateSwapchainImageView(*state_, image, swapchain_format_);
+    if (image_view == VK_NULL_HANDLE) {
+      return false;
+    }
+    swapchain_image_views_.push_back(image_view);
+  }
+  return true;
+}
+
+bool GPUPresenterVK::CreateFrameSlots() {
+  frame_slots_.resize(std::max<size_t>(2, swapchain_images_.size()));
+  for (auto& frame_slot : frame_slots_) {
+    VkSemaphoreCreateInfo semaphore_info = {};
+    semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    if (fns_.vkCreateSemaphore(state_->GetLogicalDevice(), &semaphore_info,
+                               nullptr,
+                               &frame_slot.image_available) != VK_SUCCESS ||
+        fns_.vkCreateSemaphore(state_->GetLogicalDevice(), &semaphore_info,
+                               nullptr,
+                               &frame_slot.render_finished) != VK_SUCCESS) {
+      LOGE("Failed to create Vulkan presenter semaphores");
+      return false;
+    }
+
+    VkFenceCreateInfo fence_info = {};
+    fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fence_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    if (state_->DeviceFns().vkCreateFence(
+            state_->GetLogicalDevice(), &fence_info, nullptr,
+            &frame_slot.in_flight) != VK_SUCCESS) {
+      LOGE("Failed to create Vulkan presenter fence");
+      return false;
+    }
+  }
+  return true;
+}
+
+void GPUPresenterVK::DestroyFrameSlots() {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    frame_slots_.clear();
+    return;
+  }
+
+  for (auto& frame_slot : frame_slots_) {
+    if (frame_slot.image_available != VK_NULL_HANDLE &&
+        fns_.vkDestroySemaphore != nullptr) {
+      fns_.vkDestroySemaphore(state_->GetLogicalDevice(),
+                              frame_slot.image_available, nullptr);
+    }
+    if (frame_slot.render_finished != VK_NULL_HANDLE &&
+        fns_.vkDestroySemaphore != nullptr) {
+      fns_.vkDestroySemaphore(state_->GetLogicalDevice(),
+                              frame_slot.render_finished, nullptr);
+    }
+    if (frame_slot.in_flight != VK_NULL_HANDLE &&
+        state_->DeviceFns().vkDestroyFence != nullptr) {
+      state_->DeviceFns().vkDestroyFence(state_->GetLogicalDevice(),
+                                         frame_slot.in_flight, nullptr);
+    }
+  }
+  frame_slots_.clear();
+}
+
+void GPUPresenterVK::DestroySwapchainImageViews() {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    swapchain_image_views_.clear();
+    return;
+  }
+
+  for (auto image_view : swapchain_image_views_) {
+    if (image_view != VK_NULL_HANDLE &&
+        state_->DeviceFns().vkDestroyImageView != nullptr) {
+      state_->DeviceFns().vkDestroyImageView(state_->GetLogicalDevice(),
+                                             image_view, nullptr);
+    }
+  }
+  swapchain_image_views_.clear();
+}
+
+void GPUPresenterVK::DestroySwapchain() {
+  if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+      swapchain_ != VK_NULL_HANDLE && fns_.vkDestroySwapchainKHR != nullptr) {
+    fns_.vkDestroySwapchainKHR(state_->GetLogicalDevice(), swapchain_, nullptr);
+  }
+  swapchain_ = VK_NULL_HANDLE;
+  swapchain_images_.clear();
+  image_in_flight_fences_.clear();
+}
+
+void GPUPresenterVK::Reset() {
+  if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+      state_->DeviceFns().vkDeviceWaitIdle != nullptr) {
+    state_->DeviceFns().vkDeviceWaitIdle(state_->GetLogicalDevice());
+  }
+  if (state_ != nullptr) {
+    state_->CollectPendingSubmissions(true);
+  }
+  DestroyFrameSlots();
+  DestroySwapchainImageViews();
+  DestroySwapchain();
+  current_frame_ = 0;
+  has_outstanding_surface_ = false;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_presenter_vk.hpp
+++ b/src/gpu/vk/gpu_presenter_vk.hpp
@@ -1,0 +1,103 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_PRESENTER_VK_HPP
+#define SRC_GPU_VK_GPU_PRESENTER_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <skity/gpu/gpu_presenter.hpp>
+#include <vector>
+
+#include "src/gpu/vk/gpu_surface_vk.hpp"
+
+namespace skity {
+
+class GPUContextImpl;
+class VulkanContextState;
+
+class GPUPresenterVK : public GPUPresenter {
+ public:
+  GPUPresenterVK(GPUContextImpl* context,
+                 std::shared_ptr<const VulkanContextState> state,
+                 const GPUPresenterDescriptorVK& desc);
+
+  ~GPUPresenterVK() override;
+
+  bool Init();
+
+  VkSwapchainKHR GetSwapchain() const { return swapchain_; }
+
+  int32_t GetPresentMode() const override;
+
+  GPUSurfaceAcquireResult AcquireNextSurface(
+      const GPUSurfaceAcquireDescriptor& desc) override;
+
+  GPUPresenterStatus Present(std::unique_ptr<GPUSurface> surface) override;
+
+ private:
+  struct FrameSlot {
+    VkSemaphore image_available = VK_NULL_HANDLE;
+    VkSemaphore render_finished = VK_NULL_HANDLE;
+    VkFence in_flight = VK_NULL_HANDLE;
+  };
+
+  struct PresenterFns {
+    PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR
+        vkGetPhysicalDeviceSurfaceCapabilitiesKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceFormatsKHR
+        vkGetPhysicalDeviceSurfaceFormatsKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfacePresentModesKHR
+        vkGetPhysicalDeviceSurfacePresentModesKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceSupportKHR
+        vkGetPhysicalDeviceSurfaceSupportKHR = nullptr;
+    PFN_vkCreateSwapchainKHR vkCreateSwapchainKHR = nullptr;
+    PFN_vkDestroySwapchainKHR vkDestroySwapchainKHR = nullptr;
+    PFN_vkGetSwapchainImagesKHR vkGetSwapchainImagesKHR = nullptr;
+    PFN_vkAcquireNextImageKHR vkAcquireNextImageKHR = nullptr;
+    PFN_vkQueuePresentKHR vkQueuePresentKHR = nullptr;
+    PFN_vkCreateSemaphore vkCreateSemaphore = nullptr;
+    PFN_vkDestroySemaphore vkDestroySemaphore = nullptr;
+    PFN_vkResetFences vkResetFences = nullptr;
+  };
+
+  struct SurfacePresentInfo {
+    const GPUPresenterVK* owner = nullptr;
+    uint32_t image_index = 0;
+  };
+
+  bool LoadPresenterFns();
+  bool CreateSwapchain();
+  bool CreateSwapchainImageViews();
+  bool CreateFrameSlots();
+  void DestroyFrameSlots();
+  void DestroySwapchainImageViews();
+  void DestroySwapchain();
+  void Reset();
+
+  GPUContextImpl* context_ = nullptr;
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  GPUPresenterDescriptorVK desc_ = {};
+  PresenterFns fns_ = {};
+  VkQueue present_queue_ = VK_NULL_HANDLE;
+  int32_t present_queue_family_index_ = -1;
+  VkSwapchainKHR swapchain_ = VK_NULL_HANDLE;
+  VkExtent2D swapchain_extent_ = {};
+  VkFormat swapchain_format_ = VK_FORMAT_UNDEFINED;
+  VkPresentModeKHR swapchain_present_mode_ = VK_PRESENT_MODE_FIFO_KHR;
+  VkSurfaceTransformFlagBitsKHR swapchain_transform_ =
+      VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+  std::vector<VkImage> swapchain_images_ = {};
+  std::vector<VkImageView> swapchain_image_views_ = {};
+  std::vector<FrameSlot> frame_slots_ = {};
+  std::vector<VkFence> image_in_flight_fences_ = {};
+  uint32_t current_frame_ = 0;
+  bool has_outstanding_surface_ = false;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_PRESENTER_VK_HPP

--- a/src/gpu/vk/gpu_render_pass_vk.cc
+++ b/src/gpu/vk/gpu_render_pass_vk.cc
@@ -1,0 +1,1037 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_render_pass_vk.hpp"
+
+#include <array>
+#include <unordered_set>
+
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_render_pipeline_vk.hpp"
+#include "src/gpu/vk/gpu_sampler_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+bool IsDepthStencilFormat(GPUTextureFormat format) {
+  return format == GPUTextureFormat::kStencil8 ||
+         format == GPUTextureFormat::kDepth24Stencil8;
+}
+
+VkImageAspectFlags GetImageAspectMask(GPUTextureFormat format) {
+  switch (format) {
+    case GPUTextureFormat::kStencil8:
+      return VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kDepth24Stencil8:
+      return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kInvalid:
+      return 0;
+    default:
+      return VK_IMAGE_ASPECT_COLOR_BIT;
+  }
+}
+
+VkAccessFlags AccessMaskForLayout(VkImageLayout layout) {
+  switch (layout) {
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+      return VK_ACCESS_TRANSFER_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+      return VK_ACCESS_TRANSFER_READ_BIT;
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+      return VK_ACCESS_SHADER_READ_BIT;
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+      return VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+      return VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    case VK_IMAGE_LAYOUT_GENERAL:
+      return VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+    default:
+      return 0;
+  }
+}
+
+VkPipelineStageFlags StageMaskForLayout(VkImageLayout layout) {
+  switch (layout) {
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+      return VK_PIPELINE_STAGE_TRANSFER_BIT;
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+      return VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+      return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+      return VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+             VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    case VK_IMAGE_LAYOUT_GENERAL:
+      return VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    default:
+      return VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+  }
+}
+
+bool HasTextureUsage(const GPUTextureDescriptor& descriptor,
+                     GPUTextureUsage usage) {
+  return (descriptor.usage & static_cast<GPUTextureUsageMask>(usage)) != 0;
+}
+
+VkAttachmentLoadOp ToVkLoadOp(GPULoadOp op) {
+  switch (op) {
+    case GPULoadOp::kClear:
+      return VK_ATTACHMENT_LOAD_OP_CLEAR;
+    case GPULoadOp::kLoad:
+      return VK_ATTACHMENT_LOAD_OP_LOAD;
+    case GPULoadOp::kDontCare:
+      return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  }
+
+  return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+}
+
+VkAttachmentStoreOp ToVkStoreOp(GPUStoreOp op) {
+  switch (op) {
+    case GPUStoreOp::kStore:
+      return VK_ATTACHMENT_STORE_OP_STORE;
+    case GPUStoreOp::kDiscard:
+      return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  }
+
+  return VK_ATTACHMENT_STORE_OP_STORE;
+}
+
+VkAttachmentStoreOp ToColorAttachmentStoreOp(bool has_resolve, GPUStoreOp op) {
+  if (has_resolve) {
+    return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  }
+  return ToVkStoreOp(op);
+}
+
+bool TransitionImageLayout(const VulkanContextState& state,
+                           VkCommandBuffer command_buffer,
+                           GPUTextureVK& texture, VkImageLayout new_layout) {
+  const VkImageLayout old_layout = texture.GetCurrentLayout();
+  if (old_layout == new_layout) {
+    return true;
+  }
+
+  VkImageMemoryBarrier barrier = {};
+  barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  barrier.oldLayout = old_layout;
+  barrier.newLayout = new_layout;
+  barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrier.image = texture.GetImage();
+  barrier.subresourceRange.aspectMask =
+      GetImageAspectMask(texture.GetDescriptor().format);
+  barrier.subresourceRange.baseMipLevel = 0;
+  barrier.subresourceRange.levelCount = texture.GetDescriptor().mip_level_count;
+  barrier.subresourceRange.baseArrayLayer = 0;
+  barrier.subresourceRange.layerCount = 1;
+  barrier.srcAccessMask = AccessMaskForLayout(old_layout);
+  barrier.dstAccessMask = AccessMaskForLayout(new_layout);
+
+  state.DeviceFns().vkCmdPipelineBarrier(
+      command_buffer, StageMaskForLayout(old_layout),
+      StageMaskForLayout(new_layout), 0, 0, nullptr, 0, nullptr, 1, &barrier);
+  texture.SetCurrentLayout(new_layout);
+  return true;
+}
+
+struct AttachmentContext {
+  GPUTextureVK* texture = nullptr;
+  GPUTextureVK* resolve_texture = nullptr;
+  VkImageLayout attachment_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkImageLayout final_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+};
+
+bool PrepareAttachmentContext(const GPUAttachment& attachment,
+                              VkImageLayout attachment_layout,
+                              AttachmentContext* context,
+                              bool require_depth_stencil_format = false) {
+  if (context == nullptr || attachment.texture == nullptr) {
+    return false;
+  }
+
+  auto* texture = GPUTextureVK::Cast(attachment.texture.get());
+  if (texture == nullptr || !texture->IsValid()) {
+    return false;
+  }
+  if (require_depth_stencil_format &&
+      !IsDepthStencilFormat(texture->GetDescriptor().format)) {
+    return false;
+  }
+
+  context->texture = texture;
+  context->attachment_layout = attachment_layout;
+  context->final_layout = texture->GetPreferredLayout();
+
+  if (attachment.resolve_texture != nullptr) {
+    auto* resolve_texture =
+        GPUTextureVK::Cast(attachment.resolve_texture.get());
+    if (resolve_texture == nullptr || !resolve_texture->IsValid()) {
+      return false;
+    }
+    if (!HasTextureUsage(resolve_texture->GetDescriptor(),
+                         GPUTextureUsage::kRenderAttachment)) {
+      LOGE("Vulkan resolve texture must use RenderAttachment usage");
+      return false;
+    }
+    context->resolve_texture = resolve_texture;
+  }
+
+  return true;
+}
+
+bool PrepareColorAttachment(const GPURenderPassDescriptor& desc,
+                            AttachmentContext* color_context) {
+  if (!PrepareAttachmentContext(desc.color_attachment,
+                                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                                color_context)) {
+    LOGE("Failed to prepare Vulkan color attachment");
+    return false;
+  }
+
+  return true;
+}
+
+bool PrepareDepthStencilAttachment(const GPURenderPassDescriptor& desc,
+                                   AttachmentContext* depth_stencil_context,
+                                   bool* has_depth, bool* has_stencil) {
+  if (depth_stencil_context == nullptr || has_depth == nullptr ||
+      has_stencil == nullptr) {
+    return false;
+  }
+
+  *has_depth = desc.depth_attachment.texture != nullptr;
+  *has_stencil = desc.stencil_attachment.texture != nullptr;
+
+  if (!*has_depth && !*has_stencil) {
+    return true;
+  }
+
+  if (!*has_stencil) {
+    LOGE("Vulkan render pass requires stencil when depth is attached");
+    return false;
+  }
+
+  if (*has_depth &&
+      desc.depth_attachment.texture != desc.stencil_attachment.texture) {
+    LOGE("Vulkan render pass requires depth and stencil to share one texture");
+    return false;
+  }
+
+  if (!PrepareAttachmentContext(
+          desc.stencil_attachment,
+          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+          depth_stencil_context, true)) {
+    LOGE("Failed to prepare Vulkan depth/stencil attachment");
+    return false;
+  }
+
+  const auto format = depth_stencil_context->texture->GetDescriptor().format;
+  if (*has_depth && format != GPUTextureFormat::kDepth24Stencil8) {
+    LOGE("Vulkan depth attachment must use Depth24Stencil8 format");
+    return false;
+  }
+
+  if (!*has_depth && format != GPUTextureFormat::kStencil8) {
+    LOGE("Vulkan stencil-only attachment must use Stencil8 format");
+    return false;
+  }
+
+  return true;
+}
+
+VulkanContextState::LegacyRenderPassKey BuildLegacyRenderPassKey(
+    const GPURenderPassDescriptor& desc, const AttachmentContext& color_context,
+    const AttachmentContext& depth_stencil_context, bool has_depth,
+    bool has_stencil) {
+  VulkanContextState::LegacyRenderPassKey key = {};
+  key.color_format = color_context.texture->GetVkFormat();
+  key.color_samples = static_cast<VkSampleCountFlagBits>(
+      color_context.texture->GetDescriptor().sample_count);
+  key.color_load_op = ToVkLoadOp(desc.color_attachment.load_op);
+  key.color_store_op = ToColorAttachmentStoreOp(
+      color_context.resolve_texture != nullptr, desc.color_attachment.store_op);
+  key.has_resolve = color_context.resolve_texture != nullptr;
+
+  if (key.has_resolve) {
+    key.resolve_format = color_context.resolve_texture->GetVkFormat();
+    key.resolve_store_op = ToVkStoreOp(desc.color_attachment.store_op);
+  }
+
+  key.has_depth = has_depth;
+  key.has_stencil = has_stencil;
+  if (has_depth || has_stencil) {
+    key.depth_stencil_format = depth_stencil_context.texture->GetVkFormat();
+    key.depth_stencil_samples = static_cast<VkSampleCountFlagBits>(
+        depth_stencil_context.texture->GetDescriptor().sample_count);
+    key.depth_load_op = has_depth ? ToVkLoadOp(desc.depth_attachment.load_op)
+                                  : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    key.depth_store_op = has_depth ? ToVkStoreOp(desc.depth_attachment.store_op)
+                                   : VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    key.stencil_load_op = ToVkLoadOp(desc.stencil_attachment.load_op);
+    key.stencil_store_op = ToVkStoreOp(desc.stencil_attachment.store_op);
+  }
+
+  return key;
+}
+
+VkImageLayout GetSampledImageLayout(const GPUTextureVK& texture) {
+  const auto current_layout = texture.GetCurrentLayout();
+  return current_layout != VK_IMAGE_LAYOUT_UNDEFINED
+             ? current_layout
+             : texture.GetPreferredLayout();
+}
+
+struct DescriptorPoolRequirements {
+  uint32_t max_sets = 0;
+  uint32_t uniform_buffer_count = 0;
+  uint32_t sampled_image_count = 0;
+  uint32_t sampler_count = 0;
+};
+
+void AccumulateDescriptorPoolRequirements(const Command& command,
+                                          const GPURenderPipelineVK& pipeline,
+                                          DescriptorPoolRequirements* req) {
+  if (req == nullptr) {
+    return;
+  }
+
+  req->max_sets +=
+      static_cast<uint32_t>(pipeline.GetDescriptorSetLayouts().size());
+  req->uniform_buffer_count +=
+      static_cast<uint32_t>(command.uniform_bindings.size());
+  req->sampled_image_count +=
+      static_cast<uint32_t>(command.texture_bindings.size());
+  req->sampler_count += static_cast<uint32_t>(command.sampler_bindings.size());
+}
+
+VkDescriptorPool CreateDescriptorPoolForPass(
+    const std::shared_ptr<const VulkanContextState>& state,
+    const GPURenderPass& pass) {
+  if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE) {
+    return VK_NULL_HANDLE;
+  }
+
+  DescriptorPoolRequirements requirements = {};
+  for (const auto* command : pass.GetCommands()) {
+    if (command == nullptr || !command->IsValid()) {
+      continue;
+    }
+
+    auto* pipeline = GPURenderPipelineVK::Cast(command->pipeline);
+    if (pipeline == nullptr || !pipeline->IsValid()) {
+      continue;
+    }
+
+    AccumulateDescriptorPoolRequirements(*command, *pipeline, &requirements);
+  }
+
+  if (requirements.max_sets == 0) {
+    return VK_NULL_HANDLE;
+  }
+
+  std::vector<VkDescriptorPoolSize> pool_sizes;
+  if (requirements.uniform_buffer_count > 0) {
+    pool_sizes.push_back(
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, requirements.uniform_buffer_count});
+  }
+  if (requirements.sampled_image_count > 0) {
+    pool_sizes.push_back(
+        {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, requirements.sampled_image_count});
+  }
+  if (requirements.sampler_count > 0) {
+    pool_sizes.push_back(
+        {VK_DESCRIPTOR_TYPE_SAMPLER, requirements.sampler_count});
+  }
+
+  VkDescriptorPoolCreateInfo pool_info = {};
+  pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+  pool_info.maxSets = requirements.max_sets;
+  pool_info.poolSizeCount = static_cast<uint32_t>(pool_sizes.size());
+  pool_info.pPoolSizes = pool_sizes.empty() ? nullptr : pool_sizes.data();
+
+  VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+  const VkResult result = state->DeviceFns().vkCreateDescriptorPool(
+      state->GetLogicalDevice(), &pool_info, nullptr, &descriptor_pool);
+  if (result != VK_SUCCESS || descriptor_pool == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan descriptor pool: {}",
+         static_cast<int32_t>(result));
+    return VK_NULL_HANDLE;
+  }
+
+  return descriptor_pool;
+}
+
+bool PrepareSampledTextures(const VulkanContextState& state,
+                            GPUCommandBufferVK& command_buffer,
+                            const GPURenderPass& pass) {
+  for (const auto* command : pass.GetCommands()) {
+    if (command == nullptr || !command->IsValid()) {
+      continue;
+    }
+
+    for (const auto& binding : command->texture_bindings) {
+      auto* texture = GPUTextureVK::Cast(binding.texture.get());
+      if (texture == nullptr || !texture->IsValid()) {
+        LOGE("Failed to prepare Vulkan sampled texture binding");
+        return false;
+      }
+
+      if (!TransitionImageLayout(state, command_buffer.GetCommandBuffer(),
+                                 *texture, texture->GetPreferredLayout())) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+void RecordBoundResourceCleanup(GPUCommandBufferVK& command_buffer,
+                                const GPURenderPass& pass) {
+  std::vector<std::shared_ptr<GPUTexture>> textures;
+  std::vector<std::shared_ptr<GPUSampler>> samplers;
+  std::unordered_set<const GPUTexture*> seen_textures;
+  std::unordered_set<const GPUSampler*> seen_samplers;
+
+  for (const auto* command : pass.GetCommands()) {
+    if (command == nullptr || !command->IsValid()) {
+      continue;
+    }
+
+    for (const auto& binding : command->texture_bindings) {
+      if (binding.texture != nullptr &&
+          seen_textures.insert(binding.texture.get()).second) {
+        textures.emplace_back(binding.texture);
+      }
+    }
+
+    for (const auto& binding : command->sampler_bindings) {
+      if (binding.sampler != nullptr &&
+          seen_samplers.insert(binding.sampler.get()).second) {
+        samplers.emplace_back(binding.sampler);
+      }
+    }
+  }
+
+  command_buffer.RecordCleanupAction(
+      [textures = std::move(textures), samplers = std::move(samplers)]() {});
+}
+
+bool SetupDescriptorSets(const VulkanContextState& state,
+                         VkCommandBuffer command_buffer,
+                         VkDescriptorPool descriptor_pool,
+                         const Command& command,
+                         const GPURenderPipelineVK& pipeline) {
+  const auto& set_layouts = pipeline.GetDescriptorSetLayouts();
+  if (set_layouts.empty()) {
+    return true;
+  }
+
+  if (descriptor_pool == VK_NULL_HANDLE) {
+    LOGE("Failed to bind Vulkan descriptor sets: descriptor pool is null");
+    return false;
+  }
+
+  std::vector<VkDescriptorSet> descriptor_sets(set_layouts.size(),
+                                               VK_NULL_HANDLE);
+  VkDescriptorSetAllocateInfo alloc_info = {};
+  alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+  alloc_info.descriptorPool = descriptor_pool;
+  alloc_info.descriptorSetCount = static_cast<uint32_t>(set_layouts.size());
+  alloc_info.pSetLayouts = set_layouts.data();
+
+  const VkResult alloc_result = state.DeviceFns().vkAllocateDescriptorSets(
+      state.GetLogicalDevice(), &alloc_info, descriptor_sets.data());
+  if (alloc_result != VK_SUCCESS) {
+    LOGE("Failed to allocate Vulkan descriptor sets: {}",
+         static_cast<int32_t>(alloc_result));
+    return false;
+  }
+
+  const size_t total_write_count = command.uniform_bindings.size() +
+                                   command.texture_bindings.size() +
+                                   command.sampler_bindings.size();
+  std::vector<VkWriteDescriptorSet> writes;
+  writes.reserve(total_write_count);
+  std::vector<VkDescriptorBufferInfo> buffer_infos;
+  buffer_infos.reserve(command.uniform_bindings.size());
+  std::vector<VkDescriptorImageInfo> image_infos;
+  image_infos.reserve(command.texture_bindings.size() +
+                      command.sampler_bindings.size());
+
+  for (const auto& binding : command.uniform_bindings) {
+    if (binding.group >= descriptor_sets.size()) {
+      LOGE("Invalid Vulkan uniform binding group {}", binding.group);
+      return false;
+    }
+
+    auto* buffer = static_cast<GPUBufferVK*>(binding.buffer.buffer);
+    if (buffer == nullptr || !buffer->IsValid()) {
+      LOGE("Invalid Vulkan uniform buffer binding");
+      return false;
+    }
+
+    buffer_infos.push_back(VkDescriptorBufferInfo{
+        buffer->GetBuffer(),
+        binding.buffer.offset,
+        binding.buffer.range,
+    });
+
+    VkWriteDescriptorSet write = {};
+    write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet = descriptor_sets[binding.group];
+    write.dstBinding = binding.binding;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    write.pBufferInfo = &buffer_infos.back();
+    writes.push_back(write);
+  }
+
+  for (const auto& binding : command.texture_bindings) {
+    if (binding.group >= descriptor_sets.size()) {
+      LOGE("Invalid Vulkan texture binding group {}", binding.group);
+      return false;
+    }
+
+    auto* texture = GPUTextureVK::Cast(binding.texture.get());
+    if (texture == nullptr || !texture->IsValid()) {
+      LOGE("Invalid Vulkan texture binding");
+      return false;
+    }
+
+    image_infos.push_back(VkDescriptorImageInfo{
+        VK_NULL_HANDLE,
+        texture->GetImageView(),
+        GetSampledImageLayout(*texture),
+    });
+
+    VkWriteDescriptorSet write = {};
+    write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet = descriptor_sets[binding.group];
+    write.dstBinding = binding.binding;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    write.pImageInfo = &image_infos.back();
+    writes.push_back(write);
+  }
+
+  for (const auto& binding : command.sampler_bindings) {
+    if (binding.group >= descriptor_sets.size()) {
+      LOGE("Invalid Vulkan sampler binding group {}", binding.group);
+      return false;
+    }
+
+    auto* sampler = GPUSamplerVK::Cast(binding.sampler.get());
+    if (sampler == nullptr || !sampler->IsValid()) {
+      LOGE("Invalid Vulkan sampler binding");
+      return false;
+    }
+
+    image_infos.push_back(VkDescriptorImageInfo{
+        sampler->GetSampler(),
+        VK_NULL_HANDLE,
+        VK_IMAGE_LAYOUT_UNDEFINED,
+    });
+
+    VkWriteDescriptorSet write = {};
+    write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet = descriptor_sets[binding.group];
+    write.dstBinding = binding.binding;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    write.pImageInfo = &image_infos.back();
+    writes.push_back(write);
+  }
+
+  if (!writes.empty()) {
+    state.DeviceFns().vkUpdateDescriptorSets(
+        state.GetLogicalDevice(), static_cast<uint32_t>(writes.size()),
+        writes.data(), 0, nullptr);
+  }
+
+  state.DeviceFns().vkCmdBindDescriptorSets(
+      command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+      pipeline.GetPipelineLayout(), 0,
+      static_cast<uint32_t>(descriptor_sets.size()), descriptor_sets.data(), 0,
+      nullptr);
+  return true;
+}
+
+bool RecordDrawCommands(const std::shared_ptr<const VulkanContextState>& state,
+                        GPUCommandBufferVK& command_buffer,
+                        const GPURenderPass& pass,
+                        std::optional<GPUViewport> viewport,
+                        std::optional<GPUScissorRect> scissor) {
+  const auto target_width = pass.GetDescriptor().GetTargetWidth();
+  const auto target_height = pass.GetDescriptor().GetTargetHeight();
+
+  const GPUViewport vp = viewport.value_or(GPUViewport{
+      0.f,
+      0.f,
+      static_cast<float>(target_width),
+      static_cast<float>(target_height),
+      0.f,
+      1.f,
+  });
+  const GPUScissorRect default_scissor = scissor.value_or(GPUScissorRect{
+      0,
+      0,
+      target_width,
+      target_height,
+  });
+
+  VkViewport vk_viewport = {};
+  vk_viewport.x = vp.x;
+  vk_viewport.y = vp.y + vp.height;
+  vk_viewport.width = vp.width;
+  vk_viewport.height = -1.f * vp.height;
+  vk_viewport.minDepth = vp.min_depth;
+  vk_viewport.maxDepth = vp.max_depth;
+  state->DeviceFns().vkCmdSetViewport(command_buffer.GetCommandBuffer(), 0, 1,
+                                      &vk_viewport);
+
+  VkRect2D vk_scissor = {};
+  vk_scissor.offset = {static_cast<int32_t>(default_scissor.x),
+                       static_cast<int32_t>(default_scissor.y)};
+  vk_scissor.extent = {default_scissor.width, default_scissor.height};
+  state->DeviceFns().vkCmdSetScissor(command_buffer.GetCommandBuffer(), 0, 1,
+                                     &vk_scissor);
+
+  VkDescriptorPool descriptor_pool = CreateDescriptorPoolForPass(state, pass);
+  if (descriptor_pool != VK_NULL_HANDLE) {
+    std::weak_ptr<const VulkanContextState> weak_state = state;
+    command_buffer.RecordCleanupAction([weak_state, descriptor_pool]() {
+      auto state = weak_state.lock();
+      if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE ||
+          state->DeviceFns().vkDestroyDescriptorPool == nullptr) {
+        return;
+      }
+      state->DeviceFns().vkDestroyDescriptorPool(state->GetLogicalDevice(),
+                                                 descriptor_pool, nullptr);
+    });
+  }
+
+  for (const auto* command : pass.GetCommands()) {
+    if (command == nullptr || !command->IsValid()) {
+      continue;
+    }
+
+    auto* pipeline = GPURenderPipelineVK::Cast(command->pipeline);
+    if (pipeline == nullptr || !pipeline->IsValid()) {
+      LOGE("Failed to record Vulkan draw command: invalid pipeline");
+      return false;
+    }
+
+    state->DeviceFns().vkCmdBindPipeline(command_buffer.GetCommandBuffer(),
+                                         VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                         pipeline->GetPipeline());
+
+    VkRect2D command_scissor = {};
+    command_scissor.offset = {static_cast<int32_t>(command->scissor_rect.x),
+                              static_cast<int32_t>(command->scissor_rect.y)};
+    command_scissor.extent = {command->scissor_rect.width,
+                              command->scissor_rect.height};
+    state->DeviceFns().vkCmdSetScissor(command_buffer.GetCommandBuffer(), 0, 1,
+                                       &command_scissor);
+
+    auto* vertex_buffer =
+        static_cast<GPUBufferVK*>(command->vertex_buffer.buffer);
+    auto* index_buffer =
+        static_cast<GPUBufferVK*>(command->index_buffer.buffer);
+    if (vertex_buffer == nullptr || !vertex_buffer->IsValid() ||
+        index_buffer == nullptr || !index_buffer->IsValid()) {
+      LOGE("Failed to record Vulkan draw command: invalid vertex/index buffer");
+      return false;
+    }
+
+    std::array<VkBuffer, 2> vertex_buffers = {vertex_buffer->GetBuffer(),
+                                              VK_NULL_HANDLE};
+    std::array<VkDeviceSize, 2> vertex_offsets = {
+        command->vertex_buffer.offset,
+        0,
+    };
+    uint32_t vertex_buffer_count = 1;
+    if (command->IsInstanced()) {
+      auto* instance_buffer =
+          static_cast<GPUBufferVK*>(command->instance_buffer.buffer);
+      if (instance_buffer == nullptr || !instance_buffer->IsValid()) {
+        LOGE("Failed to record Vulkan draw command: invalid instance buffer");
+        return false;
+      }
+      vertex_buffers[1] = instance_buffer->GetBuffer();
+      vertex_offsets[1] = command->instance_buffer.offset;
+      vertex_buffer_count = 2;
+    }
+
+    state->DeviceFns().vkCmdBindVertexBuffers(
+        command_buffer.GetCommandBuffer(), 0, vertex_buffer_count,
+        vertex_buffers.data(), vertex_offsets.data());
+    state->DeviceFns().vkCmdBindIndexBuffer(
+        command_buffer.GetCommandBuffer(), index_buffer->GetBuffer(),
+        command->index_buffer.offset, VK_INDEX_TYPE_UINT32);
+
+    if (!SetupDescriptorSets(*state, command_buffer.GetCommandBuffer(),
+                             descriptor_pool, *command, *pipeline)) {
+      return false;
+    }
+
+    state->DeviceFns().vkCmdSetStencilCompareMask(
+        command_buffer.GetCommandBuffer(), VK_STENCIL_FACE_FRONT_BIT,
+        command->front_stencil_compare_mask);
+    state->DeviceFns().vkCmdSetStencilCompareMask(
+        command_buffer.GetCommandBuffer(), VK_STENCIL_FACE_BACK_BIT,
+        command->back_stencil_compare_mask);
+    state->DeviceFns().vkCmdSetStencilWriteMask(
+        command_buffer.GetCommandBuffer(), VK_STENCIL_FACE_FRONT_BIT,
+        command->front_stencil_write_mask);
+    state->DeviceFns().vkCmdSetStencilWriteMask(
+        command_buffer.GetCommandBuffer(), VK_STENCIL_FACE_BACK_BIT,
+        command->back_stencil_write_mask);
+    state->DeviceFns().vkCmdSetStencilReference(
+        command_buffer.GetCommandBuffer(),
+        VK_STENCIL_FACE_FRONT_BIT | VK_STENCIL_FACE_BACK_BIT,
+        command->stencil_reference);
+
+    state->DeviceFns().vkCmdDrawIndexed(
+        command_buffer.GetCommandBuffer(), command->index_count,
+        command->instance_count == 0 ? 1 : command->instance_count, 0, 0, 0);
+  }
+
+  RecordBoundResourceCleanup(command_buffer, pass);
+  return true;
+}
+
+bool RecordDynamicRenderingPass(
+    const std::shared_ptr<const VulkanContextState>& state,
+    GPUCommandBufferVK& command_buffer, const GPURenderPass& pass,
+    std::optional<GPUViewport> viewport,
+    std::optional<GPUScissorRect> scissor) {
+  const auto& desc = pass.GetDescriptor();
+  if (desc.color_attachment.texture == nullptr) {
+    LOGE("Vulkan dynamic rendering requires a color attachment");
+    return false;
+  }
+
+  AttachmentContext color_context = {};
+  if (!PrepareColorAttachment(desc, &color_context)) {
+    return false;
+  }
+
+  AttachmentContext depth_stencil_context = {};
+  bool has_depth = false;
+  bool has_stencil = false;
+  if (!PrepareDepthStencilAttachment(desc, &depth_stencil_context, &has_depth,
+                                     &has_stencil)) {
+    return false;
+  }
+
+  if (!PrepareSampledTextures(*state, command_buffer, pass)) {
+    return false;
+  }
+
+  if (!TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                             *color_context.texture,
+                             color_context.attachment_layout)) {
+    return false;
+  }
+
+  VkRenderingAttachmentInfo color_info = {};
+  color_info.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
+  color_info.imageView = color_context.texture->GetImageView();
+  color_info.imageLayout = color_context.attachment_layout;
+  color_info.loadOp = ToVkLoadOp(desc.color_attachment.load_op);
+  color_info.storeOp = ToColorAttachmentStoreOp(
+      color_context.resolve_texture != nullptr, desc.color_attachment.store_op);
+  color_info.clearValue.color = {
+      {static_cast<float>(desc.color_attachment.clear_value.r),
+       static_cast<float>(desc.color_attachment.clear_value.g),
+       static_cast<float>(desc.color_attachment.clear_value.b),
+       static_cast<float>(desc.color_attachment.clear_value.a)}};
+
+  if (color_context.resolve_texture != nullptr) {
+    if (!TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                               *color_context.resolve_texture,
+                               VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)) {
+      return false;
+    }
+
+    color_info.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_info.resolveImageView = color_context.resolve_texture->GetImageView();
+    color_info.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  }
+
+  if (depth_stencil_context.texture != nullptr &&
+      !TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                             *depth_stencil_context.texture,
+                             depth_stencil_context.attachment_layout)) {
+    return false;
+  }
+
+  VkRenderingAttachmentInfo depth_info = {};
+  if (has_depth) {
+    depth_info.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
+    depth_info.imageView = depth_stencil_context.texture->GetImageView();
+    depth_info.imageLayout = depth_stencil_context.attachment_layout;
+    depth_info.loadOp = ToVkLoadOp(desc.depth_attachment.load_op);
+    depth_info.storeOp = ToVkStoreOp(desc.depth_attachment.store_op);
+    depth_info.clearValue.depthStencil.depth =
+        desc.depth_attachment.clear_value;
+    depth_info.clearValue.depthStencil.stencil =
+        desc.stencil_attachment.clear_value;
+  }
+
+  VkRenderingAttachmentInfo stencil_info = {};
+  if (has_stencil) {
+    stencil_info.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
+    stencil_info.imageView = depth_stencil_context.texture->GetImageView();
+    stencil_info.imageLayout = depth_stencil_context.attachment_layout;
+    stencil_info.loadOp = ToVkLoadOp(desc.stencil_attachment.load_op);
+    stencil_info.storeOp = ToVkStoreOp(desc.stencil_attachment.store_op);
+    stencil_info.clearValue.depthStencil.depth =
+        desc.depth_attachment.clear_value;
+    stencil_info.clearValue.depthStencil.stencil =
+        desc.stencil_attachment.clear_value;
+  }
+
+  VkRenderingInfo rendering_info = {};
+  rendering_info.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
+  rendering_info.renderArea.offset = {0, 0};
+  rendering_info.renderArea.extent = {desc.GetTargetWidth(),
+                                      desc.GetTargetHeight()};
+  rendering_info.layerCount = 1;
+  rendering_info.colorAttachmentCount = 1;
+  rendering_info.pColorAttachments = &color_info;
+  rendering_info.pDepthAttachment = has_depth ? &depth_info : nullptr;
+  rendering_info.pStencilAttachment = has_stencil ? &stencil_info : nullptr;
+
+  state->DeviceFns().vkCmdBeginRendering(command_buffer.GetCommandBuffer(),
+                                         &rendering_info);
+  const bool recorded =
+      RecordDrawCommands(state, command_buffer, pass, viewport, scissor);
+  state->DeviceFns().vkCmdEndRendering(command_buffer.GetCommandBuffer());
+  if (!recorded) {
+    return false;
+  }
+
+  TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                        *color_context.texture, color_context.final_layout);
+  if (color_context.resolve_texture != nullptr) {
+    TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                          *color_context.resolve_texture,
+                          color_context.resolve_texture->GetPreferredLayout());
+  }
+  if (depth_stencil_context.texture != nullptr) {
+    TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                          *depth_stencil_context.texture,
+                          depth_stencil_context.final_layout);
+  }
+
+  const auto color_texture_ref = desc.color_attachment.texture;
+  const auto resolve_texture_ref = desc.color_attachment.resolve_texture;
+  const auto depth_texture_ref = desc.depth_attachment.texture;
+  const auto stencil_texture_ref = desc.stencil_attachment.texture;
+  command_buffer.RecordCleanupAction([color_texture_ref, resolve_texture_ref,
+                                      depth_texture_ref,
+                                      stencil_texture_ref]() {});
+
+  return true;
+}
+
+bool RecordLegacyRenderPass(
+    const std::shared_ptr<const VulkanContextState>& state,
+    GPUCommandBufferVK& command_buffer, const GPURenderPass& pass,
+    std::optional<GPUViewport> viewport,
+    std::optional<GPUScissorRect> scissor) {
+  const auto& desc = pass.GetDescriptor();
+  if (desc.color_attachment.texture == nullptr) {
+    LOGE("Vulkan legacy render pass requires a color attachment");
+    return false;
+  }
+
+  AttachmentContext color_context = {};
+  if (!PrepareColorAttachment(desc, &color_context)) {
+    return false;
+  }
+
+  AttachmentContext depth_stencil_context = {};
+  bool has_depth = false;
+  bool has_stencil = false;
+  if (!PrepareDepthStencilAttachment(desc, &depth_stencil_context, &has_depth,
+                                     &has_stencil)) {
+    return false;
+  }
+
+  if (!PrepareSampledTextures(*state, command_buffer, pass)) {
+    return false;
+  }
+
+  if (!TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                             *color_context.texture,
+                             color_context.attachment_layout)) {
+    return false;
+  }
+  if (color_context.resolve_texture != nullptr &&
+      !TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                             *color_context.resolve_texture,
+                             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)) {
+    return false;
+  }
+  if (depth_stencil_context.texture != nullptr &&
+      !TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                             *depth_stencil_context.texture,
+                             depth_stencil_context.attachment_layout)) {
+    return false;
+  }
+
+  std::array<VkImageView, 3> attachments = {};
+  std::array<VkClearValue, 3> clear_values = {};
+  uint32_t attachment_count = 0;
+  uint32_t clear_value_count = 0;
+  attachments[attachment_count] = color_context.texture->GetImageView();
+  clear_values[clear_value_count].color = {
+      {static_cast<float>(desc.color_attachment.clear_value.r),
+       static_cast<float>(desc.color_attachment.clear_value.g),
+       static_cast<float>(desc.color_attachment.clear_value.b),
+       static_cast<float>(desc.color_attachment.clear_value.a)}};
+  ++attachment_count;
+  ++clear_value_count;
+
+  if (color_context.resolve_texture != nullptr) {
+    attachments[attachment_count] =
+        color_context.resolve_texture->GetImageView();
+    ++attachment_count;
+    ++clear_value_count;
+  }
+
+  if (depth_stencil_context.texture != nullptr) {
+    attachments[attachment_count] =
+        depth_stencil_context.texture->GetImageView();
+    clear_values[clear_value_count].depthStencil.depth =
+        desc.depth_attachment.clear_value;
+    clear_values[clear_value_count].depthStencil.stencil =
+        desc.stencil_attachment.clear_value;
+    ++attachment_count;
+    ++clear_value_count;
+  }
+
+  const auto render_pass_key = BuildLegacyRenderPassKey(
+      desc, color_context, depth_stencil_context, has_depth, has_stencil);
+  VkRenderPass render_pass =
+      state->GetOrCreateLegacyRenderPass(render_pass_key);
+  if (render_pass == VK_NULL_HANDLE) {
+    return false;
+  }
+
+  VkFramebufferCreateInfo framebuffer_info = {};
+  framebuffer_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+  framebuffer_info.renderPass = render_pass;
+  framebuffer_info.attachmentCount = attachment_count;
+  framebuffer_info.pAttachments = attachments.data();
+  framebuffer_info.width = desc.GetTargetWidth();
+  framebuffer_info.height = desc.GetTargetHeight();
+  framebuffer_info.layers = 1;
+
+  VkFramebuffer framebuffer = VK_NULL_HANDLE;
+  const VkResult result = state->DeviceFns().vkCreateFramebuffer(
+      state->GetLogicalDevice(), &framebuffer_info, nullptr, &framebuffer);
+  if (result != VK_SUCCESS || framebuffer == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan framebuffer: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  VkRenderPassBeginInfo begin_info = {};
+  begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+  begin_info.renderPass = render_pass;
+  begin_info.framebuffer = framebuffer;
+  begin_info.renderArea.offset = {0, 0};
+  begin_info.renderArea.extent = {desc.GetTargetWidth(),
+                                  desc.GetTargetHeight()};
+  begin_info.clearValueCount = clear_value_count;
+  begin_info.pClearValues = clear_values.data();
+
+  state->DeviceFns().vkCmdBeginRenderPass(command_buffer.GetCommandBuffer(),
+                                          &begin_info,
+                                          VK_SUBPASS_CONTENTS_INLINE);
+  const bool recorded =
+      RecordDrawCommands(state, command_buffer, pass, viewport, scissor);
+  state->DeviceFns().vkCmdEndRenderPass(command_buffer.GetCommandBuffer());
+  if (!recorded) {
+    return false;
+  }
+
+  TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                        *color_context.texture, color_context.final_layout);
+  if (color_context.resolve_texture != nullptr) {
+    TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                          *color_context.resolve_texture,
+                          color_context.resolve_texture->GetPreferredLayout());
+  }
+  if (depth_stencil_context.texture != nullptr) {
+    TransitionImageLayout(*state, command_buffer.GetCommandBuffer(),
+                          *depth_stencil_context.texture,
+                          depth_stencil_context.final_layout);
+  }
+
+  std::weak_ptr<const VulkanContextState> weak_state = state;
+  command_buffer.RecordCleanupAction([weak_state, framebuffer]() {
+    auto state = weak_state.lock();
+    if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE) {
+      return;
+    }
+
+    if (framebuffer != VK_NULL_HANDLE &&
+        state->DeviceFns().vkDestroyFramebuffer != nullptr) {
+      state->DeviceFns().vkDestroyFramebuffer(state->GetLogicalDevice(),
+                                              framebuffer, nullptr);
+    }
+  });
+  const auto color_texture_ref = desc.color_attachment.texture;
+  const auto resolve_texture_ref = desc.color_attachment.resolve_texture;
+  const auto depth_texture_ref = desc.depth_attachment.texture;
+  const auto stencil_texture_ref = desc.stencil_attachment.texture;
+  command_buffer.RecordCleanupAction([color_texture_ref, resolve_texture_ref,
+                                      depth_texture_ref,
+                                      stencil_texture_ref]() {});
+
+  return true;
+}
+
+}  // namespace
+
+GPURenderPassVK::GPURenderPassVK(
+    std::shared_ptr<const VulkanContextState> state,
+    GPUCommandBufferVK* command_buffer, const GPURenderPassDescriptor& desc)
+    : GPURenderPass(desc),
+      state_(std::move(state)),
+      command_buffer_(command_buffer) {}
+
+void GPURenderPassVK::EncodeCommands(std::optional<GPUViewport> viewport,
+                                     std::optional<GPUScissorRect> scissor) {
+  if (state_ == nullptr || command_buffer_ == nullptr) {
+    LOGE("Failed to encode Vulkan render pass: invalid state");
+    return;
+  }
+
+  if (state_->IsDynamicRenderingEnabled()) {
+    RecordDynamicRenderingPass(state_, *command_buffer_, *this, viewport,
+                               scissor);
+    return;
+  }
+
+  RecordLegacyRenderPass(state_, *command_buffer_, *this, viewport, scissor);
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_render_pass_vk.hpp
+++ b/src/gpu/vk/gpu_render_pass_vk.hpp
@@ -1,0 +1,34 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_RENDER_PASS_VK_HPP
+#define SRC_GPU_VK_GPU_RENDER_PASS_VK_HPP
+
+#include "src/gpu/gpu_render_pass.hpp"
+
+namespace skity {
+
+class GPUCommandBufferVK;
+class VulkanContextState;
+
+class GPURenderPassVK : public GPURenderPass {
+ public:
+  GPURenderPassVK(std::shared_ptr<const VulkanContextState> state,
+                  GPUCommandBufferVK* command_buffer,
+                  const GPURenderPassDescriptor& desc);
+
+  ~GPURenderPassVK() override = default;
+
+  void EncodeCommands(
+      std::optional<GPUViewport> viewport = std::nullopt,
+      std::optional<GPUScissorRect> scissor = std::nullopt) override;
+
+ private:
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  GPUCommandBufferVK* command_buffer_ = nullptr;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_RENDER_PASS_VK_HPP

--- a/src/gpu/vk/gpu_render_pipeline_vk.cc
+++ b/src/gpu/vk/gpu_render_pipeline_vk.cc
@@ -1,0 +1,51 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_render_pipeline_vk.hpp"
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
+namespace skity {
+
+GPURenderPipelineVK::GPURenderPipelineVK(
+    std::shared_ptr<const VulkanContextState> state, VkPipeline pipeline,
+    VkPipelineLayout pipeline_layout, VkRenderPass render_pass,
+    bool uses_dynamic_rendering, std::vector<VkDescriptorSetLayout> set_layouts,
+    const GPURenderPipelineDescriptor& desc)
+    : GPURenderPipeline(desc),
+      state_(std::move(state)),
+      pipeline_(pipeline),
+      pipeline_layout_(pipeline_layout),
+      render_pass_(render_pass),
+      uses_dynamic_rendering_(uses_dynamic_rendering),
+      set_layouts_(std::move(set_layouts)) {}
+
+GPURenderPipelineVK::~GPURenderPipelineVK() {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    return;
+  }
+
+  const auto& device_fns = state_->DeviceFns();
+  if (pipeline_ != VK_NULL_HANDLE && device_fns.vkDestroyPipeline != nullptr) {
+    device_fns.vkDestroyPipeline(state_->GetLogicalDevice(), pipeline_,
+                                 nullptr);
+  }
+
+  if (pipeline_layout_ != VK_NULL_HANDLE &&
+      device_fns.vkDestroyPipelineLayout != nullptr) {
+    device_fns.vkDestroyPipelineLayout(state_->GetLogicalDevice(),
+                                       pipeline_layout_, nullptr);
+  }
+
+  if (device_fns.vkDestroyDescriptorSetLayout != nullptr) {
+    for (auto set_layout : set_layouts_) {
+      if (set_layout != VK_NULL_HANDLE) {
+        device_fns.vkDestroyDescriptorSetLayout(state_->GetLogicalDevice(),
+                                                set_layout, nullptr);
+      }
+    }
+  }
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_render_pipeline_vk.hpp
+++ b/src/gpu/vk/gpu_render_pipeline_vk.hpp
@@ -1,0 +1,58 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_RENDER_PIPELINE_VK_HPP
+#define SRC_GPU_VK_GPU_RENDER_PIPELINE_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include "src/gpu/backend_cast.hpp"
+#include "src/gpu/gpu_render_pipeline.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+class GPURenderPipelineVK : public GPURenderPipeline {
+ public:
+  GPURenderPipelineVK(std::shared_ptr<const VulkanContextState> state,
+                      VkPipeline pipeline, VkPipelineLayout pipeline_layout,
+                      VkRenderPass render_pass, bool uses_dynamic_rendering,
+                      std::vector<VkDescriptorSetLayout> set_layouts,
+                      const GPURenderPipelineDescriptor& desc);
+
+  ~GPURenderPipelineVK() override;
+
+  VkPipeline GetPipeline() const { return pipeline_; }
+
+  VkPipelineLayout GetPipelineLayout() const { return pipeline_layout_; }
+
+  VkRenderPass GetRenderPass() const { return render_pass_; }
+
+  bool UsesDynamicRendering() const { return uses_dynamic_rendering_; }
+
+  const std::vector<VkDescriptorSetLayout>& GetDescriptorSetLayouts() const {
+    return set_layouts_;
+  }
+
+  bool IsValid() const override {
+    return GPURenderPipeline::IsValid() && pipeline_ != VK_NULL_HANDLE &&
+           pipeline_layout_ != VK_NULL_HANDLE &&
+           (uses_dynamic_rendering_ || render_pass_ != VK_NULL_HANDLE);
+  }
+
+  SKT_BACKEND_CAST(GPURenderPipelineVK, GPURenderPipeline)
+
+ private:
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  VkPipeline pipeline_ = VK_NULL_HANDLE;
+  VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
+  VkRenderPass render_pass_ = VK_NULL_HANDLE;
+  bool uses_dynamic_rendering_ = false;
+  std::vector<VkDescriptorSetLayout> set_layouts_ = {};
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_RENDER_PIPELINE_VK_HPP

--- a/src/gpu/vk/gpu_sampler_vk.cc
+++ b/src/gpu/vk/gpu_sampler_vk.cc
@@ -1,0 +1,28 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_sampler_vk.hpp"
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
+namespace skity {
+
+GPUSamplerVK::GPUSamplerVK(std::shared_ptr<const VulkanContextState> state,
+                           const GPUSamplerDescriptor& desc, VkSampler sampler)
+    : GPUSampler(desc), state_(std::move(state)), sampler_(sampler) {}
+
+GPUSamplerVK::~GPUSamplerVK() {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+      sampler_ == VK_NULL_HANDLE) {
+    return;
+  }
+
+  if (state_->DeviceFns().vkDestroySampler != nullptr) {
+    state_->DeviceFns().vkDestroySampler(state_->GetLogicalDevice(), sampler_,
+                                         nullptr);
+  }
+  sampler_ = VK_NULL_HANDLE;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_sampler_vk.hpp
+++ b/src/gpu/vk/gpu_sampler_vk.hpp
@@ -1,0 +1,37 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_SAMPLER_VK_HPP
+#define SRC_GPU_VK_GPU_SAMPLER_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include "src/gpu/backend_cast.hpp"
+#include "src/gpu/gpu_sampler.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+class GPUSamplerVK : public GPUSampler {
+ public:
+  GPUSamplerVK(std::shared_ptr<const VulkanContextState> state,
+               const GPUSamplerDescriptor& desc, VkSampler sampler);
+
+  ~GPUSamplerVK() override;
+
+  VkSampler GetSampler() const { return sampler_; }
+
+  bool IsValid() const { return sampler_ != VK_NULL_HANDLE; }
+
+  SKT_BACKEND_CAST(GPUSamplerVK, GPUSampler)
+
+ private:
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  VkSampler sampler_ = VK_NULL_HANDLE;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_SAMPLER_VK_HPP

--- a/src/gpu/vk/gpu_shader_function_vk.cc
+++ b/src/gpu/vk/gpu_shader_function_vk.cc
@@ -1,0 +1,30 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_shader_function_vk.hpp"
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
+namespace skity {
+
+GPUShaderFunctionVK::GPUShaderFunctionVK(
+    GPULabel label, GPUShaderStage stage, std::string entry_point,
+    std::shared_ptr<const VulkanContextState> state,
+    VkShaderModule shader_module)
+    : GPUShaderFunction(std::move(label)),
+      stage_(stage),
+      entry_point_(std::move(entry_point)),
+      state_(std::move(state)),
+      shader_module_(shader_module) {}
+
+GPUShaderFunctionVK::~GPUShaderFunctionVK() {
+  if (shader_module_ != VK_NULL_HANDLE && state_ != nullptr &&
+      state_->DeviceFns().vkDestroyShaderModule != nullptr &&
+      state_->GetLogicalDevice() != VK_NULL_HANDLE) {
+    state_->DeviceFns().vkDestroyShaderModule(state_->GetLogicalDevice(),
+                                              shader_module_, nullptr);
+  }
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_shader_function_vk.hpp
+++ b/src/gpu/vk/gpu_shader_function_vk.hpp
@@ -1,0 +1,45 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_SHADER_FUNCTION_VK_HPP
+#define SRC_GPU_VK_GPU_SHADER_FUNCTION_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include "src/gpu/backend_cast.hpp"
+#include "src/gpu/gpu_shader_function.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+class GPUShaderFunctionVK : public GPUShaderFunction {
+ public:
+  GPUShaderFunctionVK(GPULabel label, GPUShaderStage stage,
+                      std::string entry_point,
+                      std::shared_ptr<const VulkanContextState> state,
+                      VkShaderModule shader_module);
+
+  ~GPUShaderFunctionVK() override;
+
+  bool IsValid() const override { return shader_module_ != VK_NULL_HANDLE; }
+
+  GPUShaderStage GetStage() const { return stage_; }
+
+  const std::string& GetEntryPoint() const { return entry_point_; }
+
+  VkShaderModule GetShaderModule() const { return shader_module_; }
+
+  SKT_BACKEND_CAST(GPUShaderFunctionVK, GPUShaderFunction)
+
+ private:
+  GPUShaderStage stage_ = GPUShaderStage::kVertex;
+  std::string entry_point_ = {};
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  VkShaderModule shader_module_ = VK_NULL_HANDLE;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_SHADER_FUNCTION_VK_HPP

--- a/src/gpu/vk/gpu_surface_vk.cc
+++ b/src/gpu/vk/gpu_surface_vk.cc
@@ -1,0 +1,23 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_surface_vk.hpp"
+
+namespace skity {
+
+std::shared_ptr<Pixmap> GPUSurfaceVK::ReadPixels(const Rect& rect) {
+  (void)rect;
+  return {};
+}
+
+const GPUSubmitInfo* GPUSurfaceVK::GetSubmitInfo() const {
+  return has_submit_info_ ? &submit_info_ : nullptr;
+}
+
+HWRootLayer* GPUSurfaceVK::OnBeginNextFrame(bool clear) {
+  // VKRootLayer integration will be added with the HW render layer PR
+  return nullptr;
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_surface_vk.hpp
+++ b/src/gpu/vk/gpu_surface_vk.hpp
@@ -1,0 +1,80 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_SURFACE_VK_HPP
+#define SRC_GPU_VK_GPU_SURFACE_VK_HPP
+
+#include <cmath>
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+
+#include "src/gpu/gpu_surface_impl.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+
+namespace skity {
+
+class GPUTexture;
+
+class GPUSurfaceVK : public GPUSurfaceImpl {
+ public:
+  struct PresentInfo {
+    const void* owner = nullptr;
+    uint32_t image_index = 0;
+  };
+
+  GPUSurfaceVK(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx,
+               std::shared_ptr<GPUTexture> texture, GPUTextureFormat format,
+               const GPUSurfaceSyncInfoVK* sync_info)
+      : GPUSurfaceImpl(desc, ctx),
+        target_width_(static_cast<uint32_t>(
+            std::floor(static_cast<float>(desc.width) * desc.content_scale))),
+        target_height_(static_cast<uint32_t>(
+            std::floor(static_cast<float>(desc.height) * desc.content_scale))),
+        texture_(std::move(texture)),
+        format_(format),
+        has_submit_info_(sync_info != nullptr) {
+    if (sync_info != nullptr) {
+      submit_info_.wait_semaphore = sync_info->wait_semaphore;
+      submit_info_.wait_dst_stage_mask = sync_info->wait_dst_stage_mask;
+      submit_info_.signal_semaphore = sync_info->signal_semaphore;
+      submit_info_.signal_fence = sync_info->signal_fence;
+    }
+  }
+
+  ~GPUSurfaceVK() override = default;
+
+  GPUTextureFormat GetGPUFormat() const override { return format_; }
+
+  std::shared_ptr<Pixmap> ReadPixels(const Rect& rect) override;
+
+  const GPUSubmitInfo* GetSubmitInfo() const override;
+
+  void SetPresentInfo(const PresentInfo& present_info) {
+    has_present_info_ = true;
+    present_info_ = present_info;
+  }
+
+  const PresentInfo* GetPresentInfo() const {
+    return has_present_info_ ? &present_info_ : nullptr;
+  }
+
+ protected:
+  HWRootLayer* OnBeginNextFrame(bool clear) override;
+
+  void OnFlush() override {}
+
+ private:
+  uint32_t target_width_ = 0;
+  uint32_t target_height_ = 0;
+  std::shared_ptr<GPUTexture> texture_ = {};
+  GPUTextureFormat format_ = GPUTextureFormat::kInvalid;
+  bool has_submit_info_ = false;
+  GPUSubmitInfoVK submit_info_ = {};
+  bool has_present_info_ = false;
+  PresentInfo present_info_ = {};
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_SURFACE_VK_HPP

--- a/src/gpu/vk/gpu_texture_vk.cc
+++ b/src/gpu/vk/gpu_texture_vk.cc
@@ -1,0 +1,488 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+
+#include "src/gpu/vk/gpu_blit_pass_vk.hpp"
+#include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+const char* VkFormatToString(VkFormat format) {
+  switch (format) {
+    case VK_FORMAT_R8_UNORM:
+      return "VK_FORMAT_R8_UNORM";
+    case VK_FORMAT_R8G8B8_UNORM:
+      return "VK_FORMAT_R8G8B8_UNORM";
+    case VK_FORMAT_R5G6B5_UNORM_PACK16:
+      return "VK_FORMAT_R5G6B5_UNORM_PACK16";
+    case VK_FORMAT_R8G8B8A8_UNORM:
+      return "VK_FORMAT_R8G8B8A8_UNORM";
+    case VK_FORMAT_B8G8R8A8_UNORM:
+      return "VK_FORMAT_B8G8R8A8_UNORM";
+    case VK_FORMAT_S8_UINT:
+      return "VK_FORMAT_S8_UINT";
+    case VK_FORMAT_D24_UNORM_S8_UINT:
+      return "VK_FORMAT_D24_UNORM_S8_UINT";
+    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+      return "VK_FORMAT_D32_SFLOAT_S8_UINT";
+    case VK_FORMAT_UNDEFINED:
+      return "VK_FORMAT_UNDEFINED";
+    default:
+      return "VK_FORMAT_UNKNOWN";
+  }
+}
+
+bool CreateImageWithAllocation(const VulkanContextState& state,
+                               const VkImageCreateInfo& image_info,
+                               const VmaAllocationCreateInfo& allocation_info,
+                               VkImage* image, VmaAllocation* allocation) {
+  if (image == nullptr || allocation == nullptr) {
+    return false;
+  }
+
+  *image = VK_NULL_HANDLE;
+  *allocation = nullptr;
+  const VkResult create_result =
+      vmaCreateImage(state.GetAllocator(), &image_info, &allocation_info, image,
+                     allocation, nullptr);
+  if (create_result != VK_SUCCESS || *image == VK_NULL_HANDLE ||
+      *allocation == nullptr) {
+    LOGE("Failed to create Vulkan image {}x{}: {}", image_info.extent.width,
+         image_info.extent.height, static_cast<int32_t>(create_result));
+    return false;
+  }
+
+  return true;
+}
+
+VkFormat ConvertToVkFormat(GPUTextureFormat format) {
+  switch (format) {
+    case GPUTextureFormat::kR8Unorm:
+      return VK_FORMAT_R8_UNORM;
+    case GPUTextureFormat::kRGB8Unorm:
+      return VK_FORMAT_R8G8B8_UNORM;
+    case GPUTextureFormat::kRGB565Unorm:
+      return VK_FORMAT_R5G6B5_UNORM_PACK16;
+    case GPUTextureFormat::kRGBA8Unorm:
+      return VK_FORMAT_R8G8B8A8_UNORM;
+    case GPUTextureFormat::kBGRA8Unorm:
+      return VK_FORMAT_B8G8R8A8_UNORM;
+    case GPUTextureFormat::kStencil8:
+      return VK_FORMAT_S8_UINT;
+    case GPUTextureFormat::kDepth24Stencil8:
+      return VK_FORMAT_D24_UNORM_S8_UINT;
+    case GPUTextureFormat::kInvalid:
+      return VK_FORMAT_UNDEFINED;
+  }
+
+  return VK_FORMAT_UNDEFINED;
+}
+
+VkImageUsageFlags ToVkImageUsage(GPUTextureUsageMask usage) {
+  VkImageUsageFlags flags = 0;
+
+  if ((usage & static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc)) !=
+      0) {
+    flags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  }
+
+  if ((usage & static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopyDst)) !=
+      0) {
+    flags |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+  }
+
+  if ((usage & static_cast<GPUTextureUsageMask>(
+                   GPUTextureUsage::kTextureBinding)) != 0) {
+    flags |= VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+             VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  }
+
+  if ((usage & static_cast<GPUTextureUsageMask>(
+                   GPUTextureUsage::kStorageBinding)) != 0) {
+    flags |= VK_IMAGE_USAGE_STORAGE_BIT;
+  }
+
+  if ((usage & static_cast<GPUTextureUsageMask>(
+                   GPUTextureUsage::kRenderAttachment)) != 0) {
+    flags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+  }
+
+  return flags;
+}
+
+VkImageAspectFlags GetImageAspectMask(GPUTextureFormat format) {
+  switch (format) {
+    case GPUTextureFormat::kStencil8:
+      return VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kDepth24Stencil8:
+      return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    case GPUTextureFormat::kInvalid:
+      return 0;
+    default:
+      return VK_IMAGE_ASPECT_COLOR_BIT;
+  }
+}
+
+VkImageUsageFlags SanitizeImageUsage(GPUTextureFormat format,
+                                     VkImageUsageFlags usage) {
+  const bool is_depth_stencil = format == GPUTextureFormat::kStencil8 ||
+                                format == GPUTextureFormat::kDepth24Stencil8;
+
+  if (is_depth_stencil) {
+    usage &= ~VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+  } else {
+    usage &= ~VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+  }
+
+  return usage;
+}
+
+bool IsImageFormatSupported(const VulkanContextState& state, VkFormat format,
+                            VkImageUsageFlags usage,
+                            VkSampleCountFlagBits samples) {
+  if (format == VK_FORMAT_UNDEFINED ||
+      state.InstanceFns().vkGetPhysicalDeviceImageFormatProperties == nullptr) {
+    return false;
+  }
+
+  VkImageFormatProperties properties = {};
+  const VkResult result =
+      state.InstanceFns().vkGetPhysicalDeviceImageFormatProperties(
+          state.GetPhysicalDevice(), format, VK_IMAGE_TYPE_2D,
+          VK_IMAGE_TILING_OPTIMAL, usage, 0, &properties);
+  if (result != VK_SUCCESS) {
+    LOGD(
+        "Vulkan image format unsupported: format={} usage=0x{:x} "
+        "samples=0x{:x} "
+        "result={}",
+        VkFormatToString(format), static_cast<uint32_t>(usage),
+        static_cast<uint32_t>(samples), static_cast<int32_t>(result));
+    return false;
+  }
+
+  return (properties.sampleCounts & samples) != 0;
+}
+
+bool SupportsLinearBlit(const VulkanContextState& state, VkFormat format) {
+  if (format == VK_FORMAT_UNDEFINED ||
+      state.InstanceFns().vkGetPhysicalDeviceFormatProperties == nullptr) {
+    return false;
+  }
+
+  VkFormatProperties properties = {};
+  state.InstanceFns().vkGetPhysicalDeviceFormatProperties(
+      state.GetPhysicalDevice(), format, &properties);
+  return (properties.optimalTilingFeatures &
+          VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) != 0;
+}
+
+VkFormat ResolveVkFormat(const VulkanContextState& state,
+                         GPUTextureFormat texture_format,
+                         VkImageUsageFlags usage,
+                         VkSampleCountFlagBits samples) {
+  const VkFormat preferred = ConvertToVkFormat(texture_format);
+  if (IsImageFormatSupported(state, preferred, usage, samples)) {
+    return preferred;
+  }
+
+  if (texture_format == GPUTextureFormat::kDepth24Stencil8 &&
+      IsImageFormatSupported(state, VK_FORMAT_D32_SFLOAT_S8_UINT, usage,
+                             samples)) {
+    LOGD(
+        "Vulkan texture format fallback: logical_format={} preferred={} "
+        "resolved={} usage=0x{:x} samples=0x{:x}",
+        static_cast<uint32_t>(texture_format), VkFormatToString(preferred),
+        VkFormatToString(VK_FORMAT_D32_SFLOAT_S8_UINT),
+        static_cast<uint32_t>(usage), static_cast<uint32_t>(samples));
+    return VK_FORMAT_D32_SFLOAT_S8_UINT;
+  }
+
+  if (texture_format == GPUTextureFormat::kStencil8) {
+    if (IsImageFormatSupported(state, VK_FORMAT_D24_UNORM_S8_UINT, usage,
+                               samples)) {
+      LOGD(
+          "Vulkan texture format fallback: logical_format={} preferred={} "
+          "resolved={} usage=0x{:x} samples=0x{:x}",
+          static_cast<uint32_t>(texture_format), VkFormatToString(preferred),
+          VkFormatToString(VK_FORMAT_D24_UNORM_S8_UINT),
+          static_cast<uint32_t>(usage), static_cast<uint32_t>(samples));
+      return VK_FORMAT_D24_UNORM_S8_UINT;
+    }
+
+    if (IsImageFormatSupported(state, VK_FORMAT_D32_SFLOAT_S8_UINT, usage,
+                               samples)) {
+      LOGD(
+          "Vulkan texture format fallback: logical_format={} preferred={} "
+          "resolved={} usage=0x{:x} samples=0x{:x}",
+          static_cast<uint32_t>(texture_format), VkFormatToString(preferred),
+          VkFormatToString(VK_FORMAT_D32_SFLOAT_S8_UINT),
+          static_cast<uint32_t>(usage), static_cast<uint32_t>(samples));
+      return VK_FORMAT_D32_SFLOAT_S8_UINT;
+    }
+  }
+
+  return VK_FORMAT_UNDEFINED;
+}
+
+VkImageLayout ResolvePreferredLayout(const GPUTextureDescriptor& descriptor) {
+  const bool render_attachment =
+      (descriptor.usage & static_cast<GPUTextureUsageMask>(
+                              GPUTextureUsage::kRenderAttachment)) != 0;
+  const bool texture_binding =
+      (descriptor.usage &
+       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding)) != 0;
+  const bool storage_binding =
+      (descriptor.usage &
+       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kStorageBinding)) != 0;
+  const bool multi_use = (render_attachment && texture_binding) ||
+                         storage_binding || descriptor.sample_count > 1 ||
+                         descriptor.mip_level_count > 1;
+
+  if (multi_use) {
+    return VK_IMAGE_LAYOUT_GENERAL;
+  }
+
+  if (render_attachment) {
+    if (descriptor.format == GPUTextureFormat::kStencil8 ||
+        descriptor.format == GPUTextureFormat::kDepth24Stencil8) {
+      return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    }
+    return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  }
+
+  if (texture_binding) {
+    return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  }
+
+  if ((descriptor.usage &
+       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc)) != 0) {
+    return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  }
+
+  if ((descriptor.usage &
+       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopyDst)) != 0) {
+    return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  }
+
+  return VK_IMAGE_LAYOUT_GENERAL;
+}
+
+}  // namespace
+
+VkFormat GPUTextureVK::ToVkFormat(GPUTextureFormat format) {
+  return ConvertToVkFormat(format);
+}
+
+GPUTextureVK::GPUTextureVK(std::shared_ptr<const VulkanContextState> state,
+                           const GPUTextureDescriptor& descriptor,
+                           VkImage image, VmaAllocation allocation,
+                           VkImageView image_view,
+                           VkImageLayout preferred_layout, VkFormat format,
+                           bool owns_image, bool owns_image_view)
+    : GPUTexture(descriptor),
+      state_(std::move(state)),
+      image_(image),
+      allocation_(allocation),
+      image_view_(image_view),
+      preferred_layout_(preferred_layout),
+      format_(format),
+      owns_image_(owns_image),
+      owns_image_view_(owns_image_view) {}
+
+GPUTextureVK::~GPUTextureVK() {
+  if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+      owns_image_view_ && image_view_ != VK_NULL_HANDLE &&
+      state_->DeviceFns().vkDestroyImageView != nullptr) {
+    state_->DeviceFns().vkDestroyImageView(state_->GetLogicalDevice(),
+                                           image_view_, nullptr);
+  }
+
+  if (state_ != nullptr && state_->GetAllocator() != nullptr && owns_image_ &&
+      image_ != VK_NULL_HANDLE && allocation_ != nullptr) {
+    vmaDestroyImage(state_->GetAllocator(), image_, allocation_);
+  }
+}
+
+std::shared_ptr<GPUTexture> GPUTextureVK::Wrap(
+    std::shared_ptr<const VulkanContextState> state,
+    const GPUTextureDescriptor& descriptor, VkImage image,
+    VkImageView image_view, VkImageLayout initial_layout,
+    VkImageLayout preferred_layout, VkFormat format, bool owns_image,
+    bool owns_image_view) {
+  if (state == nullptr || image == VK_NULL_HANDLE ||
+      image_view == VK_NULL_HANDLE || format == VK_FORMAT_UNDEFINED) {
+    LOGE("Failed to wrap Vulkan texture: invalid external image info");
+    return {};
+  }
+
+  auto texture = std::make_shared<GPUTextureVK>(
+      std::move(state), descriptor, image, nullptr, image_view,
+      preferred_layout, format, owns_image, owns_image_view);
+  texture->SetCurrentLayout(initial_layout);
+  return texture;
+}
+
+std::shared_ptr<GPUTexture> GPUTextureVK::Create(
+    std::shared_ptr<const VulkanContextState> state,
+    const GPUTextureDescriptor& descriptor) {
+  if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state->GetAllocator() == nullptr) {
+    LOGE("Failed to create Vulkan texture: device or allocator is unavailable");
+    return {};
+  }
+
+  const VkFormat requested_format = ConvertToVkFormat(descriptor.format);
+  if (requested_format == VK_FORMAT_UNDEFINED || descriptor.width == 0 ||
+      descriptor.height == 0) {
+    LOGE("Failed to create Vulkan texture: invalid descriptor");
+    return {};
+  }
+
+  VkImageCreateInfo image_info = {};
+  image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  image_info.imageType = VK_IMAGE_TYPE_2D;
+  image_info.extent.width = descriptor.width;
+  image_info.extent.height = descriptor.height;
+  image_info.extent.depth = 1;
+  image_info.mipLevels = descriptor.mip_level_count;
+  image_info.arrayLayers = 1;
+  image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+  image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  image_info.samples =
+      static_cast<VkSampleCountFlagBits>(descriptor.sample_count);
+  image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  image_info.usage =
+      SanitizeImageUsage(descriptor.format, ToVkImageUsage(descriptor.usage));
+  if (descriptor.storage_mode == GPUTextureStorageMode::kMemoryless) {
+    image_info.usage |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+  }
+
+  if (image_info.usage == 0) {
+    LOGE("Failed to create Vulkan texture: empty image usage");
+    return {};
+  }
+
+  image_info.format = ResolveVkFormat(*state, descriptor.format,
+                                      image_info.usage, image_info.samples);
+  if (image_info.format == VK_FORMAT_UNDEFINED) {
+    LOGE(
+        "Failed to create Vulkan texture: unsupported format={} usage=0x{:x} "
+        "samples=0x{:x}",
+        static_cast<uint32_t>(descriptor.format),
+        static_cast<uint32_t>(image_info.usage),
+        static_cast<uint32_t>(image_info.samples));
+    return {};
+  }
+
+  if (descriptor.mip_level_count > 1 &&
+      !SupportsLinearBlit(*state, image_info.format)) {
+    LOGE(
+        "Failed to create Vulkan texture: mipmapped texture requires linear "
+        "blit support format={} mip_levels={}",
+        VkFormatToString(image_info.format), descriptor.mip_level_count);
+    return {};
+  }
+
+  LOGD(
+      "Creating Vulkan texture: logical_format={} resolved_format={} "
+      "size={}x{} usage=0x{:x} samples=0x{:x}",
+      static_cast<uint32_t>(descriptor.format),
+      VkFormatToString(image_info.format), descriptor.width, descriptor.height,
+      static_cast<uint32_t>(image_info.usage),
+      static_cast<uint32_t>(image_info.samples));
+
+  VmaAllocationCreateInfo allocation_info = {};
+  if (descriptor.storage_mode == GPUTextureStorageMode::kMemoryless) {
+    allocation_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    allocation_info.requiredFlags = VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+  } else if (descriptor.storage_mode == GPUTextureStorageMode::kHostVisible) {
+    allocation_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+  } else {
+    allocation_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+  }
+
+  VkImage image = VK_NULL_HANDLE;
+  VmaAllocation allocation = nullptr;
+  if (!CreateImageWithAllocation(*state, image_info, allocation_info, &image,
+                                 &allocation)) {
+    if (descriptor.storage_mode != GPUTextureStorageMode::kMemoryless) {
+      return {};
+    }
+
+    // Some Android Vulkan drivers reject lazily allocated transient
+    // attachments. Fall back to a regular device-local image so rendering can
+    // still proceed in debug/demo scenarios.
+    image_info.usage &= ~VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+    allocation_info.requiredFlags = 0;
+    if (!CreateImageWithAllocation(*state, image_info, allocation_info, &image,
+                                   &allocation)) {
+      return {};
+    }
+  }
+
+  VkImageViewCreateInfo view_info = {};
+  view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  view_info.image = image;
+  view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  view_info.format = image_info.format;
+  view_info.subresourceRange.aspectMask = GetImageAspectMask(descriptor.format);
+  view_info.subresourceRange.baseMipLevel = 0;
+  view_info.subresourceRange.levelCount = descriptor.mip_level_count;
+  view_info.subresourceRange.baseArrayLayer = 0;
+  view_info.subresourceRange.layerCount = 1;
+
+  VkImageView image_view = VK_NULL_HANDLE;
+  const VkResult view_result = state->DeviceFns().vkCreateImageView(
+      state->GetLogicalDevice(), &view_info, nullptr, &image_view);
+  if (view_result != VK_SUCCESS || image_view == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan image view: {}",
+         static_cast<int32_t>(view_result));
+    vmaDestroyImage(state->GetAllocator(), image, allocation);
+    return {};
+  }
+
+  return std::make_shared<GPUTextureVK>(
+      state, descriptor, image, allocation, image_view,
+      ResolvePreferredLayout(descriptor), image_info.format);
+}
+
+size_t GPUTextureVK::GetBytes() const {
+  const auto& desc = GetDescriptor();
+  if (desc.storage_mode == GPUTextureStorageMode::kMemoryless) {
+    return 0;
+  }
+
+  return static_cast<size_t>(desc.width) * desc.height *
+         GetTextureFormatBytesPerPixel(desc.format) * desc.sample_count;
+}
+
+void GPUTextureVK::UploadData(uint32_t offset_x, uint32_t offset_y,
+                              uint32_t width, uint32_t height, void* data) {
+  if (state_ == nullptr || data == nullptr || width == 0 || height == 0) {
+    return;
+  }
+
+  auto command_buffer = std::make_shared<GPUCommandBufferVK>(state_);
+  if (!command_buffer->Init()) {
+    return;
+  }
+
+  command_buffer->SetLabel("VkUploadTextureData");
+
+  auto blit_pass =
+      std::make_shared<GPUBlitPassVK>(state_, command_buffer.get());
+  blit_pass->UploadTextureData(shared_from_this(), offset_x, offset_y, width,
+                               height, data);
+  blit_pass->End();
+  command_buffer->Submit();
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_texture_vk.hpp
+++ b/src/gpu/vk/gpu_texture_vk.hpp
@@ -1,0 +1,80 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_TEXTURE_VK_HPP
+#define SRC_GPU_VK_GPU_TEXTURE_VK_HPP
+
+#include <vk_mem_alloc.h>
+
+#include <memory>
+
+#include "src/gpu/backend_cast.hpp"
+#include "src/gpu/gpu_texture.hpp"
+
+namespace skity {
+
+class VulkanContextState;
+
+class GPUTextureVK : public GPUTexture,
+                     public std::enable_shared_from_this<GPUTextureVK> {
+ public:
+  GPUTextureVK(std::shared_ptr<const VulkanContextState> state,
+               const GPUTextureDescriptor& descriptor, VkImage image,
+               VmaAllocation allocation, VkImageView image_view,
+               VkImageLayout preferred_layout, VkFormat format,
+               bool owns_image = true, bool owns_image_view = true);
+
+  ~GPUTextureVK() override;
+
+  static std::shared_ptr<GPUTexture> Create(
+      std::shared_ptr<const VulkanContextState> state,
+      const GPUTextureDescriptor& descriptor);
+
+  static std::shared_ptr<GPUTexture> Wrap(
+      std::shared_ptr<const VulkanContextState> state,
+      const GPUTextureDescriptor& descriptor, VkImage image,
+      VkImageView image_view, VkImageLayout initial_layout,
+      VkImageLayout preferred_layout, VkFormat format, bool owns_image,
+      bool owns_image_view);
+
+  size_t GetBytes() const override;
+
+  void UploadData(uint32_t offset_x, uint32_t offset_y, uint32_t width,
+                  uint32_t height, void* data) override;
+
+  VkImage GetImage() const { return image_; }
+
+  VkImageView GetImageView() const { return image_view_; }
+
+  VkFormat GetVkFormat() const { return format_; }
+
+  static VkFormat ToVkFormat(GPUTextureFormat format);
+
+  VkImageLayout GetPreferredLayout() const { return preferred_layout_; }
+
+  VkImageLayout GetCurrentLayout() const { return current_layout_; }
+
+  void SetCurrentLayout(VkImageLayout layout) { current_layout_ = layout; }
+
+  bool IsValid() const {
+    return image_ != VK_NULL_HANDLE && image_view_ != VK_NULL_HANDLE;
+  }
+
+  SKT_BACKEND_CAST(GPUTextureVK, GPUTexture)
+
+ private:
+  std::shared_ptr<const VulkanContextState> state_ = {};
+  VkImage image_ = VK_NULL_HANDLE;
+  VmaAllocation allocation_ = nullptr;
+  VkImageView image_view_ = VK_NULL_HANDLE;
+  VkImageLayout preferred_layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkImageLayout current_layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkFormat format_ = VK_FORMAT_UNDEFINED;
+  bool owns_image_ = true;
+  bool owns_image_view_ = true;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_TEXTURE_VK_HPP

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -1,0 +1,1515 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
+#include <vk_mem_alloc.h>
+
+#include <cstdlib>
+#include <set>
+#include <string_view>
+#include <vector>
+
+#include "src/gpu/vk/vulkan_platform_extensions.hpp"
+#include "src/logging.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
+namespace skity {
+
+namespace {
+
+constexpr char kPortabilitySubsetExtensionName[] = "VK_KHR_portability_subset";
+
+uint32_t ResolveInstanceApiVersion(const VulkanGlobalFns& global_fns) {
+  if (global_fns.vkEnumerateInstanceVersion == nullptr) {
+    return VK_API_VERSION_1_0;
+  }
+
+  uint32_t version = VK_API_VERSION_1_0;
+  if (global_fns.vkEnumerateInstanceVersion(&version) != VK_SUCCESS) {
+    return VK_API_VERSION_1_0;
+  }
+
+  return version;
+}
+
+bool IsAtLeastVulkan11(uint32_t version) {
+  return VK_API_VERSION_MAJOR(version) > 1 ||
+         (VK_API_VERSION_MAJOR(version) == 1 &&
+          VK_API_VERSION_MINOR(version) >= 1);
+}
+
+bool IsApiVersionGreater(uint32_t lhs, uint32_t rhs) {
+  if (VK_API_VERSION_MAJOR(lhs) != VK_API_VERSION_MAJOR(rhs)) {
+    return VK_API_VERSION_MAJOR(lhs) > VK_API_VERSION_MAJOR(rhs);
+  }
+
+  if (VK_API_VERSION_MINOR(lhs) != VK_API_VERSION_MINOR(rhs)) {
+    return VK_API_VERSION_MINOR(lhs) > VK_API_VERSION_MINOR(rhs);
+  }
+
+  if (VK_API_VERSION_PATCH(lhs) != VK_API_VERSION_PATCH(rhs)) {
+    return VK_API_VERSION_PATCH(lhs) > VK_API_VERSION_PATCH(rhs);
+  }
+
+  return VK_API_VERSION_VARIANT(lhs) > VK_API_VERSION_VARIANT(rhs);
+}
+
+uint32_t MinApiVersion(uint32_t lhs, uint32_t rhs) {
+  return IsApiVersionGreater(lhs, rhs) ? rhs : lhs;
+}
+
+const char* VulkanVendorName(uint32_t vendor_id) {
+  switch (vendor_id) {
+    case 0x1002:
+      return "AMD";
+    case 0x1010:
+      return "ImgTec";
+    case 0x10DE:
+      return "NVIDIA";
+    case 0x13B5:
+      return "ARM";
+    case 0x5143:
+      return "Qualcomm";
+    case 0x8086:
+      return "Intel";
+    default:
+      return "Unknown";
+  }
+}
+
+const char* MemoryPropertyFlagName(VkMemoryPropertyFlagBits flag) {
+  switch (flag) {
+    case VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT:
+      return "DEVICE_LOCAL";
+    case VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT:
+      return "HOST_VISIBLE";
+    case VK_MEMORY_PROPERTY_HOST_COHERENT_BIT:
+      return "HOST_COHERENT";
+    case VK_MEMORY_PROPERTY_HOST_CACHED_BIT:
+      return "HOST_CACHED";
+    case VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT:
+      return "LAZILY_ALLOCATED";
+    case VK_MEMORY_PROPERTY_PROTECTED_BIT:
+      return "PROTECTED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void LogPhysicalDeviceMemoryProperties(const VulkanInstanceFns& instance_fns,
+                                       VkPhysicalDevice physical_device) {
+#ifdef SKITY_RELEASE
+  (void)instance_fns;
+  (void)physical_device;
+#else
+  if (physical_device == VK_NULL_HANDLE ||
+      instance_fns.vkGetPhysicalDeviceMemoryProperties == nullptr) {
+    return;
+  }
+
+  VkPhysicalDeviceMemoryProperties memory_properties = {};
+  instance_fns.vkGetPhysicalDeviceMemoryProperties(physical_device,
+                                                   &memory_properties);
+  LOGD("Vulkan memory heaps: {}", memory_properties.memoryHeapCount);
+  for (uint32_t i = 0; i < memory_properties.memoryHeapCount; ++i) {
+    const auto& heap = memory_properties.memoryHeaps[i];
+    LOGD("Vulkan memory heap[{}]: size={} flags=0x{:x}", i,
+         static_cast<uint64_t>(heap.size), heap.flags);
+  }
+
+  LOGD("Vulkan memory types: {}", memory_properties.memoryTypeCount);
+  constexpr VkMemoryPropertyFlagBits kKnownFlags[] = {
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+      VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
+      VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT,
+      VK_MEMORY_PROPERTY_PROTECTED_BIT,
+  };
+  for (uint32_t i = 0; i < memory_properties.memoryTypeCount; ++i) {
+    const auto& type = memory_properties.memoryTypes[i];
+    LOGD("Vulkan memory type[{}]: heap={} flags=0x{:x}", i, type.heapIndex,
+         type.propertyFlags);
+    for (auto flag : kKnownFlags) {
+      if ((type.propertyFlags & flag) != 0) {
+        LOGD("  - {}", MemoryPropertyFlagName(flag));
+      }
+    }
+  }
+#endif
+}
+
+bool ContainsExtension(const std::vector<std::string>& extensions,
+                       const char* extension_name) {
+  if (extension_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& extension : extensions) {
+    if (extension == extension_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool ContainsExtension(const std::vector<VkExtensionProperties>& extensions,
+                       const char* extension_name) {
+  if (extension_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& extension : extensions) {
+    if (std::string_view(extension.extensionName) == extension_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool ContainsLayer(const std::vector<std::string>& layers,
+                   const char* layer_name) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)layers;
+  (void)layer_name;
+  return false;
+#else
+  if (layer_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& layer : layers) {
+    if (layer == layer_name) {
+      return true;
+    }
+  }
+
+  return false;
+#endif
+}
+
+bool ContainsLayer(const std::vector<VkLayerProperties>& layers,
+                   const char* layer_name) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)layers;
+  (void)layer_name;
+  return false;
+#else
+  if (layer_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& layer : layers) {
+    if (std::string_view(layer.layerName) == layer_name) {
+      return true;
+    }
+  }
+
+  return false;
+#endif
+}
+
+void LogExtensions(const char* label,
+                   const std::vector<VkExtensionProperties>& extensions) {
+#ifdef SKITY_RELEASE
+  (void)label;
+  (void)extensions;
+#else
+  LOGD("Enumerated {} Vulkan {} extension(s)", extensions.size(), label);
+  for (const auto& extension : extensions) {
+    LOGD("Vulkan {} extension: {} (spec version {})", label,
+         extension.extensionName, extension.specVersion);
+  }
+#endif
+}
+
+void LogLayers(const std::vector<VkLayerProperties>& layers) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)layers;
+#else
+  LOGD("Enumerated {} Vulkan instance layer(s)", layers.size());
+  for (const auto& layer : layers) {
+    LOGD("Vulkan instance layer: {} (spec version {}, impl version {})",
+         layer.layerName, layer.specVersion, layer.implementationVersion);
+  }
+#endif
+}
+
+std::vector<std::string> CopyEnabledExtensions(const char* const* extensions,
+                                               uint32_t extension_count) {
+  std::vector<std::string> result;
+  if (extensions == nullptr || extension_count == 0) {
+    return result;
+  }
+
+  std::set<std::string> seen_extensions;
+  result.reserve(extension_count);
+  for (uint32_t i = 0; i < extension_count; ++i) {
+    if (extensions[i] == nullptr) {
+      continue;
+    }
+
+    std::string extension_name = extensions[i];
+    if (seen_extensions.insert(extension_name).second) {
+      result.emplace_back(std::move(extension_name));
+    }
+  }
+
+  return result;
+}
+
+std::vector<const char*> BuildNamePtrs(const std::vector<std::string>& names) {
+  std::vector<const char*> result;
+  result.reserve(names.size());
+  for (const auto& name : names) {
+    result.push_back(name.c_str());
+  }
+  return result;
+}
+
+void LogEnabledExtensions(const char* label,
+                          const std::vector<std::string>& extensions) {
+#ifdef SKITY_RELEASE
+  (void)label;
+  (void)extensions;
+#else
+  if (extensions.empty()) {
+    LOGD("Enabled 0 Vulkan {} extension(s)", label);
+    return;
+  }
+
+  LOGD("Enabled {} Vulkan {} extension(s)", extensions.size(), label);
+  for (const auto& extension : extensions) {
+    LOGD("Enabled Vulkan {} extension: {}", label, extension);
+  }
+#endif
+}
+
+void LogEnabledLayers(const std::vector<std::string>& layers) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)layers;
+#else
+  if (layers.empty()) {
+    LOGD("Enabled 0 Vulkan instance layer(s)");
+    return;
+  }
+
+  LOGD("Enabled {} Vulkan instance layer(s)", layers.size());
+  for (const auto& layer : layers) {
+    LOGD("Enabled Vulkan instance layer: {}", layer);
+  }
+#endif
+}
+
+void TryEnableInstanceExtension(
+    std::vector<std::string>* enabled_extensions,
+    const std::vector<VkExtensionProperties>& available_extensions,
+    const char* extension_name) {
+  if (enabled_extensions == nullptr || extension_name == nullptr) {
+    return;
+  }
+
+  if (!ContainsExtension(available_extensions, extension_name) ||
+      ContainsExtension(*enabled_extensions, extension_name)) {
+    return;
+  }
+
+  enabled_extensions->emplace_back(extension_name);
+}
+
+void TryEnableInstanceLayer(
+    std::vector<std::string>* enabled_layers,
+    const std::vector<VkLayerProperties>& available_layers,
+    const char* layer_name) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)enabled_layers;
+  (void)available_layers;
+  (void)layer_name;
+#else
+  if (enabled_layers == nullptr || layer_name == nullptr) {
+    return;
+  }
+
+  if (!ContainsLayer(available_layers, layer_name) ||
+      ContainsLayer(*enabled_layers, layer_name)) {
+    return;
+  }
+
+  enabled_layers->emplace_back(layer_name);
+#endif
+}
+
+bool ShouldEnableVulkanDebugRuntime(const GPUContextInfoVK& info) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)info;
+  return false;
+#else
+  return info.enable_debug_runtime;
+#endif
+}
+
+bool LoadAvailableInstanceLayersImpl(const VulkanGlobalFns& global_fns,
+                                     VulkanDebugRuntimeState* debug_runtime) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  (void)global_fns;
+  (void)debug_runtime;
+  return true;
+#else
+  if (debug_runtime == nullptr) {
+    return true;
+  }
+
+  debug_runtime->available_instance_layers.clear();
+  debug_runtime->enabled_instance_layers.clear();
+  debug_runtime->enabled_instance_layers_known = false;
+  if (global_fns.vkEnumerateInstanceLayerProperties == nullptr) {
+    LOGE("Failed to enumerate Vulkan instance layers: loader is null");
+    return false;
+  }
+
+  uint32_t layer_count = 0;
+  VkResult result =
+      global_fns.vkEnumerateInstanceLayerProperties(&layer_count, nullptr);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to query Vulkan instance layer count: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  if (layer_count > 0) {
+    debug_runtime->available_instance_layers.resize(layer_count);
+    result = global_fns.vkEnumerateInstanceLayerProperties(
+        &layer_count, debug_runtime->available_instance_layers.data());
+    if (result != VK_SUCCESS) {
+      LOGE("Failed to query Vulkan instance layers: {}",
+           static_cast<int32_t>(result));
+      debug_runtime->available_instance_layers.clear();
+      return false;
+    }
+    debug_runtime->available_instance_layers.resize(layer_count);
+  }
+
+  LogLayers(debug_runtime->available_instance_layers);
+  return true;
+#endif
+}
+
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+
+void HandleUserProvidedDebugRuntimeHint(const GPUContextInfoVK& info) {
+  if (info.enable_debug_runtime) {
+    LOGW(
+        "GPUContextInfoVK::enable_debug_runtime is ignored for user "
+        "provided Vulkan instances");
+  }
+}
+
+void ConfigureDebugRuntimeForOwnedInstance(
+    const GPUContextInfoVK& info,
+    const std::vector<VkExtensionProperties>& available_instance_extensions,
+    std::vector<std::string>* enabled_instance_extensions,
+    VulkanDebugRuntimeState* debug_runtime) {
+  if (!ShouldEnableVulkanDebugRuntime(info) ||
+      enabled_instance_extensions == nullptr || debug_runtime == nullptr) {
+    return;
+  }
+
+  if (ContainsExtension(available_instance_extensions,
+                        VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+    TryEnableInstanceExtension(enabled_instance_extensions,
+                               available_instance_extensions,
+                               VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  } else {
+    LOGW("Vulkan debug runtime requested but {} is unavailable",
+         VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  }
+
+  if (ContainsLayer(debug_runtime->available_instance_layers,
+                    "VK_LAYER_KHRONOS_validation")) {
+    TryEnableInstanceLayer(&debug_runtime->enabled_instance_layers,
+                           debug_runtime->available_instance_layers,
+                           "VK_LAYER_KHRONOS_validation");
+  } else {
+    LOGW(
+        "Vulkan debug runtime requested but VK_LAYER_KHRONOS_validation is "
+        "unavailable");
+  }
+}
+
+void ApplyDebugRuntimeToInstanceCreateInfo(
+    const VulkanDebugRuntimeState& debug_runtime,
+    std::vector<const char*>* enabled_layer_ptrs,
+    VkInstanceCreateInfo* instance_info) {
+  if (enabled_layer_ptrs == nullptr || instance_info == nullptr) {
+    return;
+  }
+
+  *enabled_layer_ptrs = BuildNamePtrs(debug_runtime.enabled_instance_layers);
+  instance_info->enabledLayerCount =
+      static_cast<uint32_t>(enabled_layer_ptrs->size());
+  instance_info->ppEnabledLayerNames = enabled_layer_ptrs->data();
+}
+
+void MarkDebugRuntimeKnownAndLog(VulkanDebugRuntimeState* debug_runtime) {
+  if (debug_runtime == nullptr) {
+    return;
+  }
+  debug_runtime->enabled_instance_layers_known = true;
+  LogEnabledLayers(debug_runtime->enabled_instance_layers);
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsMessengerCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+    VkDebugUtilsMessageTypeFlagsEXT message_types,
+    const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+    void* user_data) {
+  (void)user_data;
+
+  const char* message =
+      callback_data != nullptr && callback_data->pMessage != nullptr
+          ? callback_data->pMessage
+          : "Unknown Vulkan validation message";
+
+  const bool is_validation =
+      (message_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) != 0;
+  const bool is_performance =
+      (message_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) != 0;
+
+  if ((message_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0) {
+    LOGE("Vulkan validation{}{}: {}", is_validation ? "" : " message",
+         is_performance ? " [performance]" : "", message);
+  } else if ((message_severity &
+              VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0) {
+    LOGW("Vulkan validation{}{}: {}", is_validation ? "" : " message",
+         is_performance ? " [performance]" : "", message);
+  } else {
+    LOGD("Vulkan validation{}{}: {}", is_validation ? "" : " message",
+         is_performance ? " [performance]" : "", message);
+  }
+
+  return VK_FALSE;
+}
+
+void TryCreateDebugUtilsMessenger(VkInstance instance,
+                                  const VulkanInstanceFns& instance_fns,
+                                  VulkanDebugRuntimeState* debug_runtime) {
+  if (instance == VK_NULL_HANDLE || debug_runtime == nullptr ||
+      debug_runtime->debug_utils_messenger != VK_NULL_HANDLE ||
+      instance_fns.vkCreateDebugUtilsMessengerEXT == nullptr) {
+    return;
+  }
+
+  VkDebugUtilsMessengerCreateInfoEXT create_info = {};
+  create_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+  create_info.messageSeverity =
+      VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT |
+      VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT |
+      VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+      VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+  create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                            VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                            VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+  create_info.pfnUserCallback = VulkanDebugUtilsMessengerCallback;
+
+  const VkResult result = instance_fns.vkCreateDebugUtilsMessengerEXT(
+      instance, &create_info, nullptr, &debug_runtime->debug_utils_messenger);
+  if (result != VK_SUCCESS) {
+    LOGW("Failed to create Vulkan debug utils messenger: {}",
+         static_cast<int32_t>(result));
+    debug_runtime->debug_utils_messenger = VK_NULL_HANDLE;
+    return;
+  }
+
+  LOGD("Created Vulkan debug utils messenger: {:p}",
+       reinterpret_cast<void*>(debug_runtime->debug_utils_messenger));
+}
+
+}  // namespace
+
+#else
+
+void HandleUserProvidedDebugRuntimeHint(const GPUContextInfoVK& info) {
+  (void)info;
+}
+
+void ConfigureDebugRuntimeForOwnedInstance(
+    const GPUContextInfoVK& info,
+    const std::vector<VkExtensionProperties>& available_instance_extensions,
+    std::vector<std::string>* enabled_instance_extensions,
+    VulkanDebugRuntimeState* debug_runtime) {
+  (void)info;
+  (void)available_instance_extensions;
+  (void)enabled_instance_extensions;
+  (void)debug_runtime;
+}
+
+void ApplyDebugRuntimeToInstanceCreateInfo(
+    const VulkanDebugRuntimeState& debug_runtime,
+    std::vector<const char*>* enabled_layer_ptrs,
+    VkInstanceCreateInfo* instance_info) {
+  (void)debug_runtime;
+  (void)enabled_layer_ptrs;
+  (void)instance_info;
+}
+
+void MarkDebugRuntimeKnownAndLog(VulkanDebugRuntimeState* debug_runtime) {
+  (void)debug_runtime;
+}
+
+void TryCreateDebugUtilsMessenger(VkInstance instance,
+                                  const VulkanInstanceFns& instance_fns,
+                                  VulkanDebugRuntimeState* debug_runtime) {
+  (void)instance;
+  (void)instance_fns;
+  (void)debug_runtime;
+}
+
+}  // namespace
+
+#endif
+
+VulkanContextState::~VulkanContextState() { Reset(); }
+
+bool VulkanContextState::AreEnabledInstanceLayersKnown() const {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  return false;
+#else
+  return debug_runtime_.enabled_instance_layers_known;
+#endif
+}
+
+const std::vector<VkLayerProperties>&
+VulkanContextState::GetAvailableInstanceLayers() const {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  static const std::vector<VkLayerProperties> kEmptyLayers = {};
+  return kEmptyLayers;
+#else
+  return debug_runtime_.available_instance_layers;
+#endif
+}
+
+const std::vector<std::string>& VulkanContextState::GetEnabledInstanceLayers()
+    const {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  static const std::vector<std::string> kEmptyLayers = {};
+  return kEmptyLayers;
+#else
+  return debug_runtime_.enabled_instance_layers;
+#endif
+}
+
+bool VulkanContextState::Initialize(const GPUContextInfoVK& info) {
+  Reset();
+  LOGD("Initializing VulkanContextState");
+
+  if (!InitializeInstance(info) || !InitializePhysicalDevice(info) ||
+      !InitializeQueues(info) || !InitializeDevice(info)) {
+    LOGE("Failed to initialize VulkanContextState");
+    Reset();
+    return false;
+  }
+
+  LOGD("Initialized VulkanContextState successfully");
+  return true;
+}
+
+void VulkanContextState::EnqueuePendingSubmission(
+    VulkanPendingSubmission submission) const {
+  pending_submissions_.emplace_back(std::move(submission));
+}
+
+void VulkanContextState::CollectPendingSubmissions(bool wait_all) const {
+  if (logical_device_ == VK_NULL_HANDLE ||
+      functions_.device.vkDestroyFence == nullptr ||
+      functions_.device.vkDestroyCommandPool == nullptr) {
+    return;
+  }
+
+  std::vector<VulkanPendingSubmission> completed_submissions;
+  if (pending_submissions_.empty()) {
+    return;
+  }
+
+  if (wait_all) {
+    std::vector<VkFence> fences;
+    fences.reserve(pending_submissions_.size());
+    for (const auto& submission : pending_submissions_) {
+      if (submission.fence != VK_NULL_HANDLE) {
+        fences.push_back(submission.fence);
+      }
+    }
+
+    if (!fences.empty()) {
+      const VkResult result = functions_.device.vkWaitForFences(
+          logical_device_, static_cast<uint32_t>(fences.size()), fences.data(),
+          VK_TRUE, UINT64_MAX);
+      if (result != VK_SUCCESS) {
+        LOGW("Failed to wait Vulkan pending submissions: {}",
+             static_cast<int32_t>(result));
+      }
+    }
+
+    completed_submissions = std::move(pending_submissions_);
+    pending_submissions_.clear();
+  } else {
+    auto it = pending_submissions_.begin();
+    while (it != pending_submissions_.end()) {
+      const VkResult result =
+          functions_.device.vkGetFenceStatus(logical_device_, it->fence);
+      if (result == VK_SUCCESS) {
+        completed_submissions.emplace_back(std::move(*it));
+        it = pending_submissions_.erase(it);
+        continue;
+      }
+
+      if (result != VK_NOT_READY) {
+        LOGW("Failed to query Vulkan fence status: {}",
+             static_cast<int32_t>(result));
+      }
+      ++it;
+    }
+  }
+
+  for (auto& submission : completed_submissions) {
+    if (submission.owns_fence && submission.fence != VK_NULL_HANDLE) {
+      functions_.device.vkDestroyFence(logical_device_, submission.fence,
+                                       nullptr);
+      submission.fence = VK_NULL_HANDLE;
+    }
+
+    for (auto& cleanup_action : submission.cleanup_actions) {
+      if (cleanup_action) {
+        cleanup_action();
+      }
+    }
+    submission.cleanup_actions.clear();
+
+    if (submission.command_pool != VK_NULL_HANDLE) {
+      functions_.device.vkDestroyCommandPool(logical_device_,
+                                             submission.command_pool, nullptr);
+      submission.command_pool = VK_NULL_HANDLE;
+    }
+  }
+}
+
+VkRenderPass VulkanContextState::GetOrCreateLegacyRenderPass(
+    const LegacyRenderPassKey& key) const {
+  return render_pass_cache_.GetOrCreate(*this, key);
+}
+
+bool VulkanContextState::HasAvailableInstanceExtension(
+    const char* extension_name) const {
+  return ContainsExtension(available_instance_extensions_, extension_name);
+}
+
+bool VulkanContextState::HasEnabledInstanceExtension(
+    const char* extension_name) const {
+  return ContainsExtension(enabled_instance_extensions_, extension_name);
+}
+
+bool VulkanContextState::HasAvailableDeviceExtension(
+    const char* extension_name) const {
+  return ContainsExtension(available_device_extensions_, extension_name);
+}
+
+bool VulkanContextState::HasEnabledDeviceExtension(
+    const char* extension_name) const {
+  return ContainsExtension(enabled_device_extensions_, extension_name);
+}
+
+int32_t VulkanContextState::FindQueueFamilyIndex(VkQueueFlags flags,
+                                                 bool prefer_dedicated) const {
+  int32_t fallback_index = -1;
+
+  for (size_t i = 0; i < queue_family_properties_.size(); ++i) {
+    const auto& properties = queue_family_properties_[i];
+    if ((properties.queueFlags & flags) != flags ||
+        properties.queueCount == 0) {
+      continue;
+    }
+
+    if (!prefer_dedicated) {
+      return static_cast<int32_t>(i);
+    }
+
+    const bool is_dedicated =
+        (flags == VK_QUEUE_COMPUTE_BIT &&
+         (properties.queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) ||
+        (flags == VK_QUEUE_TRANSFER_BIT &&
+         (properties.queueFlags &
+          (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)) == 0);
+    if (is_dedicated) {
+      return static_cast<int32_t>(i);
+    }
+
+    if (fallback_index < 0) {
+      fallback_index = static_cast<int32_t>(i);
+    }
+  }
+
+  return fallback_index;
+}
+
+bool VulkanContextState::InitializeInstance(const GPUContextInfoVK& info) {
+  functions_.get_instance_proc_addr = info.get_instance_proc_addr;
+  if (functions_.get_instance_proc_addr == nullptr) {
+    LOGE("Failed to initialize Vulkan instance: vkGetInstanceProcAddr is null");
+    return false;
+  }
+
+  if (!LoadVulkanGlobalFns(functions_.get_instance_proc_addr,
+                           &functions_.global)) {
+    return false;
+  }
+
+  if (!LoadAvailableInstanceExtensions()) {
+    return false;
+  }
+
+  if (!LoadAvailableInstanceLayers()) {
+    return false;
+  }
+
+  api_version_ = ResolveInstanceApiVersion(functions_.global);
+
+  if (info.instance != VK_NULL_HANDLE) {
+    instance_ = info.instance;
+    LOGD("Using user provided Vulkan instance: {:p}",
+         reinterpret_cast<void*>(instance_));
+    HandleUserProvidedDebugRuntimeHint(info);
+    if (!LoadVulkanInstanceFns(functions_.get_instance_proc_addr, instance_,
+                               &functions_.instance)) {
+      LOGE(
+          "Failed to initialize Vulkan instance procedures from user instance");
+      return false;
+    }
+
+    enabled_instance_extensions_ =
+        CopyEnabledExtensions(info.enabled_instance_extensions,
+                              info.enabled_instance_extension_count);
+    enabled_instance_extensions_known_ = info.enabled_instance_extensions_known;
+    if (enabled_instance_extensions_known_) {
+      LogEnabledExtensions("instance", enabled_instance_extensions_);
+    } else {
+      LOGW(
+          "Enabled Vulkan instance extensions are unknown for user provided "
+          "instance");
+    }
+  } else {
+    enabled_instance_extensions_ =
+        CopyEnabledExtensions(info.enabled_instance_extensions,
+                              info.enabled_instance_extension_count);
+    TryEnableInstanceExtension(&enabled_instance_extensions_,
+                               available_instance_extensions_,
+                               VK_KHR_SURFACE_EXTENSION_NAME);
+    TryEnableInstanceExtension(
+        &enabled_instance_extensions_, available_instance_extensions_,
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    VkInstanceCreateFlags instance_flags = 0;
+    EnablePortabilityEnumerationIfAvailable(available_instance_extensions_,
+                                            &enabled_instance_extensions_,
+                                            &instance_flags);
+
+    EnablePlatformSurfaceInstanceExtensions(available_instance_extensions_,
+                                            &enabled_instance_extensions_);
+
+    ConfigureDebugRuntimeForOwnedInstance(info, available_instance_extensions_,
+                                          &enabled_instance_extensions_,
+                                          &debug_runtime_);
+
+    auto enabled_extension_ptrs = BuildNamePtrs(enabled_instance_extensions_);
+    std::vector<const char*> enabled_layer_ptrs;
+
+    const uint32_t target_version = api_version_;
+    if (!IsAtLeastVulkan11(target_version)) {
+      LOGE("Vulkan 1.1 is required, but only {}.{} is available",
+           VK_API_VERSION_MAJOR(target_version),
+           VK_API_VERSION_MINOR(target_version));
+      return false;
+    }
+
+    VkApplicationInfo app_info = {};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "skity";
+    app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = "skity";
+    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.apiVersion = target_version;
+
+    VkInstanceCreateInfo instance_info = {};
+    instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_info.flags = instance_flags;
+    instance_info.pApplicationInfo = &app_info;
+    ApplyDebugRuntimeToInstanceCreateInfo(debug_runtime_, &enabled_layer_ptrs,
+                                          &instance_info);
+    instance_info.enabledExtensionCount =
+        static_cast<uint32_t>(enabled_extension_ptrs.size());
+    instance_info.ppEnabledExtensionNames = enabled_extension_ptrs.data();
+
+    own_instance_ = CreateVkInstance(functions_.get_instance_proc_addr,
+                                     &instance_, &functions_, &instance_info);
+    if (!own_instance_) {
+      LOGE("Failed to create owned Vulkan instance");
+      return false;
+    }
+
+    LOGD("Created owned Vulkan instance: {:p}",
+         reinterpret_cast<void*>(instance_));
+    enabled_instance_extensions_known_ = true;
+    if (HasEnabledInstanceExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+      TryCreateDebugUtilsMessenger(instance_, functions_.instance,
+                                   &debug_runtime_);
+    }
+    MarkDebugRuntimeKnownAndLog(&debug_runtime_);
+    LogEnabledExtensions("instance", enabled_instance_extensions_);
+  }
+
+  return true;
+}
+
+bool VulkanContextState::InitializePhysicalDevice(
+    const GPUContextInfoVK& info) {
+  if (info.physical_device != VK_NULL_HANDLE) {
+    physical_device_ = info.physical_device;
+    VkPhysicalDeviceProperties properties = {};
+    functions_.instance.vkGetPhysicalDeviceProperties(physical_device_,
+                                                      &properties);
+    api_version_ = MinApiVersion(api_version_, properties.apiVersion);
+    LOGD("Using user provided Vulkan physical device: {:p}",
+         reinterpret_cast<void*>(physical_device_));
+    LOGD("User physical device API version: {}.{}.{}",
+         VK_API_VERSION_MAJOR(properties.apiVersion),
+         VK_API_VERSION_MINOR(properties.apiVersion),
+         VK_API_VERSION_PATCH(properties.apiVersion));
+  } else {
+    uint32_t physical_device_count = 0;
+    VkResult result = functions_.instance.vkEnumeratePhysicalDevices(
+        instance_, &physical_device_count, nullptr);
+    if (result != VK_SUCCESS || physical_device_count == 0) {
+      LOGE("Failed to enumerate Vulkan physical devices: result={}, count={}",
+           static_cast<int32_t>(result), physical_device_count);
+      return false;
+    }
+
+    LOGD("Enumerated {} Vulkan physical device(s)", physical_device_count);
+
+    std::vector<VkPhysicalDevice> physical_devices(physical_device_count,
+                                                   VK_NULL_HANDLE);
+    result = functions_.instance.vkEnumeratePhysicalDevices(
+        instance_, &physical_device_count, physical_devices.data());
+    if (result != VK_SUCCESS) {
+      LOGE("Failed to fetch Vulkan physical devices: result={}",
+           static_cast<int32_t>(result));
+      return false;
+    }
+
+    uint32_t selected_api_version = 0;
+    for (auto physical_device : physical_devices) {
+      VkPhysicalDeviceProperties properties = {};
+      functions_.instance.vkGetPhysicalDeviceProperties(physical_device,
+                                                        &properties);
+      LOGD("Found Vulkan physical device: {:p}, apiVersion: {}.{}.{}",
+           reinterpret_cast<void*>(physical_device),
+           VK_API_VERSION_MAJOR(properties.apiVersion),
+           VK_API_VERSION_MINOR(properties.apiVersion),
+           VK_API_VERSION_PATCH(properties.apiVersion));
+
+      if (physical_device_ == VK_NULL_HANDLE ||
+          IsApiVersionGreater(properties.apiVersion, selected_api_version)) {
+        physical_device_ = physical_device;
+        selected_api_version = properties.apiVersion;
+      }
+    }
+
+    LOGD(
+        "Selected Vulkan physical device with highest API version: {:p}, "
+        "{}.{}.{}",
+        reinterpret_cast<void*>(physical_device_),
+        VK_API_VERSION_MAJOR(selected_api_version),
+        VK_API_VERSION_MINOR(selected_api_version),
+        VK_API_VERSION_PATCH(selected_api_version));
+    api_version_ = MinApiVersion(api_version_, selected_api_version);
+  }
+
+  if (physical_device_ == VK_NULL_HANDLE) {
+    return false;
+  }
+
+  LogPhysicalDeviceMemoryProperties(functions_.instance, physical_device_);
+
+  uint32_t queue_family_count = 0;
+  functions_.instance.vkGetPhysicalDeviceQueueFamilyProperties(
+      physical_device_, &queue_family_count, nullptr);
+  if (queue_family_count == 0) {
+    LOGE("Failed to query Vulkan queue families: no queue family available");
+    return false;
+  }
+
+  LOGD("Physical device {:p} exposes {} queue family(s)",
+       reinterpret_cast<void*>(physical_device_), queue_family_count);
+
+  queue_family_properties_.resize(queue_family_count);
+  functions_.instance.vkGetPhysicalDeviceQueueFamilyProperties(
+      physical_device_, &queue_family_count, queue_family_properties_.data());
+  return true;
+}
+
+bool VulkanContextState::InitializeQueues(const GPUContextInfoVK& info) {
+  graphics_queue_family_index_ =
+      info.graphics_queue_family_index >= 0
+          ? info.graphics_queue_family_index
+          : FindQueueFamilyIndex(VK_QUEUE_GRAPHICS_BIT, false);
+  compute_queue_family_index_ =
+      info.compute_queue_family_index >= 0
+          ? info.compute_queue_family_index
+          : FindQueueFamilyIndex(VK_QUEUE_COMPUTE_BIT, true);
+  transfer_queue_family_index_ =
+      info.transfer_queue_family_index >= 0
+          ? info.transfer_queue_family_index
+          : FindQueueFamilyIndex(VK_QUEUE_TRANSFER_BIT, true);
+
+  if (graphics_queue_family_index_ < 0) {
+    LOGE("Failed to find Vulkan graphics queue family");
+    return false;
+  }
+
+  if (compute_queue_family_index_ < 0) {
+    compute_queue_family_index_ = graphics_queue_family_index_;
+  }
+
+  if (transfer_queue_family_index_ < 0) {
+    transfer_queue_family_index_ = compute_queue_family_index_;
+  }
+
+  LOGD("Using Vulkan queue families, graphics: {}, compute: {}, transfer: {}",
+       graphics_queue_family_index_, compute_queue_family_index_,
+       transfer_queue_family_index_);
+  return true;
+}
+
+bool VulkanContextState::LoadAvailableInstanceExtensions() {
+  available_instance_extensions_.clear();
+  if (functions_.global.vkEnumerateInstanceExtensionProperties == nullptr) {
+    LOGE("Failed to enumerate Vulkan instance extensions: loader is null");
+    return false;
+  }
+
+  uint32_t extension_count = 0;
+  VkResult result = functions_.global.vkEnumerateInstanceExtensionProperties(
+      nullptr, &extension_count, nullptr);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to query Vulkan instance extension count: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  if (extension_count > 0) {
+    available_instance_extensions_.resize(extension_count);
+    result = functions_.global.vkEnumerateInstanceExtensionProperties(
+        nullptr, &extension_count, available_instance_extensions_.data());
+    if (result != VK_SUCCESS) {
+      LOGE("Failed to query Vulkan instance extensions: {}",
+           static_cast<int32_t>(result));
+      available_instance_extensions_.clear();
+      return false;
+    }
+    available_instance_extensions_.resize(extension_count);
+  }
+
+  LogExtensions("instance", available_instance_extensions_);
+  return true;
+}
+
+bool VulkanContextState::LoadAvailableInstanceLayers() {
+  return LoadAvailableInstanceLayersImpl(functions_.global, &debug_runtime_);
+}
+
+bool VulkanContextState::LoadAvailableDeviceExtensions() {
+  available_device_extensions_.clear();
+  if (functions_.instance.vkEnumerateDeviceExtensionProperties == nullptr) {
+    LOGE("Failed to enumerate Vulkan device extensions: loader is null");
+    return false;
+  }
+
+  uint32_t extension_count = 0;
+  VkResult result = functions_.instance.vkEnumerateDeviceExtensionProperties(
+      physical_device_, nullptr, &extension_count, nullptr);
+  if (result != VK_SUCCESS) {
+    LOGE("Failed to query Vulkan device extension count: {}",
+         static_cast<int32_t>(result));
+    return false;
+  }
+
+  if (extension_count > 0) {
+    available_device_extensions_.resize(extension_count);
+    result = functions_.instance.vkEnumerateDeviceExtensionProperties(
+        physical_device_, nullptr, &extension_count,
+        available_device_extensions_.data());
+    if (result != VK_SUCCESS) {
+      LOGE("Failed to query Vulkan device extensions: {}",
+           static_cast<int32_t>(result));
+      available_device_extensions_.clear();
+      return false;
+    }
+    available_device_extensions_.resize(extension_count);
+  }
+
+  LogExtensions("device", available_device_extensions_);
+  return true;
+}
+
+bool VulkanContextState::LoadDeviceFns() {
+  if (functions_.get_device_proc_addr == nullptr) {
+    LOGE(
+        "Failed to load Vulkan device procedures: vkGetDeviceProcAddr is null");
+    return false;
+  }
+
+  return LoadVulkanDeviceFns(functions_.get_device_proc_addr, logical_device_,
+                             &functions_.device);
+}
+
+bool VulkanContextState::InitializeDevice(const GPUContextInfoVK& info) {
+  enabled_device_extensions_.clear();
+  enabled_device_extensions_known_ = false;
+  synchronization2_enabled_ = false;
+  dynamic_rendering_enabled_ = false;
+  pipeline_cache_ = VK_NULL_HANDLE;
+
+  if (!LoadAvailableDeviceExtensions()) {
+    return false;
+  }
+
+  if (info.logical_device != VK_NULL_HANDLE) {
+    logical_device_ = info.logical_device;
+    functions_.get_device_proc_addr =
+        info.get_device_proc_addr != nullptr
+            ? info.get_device_proc_addr
+            : functions_.instance.vkGetDeviceProcAddr;
+    LOGD("Using user provided Vulkan logical device: {:p}",
+         reinterpret_cast<void*>(logical_device_));
+    if (!LoadDeviceFns()) {
+      LOGE("Failed to initialize procedures from user Vulkan logical device");
+      return false;
+    }
+    enabled_device_extensions_ = CopyEnabledExtensions(
+        info.enabled_device_extensions, info.enabled_device_extension_count);
+    enabled_device_extensions_known_ = info.enabled_device_extensions_known;
+    if (enabled_device_extensions_known_) {
+      synchronization2_enabled_ = ContainsExtension(
+          enabled_device_extensions_, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+      dynamic_rendering_enabled_ = ContainsExtension(
+          enabled_device_extensions_, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+      if (dynamic_rendering_enabled_ &&
+          (functions_.device.vkCmdBeginRendering == nullptr ||
+           functions_.device.vkCmdEndRendering == nullptr)) {
+        LOGW(
+            "Dynamic rendering was declared enabled, but begin/end rendering "
+            "procedures are unavailable; falling back to legacy render pass");
+        dynamic_rendering_enabled_ = false;
+      }
+      LogEnabledExtensions("device", enabled_device_extensions_);
+    } else {
+      LOGW(
+          "Enabled Vulkan device extensions are unknown for user provided "
+          "logical device");
+    }
+  } else {
+    if (!InitializeOwnedDevice()) {
+      return false;
+    }
+  }
+
+  if (!ResolveQueues(info)) {
+    return false;
+  }
+
+  VkPipelineCacheCreateInfo pipeline_cache_info = {};
+  pipeline_cache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+  const VkResult pipeline_cache_result =
+      functions_.device.vkCreatePipelineCache(
+          logical_device_, &pipeline_cache_info, nullptr, &pipeline_cache_);
+  if (pipeline_cache_result != VK_SUCCESS ||
+      pipeline_cache_ == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan pipeline cache: result={}",
+         static_cast<int32_t>(pipeline_cache_result));
+    pipeline_cache_ = VK_NULL_HANDLE;
+    return false;
+  }
+
+  LOGD("Created Vulkan pipeline cache: {:p}",
+       reinterpret_cast<void*>(pipeline_cache_));
+
+  if (!InitializeAllocator()) {
+    return false;
+  }
+
+  return graphics_queue_ != VK_NULL_HANDLE;
+}
+
+bool VulkanContextState::InitializeOwnedDevice() {
+  if (HasAvailableDeviceExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+  }
+  const bool has_dynamic_rendering_extension =
+      HasAvailableDeviceExtension(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+  if (has_dynamic_rendering_extension) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+  }
+  if (HasAvailableDeviceExtension(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+  }
+  if (HasAvailableDeviceExtension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+  }
+  if (HasAvailableDeviceExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+  }
+  if (HasAvailableDeviceExtension(kPortabilitySubsetExtensionName)) {
+    enabled_device_extensions_.emplace_back(kPortabilitySubsetExtensionName);
+  }
+
+  VkPhysicalDeviceFeatures2 physical_device_features = {};
+  physical_device_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+  VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = {};
+  dynamic_rendering_features.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES;
+  VkPhysicalDeviceSynchronization2Features synchronization2_features = {};
+  synchronization2_features.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+
+  void** feature_query_next = &physical_device_features.pNext;
+  if (has_dynamic_rendering_extension) {
+    *feature_query_next = &dynamic_rendering_features;
+    feature_query_next = &dynamic_rendering_features.pNext;
+  }
+  if (HasAvailableDeviceExtension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
+    *feature_query_next = &synchronization2_features;
+    feature_query_next = &synchronization2_features.pNext;
+  }
+
+  if (physical_device_features.pNext != nullptr) {
+    functions_.instance.vkGetPhysicalDeviceFeatures2(physical_device_,
+                                                     &physical_device_features);
+  }
+
+  if (has_dynamic_rendering_extension) {
+    if (dynamic_rendering_features.dynamicRendering == VK_TRUE) {
+      dynamic_rendering_features.dynamicRendering = VK_TRUE;
+      dynamic_rendering_enabled_ = true;
+    } else {
+      enabled_device_extensions_.erase(
+          std::remove(enabled_device_extensions_.begin(),
+                      enabled_device_extensions_.end(),
+                      VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME),
+          enabled_device_extensions_.end());
+      LOGW(
+          "Vulkan dynamic rendering extension is present but feature is "
+          "not supported, disabling extension request");
+    }
+  }
+
+  if (HasAvailableDeviceExtension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
+    if (synchronization2_features.synchronization2 == VK_TRUE) {
+      synchronization2_features.synchronization2 = VK_TRUE;
+      synchronization2_enabled_ = true;
+    } else {
+      enabled_device_extensions_.erase(
+          std::remove(enabled_device_extensions_.begin(),
+                      enabled_device_extensions_.end(),
+                      VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME),
+          enabled_device_extensions_.end());
+      LOGW(
+          "Vulkan synchronization2 extension is present but feature is not "
+          "supported, disabling extension request");
+    }
+  }
+
+  auto enabled_extension_ptrs = BuildNamePtrs(enabled_device_extensions_);
+
+  static constexpr float kQueuePriority = 1.0f;
+  const std::array<int32_t, 3> queue_family_indices = {
+      graphics_queue_family_index_, compute_queue_family_index_,
+      transfer_queue_family_index_};
+
+  std::vector<VkDeviceQueueCreateInfo> queue_infos;
+  std::set<uint32_t> unique_family_indices;
+  for (int32_t family_index : queue_family_indices) {
+    if (family_index < 0) {
+      continue;
+    }
+
+    if (!unique_family_indices.insert(static_cast<uint32_t>(family_index))
+             .second) {
+      continue;
+    }
+
+    VkDeviceQueueCreateInfo queue_info = {};
+    queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_info.queueFamilyIndex = static_cast<uint32_t>(family_index);
+    queue_info.queueCount = 1;
+    queue_info.pQueuePriorities = &kQueuePriority;
+    queue_infos.push_back(queue_info);
+  }
+
+  LOGD("Creating Vulkan logical device with {} queue create info entries",
+       queue_infos.size());
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size());
+  device_info.pQueueCreateInfos = queue_infos.data();
+
+  void* enabled_feature_chain = nullptr;
+  void** enabled_feature_next = &enabled_feature_chain;
+  if (dynamic_rendering_enabled_) {
+    *enabled_feature_next = &dynamic_rendering_features;
+    enabled_feature_next = &dynamic_rendering_features.pNext;
+  }
+  if (synchronization2_enabled_) {
+    *enabled_feature_next = &synchronization2_features;
+    enabled_feature_next = &synchronization2_features.pNext;
+  }
+  if (enabled_feature_chain != nullptr) {
+    device_info.pNext = enabled_feature_chain;
+  }
+  device_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_extension_ptrs.size());
+  device_info.ppEnabledExtensionNames = enabled_extension_ptrs.data();
+
+  VkResult result = functions_.instance.vkCreateDevice(
+      physical_device_, &device_info, nullptr, &logical_device_);
+  if (result != VK_SUCCESS || logical_device_ == VK_NULL_HANDLE) {
+    LOGE("Failed to create Vulkan logical device: result={}, device={:p}",
+         static_cast<int32_t>(result),
+         reinterpret_cast<void*>(logical_device_));
+    return false;
+  }
+
+  own_device_ = true;
+  functions_.get_device_proc_addr = functions_.instance.vkGetDeviceProcAddr;
+  LOGD("Created owned Vulkan logical device: {:p}",
+       reinterpret_cast<void*>(logical_device_));
+  if (!LoadDeviceFns()) {
+    LOGE("Failed to load procedures from created Vulkan logical device");
+    return false;
+  }
+  if (dynamic_rendering_enabled_ &&
+      (functions_.device.vkCmdBeginRendering == nullptr ||
+       functions_.device.vkCmdEndRendering == nullptr)) {
+    LOGW(
+        "Dynamic rendering feature was enabled, but begin/end rendering "
+        "procedures are unavailable; falling back to legacy render pass");
+    dynamic_rendering_enabled_ = false;
+  }
+  enabled_device_extensions_known_ = true;
+  LogEnabledExtensions("device", enabled_device_extensions_);
+  return true;
+}
+
+bool VulkanContextState::ResolveQueues(const GPUContextInfoVK& info) {
+  graphics_queue_ = info.graphics_queue;
+  compute_queue_ = info.compute_queue;
+  transfer_queue_ = info.transfer_queue;
+
+  if (graphics_queue_ == VK_NULL_HANDLE) {
+    functions_.device.vkGetDeviceQueue(
+        logical_device_, static_cast<uint32_t>(graphics_queue_family_index_), 0,
+        &graphics_queue_);
+  }
+
+  if (compute_queue_ == VK_NULL_HANDLE) {
+    functions_.device.vkGetDeviceQueue(
+        logical_device_, static_cast<uint32_t>(compute_queue_family_index_), 0,
+        &compute_queue_);
+  }
+
+  if (transfer_queue_ == VK_NULL_HANDLE) {
+    functions_.device.vkGetDeviceQueue(
+        logical_device_, static_cast<uint32_t>(transfer_queue_family_index_), 0,
+        &transfer_queue_);
+  }
+
+  LOGD("Resolved Vulkan queues, graphics: {:p}, compute: {:p}, transfer: {:p}",
+       reinterpret_cast<void*>(graphics_queue_),
+       reinterpret_cast<void*>(compute_queue_),
+       reinterpret_cast<void*>(transfer_queue_));
+  if (graphics_queue_ == VK_NULL_HANDLE) {
+    LOGE("Failed to resolve Vulkan graphics queue");
+  }
+
+  if (graphics_queue_ != VK_NULL_HANDLE) {
+    VkPhysicalDeviceProperties properties = {};
+    functions_.instance.vkGetPhysicalDeviceProperties(physical_device_,
+                                                      &properties);
+    LOGD(
+        "Using Vulkan device '{}' , vendor: {} (0x{:04x}), apiVersion: "
+        "{}.{}.{}",
+        properties.deviceName, VulkanVendorName(properties.vendorID),
+        properties.vendorID, VK_API_VERSION_MAJOR(properties.apiVersion),
+        VK_API_VERSION_MINOR(properties.apiVersion),
+        VK_API_VERSION_PATCH(properties.apiVersion));
+  }
+
+  return true;
+}
+
+bool VulkanContextState::InitializeAllocator() {
+  VmaVulkanFunctions vulkan_functions = {};
+  vulkan_functions.vkGetInstanceProcAddr = functions_.get_instance_proc_addr;
+  vulkan_functions.vkGetDeviceProcAddr = functions_.get_device_proc_addr;
+  vulkan_functions.vkGetPhysicalDeviceProperties =
+      functions_.instance.vkGetPhysicalDeviceProperties;
+  vulkan_functions.vkGetPhysicalDeviceMemoryProperties =
+      functions_.instance.vkGetPhysicalDeviceMemoryProperties;
+  vulkan_functions.vkAllocateMemory = functions_.device.vkAllocateMemory;
+  vulkan_functions.vkFreeMemory = functions_.device.vkFreeMemory;
+  vulkan_functions.vkMapMemory = functions_.device.vkMapMemory;
+  vulkan_functions.vkUnmapMemory = functions_.device.vkUnmapMemory;
+  vulkan_functions.vkFlushMappedMemoryRanges =
+      functions_.device.vkFlushMappedMemoryRanges;
+  vulkan_functions.vkInvalidateMappedMemoryRanges =
+      functions_.device.vkInvalidateMappedMemoryRanges;
+  vulkan_functions.vkBindBufferMemory = functions_.device.vkBindBufferMemory;
+  vulkan_functions.vkBindImageMemory = functions_.device.vkBindImageMemory;
+  vulkan_functions.vkGetBufferMemoryRequirements =
+      functions_.device.vkGetBufferMemoryRequirements;
+  vulkan_functions.vkGetImageMemoryRequirements =
+      functions_.device.vkGetImageMemoryRequirements;
+  vulkan_functions.vkCreateBuffer = functions_.device.vkCreateBuffer;
+  vulkan_functions.vkDestroyBuffer = functions_.device.vkDestroyBuffer;
+  vulkan_functions.vkCreateImage = functions_.device.vkCreateImage;
+  vulkan_functions.vkDestroyImage = functions_.device.vkDestroyImage;
+  vulkan_functions.vkCmdCopyBuffer = functions_.device.vkCmdCopyBuffer;
+#if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
+  vulkan_functions.vkGetBufferMemoryRequirements2KHR =
+      functions_.device.vkGetBufferMemoryRequirements2KHR;
+  vulkan_functions.vkGetImageMemoryRequirements2KHR =
+      functions_.device.vkGetImageMemoryRequirements2KHR;
+#endif
+#if VMA_BIND_MEMORY2 || VMA_VULKAN_VERSION >= 1001000
+  vulkan_functions.vkBindBufferMemory2KHR =
+      functions_.device.vkBindBufferMemory2KHR;
+  vulkan_functions.vkBindImageMemory2KHR =
+      functions_.device.vkBindImageMemory2KHR;
+#endif
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
+  vulkan_functions.vkGetPhysicalDeviceMemoryProperties2KHR =
+      functions_.instance.vkGetPhysicalDeviceMemoryProperties2KHR;
+#endif
+#if VMA_KHR_MAINTENANCE4 || VMA_VULKAN_VERSION >= 1003000
+  vulkan_functions.vkGetDeviceBufferMemoryRequirements =
+      functions_.device.vkGetDeviceBufferMemoryRequirements;
+  vulkan_functions.vkGetDeviceImageMemoryRequirements =
+      functions_.device.vkGetDeviceImageMemoryRequirements;
+#endif
+
+  VmaAllocatorCreateInfo allocator_info = {};
+  allocator_info.instance = instance_;
+  allocator_info.physicalDevice = physical_device_;
+  allocator_info.device = logical_device_;
+  allocator_info.pVulkanFunctions = &vulkan_functions;
+  allocator_info.vulkanApiVersion = api_version_;
+
+  const VkResult allocator_result =
+      vmaCreateAllocator(&allocator_info, &allocator_);
+  if (allocator_result != VK_SUCCESS || allocator_ == nullptr) {
+    LOGE("Failed to create VMA allocator: result={}",
+         static_cast<int32_t>(allocator_result));
+    allocator_ = nullptr;
+    return false;
+  }
+
+  LOGD("Created VMA allocator: {:p}", reinterpret_cast<void*>(allocator_));
+  return true;
+}
+
+void VulkanContextState::Reset() {
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  if (debug_runtime_.debug_utils_messenger != VK_NULL_HANDLE &&
+      instance_ != VK_NULL_HANDLE &&
+      functions_.instance.vkDestroyDebugUtilsMessengerEXT != nullptr) {
+    LOGD("Destroying Vulkan debug utils messenger: {:p}",
+         reinterpret_cast<void*>(debug_runtime_.debug_utils_messenger));
+    functions_.instance.vkDestroyDebugUtilsMessengerEXT(
+        instance_, debug_runtime_.debug_utils_messenger, nullptr);
+    debug_runtime_.debug_utils_messenger = VK_NULL_HANDLE;
+  }
+#endif
+
+  CollectPendingSubmissions(true);
+
+  render_pass_cache_.Reset(*this);
+
+  if (pipeline_cache_ != VK_NULL_HANDLE && logical_device_ != VK_NULL_HANDLE &&
+      functions_.device.vkDestroyPipelineCache != nullptr) {
+    LOGD("Destroying Vulkan pipeline cache: {:p}",
+         reinterpret_cast<void*>(pipeline_cache_));
+    functions_.device.vkDestroyPipelineCache(logical_device_, pipeline_cache_,
+                                             nullptr);
+    pipeline_cache_ = VK_NULL_HANDLE;
+  }
+
+  if (allocator_ != nullptr) {
+    LOGD("Destroying VMA allocator: {:p}", reinterpret_cast<void*>(allocator_));
+    vmaDestroyAllocator(allocator_);
+    allocator_ = nullptr;
+  }
+
+  if (own_device_ && logical_device_ != VK_NULL_HANDLE &&
+      functions_.device.vkDestroyDevice != nullptr) {
+    LOGD("Destroying owned Vulkan logical device: {:p}",
+         reinterpret_cast<void*>(logical_device_));
+    functions_.device.vkDestroyDevice(logical_device_, nullptr);
+  }
+
+  if (own_instance_ && instance_ != VK_NULL_HANDLE &&
+      functions_.instance.vkDestroyInstance != nullptr) {
+    LOGD("Destroying owned Vulkan instance: {:p}",
+         reinterpret_cast<void*>(instance_));
+    functions_.instance.vkDestroyInstance(instance_, nullptr);
+  }
+
+  queue_family_properties_.clear();
+  available_instance_extensions_.clear();
+  available_device_extensions_.clear();
+  enabled_instance_extensions_.clear();
+  enabled_device_extensions_.clear();
+  enabled_instance_extensions_known_ = false;
+  enabled_device_extensions_known_ = false;
+  synchronization2_enabled_ = false;
+  dynamic_rendering_enabled_ = false;
+  debug_runtime_ = {};
+  functions_ = {};
+  instance_ = VK_NULL_HANDLE;
+  physical_device_ = VK_NULL_HANDLE;
+  logical_device_ = VK_NULL_HANDLE;
+  graphics_queue_ = VK_NULL_HANDLE;
+  compute_queue_ = VK_NULL_HANDLE;
+  transfer_queue_ = VK_NULL_HANDLE;
+  pipeline_cache_ = VK_NULL_HANDLE;
+  allocator_ = nullptr;
+  api_version_ = VK_API_VERSION_1_0;
+  graphics_queue_family_index_ = -1;
+  compute_queue_family_index_ = -1;
+  transfer_queue_family_index_ = -1;
+  own_instance_ = false;
+  own_device_ = false;
+}
+
+}  // namespace skity
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/gpu/vk/vulkan_context_state.hpp
+++ b/src/gpu/vk/vulkan_context_state.hpp
@@ -1,0 +1,159 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_CONTEXT_STATE_HPP
+#define SRC_GPU_VK_VULKAN_CONTEXT_STATE_HPP
+
+#include <vk_mem_alloc.h>
+
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <vector>
+
+#include "src/gpu/vk/vulkan_debug_runtime_state.hpp"
+#include "src/gpu/vk/vulkan_pending_submission.hpp"
+#include "src/gpu/vk/vulkan_proc_table.hpp"
+#include "src/gpu/vk/vulkan_render_pass_cache.hpp"
+
+namespace skity {
+
+class VulkanContextState {
+ public:
+  using LegacyRenderPassKey = VulkanRenderPassCache::Key;
+
+  VulkanContextState() = default;
+
+  ~VulkanContextState();
+
+  bool Initialize(const GPUContextInfoVK& info);
+
+  VkInstance GetInstance() const { return instance_; }
+
+  VkPhysicalDevice GetPhysicalDevice() const { return physical_device_; }
+
+  VkDevice GetLogicalDevice() const { return logical_device_; }
+
+  VkQueue GetGraphicsQueue() const { return graphics_queue_; }
+
+  VkPipelineCache GetPipelineCache() const { return pipeline_cache_; }
+
+  int32_t GetGraphicsQueueFamilyIndex() const {
+    return graphics_queue_family_index_;
+  }
+
+  VmaAllocator GetAllocator() const { return allocator_; }
+
+  const VulkanFunctionPointers& Fns() const { return functions_; }
+
+  const VulkanGlobalFns& GlobalFns() const { return functions_.global; }
+
+  const VulkanInstanceFns& InstanceFns() const { return functions_.instance; }
+
+  const VulkanDeviceFns& DeviceFns() const { return functions_.device; }
+
+  PFN_vkGetInstanceProcAddr GetInstanceProcAddr() const {
+    return functions_.get_instance_proc_addr;
+  }
+
+  PFN_vkGetDeviceProcAddr GetDeviceProcAddr() const {
+    return functions_.get_device_proc_addr;
+  }
+
+  bool HasAvailableInstanceExtension(const char* extension_name) const;
+
+  bool HasEnabledInstanceExtension(const char* extension_name) const;
+
+  bool HasAvailableDeviceExtension(const char* extension_name) const;
+
+  bool HasEnabledDeviceExtension(const char* extension_name) const;
+
+  bool AreEnabledInstanceExtensionsKnown() const {
+    return enabled_instance_extensions_known_;
+  }
+
+  bool AreEnabledInstanceLayersKnown() const;
+
+  bool AreEnabledDeviceExtensionsKnown() const {
+    return enabled_device_extensions_known_;
+  }
+
+  bool IsSynchronization2Enabled() const { return synchronization2_enabled_; }
+
+  bool IsDynamicRenderingEnabled() const { return dynamic_rendering_enabled_; }
+
+  const std::vector<VkExtensionProperties>& GetAvailableInstanceExtensions()
+      const {
+    return available_instance_extensions_;
+  }
+
+  const std::vector<VkExtensionProperties>& GetAvailableDeviceExtensions()
+      const {
+    return available_device_extensions_;
+  }
+
+  const std::vector<VkLayerProperties>& GetAvailableInstanceLayers() const;
+
+  const std::vector<std::string>& GetEnabledInstanceExtensions() const {
+    return enabled_instance_extensions_;
+  }
+
+  const std::vector<std::string>& GetEnabledInstanceLayers() const;
+
+  const std::vector<std::string>& GetEnabledDeviceExtensions() const {
+    return enabled_device_extensions_;
+  }
+
+  void EnqueuePendingSubmission(VulkanPendingSubmission submission) const;
+
+  void CollectPendingSubmissions(bool wait_all) const;
+
+  VkRenderPass GetOrCreateLegacyRenderPass(
+      const LegacyRenderPassKey& key) const;
+
+ private:
+  int32_t FindQueueFamilyIndex(VkQueueFlags flags, bool prefer_dedicated) const;
+  bool InitializeInstance(const GPUContextInfoVK& info);
+  bool InitializePhysicalDevice(const GPUContextInfoVK& info);
+  bool InitializeQueues(const GPUContextInfoVK& info);
+  bool InitializeDevice(const GPUContextInfoVK& info);
+  bool InitializeOwnedDevice();
+  bool ResolveQueues(const GPUContextInfoVK& info);
+  bool InitializeAllocator();
+  bool LoadAvailableInstanceExtensions();
+  bool LoadAvailableInstanceLayers();
+  bool LoadAvailableDeviceExtensions();
+  bool LoadDeviceFns();
+  void Reset();
+
+  VulkanFunctionPointers functions_ = {};
+  VkInstance instance_ = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
+  VkDevice logical_device_ = VK_NULL_HANDLE;
+  VkQueue graphics_queue_ = VK_NULL_HANDLE;
+  VkQueue compute_queue_ = VK_NULL_HANDLE;
+  VkQueue transfer_queue_ = VK_NULL_HANDLE;
+  VkPipelineCache pipeline_cache_ = VK_NULL_HANDLE;
+  VmaAllocator allocator_ = nullptr;
+  uint32_t api_version_ = VK_API_VERSION_1_0;
+  int32_t graphics_queue_family_index_ = -1;
+  int32_t compute_queue_family_index_ = -1;
+  int32_t transfer_queue_family_index_ = -1;
+  bool own_instance_ = false;
+  bool own_device_ = false;
+  std::vector<VkQueueFamilyProperties> queue_family_properties_ = {};
+  std::vector<VkExtensionProperties> available_instance_extensions_ = {};
+  std::vector<VkExtensionProperties> available_device_extensions_ = {};
+  std::vector<std::string> enabled_instance_extensions_ = {};
+  std::vector<std::string> enabled_device_extensions_ = {};
+  bool enabled_instance_extensions_known_ = false;
+  bool enabled_device_extensions_known_ = false;
+  bool synchronization2_enabled_ = false;
+  bool dynamic_rendering_enabled_ = false;
+  VulkanDebugRuntimeState debug_runtime_ = {};
+  mutable std::vector<VulkanPendingSubmission> pending_submissions_ = {};
+  mutable VulkanRenderPassCache render_pass_cache_ = {};
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_CONTEXT_STATE_HPP

--- a/src/gpu/vk/vulkan_debug_runtime_state.hpp
+++ b/src/gpu/vk/vulkan_debug_runtime_state.hpp
@@ -1,0 +1,28 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_DEBUG_RUNTIME_STATE_HPP
+#define SRC_GPU_VK_VULKAN_DEBUG_RUNTIME_STATE_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <string>
+#include <vector>
+
+namespace skity {
+
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+struct VulkanDebugRuntimeState {
+  std::vector<VkLayerProperties> available_instance_layers = {};
+  std::vector<std::string> enabled_instance_layers = {};
+  bool enabled_instance_layers_known = false;
+  VkDebugUtilsMessengerEXT debug_utils_messenger = VK_NULL_HANDLE;
+};
+#else
+struct VulkanDebugRuntimeState {};
+#endif
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_DEBUG_RUNTIME_STATE_HPP

--- a/src/gpu/vk/vulkan_pending_submission.cc
+++ b/src/gpu/vk/vulkan_pending_submission.cc
@@ -1,0 +1,31 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/vulkan_pending_submission.hpp"
+
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+
+namespace skity {
+
+VulkanPendingSubmission::VulkanPendingSubmission() = default;
+
+VulkanPendingSubmission::VulkanPendingSubmission(
+    VkFence fence_in, VkCommandPool command_pool_in,
+    std::vector<std::unique_ptr<GPUBufferVK>> stage_buffers_in,
+    std::vector<std::function<void()>> cleanup_actions_in, bool owns_fence_in)
+    : fence(fence_in),
+      command_pool(command_pool_in),
+      stage_buffers(std::move(stage_buffers_in)),
+      cleanup_actions(std::move(cleanup_actions_in)),
+      owns_fence(owns_fence_in) {}
+
+VulkanPendingSubmission::VulkanPendingSubmission(
+    VulkanPendingSubmission&& other) noexcept = default;
+
+VulkanPendingSubmission& VulkanPendingSubmission::operator=(
+    VulkanPendingSubmission&& other) noexcept = default;
+
+VulkanPendingSubmission::~VulkanPendingSubmission() = default;
+
+}  // namespace skity

--- a/src/gpu/vk/vulkan_pending_submission.hpp
+++ b/src/gpu/vk/vulkan_pending_submission.hpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_PENDING_SUBMISSION_HPP
+#define SRC_GPU_VK_VULKAN_PENDING_SUBMISSION_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace skity {
+
+class GPUBufferVK;
+
+struct VulkanPendingSubmission {
+  VulkanPendingSubmission();
+  VulkanPendingSubmission(
+      VkFence fence, VkCommandPool command_pool,
+      std::vector<std::unique_ptr<GPUBufferVK>> stage_buffers,
+      std::vector<std::function<void()>> cleanup_actions = {},
+      bool owns_fence = true);
+  VulkanPendingSubmission(VulkanPendingSubmission&& other) noexcept;
+  VulkanPendingSubmission& operator=(VulkanPendingSubmission&& other) noexcept;
+  ~VulkanPendingSubmission();
+
+  VulkanPendingSubmission(const VulkanPendingSubmission&) = delete;
+  VulkanPendingSubmission& operator=(const VulkanPendingSubmission&) = delete;
+
+  VkFence fence = VK_NULL_HANDLE;
+  VkCommandPool command_pool = VK_NULL_HANDLE;
+  std::vector<std::unique_ptr<GPUBufferVK>> stage_buffers;
+  std::vector<std::function<void()>> cleanup_actions;
+  bool owns_fence = true;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_PENDING_SUBMISSION_HPP

--- a/src/gpu/vk/vulkan_platform_extensions.cc
+++ b/src/gpu/vk/vulkan_platform_extensions.cc
@@ -1,0 +1,82 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/vulkan_platform_extensions.hpp"
+
+#include <skity/macros.hpp>
+#include <string_view>
+
+namespace skity {
+namespace {
+
+bool ContainsExtension(const std::vector<VkExtensionProperties>& extensions,
+                       const char* extension_name) {
+  if (extension_name == nullptr) {
+    return false;
+  }
+
+  for (const auto& extension : extensions) {
+    if (std::string_view(extension.extensionName) == extension_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void TryEnableInstanceExtension(
+    std::vector<std::string>* enabled_instance_extensions,
+    const std::vector<VkExtensionProperties>& available_instance_extensions,
+    const char* extension_name) {
+  if (enabled_instance_extensions == nullptr || extension_name == nullptr) {
+    return;
+  }
+
+  for (const auto& extension : *enabled_instance_extensions) {
+    if (extension == extension_name) {
+      return;
+    }
+  }
+
+  if (!ContainsExtension(available_instance_extensions, extension_name)) {
+    return;
+  }
+
+  enabled_instance_extensions->emplace_back(extension_name);
+}
+
+}  // namespace
+
+void EnablePlatformSurfaceInstanceExtensions(
+    const std::vector<VkExtensionProperties>& available_instance_extensions,
+    std::vector<std::string>* enabled_instance_extensions) {
+#if defined(SKITY_ANDROID)
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_KHR_android_surface");
+#elif defined(SKITY_WIN)
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_KHR_win32_surface");
+#elif defined(SKITY_MACOS) || defined(SKITY_IOS)
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_EXT_metal_surface");
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_MVK_macos_surface");
+#elif defined(SKITY_LINUX)
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_KHR_wayland_surface");
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_KHR_xcb_surface");
+  TryEnableInstanceExtension(enabled_instance_extensions,
+                             available_instance_extensions,
+                             "VK_KHR_xlib_surface");
+#endif
+}
+
+}  // namespace skity

--- a/src/gpu/vk/vulkan_platform_extensions.hpp
+++ b/src/gpu/vk/vulkan_platform_extensions.hpp
@@ -1,0 +1,21 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_PLATFORM_EXTENSIONS_HPP
+#define SRC_GPU_VK_VULKAN_PLATFORM_EXTENSIONS_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <string>
+#include <vector>
+
+namespace skity {
+
+void EnablePlatformSurfaceInstanceExtensions(
+    const std::vector<VkExtensionProperties>& available_instance_extensions,
+    std::vector<std::string>* enabled_instance_extensions);
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_PLATFORM_EXTENSIONS_HPP

--- a/src/gpu/vk/vulkan_proc_table.hpp
+++ b/src/gpu/vk/vulkan_proc_table.hpp
@@ -1,0 +1,168 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_PROC_TABLE_HPP
+#define SRC_GPU_VK_VULKAN_PROC_TABLE_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <string>
+#include <vector>
+
+namespace skity {
+
+struct VulkanGlobalFns {
+  PFN_vkCreateInstance vkCreateInstance = nullptr;
+  PFN_vkEnumerateInstanceExtensionProperties
+      vkEnumerateInstanceExtensionProperties = nullptr;
+  PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties =
+      nullptr;
+  PFN_vkEnumerateInstanceVersion vkEnumerateInstanceVersion = nullptr;
+};
+
+struct VulkanInstanceFns {
+  PFN_vkDestroyInstance vkDestroyInstance = nullptr;
+  PFN_vkEnumeratePhysicalDevices vkEnumeratePhysicalDevices = nullptr;
+  PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties = nullptr;
+  PFN_vkGetPhysicalDeviceFormatProperties vkGetPhysicalDeviceFormatProperties =
+      nullptr;
+  PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties =
+      nullptr;
+  PFN_vkGetPhysicalDeviceImageFormatProperties
+      vkGetPhysicalDeviceImageFormatProperties = nullptr;
+  PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 = nullptr;
+  PFN_vkGetPhysicalDeviceMemoryProperties2KHR
+      vkGetPhysicalDeviceMemoryProperties2KHR = nullptr;
+  PFN_vkEnumerateDeviceExtensionProperties
+      vkEnumerateDeviceExtensionProperties = nullptr;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties
+      vkGetPhysicalDeviceQueueFamilyProperties = nullptr;
+  PFN_vkCreateDevice vkCreateDevice = nullptr;
+  PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr = nullptr;
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT = nullptr;
+  PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT = nullptr;
+#endif
+};
+
+struct VulkanDeviceFns {
+  PFN_vkDestroyDevice vkDestroyDevice = nullptr;
+  PFN_vkDeviceWaitIdle vkDeviceWaitIdle = nullptr;
+  PFN_vkGetDeviceQueue vkGetDeviceQueue = nullptr;
+  PFN_vkQueueSubmit vkQueueSubmit = nullptr;
+  PFN_vkQueueSubmit2 vkQueueSubmit2 = nullptr;
+  PFN_vkCreateCommandPool vkCreateCommandPool = nullptr;
+  PFN_vkDestroyCommandPool vkDestroyCommandPool = nullptr;
+  PFN_vkAllocateCommandBuffers vkAllocateCommandBuffers = nullptr;
+  PFN_vkBeginCommandBuffer vkBeginCommandBuffer = nullptr;
+  PFN_vkEndCommandBuffer vkEndCommandBuffer = nullptr;
+  PFN_vkCreateFence vkCreateFence = nullptr;
+  PFN_vkDestroyFence vkDestroyFence = nullptr;
+  PFN_vkGetFenceStatus vkGetFenceStatus = nullptr;
+  PFN_vkWaitForFences vkWaitForFences = nullptr;
+  PFN_vkAllocateMemory vkAllocateMemory = nullptr;
+  PFN_vkFreeMemory vkFreeMemory = nullptr;
+  PFN_vkMapMemory vkMapMemory = nullptr;
+  PFN_vkUnmapMemory vkUnmapMemory = nullptr;
+  PFN_vkFlushMappedMemoryRanges vkFlushMappedMemoryRanges = nullptr;
+  PFN_vkInvalidateMappedMemoryRanges vkInvalidateMappedMemoryRanges = nullptr;
+  PFN_vkBindBufferMemory vkBindBufferMemory = nullptr;
+  PFN_vkBindImageMemory vkBindImageMemory = nullptr;
+  PFN_vkGetBufferMemoryRequirements vkGetBufferMemoryRequirements = nullptr;
+  PFN_vkGetImageMemoryRequirements vkGetImageMemoryRequirements = nullptr;
+  PFN_vkCreateBuffer vkCreateBuffer = nullptr;
+  PFN_vkDestroyBuffer vkDestroyBuffer = nullptr;
+  PFN_vkCreateImage vkCreateImage = nullptr;
+  PFN_vkDestroyImage vkDestroyImage = nullptr;
+  PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR =
+      nullptr;
+  PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2KHR =
+      nullptr;
+  PFN_vkBindBufferMemory2KHR vkBindBufferMemory2KHR = nullptr;
+  PFN_vkBindImageMemory2KHR vkBindImageMemory2KHR = nullptr;
+  PFN_vkGetDeviceBufferMemoryRequirementsKHR
+      vkGetDeviceBufferMemoryRequirements = nullptr;
+  PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirements =
+      nullptr;
+  PFN_vkCmdCopyBuffer vkCmdCopyBuffer = nullptr;
+  PFN_vkCreateFramebuffer vkCreateFramebuffer = nullptr;
+  PFN_vkDestroyFramebuffer vkDestroyFramebuffer = nullptr;
+  PFN_vkCreateRenderPass vkCreateRenderPass = nullptr;
+  PFN_vkDestroyRenderPass vkDestroyRenderPass = nullptr;
+  PFN_vkCreateImageView vkCreateImageView = nullptr;
+  PFN_vkDestroyImageView vkDestroyImageView = nullptr;
+  PFN_vkCmdBeginRenderPass vkCmdBeginRenderPass = nullptr;
+  PFN_vkCmdEndRenderPass vkCmdEndRenderPass = nullptr;
+  PFN_vkCmdBlitImage vkCmdBlitImage = nullptr;
+  PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage = nullptr;
+  PFN_vkCmdPipelineBarrier vkCmdPipelineBarrier = nullptr;
+  PFN_vkCmdBeginRendering vkCmdBeginRendering = nullptr;
+  PFN_vkCmdEndRendering vkCmdEndRendering = nullptr;
+  PFN_vkCreateShaderModule vkCreateShaderModule = nullptr;
+  PFN_vkDestroyShaderModule vkDestroyShaderModule = nullptr;
+  PFN_vkCreateSampler vkCreateSampler = nullptr;
+  PFN_vkDestroySampler vkDestroySampler = nullptr;
+  PFN_vkCreateDescriptorPool vkCreateDescriptorPool = nullptr;
+  PFN_vkDestroyDescriptorPool vkDestroyDescriptorPool = nullptr;
+  PFN_vkAllocateDescriptorSets vkAllocateDescriptorSets = nullptr;
+  PFN_vkUpdateDescriptorSets vkUpdateDescriptorSets = nullptr;
+  PFN_vkCreateDescriptorSetLayout vkCreateDescriptorSetLayout = nullptr;
+  PFN_vkDestroyDescriptorSetLayout vkDestroyDescriptorSetLayout = nullptr;
+  PFN_vkCreatePipelineLayout vkCreatePipelineLayout = nullptr;
+  PFN_vkDestroyPipelineLayout vkDestroyPipelineLayout = nullptr;
+  PFN_vkCreatePipelineCache vkCreatePipelineCache = nullptr;
+  PFN_vkDestroyPipelineCache vkDestroyPipelineCache = nullptr;
+  PFN_vkCreateGraphicsPipelines vkCreateGraphicsPipelines = nullptr;
+  PFN_vkDestroyPipeline vkDestroyPipeline = nullptr;
+  PFN_vkCmdBindPipeline vkCmdBindPipeline = nullptr;
+  PFN_vkCmdBindDescriptorSets vkCmdBindDescriptorSets = nullptr;
+  PFN_vkCmdBindVertexBuffers vkCmdBindVertexBuffers = nullptr;
+  PFN_vkCmdBindIndexBuffer vkCmdBindIndexBuffer = nullptr;
+  PFN_vkCmdDrawIndexed vkCmdDrawIndexed = nullptr;
+  PFN_vkCmdSetViewport vkCmdSetViewport = nullptr;
+  PFN_vkCmdSetScissor vkCmdSetScissor = nullptr;
+  PFN_vkCmdSetStencilCompareMask vkCmdSetStencilCompareMask = nullptr;
+  PFN_vkCmdSetStencilWriteMask vkCmdSetStencilWriteMask = nullptr;
+  PFN_vkCmdSetStencilReference vkCmdSetStencilReference = nullptr;
+  PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = nullptr;
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  PFN_vkCmdBeginDebugUtilsLabelEXT vkCmdBeginDebugUtilsLabelEXT = nullptr;
+  PFN_vkCmdEndDebugUtilsLabelEXT vkCmdEndDebugUtilsLabelEXT = nullptr;
+  PFN_vkCmdInsertDebugUtilsLabelEXT vkCmdInsertDebugUtilsLabelEXT = nullptr;
+#endif
+};
+
+struct VulkanFunctionPointers {
+  PFN_vkGetInstanceProcAddr get_instance_proc_addr = nullptr;
+  PFN_vkGetDeviceProcAddr get_device_proc_addr = nullptr;
+  VulkanGlobalFns global = {};
+  VulkanInstanceFns instance = {};
+  VulkanDeviceFns device = {};
+};
+
+struct GPUContextInfoVK;
+
+bool LoadVulkanGlobalFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                         VulkanGlobalFns* fns);
+
+bool LoadVulkanInstanceFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                           VkInstance instance, VulkanInstanceFns* fns);
+
+bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
+                         VkDevice device, VulkanDeviceFns* fns);
+
+void EnablePortabilityEnumerationIfAvailable(
+    const std::vector<VkExtensionProperties>& available_extensions,
+    std::vector<std::string>* enabled_extensions,
+    VkInstanceCreateFlags* instance_flags);
+
+bool CreateVkInstance(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                      VkInstance* instance,
+                      VulkanFunctionPointers* functions = nullptr,
+                      const VkInstanceCreateInfo* create_info = nullptr,
+                      const VkAllocationCallbacks* allocator = nullptr);
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_PROC_TABLE_HPP

--- a/src/gpu/vk/vulkan_render_pass_cache.cc
+++ b/src/gpu/vk/vulkan_render_pass_cache.cc
@@ -1,0 +1,160 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/vulkan_render_pass_cache.hpp"
+
+#include <array>
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+namespace {
+
+constexpr size_t kInitialRenderPassCacheCapacity = 8;
+
+}  // namespace
+
+VulkanRenderPassCache::VulkanRenderPassCache() {
+  // Legacy render pass variants are expected to stay small in practice.
+  render_passes_.reserve(kInitialRenderPassCacheCapacity);
+}
+
+bool VulkanRenderPassCache::Key::operator==(const Key& other) const {
+  return color_format == other.color_format &&
+         color_samples == other.color_samples &&
+         color_load_op == other.color_load_op &&
+         color_store_op == other.color_store_op &&
+         has_resolve == other.has_resolve &&
+         resolve_format == other.resolve_format &&
+         resolve_store_op == other.resolve_store_op &&
+         has_depth == other.has_depth && has_stencil == other.has_stencil &&
+         depth_stencil_format == other.depth_stencil_format &&
+         depth_stencil_samples == other.depth_stencil_samples &&
+         depth_load_op == other.depth_load_op &&
+         depth_store_op == other.depth_store_op &&
+         stencil_load_op == other.stencil_load_op &&
+         stencil_store_op == other.stencil_store_op;
+}
+
+VkRenderPass VulkanRenderPassCache::GetOrCreate(const VulkanContextState& state,
+                                                const Key& key) {
+  if (state.GetLogicalDevice() == VK_NULL_HANDLE ||
+      state.DeviceFns().vkCreateRenderPass == nullptr) {
+    return VK_NULL_HANDLE;
+  }
+
+  for (const auto& entry : render_passes_) {
+    if (entry.key == key) {
+      return entry.render_pass;
+    }
+  }
+
+  std::array<VkAttachmentDescription, 3> attachment_descs = {};
+  uint32_t attachment_count = 0;
+
+  VkAttachmentReference color_ref = {};
+  attachment_descs[attachment_count].format = key.color_format;
+  attachment_descs[attachment_count].samples = key.color_samples;
+  attachment_descs[attachment_count].loadOp = key.color_load_op;
+  attachment_descs[attachment_count].storeOp = key.color_store_op;
+  attachment_descs[attachment_count].stencilLoadOp =
+      VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  attachment_descs[attachment_count].stencilStoreOp =
+      VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  attachment_descs[attachment_count].initialLayout =
+      key.color_load_op == VK_ATTACHMENT_LOAD_OP_LOAD
+          ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+          : VK_IMAGE_LAYOUT_UNDEFINED;
+  attachment_descs[attachment_count].finalLayout =
+      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  color_ref.attachment = attachment_count;
+  color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  ++attachment_count;
+
+  VkAttachmentReference resolve_ref = {};
+  const VkAttachmentReference* resolve_ref_ptr = nullptr;
+  if (key.has_resolve) {
+    attachment_descs[attachment_count].format = key.resolve_format;
+    attachment_descs[attachment_count].samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_descs[attachment_count].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_descs[attachment_count].storeOp = key.resolve_store_op;
+    attachment_descs[attachment_count].stencilLoadOp =
+        VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_descs[attachment_count].stencilStoreOp =
+        VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_descs[attachment_count].initialLayout =
+        VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_descs[attachment_count].finalLayout =
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    resolve_ref.attachment = attachment_count;
+    resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    resolve_ref_ptr = &resolve_ref;
+    ++attachment_count;
+  }
+
+  VkAttachmentReference depth_stencil_ref = {};
+  const VkAttachmentReference* depth_stencil_ref_ptr = nullptr;
+  if (key.has_depth || key.has_stencil) {
+    attachment_descs[attachment_count].format = key.depth_stencil_format;
+    attachment_descs[attachment_count].samples = key.depth_stencil_samples;
+    attachment_descs[attachment_count].loadOp =
+        key.has_depth ? key.depth_load_op : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_descs[attachment_count].storeOp =
+        key.has_depth ? key.depth_store_op : VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_descs[attachment_count].stencilLoadOp = key.stencil_load_op;
+    attachment_descs[attachment_count].stencilStoreOp = key.stencil_store_op;
+    attachment_descs[attachment_count].initialLayout =
+        VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_descs[attachment_count].finalLayout =
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    depth_stencil_ref.attachment = attachment_count;
+    depth_stencil_ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    depth_stencil_ref_ptr = &depth_stencil_ref;
+    ++attachment_count;
+  }
+
+  VkSubpassDescription subpass = {};
+  subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+  subpass.colorAttachmentCount = 1;
+  subpass.pColorAttachments = &color_ref;
+  subpass.pResolveAttachments = resolve_ref_ptr;
+  subpass.pDepthStencilAttachment = depth_stencil_ref_ptr;
+
+  VkRenderPassCreateInfo render_pass_info = {};
+  render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+  render_pass_info.attachmentCount = attachment_count;
+  render_pass_info.pAttachments = attachment_descs.data();
+  render_pass_info.subpassCount = 1;
+  render_pass_info.pSubpasses = &subpass;
+
+  VkRenderPass render_pass = VK_NULL_HANDLE;
+  const VkResult result = state.DeviceFns().vkCreateRenderPass(
+      state.GetLogicalDevice(), &render_pass_info, nullptr, &render_pass);
+  if (result != VK_SUCCESS || render_pass == VK_NULL_HANDLE) {
+    LOGE("Failed to create cached Vulkan render pass: {}",
+         static_cast<int32_t>(result));
+    return VK_NULL_HANDLE;
+  }
+
+  render_passes_.push_back({key, render_pass});
+  return render_pass;
+}
+
+void VulkanRenderPassCache::Reset(const VulkanContextState& state) {
+  if (state.GetLogicalDevice() != VK_NULL_HANDLE &&
+      state.DeviceFns().vkDestroyRenderPass != nullptr) {
+    for (const auto& entry : render_passes_) {
+      if (entry.render_pass != VK_NULL_HANDLE) {
+        state.DeviceFns().vkDestroyRenderPass(state.GetLogicalDevice(),
+                                              entry.render_pass, nullptr);
+      }
+    }
+  }
+
+  render_passes_.clear();
+}
+
+}  // namespace skity

--- a/src/gpu/vk/vulkan_render_pass_cache.hpp
+++ b/src/gpu/vk/vulkan_render_pass_cache.hpp
@@ -1,0 +1,56 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_VULKAN_RENDER_PASS_CACHE_HPP
+#define SRC_GPU_VK_VULKAN_RENDER_PASS_CACHE_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <vector>
+
+namespace skity {
+
+class VulkanContextState;
+
+class VulkanRenderPassCache {
+ public:
+  struct Key {
+    VkFormat color_format = VK_FORMAT_UNDEFINED;
+    VkSampleCountFlagBits color_samples = VK_SAMPLE_COUNT_1_BIT;
+    VkAttachmentLoadOp color_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    VkAttachmentStoreOp color_store_op = VK_ATTACHMENT_STORE_OP_STORE;
+    bool has_resolve = false;
+    VkFormat resolve_format = VK_FORMAT_UNDEFINED;
+    VkAttachmentStoreOp resolve_store_op = VK_ATTACHMENT_STORE_OP_STORE;
+    bool has_depth = false;
+    bool has_stencil = false;
+    VkFormat depth_stencil_format = VK_FORMAT_UNDEFINED;
+    VkSampleCountFlagBits depth_stencil_samples = VK_SAMPLE_COUNT_1_BIT;
+    VkAttachmentLoadOp depth_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    VkAttachmentStoreOp depth_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    VkAttachmentLoadOp stencil_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    VkAttachmentStoreOp stencil_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+
+    bool operator==(const Key& other) const;
+  };
+
+  VulkanRenderPassCache();
+  ~VulkanRenderPassCache() = default;
+
+  VkRenderPass GetOrCreate(const VulkanContextState& state, const Key& key);
+
+  void Reset(const VulkanContextState& state);
+
+ private:
+  struct Entry {
+    Key key = {};
+    VkRenderPass render_pass = VK_NULL_HANDLE;
+  };
+
+  std::vector<Entry> render_passes_ = {};
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_VULKAN_RENDER_PASS_CACHE_HPP

--- a/src/gpu/web/gpu_command_buffer_web.cc
+++ b/src/gpu/web/gpu_command_buffer_web.cc
@@ -71,7 +71,8 @@ void GPUCommandBufferWEB::RecordBindGroup(WGPUBindGroup bind_group) {
   bind_groups_.emplace_back(bind_group);
 }
 
-bool GPUCommandBufferWEB::Submit() {
+bool GPUCommandBufferWEB::Submit(const GPUSubmitInfo* submit_info) {
+  (void)submit_info;
   WGPUCommandBufferDescriptor desc = {};
 
   WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(encoder_, &desc);

--- a/src/gpu/web/gpu_command_buffer_web.hpp
+++ b/src/gpu/web/gpu_command_buffer_web.hpp
@@ -18,11 +18,11 @@ class GPUCommandBufferWEB : public GPUCommandBuffer {
   ~GPUCommandBufferWEB() override;
 
   std::shared_ptr<GPURenderPass> BeginRenderPass(
-      const GPURenderPassDescriptor &desc) override;
+      const GPURenderPassDescriptor& desc) override;
 
   std::shared_ptr<GPUBlitPass> BeginBlitPass() override;
 
-  bool Submit() override;
+  bool Submit(const GPUSubmitInfo* submit_info = nullptr) override;
 
   void RecordStageBuffer(WGPUBuffer buffer);
   void RecordBindGroup(WGPUBindGroup bind_group);

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -122,18 +122,76 @@ target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
 target_link_libraries(skity_unit_test PRIVATE wgsl-cross)
 
 if (${SKITY_VK_BACKEND})
-    target_sources(skity_unit_test PRIVATE
-        wgx/wgx_value_test.cc
+    set(SKITY_VK_TEST_LOADER_LIBRARIES)
+    set(SKITY_VK_TEST_RPATH)
+    if (${SKITY_VK_TEST_USE_SYSTEM_LOADER})
+        find_package(Vulkan REQUIRED)
+        list(APPEND SKITY_VK_TEST_LOADER_LIBRARIES Vulkan::Vulkan)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        list(APPEND SKITY_VK_TEST_LOADER_LIBRARIES
+            ${CMAKE_SOURCE_DIR}/third_party/libSwiftShader/libvulkan.so.1
+        )
+        set(SKITY_VK_TEST_RPATH "${CMAKE_SOURCE_DIR}/third_party/libSwiftShader")
+    else()
+        list(APPEND SKITY_VK_TEST_LOADER_LIBRARIES
+            ${CMAKE_SOURCE_DIR}/third_party/libSwAngle/lib/libvk_swiftshader.dylib
+        )
+        set(SKITY_VK_TEST_RPATH "${CMAKE_SOURCE_DIR}/third_party/libSwAngle/lib")
+    endif()
+
+    add_executable(skity_vulkan_unit_test
+        gpu/vk/gpu_context_vk_test.cc
         wgx/wgx_spirv_smoke_test.cc
+        wgx/wgx_vulkan_pipeline_test.cc
+        wgx/wgx_value_test.cc
     )
-    target_compile_definitions(skity_unit_test PRIVATE
-        -DWGX_VULKAN=1
-        -DWGX_SPIRV_DUMP_DEFAULT_DIR="${CMAKE_BINARY_DIR}"
+
+    target_include_directories(skity_vulkan_unit_test
+        PUBLIC
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/module/wgx
     )
-    target_include_directories(skity_unit_test PRIVATE
+    target_compile_definitions(skity_vulkan_unit_test PRIVATE -DWGX_VULKAN=1)
+    if (${SKITY_VK_TEST_USE_SYSTEM_LOADER})
+        target_compile_definitions(skity_vulkan_unit_test PRIVATE -DSKITY_VK_TEST_USE_SYSTEM_LOADER=1)
+    endif()
+    target_compile_definitions(skity_vulkan_unit_test PRIVATE -DWGX_SPIRV_DUMP_DEFAULT_DIR="${CMAKE_BINARY_DIR}")
+    target_include_directories(skity_vulkan_unit_test PRIVATE
         ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
+        ${CMAKE_SOURCE_DIR}/third_party/VulkanMemoryAllocator/include
     )
-    target_link_libraries(skity_unit_test PRIVATE SPIRV-Headers::SPIRV-Headers)
+    target_link_libraries(skity_vulkan_unit_test PRIVATE
+        skity::skity
+        gmock_main
+        glm::glm-header-only
+        wgsl-cross
+        SPIRV-Headers::SPIRV-Headers
+        ${SKITY_VK_TEST_LOADER_LIBRARIES}
+    )
+    if (NOT USE_THIRD_PARTY_ZLIB)
+        target_link_libraries(skity_vulkan_unit_test PRIVATE z)
+    else()
+        target_link_libraries(skity_vulkan_unit_test PRIVATE ${SKITY_ZLIB_NAME})
+        target_link_directories(skity_vulkan_unit_test PRIVATE ${CMAKE_BINARY_DIR}/third_party/zlib/lib)
+        add_dependencies(skity_vulkan_unit_test zlib)
+    endif()
+    if (MSVC)
+        target_compile_options(skity_vulkan_unit_test PUBLIC /EHsc /GR-)
+    else()
+        target_compile_options(skity_vulkan_unit_test PUBLIC -fno-rtti)
+    endif()
+    if (${SKITY_TEST_COVERAGE} AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(skity_vulkan_unit_test PRIVATE --coverage -O0 -g)
+        target_link_options(skity_vulkan_unit_test PRIVATE --coverage)
+    endif()
+    if (SKITY_VK_TEST_RPATH)
+        set_target_properties(skity_vulkan_unit_test PROPERTIES
+            BUILD_RPATH "${SKITY_VK_TEST_RPATH}"
+        )
+    endif()
+
+    gtest_add_tests(skity_vulkan_unit_test "" AUTO)
 endif()
+
 
 gtest_add_tests(skity_unit_test "" AUTO)

--- a/test/ut/gpu/vk/gpu_context_vk_test.cc
+++ b/test/ut/gpu/vk/gpu_context_vk_test.cc
@@ -1,0 +1,1906 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <vulkan/vulkan.h>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <string>
+#include <vector>
+
+#include "src/gpu/gpu_context_impl.hpp"
+#include "src/gpu/gpu_shader_module.hpp"
+#include "src/gpu/vk/gpu_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_context_impl_vk.hpp"
+#include "src/gpu/vk/gpu_render_pipeline_vk.hpp"
+#include "src/gpu/vk/gpu_sampler_vk.hpp"
+#include "src/gpu/vk/gpu_shader_function_vk.hpp"
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/gpu/vk/vulkan_proc_table.hpp"
+
+namespace {
+
+constexpr char kSimpleVertexWGSL[] = R"(
+@vertex
+fn vs_main() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+)";
+
+constexpr char kSimpleFragmentWGSL[] = R"(
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+)";
+
+constexpr char kUniformFragmentWGSL[] = R"(
+struct FSUniforms {
+  color : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> fs_uniforms : FSUniforms;
+
+@fragment
+fn fs_uniform_main() -> @location(0) vec4<f32> {
+  return fs_uniforms.color;
+}
+)";
+
+constexpr char kUniformHelperVertexWGSL[] = R"(
+struct CommonSlot {
+  transform : mat4x4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> common_slot : CommonSlot;
+
+fn get_vertex_position(a_pos: vec2<f32>, cs: CommonSlot) -> vec4<f32> {
+  return cs.transform * vec4<f32>(a_pos, 0.0, 1.0);
+}
+
+@vertex
+fn vs_main(@location(0) a_pos: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return get_vertex_position(a_pos, common_slot);
+}
+)";
+
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+constexpr bool kThreadSanitizerEnabled = true;
+#else
+constexpr bool kThreadSanitizerEnabled = false;
+#endif
+#else
+constexpr bool kThreadSanitizerEnabled = false;
+#endif
+
+bool SkipVulkanTestsOnThreadSanitizer() { return kThreadSanitizerEnabled; }
+
+bool SkipVulkanRenderPassTestsOnThreadSanitizer() {
+  return kThreadSanitizerEnabled;
+}
+
+int32_t FindGraphicsQueueFamilyIndex(
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties
+        vk_get_physical_device_queue_family_properties,
+    VkPhysicalDevice physical_device);
+
+bool ContainsLayer(const std::vector<VkLayerProperties>& layers,
+                   const char* layer_name) {
+  return std::any_of(layers.begin(), layers.end(),
+                     [layer_name](const auto& layer) {
+                       return std::string(layer.layerName) == layer_name;
+                     });
+}
+
+bool ContainsLayer(const std::vector<std::string>& layers,
+                   const char* layer_name) {
+  return std::find(layers.begin(), layers.end(), layer_name) != layers.end();
+}
+
+std::unique_ptr<skity::GPUContext> CreateDebugGPUContext() {
+  skity::GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enable_debug_runtime = true;
+  return skity::CreateGPUContextVK(&info);
+}
+
+struct LegacyContextBundle {
+  std::unique_ptr<skity::GPUContext> context = nullptr;
+  skity::VulkanFunctionPointers functions = {};
+  VkInstance instance = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+
+  LegacyContextBundle() = default;
+  LegacyContextBundle(const LegacyContextBundle&) = delete;
+  LegacyContextBundle& operator=(const LegacyContextBundle&) = delete;
+  LegacyContextBundle(LegacyContextBundle&& other) noexcept
+      : context(std::move(other.context)),
+        functions(other.functions),
+        instance(other.instance),
+        device(other.device) {
+    other.instance = VK_NULL_HANDLE;
+    other.device = VK_NULL_HANDLE;
+    other.functions = {};
+  }
+
+  LegacyContextBundle& operator=(LegacyContextBundle&& other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+
+    context.reset();
+    if (device != VK_NULL_HANDLE) {
+      functions.device.vkDeviceWaitIdle(device);
+      functions.device.vkDestroyDevice(device, nullptr);
+    }
+    if (instance != VK_NULL_HANDLE) {
+      functions.instance.vkDestroyInstance(instance, nullptr);
+    }
+
+    context = std::move(other.context);
+    functions = other.functions;
+    instance = other.instance;
+    device = other.device;
+
+    other.instance = VK_NULL_HANDLE;
+    other.device = VK_NULL_HANDLE;
+    other.functions = {};
+    return *this;
+  }
+
+  ~LegacyContextBundle() {
+    context.reset();
+    if (device != VK_NULL_HANDLE) {
+      functions.device.vkDeviceWaitIdle(device);
+      functions.device.vkDestroyDevice(device, nullptr);
+    }
+    if (instance != VK_NULL_HANDLE) {
+      functions.instance.vkDestroyInstance(instance, nullptr);
+    }
+  }
+};
+
+LegacyContextBundle CreateLegacyGPUContextForTest() {
+  LegacyContextBundle bundle = {};
+
+  if (!skity::CreateVkInstance(vkGetInstanceProcAddr, &bundle.instance,
+                               &bundle.functions) ||
+      bundle.instance == VK_NULL_HANDLE) {
+    return std::move(bundle);
+  }
+
+  uint32_t physical_device_count = 0;
+  if (bundle.functions.instance.vkEnumeratePhysicalDevices(
+          bundle.instance, &physical_device_count, nullptr) != VK_SUCCESS ||
+      physical_device_count == 0) {
+    return std::move(bundle);
+  }
+
+  std::vector<VkPhysicalDevice> physical_devices(physical_device_count,
+                                                 VK_NULL_HANDLE);
+  if (bundle.functions.instance.vkEnumeratePhysicalDevices(
+          bundle.instance, &physical_device_count, physical_devices.data()) !=
+      VK_SUCCESS) {
+    return std::move(bundle);
+  }
+
+  const VkPhysicalDevice physical_device = physical_devices[0];
+  const int32_t graphics_queue_family_index = FindGraphicsQueueFamilyIndex(
+      bundle.functions.instance.vkGetPhysicalDeviceQueueFamilyProperties,
+      physical_device);
+  if (graphics_queue_family_index < 0) {
+    return std::move(bundle);
+  }
+
+  const float queue_priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info = {};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex =
+      static_cast<uint32_t>(graphics_queue_family_index);
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &queue_priority;
+
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+
+  if (bundle.functions.instance.vkCreateDevice(physical_device, &device_info,
+                                               nullptr,
+                                               &bundle.device) != VK_SUCCESS ||
+      bundle.device == VK_NULL_HANDLE) {
+    return std::move(bundle);
+  }
+
+  if (!skity::LoadVulkanDeviceFns(bundle.functions.instance.vkGetDeviceProcAddr,
+                                  bundle.device, &bundle.functions.device)) {
+    return std::move(bundle);
+  }
+
+  skity::GPUContextInfoVK info = {};
+  info.instance = bundle.instance;
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enabled_instance_extensions_known = true;
+  info.physical_device = physical_device;
+  info.logical_device = bundle.device;
+  info.get_device_proc_addr = bundle.functions.instance.vkGetDeviceProcAddr;
+  info.enabled_device_extension_count = 0;
+  info.enabled_device_extensions_known = true;
+  info.graphics_queue_family_index = graphics_queue_family_index;
+
+  bundle.context = skity::CreateGPUContextVK(&info);
+  return std::move(bundle);
+}
+
+class VulkanSharedContextTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { context_ = CreateDebugGPUContext(); }
+
+  static void TearDownTestSuite() { context_.reset(); }
+
+  static skity::GPUContext* GetContext() { return context_.get(); }
+
+  static skity::GPUContextVK* GetVKContext() {
+    return static_cast<skity::GPUContextVK*>(context_.get());
+  }
+
+  static skity::GPUContextImpl* GetContextImpl() {
+    return static_cast<skity::GPUContextImpl*>(GetVKContext());
+  }
+
+  static skity::GPUDevice* GetDevice() {
+    return GetContextImpl()->GetGPUDevice();
+  }
+
+  static const skity::VulkanContextState* GetState() {
+    return GetVKContext()->GetState();
+  }
+
+  static std::unique_ptr<skity::GPUContext> context_;
+};
+
+std::unique_ptr<skity::GPUContext> VulkanSharedContextTest::context_ = nullptr;
+
+int32_t FindGraphicsQueueFamilyIndex(
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties
+        vk_get_physical_device_queue_family_properties,
+    VkPhysicalDevice physical_device) {
+  uint32_t queue_family_count = 0;
+  vk_get_physical_device_queue_family_properties(physical_device,
+                                                 &queue_family_count, nullptr);
+  if (queue_family_count == 0) {
+    return -1;
+  }
+
+  std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+  vk_get_physical_device_queue_family_properties(
+      physical_device, &queue_family_count, queue_families.data());
+
+  for (uint32_t i = 0; i < queue_family_count; ++i) {
+    if ((queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0 &&
+        queue_families[i].queueCount > 0) {
+      return static_cast<int32_t>(i);
+    }
+  }
+
+  return -1;
+}
+
+std::shared_ptr<skity::GPUShaderFunction> CreateWGXShaderFunction(
+    skity::GPUDevice* device, const char* source, const char* label,
+    const char* entry_point, skity::GPUShaderStage stage) {
+  skity::GPUShaderModuleDescriptor module_desc = {};
+  module_desc.label = skity::GPULabel(label);
+  module_desc.source = source;
+  auto module = skity::GPUShaderModule::Create(module_desc);
+  if (module == nullptr) {
+    return nullptr;
+  }
+
+  skity::GPUShaderSourceWGX shader_source = {};
+  shader_source.module = module;
+  shader_source.entry_point = entry_point;
+
+  skity::GPUShaderFunctionDescriptor function_desc = {};
+  function_desc.label = skity::GPULabel(label);
+  function_desc.stage = stage;
+  function_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  function_desc.shader_source = &shader_source;
+  return device->CreateShaderFunction(function_desc);
+}
+
+TEST(VulkanProcLoaderTest, CreateVkInstanceWithProcLoader) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+  skity::VulkanFunctionPointers functions = {};
+  VkInstance instance = VK_NULL_HANDLE;
+
+  ASSERT_TRUE(
+      skity::CreateVkInstance(vkGetInstanceProcAddr, &instance, &functions));
+  ASSERT_NE(instance, VK_NULL_HANDLE);
+  EXPECT_NE(functions.global.vkCreateInstance, nullptr);
+  EXPECT_NE(functions.instance.vkDestroyInstance, nullptr);
+  EXPECT_NE(functions.instance.vkEnumeratePhysicalDevices, nullptr);
+  EXPECT_NE(functions.instance.vkGetDeviceProcAddr, nullptr);
+
+  functions.instance.vkDestroyInstance(instance, nullptr);
+}
+
+TEST(VulkanProcLoaderTest, CreateDeviceAndLoadDeviceFns) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+  skity::VulkanFunctionPointers functions = {};
+  VkInstance instance = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+
+  ASSERT_TRUE(
+      skity::CreateVkInstance(vkGetInstanceProcAddr, &instance, &functions));
+  ASSERT_NE(instance, VK_NULL_HANDLE);
+
+  uint32_t physical_device_count = 0;
+  ASSERT_EQ(functions.instance.vkEnumeratePhysicalDevices(
+                instance, &physical_device_count, nullptr),
+            VK_SUCCESS);
+  ASSERT_GT(physical_device_count, 0u);
+
+  std::vector<VkPhysicalDevice> physical_devices(physical_device_count,
+                                                 VK_NULL_HANDLE);
+  ASSERT_EQ(functions.instance.vkEnumeratePhysicalDevices(
+                instance, &physical_device_count, physical_devices.data()),
+            VK_SUCCESS);
+
+  const VkPhysicalDevice physical_device = physical_devices[0];
+  ASSERT_NE(physical_device, VK_NULL_HANDLE);
+
+  const int32_t graphics_queue_family_index = FindGraphicsQueueFamilyIndex(
+      functions.instance.vkGetPhysicalDeviceQueueFamilyProperties,
+      physical_device);
+  ASSERT_GE(graphics_queue_family_index, 0);
+
+  const float queue_priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info = {};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex =
+      static_cast<uint32_t>(graphics_queue_family_index);
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &queue_priority;
+
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+
+  ASSERT_EQ(functions.instance.vkCreateDevice(physical_device, &device_info,
+                                              nullptr, &device),
+            VK_SUCCESS);
+  ASSERT_NE(device, VK_NULL_HANDLE);
+
+  ASSERT_TRUE(skity::LoadVulkanDeviceFns(functions.instance.vkGetDeviceProcAddr,
+                                         device, &functions.device));
+  EXPECT_NE(functions.device.vkDestroyDevice, nullptr);
+  EXPECT_NE(functions.device.vkGetDeviceQueue, nullptr);
+
+  VkQueue graphics_queue = VK_NULL_HANDLE;
+  functions.device.vkGetDeviceQueue(
+      device, static_cast<uint32_t>(graphics_queue_family_index), 0,
+      &graphics_queue);
+  EXPECT_NE(graphics_queue, VK_NULL_HANDLE);
+
+  functions.device.vkDestroyDevice(device, nullptr);
+  functions.instance.vkDestroyInstance(instance, nullptr);
+}
+
+TEST_F(VulkanSharedContextTest, CreateGPUContextWithProcLoader) {
+  ASSERT_NE(GetContext(), nullptr);
+  EXPECT_EQ(GetContext()->GetBackendType(), skity::GPUBackendType::kVulkan);
+
+  auto* vk_context = GetVKContext();
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_NE(state->GetInstance(), VK_NULL_HANDLE);
+  EXPECT_NE(state->GetPhysicalDevice(), VK_NULL_HANDLE);
+  EXPECT_NE(state->GetLogicalDevice(), VK_NULL_HANDLE);
+  EXPECT_NE(state->GetGraphicsQueue(), VK_NULL_HANDLE);
+  EXPECT_NE(state->GetAllocator(), nullptr);
+  EXPECT_NE(state->GetInstanceProcAddr(), nullptr);
+  EXPECT_NE(state->GetDeviceProcAddr(), nullptr);
+  EXPECT_NE(state->GlobalFns().vkCreateInstance, nullptr);
+  EXPECT_NE(state->InstanceFns().vkCreateDevice, nullptr);
+  EXPECT_NE(state->DeviceFns().vkGetDeviceQueue, nullptr);
+  EXPECT_EQ(state->Fns().device.vkGetDeviceQueue,
+            state->DeviceFns().vkGetDeviceQueue);
+}
+
+TEST(VulkanProcLoaderTest, CreateGPUContextWithInfo) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+  skity::GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enable_debug_runtime = true;
+
+  auto context = skity::CreateGPUContextVK(&info);
+
+  ASSERT_NE(context, nullptr);
+  EXPECT_EQ(context->GetBackendType(), skity::GPUBackendType::kVulkan);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_TRUE(state->AreEnabledInstanceExtensionsKnown());
+#if defined(SKITY_VK_DEBUG_RUNTIME)
+  EXPECT_TRUE(state->AreEnabledInstanceLayersKnown());
+#endif
+  EXPECT_TRUE(state->AreEnabledDeviceExtensionsKnown());
+  EXPECT_NE(state->GetAllocator(), nullptr);
+  EXPECT_EQ(state->HasEnabledInstanceExtension("VK_KHR_surface"),
+            state->HasAvailableInstanceExtension("VK_KHR_surface"));
+  EXPECT_EQ(state->HasEnabledDeviceExtension("VK_KHR_swapchain"),
+            state->HasAvailableDeviceExtension("VK_KHR_swapchain"));
+}
+
+TEST(VulkanProcLoaderTest, CreateGPUContextWithRequestedInstanceExtensions) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+
+  skity::VulkanGlobalFns global_fns = {};
+  ASSERT_TRUE(skity::LoadVulkanGlobalFns(vkGetInstanceProcAddr, &global_fns));
+
+  uint32_t extension_count = 0;
+  ASSERT_EQ(global_fns.vkEnumerateInstanceExtensionProperties(
+                nullptr, &extension_count, nullptr),
+            VK_SUCCESS);
+  ASSERT_GT(extension_count, 0u);
+
+  std::vector<VkExtensionProperties> extensions(extension_count);
+  ASSERT_EQ(global_fns.vkEnumerateInstanceExtensionProperties(
+                nullptr, &extension_count, extensions.data()),
+            VK_SUCCESS);
+
+  const char* requested_extension = nullptr;
+  for (const auto& extension : extensions) {
+    if (std::string(extension.extensionName) ==
+        VK_EXT_DEBUG_UTILS_EXTENSION_NAME) {
+      requested_extension = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+      break;
+    }
+  }
+
+  if (requested_extension == nullptr) {
+    GTEST_SKIP() << "VK_EXT_debug_utils is unavailable in this environment";
+  }
+
+  skity::GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enabled_instance_extensions = &requested_extension;
+  info.enabled_instance_extension_count = 1;
+
+  auto context = skity::CreateGPUContextVK(&info);
+
+  ASSERT_NE(context, nullptr);
+  auto* vk_context = static_cast<skity::GPUContextVK*>(context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_TRUE(state->HasEnabledInstanceExtension(requested_extension));
+}
+
+TEST(VulkanProcLoaderTest, DeduplicateRequestedInstanceExtensions) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+
+  const char* requested_extensions[] = {
+      VK_KHR_SURFACE_EXTENSION_NAME,
+      VK_KHR_SURFACE_EXTENSION_NAME,
+  };
+
+  skity::GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enabled_instance_extensions = requested_extensions;
+  info.enabled_instance_extension_count = 2;
+
+  auto context = skity::CreateGPUContextVK(&info);
+
+  ASSERT_NE(context, nullptr);
+  auto* vk_context = static_cast<skity::GPUContextVK*>(context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+
+  size_t surface_extension_count = 0;
+  for (const auto& extension : state->GetEnabledInstanceExtensions()) {
+    if (extension == VK_KHR_SURFACE_EXTENSION_NAME) {
+      ++surface_extension_count;
+    }
+  }
+  EXPECT_EQ(surface_extension_count, 1u);
+}
+
+TEST(VulkanProcLoaderTest, PreserveUserProvidedExtensionInfo) {
+  if (SkipVulkanTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan tests are unstable under ThreadSanitizer with "
+                    "SwiftShader in this environment";
+  }
+  skity::VulkanFunctionPointers functions = {};
+  VkInstance instance = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  skity::VulkanDeviceFns device_fns = {};
+
+  ASSERT_TRUE(
+      skity::CreateVkInstance(vkGetInstanceProcAddr, &instance, &functions));
+  ASSERT_NE(instance, VK_NULL_HANDLE);
+
+  uint32_t physical_device_count = 0;
+  ASSERT_EQ(functions.instance.vkEnumeratePhysicalDevices(
+                instance, &physical_device_count, nullptr),
+            VK_SUCCESS);
+  ASSERT_GT(physical_device_count, 0u);
+
+  std::vector<VkPhysicalDevice> physical_devices(physical_device_count,
+                                                 VK_NULL_HANDLE);
+  ASSERT_EQ(functions.instance.vkEnumeratePhysicalDevices(
+                instance, &physical_device_count, physical_devices.data()),
+            VK_SUCCESS);
+
+  const VkPhysicalDevice physical_device = physical_devices[0];
+  ASSERT_NE(physical_device, VK_NULL_HANDLE);
+
+  const int32_t graphics_queue_family_index = FindGraphicsQueueFamilyIndex(
+      functions.instance.vkGetPhysicalDeviceQueueFamilyProperties,
+      physical_device);
+  ASSERT_GE(graphics_queue_family_index, 0);
+
+  std::vector<const char*> enabled_device_extensions;
+  if (functions.instance.vkEnumerateDeviceExtensionProperties != nullptr) {
+    uint32_t extension_count = 0;
+    ASSERT_EQ(functions.instance.vkEnumerateDeviceExtensionProperties(
+                  physical_device, nullptr, &extension_count, nullptr),
+              VK_SUCCESS);
+    if (extension_count > 0) {
+      std::vector<VkExtensionProperties> extensions(extension_count);
+      ASSERT_EQ(
+          functions.instance.vkEnumerateDeviceExtensionProperties(
+              physical_device, nullptr, &extension_count, extensions.data()),
+          VK_SUCCESS);
+      for (const auto& extension : extensions) {
+        if (std::string(extension.extensionName) ==
+            VK_KHR_SWAPCHAIN_EXTENSION_NAME) {
+          enabled_device_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+        }
+        if (std::string(extension.extensionName) ==
+            VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME) {
+          enabled_device_extensions.push_back(
+              VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+        }
+      }
+    }
+  }
+
+  const float queue_priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info = {};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex =
+      static_cast<uint32_t>(graphics_queue_family_index);
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &queue_priority;
+
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+  device_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_device_extensions.size());
+  device_info.ppEnabledExtensionNames = enabled_device_extensions.data();
+
+  ASSERT_EQ(functions.instance.vkCreateDevice(physical_device, &device_info,
+                                              nullptr, &device),
+            VK_SUCCESS);
+  ASSERT_NE(device, VK_NULL_HANDLE);
+  ASSERT_TRUE(skity::LoadVulkanDeviceFns(functions.instance.vkGetDeviceProcAddr,
+                                         device, &device_fns));
+
+  const char* enabled_instance_extensions[] = {VK_KHR_SURFACE_EXTENSION_NAME};
+
+  skity::GPUContextInfoVK info = {};
+  info.instance = instance;
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enabled_instance_extensions = enabled_instance_extensions;
+  info.enabled_instance_extension_count = 1;
+  info.enabled_instance_extensions_known = true;
+  info.physical_device = physical_device;
+  info.logical_device = device;
+  info.get_device_proc_addr = functions.instance.vkGetDeviceProcAddr;
+  info.enabled_device_extensions = enabled_device_extensions.data();
+  info.enabled_device_extension_count =
+      static_cast<uint32_t>(enabled_device_extensions.size());
+  info.enabled_device_extensions_known = true;
+  info.graphics_queue_family_index = graphics_queue_family_index;
+  info.enable_debug_runtime = true;
+
+  auto context = skity::CreateGPUContextVK(&info);
+
+  ASSERT_NE(context, nullptr);
+  auto* vk_context = static_cast<skity::GPUContextVK*>(context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_TRUE(state->AreEnabledInstanceExtensionsKnown());
+  EXPECT_TRUE(
+      state->HasEnabledInstanceExtension(VK_KHR_SURFACE_EXTENSION_NAME));
+  EXPECT_TRUE(state->AreEnabledDeviceExtensionsKnown());
+  EXPECT_EQ(state->HasEnabledDeviceExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME),
+            !enabled_device_extensions.empty());
+  EXPECT_EQ(state->IsSynchronization2Enabled(),
+            std::find(enabled_device_extensions.begin(),
+                      enabled_device_extensions.end(),
+                      VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME) !=
+                enabled_device_extensions.end());
+
+  device_fns.vkDestroyDevice(device, nullptr);
+  functions.instance.vkDestroyInstance(instance, nullptr);
+}
+
+TEST_F(VulkanSharedContextTest, CreateShaderFunctionFromWGXModule) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUShaderModuleDescriptor module_desc = {};
+  module_desc.label = skity::GPULabel("vk_shader_module");
+  module_desc.source = kSimpleVertexWGSL;
+  auto module = skity::GPUShaderModule::Create(module_desc);
+  ASSERT_NE(module, nullptr);
+
+  skity::GPUShaderSourceWGX source = {};
+  source.module = module;
+  source.entry_point = "vs_main";
+
+  skity::GPUShaderFunctionDescriptor function_desc = {};
+  function_desc.label = skity::GPULabel("vk_shader_function");
+  function_desc.stage = skity::GPUShaderStage::kVertex;
+  function_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  function_desc.shader_source = &source;
+
+  auto function = device->CreateShaderFunction(function_desc);
+  ASSERT_NE(function, nullptr);
+  EXPECT_TRUE(function->IsValid());
+  EXPECT_EQ(function->GetLabel(), "vk_shader_function");
+
+  auto vk_function =
+      std::static_pointer_cast<skity::GPUShaderFunctionVK>(function);
+  ASSERT_NE(vk_function, nullptr);
+  EXPECT_EQ(vk_function->GetStage(), skity::GPUShaderStage::kVertex);
+  EXPECT_EQ(vk_function->GetEntryPoint(), "vs_main");
+  EXPECT_NE(vk_function->GetShaderModule(), VK_NULL_HANDLE);
+}
+
+TEST_F(VulkanSharedContextTest,
+       FailToCreateShaderFunctionForMissingEntryPoint) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUShaderModuleDescriptor module_desc = {};
+  module_desc.label = skity::GPULabel("vk_shader_module");
+  module_desc.source = kSimpleVertexWGSL;
+  auto module = skity::GPUShaderModule::Create(module_desc);
+  ASSERT_NE(module, nullptr);
+
+  skity::GPUShaderSourceWGX source = {};
+  source.module = module;
+  source.entry_point = "missing_main";
+
+  std::string error_message;
+  skity::GPUShaderFunctionDescriptor function_desc = {};
+  function_desc.label = skity::GPULabel("vk_shader_function");
+  function_desc.stage = skity::GPUShaderStage::kVertex;
+  function_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  function_desc.shader_source = &source;
+  function_desc.error_callback = [&error_message](char const* message) {
+    error_message = message != nullptr ? message : "";
+  };
+
+  auto function = device->CreateShaderFunction(function_desc);
+  EXPECT_EQ(function, nullptr);
+  EXPECT_EQ(error_message, "WGX translate to SPIR-V failed");
+}
+
+TEST_F(VulkanSharedContextTest, RejectRawShaderSource) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUShaderSourceRaw source = {};
+  source.source = "void main() {}";
+  source.entry_point = "main";
+
+  skity::GPUShaderFunctionDescriptor function_desc = {};
+  function_desc.label = skity::GPULabel("vk_raw_shader");
+  function_desc.stage = skity::GPUShaderStage::kVertex;
+  function_desc.source_type = skity::GPUShaderSourceType::kRaw;
+  function_desc.shader_source = &source;
+
+  auto function = device->CreateShaderFunction(function_desc);
+  EXPECT_EQ(function, nullptr);
+}
+
+TEST_F(VulkanSharedContextTest, CreateRenderPipelineFromWGXFunctions) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUShaderModuleDescriptor vertex_module_desc = {};
+  vertex_module_desc.label = skity::GPULabel("vk_vertex_shader_module");
+  vertex_module_desc.source = kSimpleVertexWGSL;
+  auto vertex_module = skity::GPUShaderModule::Create(vertex_module_desc);
+  ASSERT_NE(vertex_module, nullptr);
+
+  skity::GPUShaderSourceWGX vertex_source = {};
+  vertex_source.module = vertex_module;
+  vertex_source.entry_point = "vs_main";
+
+  skity::GPUShaderFunctionDescriptor vertex_desc = {};
+  vertex_desc.label = skity::GPULabel("vk_vertex_shader_function");
+  vertex_desc.stage = skity::GPUShaderStage::kVertex;
+  vertex_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  vertex_desc.shader_source = &vertex_source;
+
+  auto vertex_function = device->CreateShaderFunction(vertex_desc);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  skity::GPUShaderModuleDescriptor fragment_module_desc = {};
+  fragment_module_desc.label = skity::GPULabel("vk_fragment_shader_module");
+  fragment_module_desc.source = kSimpleFragmentWGSL;
+  auto fragment_module = skity::GPUShaderModule::Create(fragment_module_desc);
+  ASSERT_NE(fragment_module, nullptr);
+
+  skity::GPUShaderSourceWGX fragment_source = {};
+  fragment_source.module = fragment_module;
+  fragment_source.entry_point = "fs_main";
+
+  skity::GPUShaderFunctionDescriptor fragment_desc = {};
+  fragment_desc.label = skity::GPULabel("vk_fragment_shader_function");
+  fragment_desc.stage = skity::GPUShaderStage::kFragment;
+  fragment_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  fragment_desc.shader_source = &fragment_source;
+
+  auto fragment_function = device->CreateShaderFunction(fragment_desc);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.label = skity::GPULabel("vk_render_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+
+  auto* vk_pipeline = skity::GPURenderPipelineVK::Cast(pipeline.get());
+  ASSERT_NE(vk_pipeline, nullptr);
+  EXPECT_NE(vk_pipeline->GetPipeline(), VK_NULL_HANDLE);
+  EXPECT_NE(vk_pipeline->GetPipelineLayout(), VK_NULL_HANDLE);
+  if (GetState()->IsDynamicRenderingEnabled()) {
+    EXPECT_TRUE(vk_pipeline->UsesDynamicRendering());
+    EXPECT_EQ(vk_pipeline->GetRenderPass(), VK_NULL_HANDLE);
+  } else {
+    EXPECT_FALSE(vk_pipeline->UsesDynamicRendering());
+    EXPECT_NE(vk_pipeline->GetRenderPass(), VK_NULL_HANDLE);
+  }
+}
+
+TEST_F(VulkanSharedContextTest,
+       CreateRenderPipelineWithDepthStencilFormatFallback) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  auto vertex_function =
+      CreateWGXShaderFunction(device, kSimpleVertexWGSL, "vk_depth_pipeline_vs",
+                              "vs_main", skity::GPUShaderStage::kVertex);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  auto fragment_function = CreateWGXShaderFunction(
+      device, kSimpleFragmentWGSL, "vk_depth_pipeline_fs", "fs_main",
+      skity::GPUShaderStage::kFragment);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.depth_stencil.format =
+      skity::GPUTextureFormat::kDepth24Stencil8;
+  pipeline_desc.depth_stencil.enable_depth = true;
+  pipeline_desc.depth_stencil.depth_state.enableWrite = true;
+  pipeline_desc.depth_stencil.depth_state.compare =
+      skity::GPUCompareFunction::kLessEqual;
+  pipeline_desc.label = skity::GPULabel("vk_depth_fallback_render_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+}
+
+TEST_F(VulkanSharedContextTest,
+       CreateRenderPipelineFromWGXFunctionsWithUniformHelperVertexShader) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  auto vertex_function = CreateWGXShaderFunction(
+      device, kUniformHelperVertexWGSL, "vk_vertex_helper_uniform_shader",
+      "vs_main", skity::GPUShaderStage::kVertex);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  auto fragment_function = CreateWGXShaderFunction(
+      device, kSimpleFragmentWGSL, "vk_fragment_simple_shader", "fs_main",
+      skity::GPUShaderStage::kFragment);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.label = skity::GPULabel("vk_helper_uniform_render_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+}
+
+TEST_F(VulkanSharedContextTest, CreateAndReuseSampler) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUSamplerDescriptor desc = {};
+  desc.address_mode_u = skity::GPUAddressMode::kRepeat;
+  desc.address_mode_v = skity::GPUAddressMode::kClampToEdge;
+  desc.address_mode_w = skity::GPUAddressMode::kMirrorRepeat;
+  desc.mag_filter = skity::GPUFilterMode::kLinear;
+  desc.min_filter = skity::GPUFilterMode::kLinear;
+  desc.mipmap_filter = skity::GPUMipmapMode::kLinear;
+
+  auto sampler = device->CreateSampler(desc);
+  ASSERT_NE(sampler, nullptr);
+
+  auto* vk_sampler = skity::GPUSamplerVK::Cast(sampler.get());
+  ASSERT_NE(vk_sampler, nullptr);
+  EXPECT_TRUE(vk_sampler->IsValid());
+  EXPECT_NE(vk_sampler->GetSampler(), VK_NULL_HANDLE);
+
+  auto same_sampler = device->CreateSampler(desc);
+  ASSERT_NE(same_sampler, nullptr);
+  EXPECT_EQ(same_sampler.get(), sampler.get());
+}
+
+TEST_F(VulkanSharedContextTest, EncodeDrawCommandWithUniformBinding) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  auto vertex_function =
+      CreateWGXShaderFunction(device, kSimpleVertexWGSL, "vk_draw_uniform_vs",
+                              "vs_main", skity::GPUShaderStage::kVertex);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  auto fragment_function = CreateWGXShaderFunction(
+      device, kUniformFragmentWGSL, "vk_draw_uniform_fs", "fs_uniform_main",
+      skity::GPUShaderStage::kFragment);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.label = skity::GPULabel("vk_draw_uniform_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+
+  auto vertex_buffer =
+      device->CreateBuffer(skity::GPUBufferUsage::kVertexBuffer);
+  auto index_buffer = device->CreateBuffer(skity::GPUBufferUsage::kIndexBuffer);
+  auto uniform_buffer =
+      device->CreateBuffer(skity::GPUBufferUsage::kUniformBuffer);
+  ASSERT_NE(vertex_buffer, nullptr);
+  ASSERT_NE(index_buffer, nullptr);
+  ASSERT_NE(uniform_buffer, nullptr);
+
+  skity::GPUTextureDescriptor texture_desc = {};
+  texture_desc.width = 16;
+  texture_desc.height = 16;
+  texture_desc.mip_level_count = 1;
+  texture_desc.sample_count = 1;
+  texture_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  texture_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  texture_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(texture_desc);
+  ASSERT_NE(texture, nullptr);
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  float vertex_data[4] = {0.f, 0.f, 0.f, 1.f};
+  uint32_t index_data[3] = {0u, 0u, 0u};
+  float uniform_data[4] = {0.25f, 0.5f, 0.75f, 1.f};
+
+  auto blit_pass = command_buffer->BeginBlitPass();
+  ASSERT_NE(blit_pass, nullptr);
+  blit_pass->UploadBufferData(vertex_buffer.get(), vertex_data,
+                              sizeof(vertex_data));
+  blit_pass->UploadBufferData(index_buffer.get(), index_data,
+                              sizeof(index_data));
+  blit_pass->UploadBufferData(uniform_buffer.get(), uniform_data,
+                              sizeof(uniform_data));
+  blit_pass->End();
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_draw_uniform_render_pass";
+  render_pass_desc.color_attachment.texture = texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.color_attachment.clear_value =
+      skity::GPUColor{0.0, 0.0, 0.0, 0.0};
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+
+  skity::Command command = {};
+  command.pipeline = pipeline.get();
+  command.vertex_buffer = {vertex_buffer.get(), 0,
+                           static_cast<uint32_t>(sizeof(vertex_data))};
+  command.index_buffer = {index_buffer.get(), 0,
+                          static_cast<uint32_t>(sizeof(index_data))};
+  command.index_count = 3;
+  command.scissor_rect = {0, 0, texture_desc.width, texture_desc.height};
+
+  skity::UniformBinding uniform_binding = {};
+  uniform_binding.stages =
+      static_cast<skity::GPUShaderStageMask>(skity::GPUShaderStage::kFragment);
+  uniform_binding.index = 0;
+  uniform_binding.group = 0;
+  uniform_binding.binding = 0;
+  uniform_binding.name = "fs_uniforms";
+  uniform_binding.buffer = {uniform_buffer.get(), 0,
+                            static_cast<uint32_t>(sizeof(uniform_data))};
+  command.uniform_bindings.push_back(uniform_binding);
+
+  render_pass->AddCommand(&command);
+  render_pass->EncodeCommands();
+
+  EXPECT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+}
+
+TEST(VulkanProcLoaderTest, EncodeLegacyDrawCommandWithUniformBinding) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_FALSE(state->IsDynamicRenderingEnabled());
+
+  auto* context_impl = static_cast<skity::GPUContextImpl*>(vk_context);
+  auto* device = context_impl->GetGPUDevice();
+  ASSERT_NE(device, nullptr);
+
+  auto vertex_function = CreateWGXShaderFunction(
+      device, kSimpleVertexWGSL, "legacy_vk_draw_uniform_vs", "vs_main",
+      skity::GPUShaderStage::kVertex);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  auto fragment_function = CreateWGXShaderFunction(
+      device, kUniformFragmentWGSL, "legacy_vk_draw_uniform_fs",
+      "fs_uniform_main", skity::GPUShaderStage::kFragment);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.label = skity::GPULabel("legacy_vk_draw_uniform_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+
+  auto vertex_buffer =
+      device->CreateBuffer(skity::GPUBufferUsage::kVertexBuffer);
+  auto index_buffer = device->CreateBuffer(skity::GPUBufferUsage::kIndexBuffer);
+  auto uniform_buffer =
+      device->CreateBuffer(skity::GPUBufferUsage::kUniformBuffer);
+  ASSERT_NE(vertex_buffer, nullptr);
+  ASSERT_NE(index_buffer, nullptr);
+  ASSERT_NE(uniform_buffer, nullptr);
+
+  skity::GPUTextureDescriptor texture_desc = {};
+  texture_desc.width = 16;
+  texture_desc.height = 16;
+  texture_desc.mip_level_count = 1;
+  texture_desc.sample_count = 1;
+  texture_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  texture_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  texture_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(texture_desc);
+  ASSERT_NE(texture, nullptr);
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  float vertex_data[4] = {0.f, 0.f, 0.f, 1.f};
+  uint32_t index_data[3] = {0u, 0u, 0u};
+  float uniform_data[4] = {1.f, 0.f, 0.f, 1.f};
+
+  auto blit_pass = command_buffer->BeginBlitPass();
+  ASSERT_NE(blit_pass, nullptr);
+  blit_pass->UploadBufferData(vertex_buffer.get(), vertex_data,
+                              sizeof(vertex_data));
+  blit_pass->UploadBufferData(index_buffer.get(), index_data,
+                              sizeof(index_data));
+  blit_pass->UploadBufferData(uniform_buffer.get(), uniform_data,
+                              sizeof(uniform_data));
+  blit_pass->End();
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "legacy_vk_draw_uniform_render_pass";
+  render_pass_desc.color_attachment.texture = texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.color_attachment.clear_value =
+      skity::GPUColor{0.0, 0.0, 0.0, 0.0};
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+
+  skity::Command command = {};
+  command.pipeline = pipeline.get();
+  command.vertex_buffer = {vertex_buffer.get(), 0,
+                           static_cast<uint32_t>(sizeof(vertex_data))};
+  command.index_buffer = {index_buffer.get(), 0,
+                          static_cast<uint32_t>(sizeof(index_data))};
+  command.index_count = 3;
+  command.scissor_rect = {0, 0, texture_desc.width, texture_desc.height};
+
+  skity::UniformBinding uniform_binding = {};
+  uniform_binding.stages =
+      static_cast<skity::GPUShaderStageMask>(skity::GPUShaderStage::kFragment);
+  uniform_binding.index = 0;
+  uniform_binding.group = 0;
+  uniform_binding.binding = 0;
+  uniform_binding.name = "fs_uniforms";
+  uniform_binding.buffer = {uniform_buffer.get(), 0,
+                            static_cast<uint32_t>(sizeof(uniform_data))};
+  command.uniform_bindings.push_back(uniform_binding);
+
+  render_pass->AddCommand(&command);
+  render_pass->EncodeCommands();
+
+  EXPECT_TRUE(command_buffer->Submit());
+  state->CollectPendingSubmissions(true);
+}
+
+TEST(VulkanProcLoaderTest, CreateLegacyRenderPipelineFromWGXFunctions) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_FALSE(state->IsDynamicRenderingEnabled());
+
+  auto* context_impl = static_cast<skity::GPUContextImpl*>(vk_context);
+  auto* device = context_impl->GetGPUDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUShaderModuleDescriptor vertex_module_desc = {};
+  vertex_module_desc.label = skity::GPULabel("legacy_vk_vertex_shader_module");
+  vertex_module_desc.source = kSimpleVertexWGSL;
+  auto vertex_module = skity::GPUShaderModule::Create(vertex_module_desc);
+  ASSERT_NE(vertex_module, nullptr);
+
+  skity::GPUShaderSourceWGX vertex_source = {};
+  vertex_source.module = vertex_module;
+  vertex_source.entry_point = "vs_main";
+
+  skity::GPUShaderFunctionDescriptor vertex_desc = {};
+  vertex_desc.label = skity::GPULabel("legacy_vk_vertex_shader_function");
+  vertex_desc.stage = skity::GPUShaderStage::kVertex;
+  vertex_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  vertex_desc.shader_source = &vertex_source;
+
+  auto vertex_function = device->CreateShaderFunction(vertex_desc);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_TRUE(vertex_function->IsValid());
+
+  skity::GPUShaderModuleDescriptor fragment_module_desc = {};
+  fragment_module_desc.label =
+      skity::GPULabel("legacy_vk_fragment_shader_module");
+  fragment_module_desc.source = kSimpleFragmentWGSL;
+  auto fragment_module = skity::GPUShaderModule::Create(fragment_module_desc);
+  ASSERT_NE(fragment_module, nullptr);
+
+  skity::GPUShaderSourceWGX fragment_source = {};
+  fragment_source.module = fragment_module;
+  fragment_source.entry_point = "fs_main";
+
+  skity::GPUShaderFunctionDescriptor fragment_desc = {};
+  fragment_desc.label = skity::GPULabel("legacy_vk_fragment_shader_function");
+  fragment_desc.stage = skity::GPUShaderStage::kFragment;
+  fragment_desc.source_type = skity::GPUShaderSourceType::kWGX;
+  fragment_desc.shader_source = &fragment_source;
+
+  auto fragment_function = device->CreateShaderFunction(fragment_desc);
+  ASSERT_NE(fragment_function, nullptr);
+  ASSERT_TRUE(fragment_function->IsValid());
+
+  skity::GPURenderPipelineDescriptor pipeline_desc = {};
+  pipeline_desc.vertex_function = vertex_function;
+  pipeline_desc.fragment_function = fragment_function;
+  pipeline_desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  pipeline_desc.sample_count = 1;
+  pipeline_desc.label = skity::GPULabel("legacy_vk_render_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(pipeline_desc);
+  ASSERT_NE(pipeline, nullptr);
+  ASSERT_TRUE(pipeline->IsValid());
+
+  auto* vk_pipeline = skity::GPURenderPipelineVK::Cast(pipeline.get());
+  ASSERT_NE(vk_pipeline, nullptr);
+  EXPECT_FALSE(vk_pipeline->UsesDynamicRendering());
+  EXPECT_NE(vk_pipeline->GetPipeline(), VK_NULL_HANDLE);
+  EXPECT_NE(vk_pipeline->GetPipelineLayout(), VK_NULL_HANDLE);
+  EXPECT_NE(vk_pipeline->GetRenderPass(), VK_NULL_HANDLE);
+}
+
+TEST_F(VulkanSharedContextTest, CreateAndUploadBufferData) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  auto buffer = device->CreateBuffer(skity::GPUBufferUsage::kVertexBuffer |
+                                     skity::GPUBufferUsage::kUniformBuffer);
+  ASSERT_NE(buffer, nullptr);
+
+  auto* vk_buffer = static_cast<skity::GPUBufferVK*>(buffer.get());
+  ASSERT_NE(vk_buffer, nullptr);
+  EXPECT_FALSE(vk_buffer->IsValid());
+  EXPECT_EQ(vk_buffer->GetMemoryType(),
+            skity::GPUBufferVKMemoryType::kDeviceLocal);
+
+  const uint32_t payload[] = {1u, 2u, 3u, 4u};
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto blit_pass = command_buffer->BeginBlitPass();
+  ASSERT_NE(blit_pass, nullptr);
+  blit_pass->UploadBufferData(vk_buffer, const_cast<uint32_t*>(payload),
+                              sizeof(payload));
+  blit_pass->End();
+  ASSERT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  EXPECT_TRUE(vk_buffer->IsValid());
+  EXPECT_NE(vk_buffer->GetBuffer(), VK_NULL_HANDLE);
+  EXPECT_NE(vk_buffer->GetAllocation(), VK_NULL_HANDLE);
+  EXPECT_EQ(vk_buffer->GetMappedData(), nullptr);
+  EXPECT_GE(vk_buffer->GetSize(), sizeof(payload));
+}
+
+TEST_F(VulkanSharedContextTest, CreateTextureAndUploadData) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 4;
+  desc.height = 4;
+  desc.mip_level_count = 1;
+  desc.sample_count = 1;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.usage =
+      static_cast<skity::GPUTextureUsageMask>(
+          skity::GPUTextureUsage::kTextureBinding) |
+      static_cast<skity::GPUTextureUsageMask>(skity::GPUTextureUsage::kCopyDst);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(desc);
+  ASSERT_NE(texture, nullptr);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_TRUE(vk_texture->IsValid());
+  EXPECT_NE(vk_texture->GetImage(), VK_NULL_HANDLE);
+  EXPECT_NE(vk_texture->GetImageView(), VK_NULL_HANDLE);
+  EXPECT_EQ(vk_texture->GetDescriptor().width, desc.width);
+  EXPECT_EQ(vk_texture->GetDescriptor().height, desc.height);
+  EXPECT_EQ(vk_texture->GetDescriptor().format, desc.format);
+  EXPECT_EQ(vk_texture->GetPreferredLayout(),
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_UNDEFINED);
+  EXPECT_EQ(vk_texture->GetBytes(), 4u * 4u * 4u);
+
+  uint32_t pixels[16] = {};
+  for (size_t i = 0; i < std::size(pixels); ++i) {
+    pixels[i] = 0xFF000000u | static_cast<uint32_t>(i);
+  }
+
+  texture->UploadData(0, 0, 4, 4, pixels);
+  GetState()->CollectPendingSubmissions(true);
+
+  EXPECT_EQ(vk_texture->GetCurrentLayout(),
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
+TEST_F(VulkanSharedContextTest, GenerateTextureMipmapsWithBlitPass) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  ASSERT_NE(GetState(), nullptr);
+
+  VkFormatProperties format_properties = {};
+  GetState()->InstanceFns().vkGetPhysicalDeviceFormatProperties(
+      GetState()->GetPhysicalDevice(), VK_FORMAT_R8G8B8A8_UNORM,
+      &format_properties);
+  if ((format_properties.optimalTilingFeatures &
+       VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) == 0) {
+    GTEST_SKIP() << "RGBA8 linear blit mipmap generation is unsupported";
+  }
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 8;
+  desc.height = 8;
+  desc.mip_level_count = 4;
+  desc.sample_count = 1;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.usage =
+      static_cast<skity::GPUTextureUsageMask>(
+          skity::GPUTextureUsage::kTextureBinding) |
+      static_cast<skity::GPUTextureUsageMask>(skity::GPUTextureUsage::kCopyDst);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(desc);
+  ASSERT_NE(texture, nullptr);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  ASSERT_TRUE(vk_texture->IsValid());
+  EXPECT_EQ(vk_texture->GetPreferredLayout(), VK_IMAGE_LAYOUT_GENERAL);
+
+  uint32_t pixels[64] = {};
+  for (size_t i = 0; i < std::size(pixels); ++i) {
+    pixels[i] = 0xFF000000u | static_cast<uint32_t>(i);
+  }
+
+  texture->UploadData(0, 0, 8, 8, pixels);
+  GetState()->CollectPendingSubmissions(true);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_GENERAL);
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto blit_pass = command_buffer->BeginBlitPass();
+  ASSERT_NE(blit_pass, nullptr);
+  blit_pass->GenerateMipmaps(texture);
+  blit_pass->End();
+
+  ASSERT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  EXPECT_EQ(vk_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_GENERAL);
+}
+
+TEST_F(VulkanSharedContextTest, CollectPendingSubmissionsRunsCleanupActions) {
+  ASSERT_NE(GetState(), nullptr);
+
+  bool cleanup_ran = false;
+  std::vector<std::function<void()>> cleanup_actions;
+  cleanup_actions.emplace_back([&cleanup_ran]() { cleanup_ran = true; });
+
+  GetState()->EnqueuePendingSubmission(skity::VulkanPendingSubmission(
+      VK_NULL_HANDLE, VK_NULL_HANDLE, {}, std::move(cleanup_actions)));
+  GetState()->CollectPendingSubmissions(true);
+
+  EXPECT_TRUE(cleanup_ran);
+}
+
+TEST_F(VulkanSharedContextTest, CreateMultiUseTextureUsesGeneralLayout) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 8;
+  desc.height = 8;
+  desc.mip_level_count = 1;
+  desc.sample_count = 1;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.usage = static_cast<skity::GPUTextureUsageMask>(
+                   skity::GPUTextureUsage::kTextureBinding) |
+               static_cast<skity::GPUTextureUsageMask>(
+                   skity::GPUTextureUsage::kRenderAttachment);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(desc);
+  ASSERT_NE(texture, nullptr);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_TRUE(vk_texture->IsValid());
+  EXPECT_EQ(vk_texture->GetPreferredLayout(), VK_IMAGE_LAYOUT_GENERAL);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_UNDEFINED);
+}
+
+TEST_F(VulkanSharedContextTest, RejectTextureWithInvalidDescriptor) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUTextureDescriptor invalid_desc = {};
+  invalid_desc.width = 0;
+  invalid_desc.height = 8;
+  invalid_desc.mip_level_count = 1;
+  invalid_desc.sample_count = 1;
+  invalid_desc.format = skity::GPUTextureFormat::kInvalid;
+  invalid_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kTextureBinding);
+  invalid_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  EXPECT_EQ(device->CreateTexture(invalid_desc), nullptr);
+}
+
+TEST_F(VulkanSharedContextTest,
+       RejectMipmappedTextureWithoutLinearBlitSupport) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  ASSERT_NE(GetState(), nullptr);
+
+  auto format_lacks_linear_blit = [this](VkFormat format) {
+    VkFormatProperties format_properties = {};
+    GetState()->InstanceFns().vkGetPhysicalDeviceFormatProperties(
+        GetState()->GetPhysicalDevice(), format, &format_properties);
+    return (format_properties.optimalTilingFeatures &
+            VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) == 0;
+  };
+
+  skity::GPUTextureFormat rejected_format = skity::GPUTextureFormat::kInvalid;
+  if (format_lacks_linear_blit(VK_FORMAT_S8_UINT)) {
+    rejected_format = skity::GPUTextureFormat::kStencil8;
+  } else if (format_lacks_linear_blit(VK_FORMAT_D24_UNORM_S8_UINT) &&
+             format_lacks_linear_blit(VK_FORMAT_D32_SFLOAT_S8_UINT)) {
+    rejected_format = skity::GPUTextureFormat::kDepth24Stencil8;
+  } else {
+    GTEST_SKIP() << "No depth/stencil test format without linear blit support";
+  }
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 8;
+  desc.height = 8;
+  desc.mip_level_count = 2;
+  desc.sample_count = 1;
+  desc.format = rejected_format;
+  desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  EXPECT_EQ(device->CreateTexture(desc), nullptr);
+}
+
+TEST_F(VulkanSharedContextTest, BeginAndEndRenderPassWithoutCommands) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  if (SkipVulkanRenderPassTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan render pass tests are unstable under "
+                    "ThreadSanitizer with SwiftShader in this environment";
+  }
+  if (!GetState()->IsDynamicRenderingEnabled()) {
+    GTEST_SKIP() << "Dynamic rendering is not enabled in this Vulkan context";
+  }
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 16;
+  desc.height = 16;
+  desc.mip_level_count = 1;
+  desc.sample_count = 1;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.usage = static_cast<skity::GPUTextureUsageMask>(
+                   skity::GPUTextureUsage::kTextureBinding) |
+               static_cast<skity::GPUTextureUsageMask>(
+                   skity::GPUTextureUsage::kRenderAttachment);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(desc);
+  ASSERT_NE(texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_dynamic_render_pass";
+  render_pass_desc.color_attachment.texture = texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.color_attachment.clear_value =
+      skity::GPUColor{0.25, 0.5, 0.75, 1.0};
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_GENERAL);
+}
+
+TEST_F(VulkanSharedContextTest, EnablesValidationLayerWhenAvailable) {
+  ASSERT_NE(GetContext(), nullptr);
+  const auto* state = GetState();
+  ASSERT_NE(state, nullptr);
+  ASSERT_TRUE(state->AreEnabledInstanceLayersKnown());
+
+  constexpr char kValidationLayer[] = "VK_LAYER_KHRONOS_validation";
+  if (!ContainsLayer(state->GetAvailableInstanceLayers(), kValidationLayer)) {
+    GTEST_SKIP() << "Vulkan validation layer is not available";
+  }
+
+  EXPECT_TRUE(
+      ContainsLayer(state->GetEnabledInstanceLayers(), kValidationLayer));
+}
+
+TEST_F(VulkanSharedContextTest, EnablesPortabilitySubsetWhenAvailable) {
+  ASSERT_NE(GetContext(), nullptr);
+  const auto* state = GetState();
+  ASSERT_NE(state, nullptr);
+  ASSERT_TRUE(state->AreEnabledDeviceExtensionsKnown());
+
+  constexpr char kPortabilitySubsetExtension[] = "VK_KHR_portability_subset";
+  if (!state->HasAvailableDeviceExtension(kPortabilitySubsetExtension)) {
+    GTEST_SKIP() << "Vulkan portability subset extension is not available";
+  }
+
+  EXPECT_TRUE(state->HasEnabledDeviceExtension(kPortabilitySubsetExtension));
+}
+
+TEST_F(VulkanSharedContextTest, BeginAndEndMSAARenderPassWithoutCommands) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  if (SkipVulkanRenderPassTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan render pass tests are unstable under "
+                    "ThreadSanitizer with SwiftShader in this environment";
+  }
+  if (!GetState()->IsDynamicRenderingEnabled()) {
+    GTEST_SKIP() << "Dynamic rendering is not enabled in this Vulkan context";
+  }
+
+  skity::GPUTextureDescriptor msaa_desc = {};
+  msaa_desc.width = 16;
+  msaa_desc.height = 16;
+  msaa_desc.mip_level_count = 1;
+  msaa_desc.sample_count = 4;
+  msaa_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  msaa_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  msaa_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto msaa_texture = device->CreateTexture(msaa_desc);
+  ASSERT_NE(msaa_texture, nullptr);
+
+  skity::GPUTextureDescriptor resolve_desc = {};
+  resolve_desc.width = msaa_desc.width;
+  resolve_desc.height = msaa_desc.height;
+  resolve_desc.mip_level_count = 1;
+  resolve_desc.sample_count = 1;
+  resolve_desc.format = msaa_desc.format;
+  resolve_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+                           skity::GPUTextureUsage::kTextureBinding) |
+                       static_cast<skity::GPUTextureUsageMask>(
+                           skity::GPUTextureUsage::kRenderAttachment);
+  resolve_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto resolve_texture = device->CreateTexture(resolve_desc);
+  ASSERT_NE(resolve_texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_dynamic_msaa_render_pass";
+  render_pass_desc.color_attachment.texture = msaa_texture;
+  render_pass_desc.color_attachment.resolve_texture = resolve_texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.color_attachment.clear_value =
+      skity::GPUColor{0.1, 0.2, 0.3, 1.0};
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  auto* vk_msaa_texture = skity::GPUTextureVK::Cast(msaa_texture.get());
+  ASSERT_NE(vk_msaa_texture, nullptr);
+  EXPECT_EQ(vk_msaa_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_GENERAL);
+
+  auto* vk_resolve_texture = skity::GPUTextureVK::Cast(resolve_texture.get());
+  ASSERT_NE(vk_resolve_texture, nullptr);
+  EXPECT_EQ(vk_resolve_texture->GetCurrentLayout(), VK_IMAGE_LAYOUT_GENERAL);
+}
+
+TEST_F(VulkanSharedContextTest,
+       BeginAndEndDepthStencilRenderPassWithoutCommands) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  if (SkipVulkanRenderPassTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan render pass tests are unstable under "
+                    "ThreadSanitizer with SwiftShader in this environment";
+  }
+  if (!GetState()->IsDynamicRenderingEnabled()) {
+    GTEST_SKIP() << "Dynamic rendering is not enabled in this Vulkan context";
+  }
+
+  skity::GPUTextureDescriptor color_desc = {};
+  color_desc.width = 12;
+  color_desc.height = 12;
+  color_desc.mip_level_count = 1;
+  color_desc.sample_count = 1;
+  color_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  color_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  color_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto color_texture = device->CreateTexture(color_desc);
+  ASSERT_NE(color_texture, nullptr);
+
+  skity::GPUTextureDescriptor depth_desc = {};
+  depth_desc.width = color_desc.width;
+  depth_desc.height = color_desc.height;
+  depth_desc.mip_level_count = 1;
+  depth_desc.sample_count = 1;
+  depth_desc.format = skity::GPUTextureFormat::kDepth24Stencil8;
+  depth_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  depth_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto depth_stencil_texture = device->CreateTexture(depth_desc);
+  ASSERT_NE(depth_stencil_texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_dynamic_depth_stencil_render_pass";
+  render_pass_desc.color_attachment.texture = color_texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.depth_attachment.texture = depth_stencil_texture;
+  render_pass_desc.depth_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.depth_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.depth_attachment.clear_value = 0.5f;
+  render_pass_desc.stencil_attachment.texture = depth_stencil_texture;
+  render_pass_desc.stencil_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.stencil_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.stencil_attachment.clear_value = 7u;
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(depth_stencil_texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(),
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+}
+
+TEST_F(VulkanSharedContextTest, BeginAndEndStencilRenderPassWithoutCommands) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  if (SkipVulkanRenderPassTestsOnThreadSanitizer()) {
+    GTEST_SKIP() << "Vulkan render pass tests are unstable under "
+                    "ThreadSanitizer with SwiftShader in this environment";
+  }
+  if (!GetState()->IsDynamicRenderingEnabled()) {
+    GTEST_SKIP() << "Dynamic rendering is not enabled in this Vulkan context";
+  }
+
+  skity::GPUTextureDescriptor color_desc = {};
+  color_desc.width = 14;
+  color_desc.height = 14;
+  color_desc.mip_level_count = 1;
+  color_desc.sample_count = 1;
+  color_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  color_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  color_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto color_texture = device->CreateTexture(color_desc);
+  ASSERT_NE(color_texture, nullptr);
+
+  skity::GPUTextureDescriptor stencil_desc = {};
+  stencil_desc.width = color_desc.width;
+  stencil_desc.height = color_desc.height;
+  stencil_desc.mip_level_count = 1;
+  stencil_desc.sample_count = 1;
+  stencil_desc.format = skity::GPUTextureFormat::kStencil8;
+  stencil_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  stencil_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto stencil_texture = device->CreateTexture(stencil_desc);
+  ASSERT_NE(stencil_texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_dynamic_stencil_render_pass";
+  render_pass_desc.color_attachment.texture = color_texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.stencil_attachment.texture = stencil_texture;
+  render_pass_desc.stencil_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.stencil_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.stencil_attachment.clear_value = 5u;
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  GetState()->CollectPendingSubmissions(true);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(stencil_texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(),
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+}
+
+TEST(VulkanProcLoaderTest, BeginAndEndLegacyRenderPassWithoutCommands) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_FALSE(state->IsDynamicRenderingEnabled());
+
+  auto* context_impl = static_cast<skity::GPUContextImpl*>(vk_context);
+  auto* device = context_impl->GetGPUDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUTextureDescriptor desc = {};
+  desc.width = 8;
+  desc.height = 8;
+  desc.mip_level_count = 1;
+  desc.sample_count = 1;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto texture = device->CreateTexture(desc);
+  ASSERT_NE(texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_legacy_render_pass";
+  render_pass_desc.color_attachment.texture = texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.color_attachment.clear_value =
+      skity::GPUColor{0.0, 0.0, 0.0, 0.0};
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  state->CollectPendingSubmissions(true);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(),
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+}
+
+TEST(VulkanProcLoaderTest,
+     BeginAndEndLegacyDepthStencilRenderPassWithoutCommands) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_FALSE(state->IsDynamicRenderingEnabled());
+
+  auto* context_impl = static_cast<skity::GPUContextImpl*>(vk_context);
+  auto* device = context_impl->GetGPUDevice();
+  ASSERT_NE(device, nullptr);
+
+  skity::GPUTextureDescriptor color_desc = {};
+  color_desc.width = 10;
+  color_desc.height = 10;
+  color_desc.mip_level_count = 1;
+  color_desc.sample_count = 1;
+  color_desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  color_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  color_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto color_texture = device->CreateTexture(color_desc);
+  ASSERT_NE(color_texture, nullptr);
+
+  skity::GPUTextureDescriptor depth_desc = {};
+  depth_desc.width = color_desc.width;
+  depth_desc.height = color_desc.height;
+  depth_desc.mip_level_count = 1;
+  depth_desc.sample_count = 1;
+  depth_desc.format = skity::GPUTextureFormat::kDepth24Stencil8;
+  depth_desc.usage = static_cast<skity::GPUTextureUsageMask>(
+      skity::GPUTextureUsage::kRenderAttachment);
+  depth_desc.storage_mode = skity::GPUTextureStorageMode::kPrivate;
+
+  auto depth_stencil_texture = device->CreateTexture(depth_desc);
+  ASSERT_NE(depth_stencil_texture, nullptr);
+
+  skity::GPURenderPassDescriptor render_pass_desc = {};
+  render_pass_desc.label = "vk_legacy_depth_stencil_render_pass";
+  render_pass_desc.color_attachment.texture = color_texture;
+  render_pass_desc.color_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.color_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.depth_attachment.texture = depth_stencil_texture;
+  render_pass_desc.depth_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.depth_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.depth_attachment.clear_value = 1.0f;
+  render_pass_desc.stencil_attachment.texture = depth_stencil_texture;
+  render_pass_desc.stencil_attachment.load_op = skity::GPULoadOp::kClear;
+  render_pass_desc.stencil_attachment.store_op = skity::GPUStoreOp::kStore;
+  render_pass_desc.stencil_attachment.clear_value = 3u;
+
+  auto command_buffer = device->CreateCommandBuffer();
+  ASSERT_NE(command_buffer, nullptr);
+
+  auto render_pass = command_buffer->BeginRenderPass(render_pass_desc);
+  ASSERT_NE(render_pass, nullptr);
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(command_buffer->Submit());
+  state->CollectPendingSubmissions(true);
+
+  auto* vk_texture = skity::GPUTextureVK::Cast(depth_stencil_texture.get());
+  ASSERT_NE(vk_texture, nullptr);
+  EXPECT_EQ(vk_texture->GetCurrentLayout(),
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+}
+
+TEST(VulkanProcLoaderTest, LegacyRenderPassCacheReusesCompatibleRenderPass) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  const auto* state = vk_context->GetState();
+  ASSERT_NE(state, nullptr);
+  EXPECT_FALSE(state->IsDynamicRenderingEnabled());
+
+  skity::VulkanContextState::LegacyRenderPassKey key = {};
+  key.color_format = VK_FORMAT_R8G8B8A8_UNORM;
+  key.color_samples = VK_SAMPLE_COUNT_1_BIT;
+  key.color_load_op = VK_ATTACHMENT_LOAD_OP_CLEAR;
+  key.color_store_op = VK_ATTACHMENT_STORE_OP_STORE;
+
+  const VkRenderPass first = state->GetOrCreateLegacyRenderPass(key);
+  ASSERT_NE(first, VK_NULL_HANDLE);
+
+  const VkRenderPass second = state->GetOrCreateLegacyRenderPass(key);
+  EXPECT_EQ(first, second);
+
+  key.has_stencil = true;
+  key.depth_stencil_format = VK_FORMAT_S8_UINT;
+  key.depth_stencil_samples = VK_SAMPLE_COUNT_1_BIT;
+  key.stencil_load_op = VK_ATTACHMENT_LOAD_OP_CLEAR;
+  key.stencil_store_op = VK_ATTACHMENT_STORE_OP_STORE;
+
+  const VkRenderPass third = state->GetOrCreateLegacyRenderPass(key);
+  ASSERT_NE(third, VK_NULL_HANDLE);
+  EXPECT_NE(first, third);
+}
+
+TEST(GPUNativeWindowVKTest, CreateRejectsNullInfo) {
+  auto context = skity::CreateGPUNativeWindowVK(
+      static_cast<skity::GPUContext*>(nullptr), nullptr);
+  EXPECT_EQ(context, nullptr);
+}
+
+TEST(GPUNativeWindowVKTest, CreateRejectsMissingContext) {
+  skity::GPUNativeWindowInfoVK info = {};
+  info.native_window.type = skity::VKNativeWindowType::kMetalLayer;
+  info.native_window.handle = reinterpret_cast<void*>(0x1);
+  info.width = 128;
+  info.height = 128;
+
+  auto context = skity::CreateGPUNativeWindowVK(
+      static_cast<skity::GPUContext*>(nullptr), &info);
+  EXPECT_EQ(context, nullptr);
+}
+
+TEST(GPUNativeWindowVKTest, CreateRejectsInvalidDescriptor) {
+  skity::GPUNativeWindowInfoVK info = {};
+  info.native_window.type = skity::VKNativeWindowType::kInvalid;
+  info.width = 128;
+  info.height = 128;
+
+  auto gpu_context = CreateDebugGPUContext();
+  ASSERT_NE(gpu_context, nullptr);
+
+  auto context = skity::CreateGPUNativeWindowVK(gpu_context.get(), &info);
+  EXPECT_EQ(context, nullptr);
+}
+
+TEST(GPUNativeWindowVKTest, CreateRejectsZeroSizedWindow) {
+  auto gpu_context = CreateDebugGPUContext();
+  ASSERT_NE(gpu_context, nullptr);
+
+  skity::GPUNativeWindowInfoVK info = {};
+  info.native_window.type = skity::VKNativeWindowType::kMetalLayer;
+  info.native_window.handle = reinterpret_cast<void*>(0x1);
+  info.width = 0;
+  info.height = 128;
+
+  auto native_window = skity::CreateGPUNativeWindowVK(gpu_context.get(), &info);
+  EXPECT_EQ(native_window, nullptr);
+}
+
+}  // namespace

--- a/test/ut/wgx/wgx_vulkan_pipeline_test.cc
+++ b/test/ut/wgx/wgx_vulkan_pipeline_test.cc
@@ -1,0 +1,1324 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <vulkan/vulkan.h>
+#include <wgsl_cross.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct GlobalFns {
+  PFN_vkCreateInstance vkCreateInstance = nullptr;
+  PFN_vkEnumerateInstanceExtensionProperties
+      vkEnumerateInstanceExtensionProperties = nullptr;
+  PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties =
+      nullptr;
+};
+
+struct InstanceFns {
+  PFN_vkDestroyInstance vkDestroyInstance = nullptr;
+  PFN_vkEnumeratePhysicalDevices vkEnumeratePhysicalDevices = nullptr;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties
+      vkGetPhysicalDeviceQueueFamilyProperties = nullptr;
+  PFN_vkCreateDevice vkCreateDevice = nullptr;
+  PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr = nullptr;
+};
+
+struct DeviceFns {
+  PFN_vkDestroyDevice vkDestroyDevice = nullptr;
+  PFN_vkGetDeviceQueue vkGetDeviceQueue = nullptr;
+  PFN_vkCreateDescriptorSetLayout vkCreateDescriptorSetLayout = nullptr;
+  PFN_vkDestroyDescriptorSetLayout vkDestroyDescriptorSetLayout = nullptr;
+  PFN_vkCreateShaderModule vkCreateShaderModule = nullptr;
+  PFN_vkDestroyShaderModule vkDestroyShaderModule = nullptr;
+  PFN_vkCreatePipelineLayout vkCreatePipelineLayout = nullptr;
+  PFN_vkDestroyPipelineLayout vkDestroyPipelineLayout = nullptr;
+  PFN_vkCreateRenderPass vkCreateRenderPass = nullptr;
+  PFN_vkDestroyRenderPass vkDestroyRenderPass = nullptr;
+  PFN_vkCreateGraphicsPipelines vkCreateGraphicsPipelines = nullptr;
+  PFN_vkDestroyPipeline vkDestroyPipeline = nullptr;
+};
+
+bool LoadGlobalFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                   GlobalFns* fns) {
+  if (get_instance_proc_addr == nullptr || fns == nullptr) {
+    return false;
+  }
+
+  fns->vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(
+      get_instance_proc_addr(nullptr, "vkCreateInstance"));
+  fns->vkEnumerateInstanceExtensionProperties =
+      reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
+          get_instance_proc_addr(nullptr,
+                                 "vkEnumerateInstanceExtensionProperties"));
+  fns->vkEnumerateInstanceLayerProperties =
+      reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(
+          get_instance_proc_addr(nullptr,
+                                 "vkEnumerateInstanceLayerProperties"));
+
+  return fns->vkCreateInstance != nullptr;
+}
+
+bool LoadInstanceFns(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                     VkInstance instance, InstanceFns* fns) {
+  if (get_instance_proc_addr == nullptr || instance == VK_NULL_HANDLE ||
+      fns == nullptr) {
+    return false;
+  }
+
+  fns->vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(
+      get_instance_proc_addr(instance, "vkDestroyInstance"));
+  fns->vkEnumeratePhysicalDevices =
+      reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(
+          get_instance_proc_addr(instance, "vkEnumeratePhysicalDevices"));
+  fns->vkGetPhysicalDeviceQueueFamilyProperties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(
+          get_instance_proc_addr(instance,
+                                 "vkGetPhysicalDeviceQueueFamilyProperties"));
+  fns->vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(
+      get_instance_proc_addr(instance, "vkCreateDevice"));
+  fns->vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(
+      get_instance_proc_addr(instance, "vkGetDeviceProcAddr"));
+
+  return fns->vkDestroyInstance != nullptr &&
+         fns->vkEnumeratePhysicalDevices != nullptr &&
+         fns->vkGetPhysicalDeviceQueueFamilyProperties != nullptr &&
+         fns->vkCreateDevice != nullptr && fns->vkGetDeviceProcAddr != nullptr;
+}
+
+bool LoadDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
+                   VkDevice device, DeviceFns* fns) {
+  if (get_device_proc_addr == nullptr || device == VK_NULL_HANDLE ||
+      fns == nullptr) {
+    return false;
+  }
+
+  fns->vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(
+      get_device_proc_addr(device, "vkDestroyDevice"));
+  fns->vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(
+      get_device_proc_addr(device, "vkGetDeviceQueue"));
+  fns->vkCreateDescriptorSetLayout =
+      reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(
+          get_device_proc_addr(device, "vkCreateDescriptorSetLayout"));
+  fns->vkDestroyDescriptorSetLayout =
+      reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(
+          get_device_proc_addr(device, "vkDestroyDescriptorSetLayout"));
+  fns->vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(
+      get_device_proc_addr(device, "vkCreateShaderModule"));
+  fns->vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(
+      get_device_proc_addr(device, "vkDestroyShaderModule"));
+  fns->vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(
+      get_device_proc_addr(device, "vkCreatePipelineLayout"));
+  fns->vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(
+      get_device_proc_addr(device, "vkDestroyPipelineLayout"));
+  fns->vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(
+      get_device_proc_addr(device, "vkCreateRenderPass"));
+  fns->vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(
+      get_device_proc_addr(device, "vkDestroyRenderPass"));
+  fns->vkCreateGraphicsPipelines =
+      reinterpret_cast<PFN_vkCreateGraphicsPipelines>(
+          get_device_proc_addr(device, "vkCreateGraphicsPipelines"));
+  fns->vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(
+      get_device_proc_addr(device, "vkDestroyPipeline"));
+
+  return fns->vkDestroyDevice != nullptr && fns->vkGetDeviceQueue != nullptr &&
+         fns->vkCreateDescriptorSetLayout != nullptr &&
+         fns->vkDestroyDescriptorSetLayout != nullptr &&
+         fns->vkCreateShaderModule != nullptr &&
+         fns->vkDestroyShaderModule != nullptr &&
+         fns->vkCreatePipelineLayout != nullptr &&
+         fns->vkDestroyPipelineLayout != nullptr &&
+         fns->vkCreateRenderPass != nullptr &&
+         fns->vkDestroyRenderPass != nullptr &&
+         fns->vkCreateGraphicsPipelines != nullptr &&
+         fns->vkDestroyPipeline != nullptr;
+}
+
+std::vector<uint32_t> CompileToSpirv(const char* source, const char* entry) {
+  auto program = wgx::Program::Parse(source);
+  if (program == nullptr) {
+    ADD_FAILURE() << "WGSL parse returned null program for entry " << entry;
+    return {};
+  }
+
+  if (program->GetDiagnosis().has_value()) {
+    const auto& diagnosis = program->GetDiagnosis().value();
+    ADD_FAILURE() << "WGSL diagnosis for entry " << entry << ": "
+                  << diagnosis.message << " at " << diagnosis.line << ":"
+                  << diagnosis.column;
+    return {};
+  }
+
+  wgx::SpirvOptions options;
+  auto result = program->WriteToSpirv(entry, options);
+  if (!result.success) {
+    ADD_FAILURE() << "WriteToSpirv failed for entry " << entry;
+    return {};
+  }
+  return result.spirv;
+}
+
+class VulkanTestContext {
+ public:
+  ~VulkanTestContext() { Reset(); }
+
+  bool Initialize() {
+    if (!LoadGlobalFns(vkGetInstanceProcAddr, &global_fns_)) {
+      return false;
+    }
+
+    VkApplicationInfo app_info = {};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "wgx_vulkan_pipeline_test";
+    app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = "wgx";
+    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo instance_info = {};
+    instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_info.pApplicationInfo = &app_info;
+
+    if (global_fns_.vkCreateInstance(&instance_info, nullptr, &instance_) !=
+        VK_SUCCESS) {
+      return false;
+    }
+
+    if (!LoadInstanceFns(vkGetInstanceProcAddr, instance_, &instance_fns_)) {
+      return false;
+    }
+
+    uint32_t physical_device_count = 0;
+    if (instance_fns_.vkEnumeratePhysicalDevices(
+            instance_, &physical_device_count, nullptr) != VK_SUCCESS ||
+        physical_device_count == 0) {
+      return false;
+    }
+
+    std::vector<VkPhysicalDevice> physical_devices(physical_device_count,
+                                                   VK_NULL_HANDLE);
+    if (instance_fns_.vkEnumeratePhysicalDevices(
+            instance_, &physical_device_count, physical_devices.data()) !=
+        VK_SUCCESS) {
+      return false;
+    }
+    physical_device_ = physical_devices[0];
+    if (physical_device_ == VK_NULL_HANDLE) {
+      return false;
+    }
+
+    uint32_t queue_family_count = 0;
+    instance_fns_.vkGetPhysicalDeviceQueueFamilyProperties(
+        physical_device_, &queue_family_count, nullptr);
+    if (queue_family_count == 0) {
+      return false;
+    }
+
+    std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+    instance_fns_.vkGetPhysicalDeviceQueueFamilyProperties(
+        physical_device_, &queue_family_count, queue_families.data());
+
+    for (uint32_t i = 0; i < queue_family_count; ++i) {
+      if ((queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
+        graphics_queue_family_index_ = i;
+        break;
+      }
+    }
+    if (graphics_queue_family_index_ == UINT32_MAX) {
+      return false;
+    }
+
+    const float queue_priority = 1.0f;
+    VkDeviceQueueCreateInfo queue_info = {};
+    queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_info.queueFamilyIndex = graphics_queue_family_index_;
+    queue_info.queueCount = 1;
+    queue_info.pQueuePriorities = &queue_priority;
+
+    VkDeviceCreateInfo device_info = {};
+    device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    device_info.queueCreateInfoCount = 1;
+    device_info.pQueueCreateInfos = &queue_info;
+
+    if (instance_fns_.vkCreateDevice(physical_device_, &device_info, nullptr,
+                                     &device_) != VK_SUCCESS) {
+      return false;
+    }
+
+    if (!LoadDeviceFns(instance_fns_.vkGetDeviceProcAddr, device_,
+                       &device_fns_)) {
+      return false;
+    }
+
+    device_fns_.vkGetDeviceQueue(device_, graphics_queue_family_index_, 0,
+                                 &graphics_queue_);
+    return graphics_queue_ != VK_NULL_HANDLE;
+  }
+
+  VkShaderModule CreateShaderModule(const std::vector<uint32_t>& spirv) const {
+    if (device_ == VK_NULL_HANDLE || spirv.empty()) {
+      return VK_NULL_HANDLE;
+    }
+
+    VkShaderModuleCreateInfo module_info = {};
+    module_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    module_info.codeSize = spirv.size() * sizeof(uint32_t);
+    module_info.pCode = spirv.data();
+
+    VkShaderModule module = VK_NULL_HANDLE;
+    if (device_fns_.vkCreateShaderModule(device_, &module_info, nullptr,
+                                         &module) != VK_SUCCESS) {
+      return VK_NULL_HANDLE;
+    }
+    return module;
+  }
+
+  VkDescriptorSetLayout CreateDescriptorSetLayout(
+      const std::vector<VkDescriptorSetLayoutBinding>& bindings) const {
+    VkDescriptorSetLayoutCreateInfo layout_info = {};
+    layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layout_info.bindingCount = static_cast<uint32_t>(bindings.size());
+    layout_info.pBindings = bindings.empty() ? nullptr : bindings.data();
+
+    VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
+    if (device_fns_.vkCreateDescriptorSetLayout(device_, &layout_info, nullptr,
+                                                &descriptor_set_layout) !=
+        VK_SUCCESS) {
+      return VK_NULL_HANDLE;
+    }
+    return descriptor_set_layout;
+  }
+
+  VkPipelineLayout CreatePipelineLayout(
+      const std::vector<VkDescriptorSetLayout>& set_layouts = {}) const {
+    VkPipelineLayoutCreateInfo pipeline_layout_info = {};
+    pipeline_layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipeline_layout_info.setLayoutCount =
+        static_cast<uint32_t>(set_layouts.size());
+    pipeline_layout_info.pSetLayouts =
+        set_layouts.empty() ? nullptr : set_layouts.data();
+
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    if (device_fns_.vkCreatePipelineLayout(device_, &pipeline_layout_info,
+                                           nullptr,
+                                           &pipeline_layout) != VK_SUCCESS) {
+      return VK_NULL_HANDLE;
+    }
+    return pipeline_layout;
+  }
+
+  VkRenderPass CreateSimpleColorRenderPass() const {
+    VkAttachmentDescription color_attachment = {};
+    color_attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    color_attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    color_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    color_attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_attachment_ref = {};
+    color_attachment_ref.attachment = 0;
+    color_attachment_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass = {};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &color_attachment_ref;
+
+    VkRenderPassCreateInfo render_pass_info = {};
+    render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    render_pass_info.attachmentCount = 1;
+    render_pass_info.pAttachments = &color_attachment;
+    render_pass_info.subpassCount = 1;
+    render_pass_info.pSubpasses = &subpass;
+
+    VkRenderPass render_pass = VK_NULL_HANDLE;
+    if (device_fns_.vkCreateRenderPass(device_, &render_pass_info, nullptr,
+                                       &render_pass) != VK_SUCCESS) {
+      return VK_NULL_HANDLE;
+    }
+    return render_pass;
+  }
+
+  VkPipeline CreateSimpleGraphicsPipeline(
+      VkShaderModule vertex_module, const char* vertex_entry,
+      VkShaderModule fragment_module, const char* fragment_entry,
+      VkPipelineLayout pipeline_layout, VkRenderPass render_pass,
+      const std::vector<VkVertexInputBindingDescription>& vertex_bindings = {},
+      const std::vector<VkVertexInputAttributeDescription>& vertex_attributes =
+          {}) const {
+    if (vertex_module == VK_NULL_HANDLE || fragment_module == VK_NULL_HANDLE ||
+        pipeline_layout == VK_NULL_HANDLE || render_pass == VK_NULL_HANDLE) {
+      return VK_NULL_HANDLE;
+    }
+
+    VkPipelineShaderStageCreateInfo shader_stages[2] = {};
+    shader_stages[0].sType =
+        VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    shader_stages[0].module = vertex_module;
+    shader_stages[0].pName = vertex_entry;
+    shader_stages[1].sType =
+        VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shader_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shader_stages[1].module = fragment_module;
+    shader_stages[1].pName = fragment_entry;
+
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = {};
+    vertex_input_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertex_input_state.vertexBindingDescriptionCount =
+        static_cast<uint32_t>(vertex_bindings.size());
+    vertex_input_state.pVertexBindingDescriptions =
+        vertex_bindings.empty() ? nullptr : vertex_bindings.data();
+    vertex_input_state.vertexAttributeDescriptionCount =
+        static_cast<uint32_t>(vertex_attributes.size());
+    vertex_input_state.pVertexAttributeDescriptions =
+        vertex_attributes.empty() ? nullptr : vertex_attributes.data();
+
+    VkPipelineInputAssemblyStateCreateInfo input_assembly_state = {};
+    input_assembly_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    input_assembly_state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkViewport viewport = {};
+    viewport.width = 1.0f;
+    viewport.height = 1.0f;
+    viewport.maxDepth = 1.0f;
+
+    VkRect2D scissor = {};
+    scissor.extent.width = 1;
+    scissor.extent.height = 1;
+
+    VkPipelineViewportStateCreateInfo viewport_state = {};
+    viewport_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewport_state.viewportCount = 1;
+    viewport_state.pViewports = &viewport;
+    viewport_state.scissorCount = 1;
+    viewport_state.pScissors = &scissor;
+
+    VkPipelineRasterizationStateCreateInfo rasterization_state = {};
+    rasterization_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterization_state.cullMode = VK_CULL_MODE_NONE;
+    rasterization_state.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterization_state.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo multisample_state = {};
+    multisample_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisample_state.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineColorBlendAttachmentState color_blend_attachment = {};
+    color_blend_attachment.colorWriteMask =
+        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+        VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineColorBlendStateCreateInfo color_blend_state = {};
+    color_blend_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    color_blend_state.attachmentCount = 1;
+    color_blend_state.pAttachments = &color_blend_attachment;
+
+    VkGraphicsPipelineCreateInfo pipeline_info = {};
+    pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipeline_info.stageCount = 2;
+    pipeline_info.pStages = shader_stages;
+    pipeline_info.pVertexInputState = &vertex_input_state;
+    pipeline_info.pInputAssemblyState = &input_assembly_state;
+    pipeline_info.pViewportState = &viewport_state;
+    pipeline_info.pRasterizationState = &rasterization_state;
+    pipeline_info.pMultisampleState = &multisample_state;
+    pipeline_info.pColorBlendState = &color_blend_state;
+    pipeline_info.layout = pipeline_layout;
+    pipeline_info.renderPass = render_pass;
+    pipeline_info.subpass = 0;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    if (device_fns_.vkCreateGraphicsPipelines(device_, VK_NULL_HANDLE, 1,
+                                              &pipeline_info, nullptr,
+                                              &pipeline) != VK_SUCCESS) {
+      return VK_NULL_HANDLE;
+    }
+    return pipeline;
+  }
+
+  void DestroyShaderModule(VkShaderModule module) const {
+    if (module != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyShaderModule(device_, module, nullptr);
+    }
+  }
+
+  void DestroyDescriptorSetLayout(
+      VkDescriptorSetLayout descriptor_set_layout) const {
+    if (descriptor_set_layout != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyDescriptorSetLayout(device_, descriptor_set_layout,
+                                               nullptr);
+    }
+  }
+
+  void DestroyPipelineLayout(VkPipelineLayout pipeline_layout) const {
+    if (pipeline_layout != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyPipelineLayout(device_, pipeline_layout, nullptr);
+    }
+  }
+
+  void DestroyRenderPass(VkRenderPass render_pass) const {
+    if (render_pass != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyRenderPass(device_, render_pass, nullptr);
+    }
+  }
+
+  void DestroyPipeline(VkPipeline pipeline) const {
+    if (pipeline != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyPipeline(device_, pipeline, nullptr);
+    }
+  }
+
+ private:
+  void Reset() {
+    if (device_ != VK_NULL_HANDLE) {
+      device_fns_.vkDestroyDevice(device_, nullptr);
+      device_ = VK_NULL_HANDLE;
+    }
+    if (instance_ != VK_NULL_HANDLE) {
+      instance_fns_.vkDestroyInstance(instance_, nullptr);
+      instance_ = VK_NULL_HANDLE;
+    }
+  }
+
+  GlobalFns global_fns_ = {};
+  InstanceFns instance_fns_ = {};
+  DeviceFns device_fns_ = {};
+  VkInstance instance_ = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
+  VkDevice device_ = VK_NULL_HANDLE;
+  VkQueue graphics_queue_ = VK_NULL_HANDLE;
+  uint32_t graphics_queue_family_index_ = UINT32_MAX;
+};
+
+class WgxVulkanPipelineTest : public ::testing::Test {
+ protected:
+  void SetUp() override { ASSERT_TRUE(context_.Initialize()); }
+
+  VulkanTestContext context_;
+};
+
+}  // namespace
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForStructInterfaceShaders) {
+  const char* vertex_source = R"(
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main() -> VertexOutput {
+  var output: VertexOutput;
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+struct FragmentInput {
+  @location(0) color: vec4<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  var i: i32 = 0;
+  output.color = input.color;
+  while (i < 1) {
+    i = i + 1;
+    output.color = input.color;
+  }
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout = context_.CreatePipelineLayout();
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass);
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForDescriptorSetMappedShaders) {
+  const char* vertex_source = R"(
+@group(0) @binding(1)
+var<uniform> u_data: vec4<f32>;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main() -> VertexOutput {
+  var output: VertexOutput;
+  output.position = u_data;
+  output.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+struct FragmentInput {
+  @location(0) color: vec4<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  output.color = input.color;
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding uniform_binding = {};
+  uniform_binding.binding = 1;
+  uniform_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  uniform_binding.descriptorCount = 1;
+  uniform_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+  VkDescriptorSetLayout descriptor_set_layout =
+      context_.CreateDescriptorSetLayout({uniform_binding});
+  ASSERT_NE(descriptor_set_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({descriptor_set_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkVertexInputBindingDescription vertex_binding = {};
+  vertex_binding.binding = 0;
+  vertex_binding.stride = 4 * sizeof(float);
+  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+  VkVertexInputAttributeDescription position_attribute = {};
+  position_attribute.location = 0;
+  position_attribute.binding = 0;
+  position_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  position_attribute.offset = 0;
+
+  VkVertexInputAttributeDescription uv_attribute = {};
+  uv_attribute.location = 1;
+  uv_attribute.binding = 0;
+  uv_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  uv_attribute.offset = 2 * sizeof(float);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass, {vertex_binding}, {position_attribute, uv_attribute});
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(descriptor_set_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForTextureAndSamplerMappedShaders) {
+  const char* vertex_source = R"(
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+struct VertexInput {
+  @location(0) pos: vec2<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.uv = input.pos + input.uv;
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+@group(0) @binding(0)
+var tex: texture_2d<f32>;
+
+@group(0) @binding(1)
+var samp: sampler;
+
+struct FragmentInput {
+  @location(0) uv: vec2<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  output.color = textureSample(tex, samp, input.uv);
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding texture_binding = {};
+  texture_binding.binding = 0;
+  texture_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+  texture_binding.descriptorCount = 1;
+  texture_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding sampler_binding = {};
+  sampler_binding.binding = 1;
+  sampler_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+  sampler_binding.descriptorCount = 1;
+  sampler_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayout descriptor_set_layout =
+      context_.CreateDescriptorSetLayout({texture_binding, sampler_binding});
+  ASSERT_NE(descriptor_set_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({descriptor_set_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass);
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(descriptor_set_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForVertexAttributeInputShaders) {
+  const char* vertex_source = R"(
+struct VertexInput {
+  @location(0) pos: vec2<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.uv = input.pos + input.uv;
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+@group(0) @binding(0)
+var tex: texture_2d<f32>;
+
+@group(0) @binding(1)
+var samp: sampler;
+
+struct FragmentInput {
+  @location(0) uv: vec2<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  output.color = textureSample(tex, samp, input.uv);
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding texture_binding = {};
+  texture_binding.binding = 0;
+  texture_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+  texture_binding.descriptorCount = 1;
+  texture_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding sampler_binding = {};
+  sampler_binding.binding = 1;
+  sampler_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+  sampler_binding.descriptorCount = 1;
+  sampler_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayout descriptor_set_layout =
+      context_.CreateDescriptorSetLayout({texture_binding, sampler_binding});
+  ASSERT_NE(descriptor_set_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({descriptor_set_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkVertexInputBindingDescription vertex_binding = {};
+  vertex_binding.binding = 0;
+  vertex_binding.stride = 4 * sizeof(float);
+  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+  VkVertexInputAttributeDescription position_attribute = {};
+  position_attribute.location = 0;
+  position_attribute.binding = 0;
+  position_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  position_attribute.offset = 0;
+
+  VkVertexInputAttributeDescription uv_attribute = {};
+  uv_attribute.location = 1;
+  uv_attribute.binding = 0;
+  uv_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  uv_attribute.offset = 2 * sizeof(float);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass, {vertex_binding}, {position_attribute, uv_attribute});
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(descriptor_set_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForRepositoryStyleTextureShaders) {
+  const char* vertex_source = R"(
+struct VertexInput {
+  @location(0) pos: vec2<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) f_frag_coord: vec2<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.f_frag_coord = input.uv;
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+struct ImageColorInfo {
+  infos: vec3<i32>,
+  global_alpha: f32,
+};
+
+@group(1) @binding(0)
+var<uniform> image_color_info: ImageColorInfo;
+
+@group(1) @binding(1)
+var uSampler: sampler;
+
+@group(1) @binding(2)
+var uTexture: texture_2d<f32>;
+
+struct FragmentInput {
+  @location(0) f_frag_coord: vec2<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  var color: vec4<f32> =
+      textureSample(uTexture, uSampler, input.f_frag_coord);
+  output.color = color * image_color_info.global_alpha;
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding image_color_binding = {};
+  image_color_binding.binding = 0;
+  image_color_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  image_color_binding.descriptorCount = 1;
+  image_color_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding sampler_binding = {};
+  sampler_binding.binding = 1;
+  sampler_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+  sampler_binding.descriptorCount = 1;
+  sampler_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding texture_binding = {};
+  texture_binding.binding = 2;
+  texture_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+  texture_binding.descriptorCount = 1;
+  texture_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayout set1_layout = context_.CreateDescriptorSetLayout(
+      {image_color_binding, sampler_binding, texture_binding});
+  ASSERT_NE(set1_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({set1_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkVertexInputBindingDescription vertex_binding = {};
+  vertex_binding.binding = 0;
+  vertex_binding.stride = 4 * sizeof(float);
+  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+  VkVertexInputAttributeDescription position_attribute = {};
+  position_attribute.location = 0;
+  position_attribute.binding = 0;
+  position_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  position_attribute.offset = 0;
+
+  VkVertexInputAttributeDescription uv_attribute = {};
+  uv_attribute.location = 1;
+  uv_attribute.binding = 0;
+  uv_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  uv_attribute.offset = 2 * sizeof(float);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass, {vertex_binding}, {position_attribute, uv_attribute});
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(set1_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForRepositoryStyleGradientShaders) {
+  const char* vertex_source = R"(
+struct VertexInput {
+  @location(0) local_pos: vec2<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) f_param_pos: vec2<f32>,
+};
+
+@group(0) @binding(1)
+var<uniform> inv_matrix: mat4x4<f32>;
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  var mapped_pos: vec4<f32> = inv_matrix * vec4<f32>(input.local_pos, 0.0, 1.0);
+  output.position = vec4<f32>(input.local_pos, 0.0, 1.0);
+  output.f_param_pos = vec2<f32>(mapped_pos[0], mapped_pos[1]);
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+struct GradientInfo {
+  infos: vec3<i32>,
+  global_alpha: f32,
+};
+
+@group(1) @binding(0)
+var<uniform> gradient_info: GradientInfo;
+
+@group(1) @binding(1)
+var<uniform> linear_start: vec2<f32>;
+
+@group(1) @binding(2)
+var<uniform> linear_end: vec2<f32>;
+
+struct FragmentInput {
+  @location(0) f_param_pos: vec2<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+};
+
+fn generate_gradient_color(v_pos: vec2<f32>) -> vec4<f32> {
+  var cs: vec2<f32> = v_pos - linear_start;
+  var se: vec2<f32> = linear_end - linear_start;
+  var t: f32 = dot(cs, se) / dot(se, se);
+  var t_clamped: f32 = clamp(t, 0.0, 1.0);
+  var color: vec4<f32> = mix(
+      vec4<f32>(1.0, 0.0, 0.0, 1.0),
+      vec4<f32>(0.0, 0.0, 1.0, 1.0),
+      t_clamped);
+  if gradient_info.infos[0] == 0 {
+    var premul_rgb: vec3<f32> = vec3<f32>(
+        color[0] * color[3],
+        color[1] * color[3],
+        color[2] * color[3]);
+    color = vec4<f32>(premul_rgb, color[3]);
+  }
+  return color * gradient_info.global_alpha;
+}
+
+@fragment
+fn fs_main(input: FragmentInput) -> FragmentOutput {
+  var output: FragmentOutput;
+  output.color = generate_gradient_color(input.f_param_pos);
+  return output;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding inv_matrix_binding = {};
+  inv_matrix_binding.binding = 1;
+  inv_matrix_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  inv_matrix_binding.descriptorCount = 1;
+  inv_matrix_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+  VkDescriptorSetLayout set0_layout =
+      context_.CreateDescriptorSetLayout({inv_matrix_binding});
+  ASSERT_NE(set0_layout, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding gradient_info_binding = {};
+  gradient_info_binding.binding = 0;
+  gradient_info_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  gradient_info_binding.descriptorCount = 1;
+  gradient_info_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding linear_pts_binding = {};
+  linear_pts_binding.binding = 1;
+  linear_pts_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  linear_pts_binding.descriptorCount = 1;
+  linear_pts_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding linear_end_binding = {};
+  linear_end_binding.binding = 2;
+  linear_end_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  linear_end_binding.descriptorCount = 1;
+  linear_end_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayout set1_layout = context_.CreateDescriptorSetLayout(
+      {gradient_info_binding, linear_pts_binding, linear_end_binding});
+  ASSERT_NE(set1_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({set0_layout, set1_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkVertexInputBindingDescription vertex_binding = {};
+  vertex_binding.binding = 0;
+  vertex_binding.stride = 2 * sizeof(float);
+  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+  VkVertexInputAttributeDescription position_attribute = {};
+  position_attribute.location = 0;
+  position_attribute.binding = 0;
+  position_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  position_attribute.offset = 0;
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass, {vertex_binding}, {position_attribute});
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(set1_layout);
+  context_.DestroyDescriptorSetLayout(set0_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}
+
+TEST_F(WgxVulkanPipelineTest,
+       CreatesGraphicsPipelineForRepositoryStyleTextureFragmentShaders) {
+  const char* vertex_source = R"(
+struct VertexInput {
+  @location(0) local_pos: vec2<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+struct ImageBoundsInfo {
+  bounds: vec2<f32>,
+  inv_matrix: mat4x4<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) f_frag_coord: vec2<f32>,
+};
+
+@group(0) @binding(1)
+var<uniform> image_bounds: ImageBoundsInfo;
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  var mapped_pos: vec2<f32> =
+      (image_bounds.inv_matrix * vec4<f32>(input.local_pos.xy, 0.0, 1.0)).xy;
+  var mapped_lt: vec2<f32> = vec2<f32>(0.0, 0.0);
+  var mapped_rb: vec2<f32> = image_bounds.bounds;
+  var total_x: f32 = mapped_rb.x - mapped_lt.x;
+  var total_y: f32 = mapped_rb.y - mapped_lt.y;
+  var v_x: f32 = (mapped_pos.x - mapped_lt.x) / total_x;
+  var v_y: f32 = (mapped_pos.y - mapped_lt.y) / total_y;
+  output.position = vec4<f32>(input.local_pos, 0.0, 1.0);
+  output.f_frag_coord = vec2<f32>(v_x, v_y);
+  return output;
+}
+)";
+
+  const char* fragment_source = R"(
+fn remap_float_tile(t: f32, tile_mode: i32) -> f32 {
+  if tile_mode == 0 {
+    return clamp(t, 0.0, 1.0);
+  } else if tile_mode == 1 {
+    return fract(t);
+  } else if tile_mode == 2 {
+    var t1: f32 = t - 1.0;
+    var t2: f32 = t1 - 2.0 * floor(t1 / 2.0) - 1.0;
+    return abs(t2);
+  }
+  return t;
+}
+
+struct ImageColorInfo {
+  infos: vec3<i32>,
+  global_alpha: f32,
+};
+
+@group(1) @binding(0)
+var<uniform> image_color_info: ImageColorInfo;
+
+@group(1) @binding(1)
+var uSampler: sampler;
+
+@group(1) @binding(2)
+var uTexture: texture_2d<f32>;
+
+@fragment
+fn fs_main(@location(0) f_frag_coord: vec2<f32>) -> @location(0) vec4<f32> {
+  var uv: vec2<f32> = f_frag_coord;
+  var color: vec4<f32> = textureSample(uTexture, uSampler, uv);
+
+  if (image_color_info.infos.y == 3 && (uv.x < 0.0 || uv.x >= 1.0)) ||
+      (image_color_info.infos.z == 3 && (uv.y < 0.0 || uv.y >= 1.0)) {
+    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+  }
+
+  uv.x = remap_float_tile(uv.x, image_color_info.infos.y);
+  uv.y = remap_float_tile(uv.y, image_color_info.infos.z);
+
+  if image_color_info.infos.x == 3 {
+    color = vec4<f32>(color.xyz * color.w, color.w);
+  }
+
+  return color * image_color_info.global_alpha;
+}
+)";
+
+  std::vector<uint32_t> vertex_spirv = CompileToSpirv(vertex_source, "vs_main");
+  std::vector<uint32_t> fragment_spirv =
+      CompileToSpirv(fragment_source, "fs_main");
+  ASSERT_FALSE(vertex_spirv.empty());
+  ASSERT_FALSE(fragment_spirv.empty());
+
+  VkShaderModule vertex_module = context_.CreateShaderModule(vertex_spirv);
+  VkShaderModule fragment_module = context_.CreateShaderModule(fragment_spirv);
+  ASSERT_NE(vertex_module, VK_NULL_HANDLE);
+  ASSERT_NE(fragment_module, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding image_bounds_binding = {};
+  image_bounds_binding.binding = 1;
+  image_bounds_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  image_bounds_binding.descriptorCount = 1;
+  image_bounds_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+  VkDescriptorSetLayout set0_layout =
+      context_.CreateDescriptorSetLayout({image_bounds_binding});
+  ASSERT_NE(set0_layout, VK_NULL_HANDLE);
+
+  VkDescriptorSetLayoutBinding image_color_binding = {};
+  image_color_binding.binding = 0;
+  image_color_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  image_color_binding.descriptorCount = 1;
+  image_color_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding sampler_binding = {};
+  sampler_binding.binding = 1;
+  sampler_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+  sampler_binding.descriptorCount = 1;
+  sampler_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayoutBinding texture_binding = {};
+  texture_binding.binding = 2;
+  texture_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+  texture_binding.descriptorCount = 1;
+  texture_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+  VkDescriptorSetLayout set1_layout = context_.CreateDescriptorSetLayout(
+      {image_color_binding, sampler_binding, texture_binding});
+  ASSERT_NE(set1_layout, VK_NULL_HANDLE);
+
+  VkPipelineLayout pipeline_layout =
+      context_.CreatePipelineLayout({set0_layout, set1_layout});
+  ASSERT_NE(pipeline_layout, VK_NULL_HANDLE);
+
+  VkRenderPass render_pass = context_.CreateSimpleColorRenderPass();
+  ASSERT_NE(render_pass, VK_NULL_HANDLE);
+
+  VkVertexInputBindingDescription vertex_binding = {};
+  vertex_binding.binding = 0;
+  vertex_binding.stride = 4 * sizeof(float);
+  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+  VkVertexInputAttributeDescription position_attribute = {};
+  position_attribute.location = 0;
+  position_attribute.binding = 0;
+  position_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  position_attribute.offset = 0;
+
+  VkVertexInputAttributeDescription uv_attribute = {};
+  uv_attribute.location = 1;
+  uv_attribute.binding = 0;
+  uv_attribute.format = VK_FORMAT_R32G32_SFLOAT;
+  uv_attribute.offset = 2 * sizeof(float);
+
+  VkPipeline pipeline = context_.CreateSimpleGraphicsPipeline(
+      vertex_module, "vs_main", fragment_module, "fs_main", pipeline_layout,
+      render_pass, {vertex_binding}, {position_attribute, uv_attribute});
+  ASSERT_NE(pipeline, VK_NULL_HANDLE);
+
+  context_.DestroyPipeline(pipeline);
+  context_.DestroyRenderPass(render_pass);
+  context_.DestroyPipelineLayout(pipeline_layout);
+  context_.DestroyDescriptorSetLayout(set1_layout);
+  context_.DestroyDescriptorSetLayout(set0_layout);
+  context_.DestroyShaderModule(fragment_module);
+  context_.DestroyShaderModule(vertex_module);
+}


### PR DESCRIPTION
Implement the complete Vulkan GPU backend for skity, including device management, command buffer, render pass, pipeline, buffer, texture, sampler, surface, presenter (swapchain), blit pass, and all supporting infrastructure (context state, render pass cache, proc table, platform extensions, debug runtime).

Also extends GPU abstraction interfaces to support the Vulkan backend and adapts GL/MTL/Web backends accordingly.