### PR TITLE
chore(hw): reuse clip draws for replay

### DIFF
--- a/src/render/hw/draw/hw_dynamic_path_clip.cc
+++ b/src/render/hw/draw/hw_dynamic_path_clip.cc
@@ -24,14 +24,6 @@ HWDynamicPathClip::HWDynamicPathClip(Matrix transform, Path path,
   bounds_.AddRect(bounds);
 }
 
-HWDraw *HWDynamicPathClip::MakeClipReplay(
-    ArenaAllocator *arena_allocator) const {
-  DEBUG_CHECK(arena_allocator != nullptr);
-
-  return arena_allocator->Make<HWDynamicPathClip>(
-      GetTransform(), path_, op_, bounds_.GetBounds(), use_gpu_tessellation_);
-}
-
 void HWDynamicPathClip::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                                            HWDrawContext *context) {
   auto arena_allocator = context->arena_allocator;

--- a/src/render/hw/draw/hw_dynamic_path_clip.hpp
+++ b/src/render/hw/draw/hw_dynamic_path_clip.hpp
@@ -21,8 +21,6 @@ class HWDynamicPathClip : public HWDynamicDraw {
 
   HWDrawType GetDrawType() const override { return HWDrawType::kClip; }
 
-  HWDraw *MakeClipReplay(ArenaAllocator *arena_allocator) const override;
-
  protected:
   void OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
                           HWDrawContext *context) override;

--- a/src/render/hw/hw_draw.hpp
+++ b/src/render/hw/hw_draw.hpp
@@ -139,11 +139,6 @@ class HWDraw {
 
   virtual HWDrawType GetDrawType() const { return HWDrawType::kUnknow; }
 
-  virtual HWDraw* MakeClipReplay(ArenaAllocator* arena_allocator) const {
-    (void)arena_allocator;
-    return nullptr;
-  }
-
   void SetClipDepth(uint32_t clip_depth) { clip_depth_ = clip_depth; }
 
   DstReadStrategy GetDstReadStrategy() const { return dst_read_strategy_; }

--- a/src/render/hw/hw_draw_pass.hpp
+++ b/src/render/hw/hw_draw_pass.hpp
@@ -36,6 +36,8 @@ struct HWDrawPass {
   std::vector<HWDraw*> draw_ops;
   uint32_t clip_replay_count = 0;
   uint32_t first_draw_depth = 0;
+  // Aliases to original clip draws. Their generated commands are replayed into
+  // split render passes without re-running draw preparation or command setup.
   std::vector<HWDraw*> clip_replay_draws;
   std::optional<DstTextureCopyInfo> dst_texture_copy_info = std::nullopt;
   const DstTextureCopyInfo* dst_read_texture_copy_info = nullptr;

--- a/src/render/hw/hw_layer.cc
+++ b/src/render/hw/hw_layer.cc
@@ -18,6 +18,7 @@
 #include "src/gpu/gpu_sampler.hpp"
 #include "src/gpu/gpu_texture.hpp"
 #include "src/gpu/texture_impl.hpp"
+#include "src/logging.hpp"
 #include "src/render/hw/draw/hw_dynamic_path_draw.hpp"
 #include "src/render/hw/hw_draw.hpp"
 #include "src/render/hw/hw_draw_pass.hpp"
@@ -241,7 +242,7 @@ HWDrawState HWLayer::OnPrepare(HWDrawContext* context) {
   sub_context.scale = scale_;
 
   for (auto pass : draw_passes_) {
-    PrepareReplayDraws(pass, &sub_context);
+    CollectClipReplayDraws(pass);
 
     if (pass->emulated_load_info) {
       auto resolve_color_texture = GetResolveColorTexture();
@@ -255,9 +256,6 @@ HWDrawState HWLayer::OnPrepare(HWDrawContext* context) {
         pass->emulated_load_info ? pass->emulated_load_info->draw : nullptr;
     if (emulated_load_draw) {
       layer_state_ |= pass->emulated_load_info->draw->Prepare(&sub_context);
-    }
-    for (auto draw : pass->clip_replay_draws) {
-      layer_state_ |= draw->Prepare(&sub_context);
     }
     for (auto draw : pass->draw_ops) {
       layer_state_ |= draw->Prepare(&sub_context);
@@ -310,10 +308,6 @@ void HWLayer::OnGenerateCommand(HWDrawContext* context, HWDrawState state) {
       pass->emulated_load_info->draw->GenerateCommand(&sub_context,
                                                       layer_state_);
     }
-    for (auto draw : pass->clip_replay_draws) {
-      sub_context.dst_read_texture_copy_info = nullptr;
-      draw->GenerateCommand(&sub_context, layer_state_);
-    }
     for (auto draw : pass->draw_ops) {
       sub_context.dst_read_texture_copy_info =
           draw->GetDstReadStrategy() == DstReadStrategy::kTextureCopy
@@ -325,10 +319,7 @@ void HWLayer::OnGenerateCommand(HWDrawContext* context, HWDrawState state) {
   sub_context.dst_read_texture_copy_info = nullptr;
 }
 
-void HWLayer::PrepareReplayDraws(HWDrawPass* pass, HWDrawContext* context) {
-  DEBUG_CHECK(context != nullptr);
-  DEBUG_CHECK(context->arena_allocator != nullptr);
-
+void HWLayer::CollectClipReplayDraws(HWDrawPass* pass) {
   if (pass->clip_replay_count == 0) {
     return;
   }
@@ -349,15 +340,7 @@ void HWLayer::PrepareReplayDraws(HWDrawPass* pass, HWDrawContext* context) {
       continue;
     }
 
-    auto* replay_draw = source_draw->MakeClipReplay(context->arena_allocator);
-    DEBUG_CHECK(replay_draw != nullptr);
-
-    replay_draw->SetSampleCount(source_draw->GetSampleCount());
-    replay_draw->SetColorFormat(source_draw->GetColorFormat());
-    replay_draw->SetScissorBox(source_draw->GetScissorBox());
-    replay_draw->SetLayerSpaceBounds(source_draw->GetLayerSpaceBounds());
-    replay_draw->SetClipDepth(source_draw->GetClipDepth());
-    pass->clip_replay_draws.push_back(replay_draw);
+    pass->clip_replay_draws.push_back(source_draw);
   }
 }
 

--- a/src/render/hw/hw_layer.hpp
+++ b/src/render/hw/hw_layer.hpp
@@ -153,7 +153,7 @@ class HWLayer : public HWDraw {
 
   bool TryMerge(HWDraw* draw);
 
-  void PrepareReplayDraws(HWDrawPass* pass, HWDrawContext* context);
+  void CollectClipReplayDraws(HWDrawPass* pass);
 
   std::optional<DstTextureCopyInfo> BuildDstTextureCopyInfo(
       const Rect& layer_space_bounds) const;


### PR DESCRIPTION
Replay texture-copy clip state by aliasing the original clip draw commands instead of cloning draws. Remove the clip replay factory path so draw preparation and command generation stay single-use.