### PR TITLE
feat(gpu): integrate Vulkan render pipeline and add example support

### DIFF
--- a/example/common/CMakeLists.txt
+++ b/example/common/CMakeLists.txt
@@ -45,6 +45,29 @@ if (${SKITY_MTL_BACKEND})
 
 endif()
 
+if (${SKITY_VK_BACKEND})
+  if (NOT TARGET volk::volk)
+    set(VOLK_PULL_IN_VULKAN OFF CACHE BOOL "Disable Volk Vulkan lookup" FORCE)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/volk third_party/volk)
+  endif()
+
+  target_compile_definitions(skity_example_common PUBLIC -DSKITY_EXAMPLE_VK_BACKEND=1)
+
+  target_sources(skity_example_common PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/vk/window_vk.cc
+    ${CMAKE_CURRENT_LIST_DIR}/vk/window_vk.hpp
+  )
+
+  if (APPLE)
+    target_sources(skity_example_common PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/vk/window_vk_native_macos.mm
+    )
+  endif()
+
+  target_include_directories(skity_example_common PUBLIC ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include)
+  target_link_libraries(skity_example_common PRIVATE volk::volk)
+endif()
+
 add_library(skity::example_common ALIAS skity_example_common)
 
 target_include_directories(skity_example_common PUBLIC ${CMAKE_SOURCE_DIR}/example)

--- a/example/common/vk/window_vk.cc
+++ b/example/common/vk/window_vk.cc
@@ -1,0 +1,285 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// This example uses volk as the Vulkan loader. Keep `VK_NO_PROTOTYPES`
+// defined before including any Vulkan headers so the TU consistently uses
+// volk-managed function pointers instead of mixing prototype declarations with
+// dynamic loader symbols.
+#ifndef VK_NO_PROTOTYPES
+#define VK_NO_PROTOTYPES
+#endif
+#include "common/vk/window_vk.hpp"
+
+#include <volk.h>
+
+#if defined(SKITY_WIN)
+#define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined(SKITY_MACOS)
+#define GLFW_EXPOSE_NATIVE_COCOA
+#elif defined(SKITY_LINUX)
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#define GLFW_EXPOSE_NATIVE_X11
+#endif
+#include <GLFW/glfw3native.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+namespace skity {
+namespace example {
+
+#if defined(SKITY_MACOS)
+bool SetupCocoaVulkanWindow(GLFWwindow* window);
+void* GetCocoaVulkanLayer(GLFWwindow* window);
+void* GetCocoaVulkanView(GLFWwindow* window);
+#endif
+
+namespace {
+
+void AddUniqueExtension(std::vector<const char*>* extensions,
+                        const char* name) {
+  if (extensions == nullptr || name == nullptr) {
+    return;
+  }
+
+  if (std::find(extensions->begin(), extensions->end(), name) !=
+      extensions->end()) {
+    return;
+  }
+
+  extensions->push_back(name);
+}
+
+bool ContainsString(const char* const* names, uint32_t count,
+                    const char* target) {
+  if (names == nullptr || target == nullptr) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < count; ++i) {
+    if (names[i] != nullptr && std::string(names[i]) == target) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool BuildNativeWindowInfo(GLFWwindow* window,
+                           skity::VKNativeWindowInfo* info) {
+  if (window == nullptr || info == nullptr) {
+    return false;
+  }
+
+  *info = {};
+
+#if defined(SKITY_WIN)
+  info->type = skity::VKNativeWindowType::kWin32;
+  info->handle = glfwGetWin32Window(window);
+  info->secondary_handle = GetModuleHandle(nullptr);
+  return info->handle != nullptr;
+#elif defined(SKITY_MACOS)
+  info->type = skity::VKNativeWindowType::kMetalLayer;
+  info->handle = GetCocoaVulkanLayer(window);
+  info->secondary_handle = GetCocoaVulkanView(window);
+  return info->handle != nullptr || info->secondary_handle != nullptr;
+#elif defined(SKITY_LINUX)
+  uint32_t extension_count = 0;
+  const char** extensions = glfwGetRequiredInstanceExtensions(&extension_count);
+  if (ContainsString(extensions, extension_count,
+                     VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+    info->type = skity::VKNativeWindowType::kWayland;
+    info->handle = glfwGetWaylandDisplay();
+    info->secondary_handle = glfwGetWaylandWindow(window);
+    return info->handle != nullptr && info->secondary_handle != nullptr;
+  }
+
+  info->type = skity::VKNativeWindowType::kXlib;
+  info->handle = glfwGetX11Display();
+  info->window_id = static_cast<uint64_t>(glfwGetX11Window(window));
+  return info->handle != nullptr && info->window_id != 0;
+#else
+  (void)window;
+  return false;
+#endif
+}
+
+}  // namespace
+
+bool WindowVK::OnInit() {
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  return true;
+}
+
+GLFWwindow* WindowVK::CreateWindowHandler() {
+  auto* window = glfwCreateWindow(GetWidth(), GetHeight(), GetTitle().c_str(),
+                                  nullptr, nullptr);
+  if (window == nullptr) {
+    return nullptr;
+  }
+
+#if defined(SKITY_MACOS)
+  if (!SetupCocoaVulkanWindow(window)) {
+    glfwDestroyWindow(window);
+    return nullptr;
+  }
+#endif
+
+  return window;
+}
+
+std::unique_ptr<skity::GPUContext> WindowVK::CreateGPUContext() {
+  if (volkInitialize() != VK_SUCCESS) {
+    std::cerr << "Failed to initialize volk." << std::endl;
+    return nullptr;
+  }
+
+  uint32_t required_extension_count = 0;
+  const char** required_extensions =
+      glfwGetRequiredInstanceExtensions(&required_extension_count);
+  if (required_extensions == nullptr || required_extension_count == 0) {
+    std::cerr << "Failed to query GLFW Vulkan instance extensions."
+              << std::endl;
+    return nullptr;
+  }
+
+  std::vector<const char*> requested_extensions(
+      required_extensions, required_extensions + required_extension_count);
+
+#if defined(SKITY_MACOS) || defined(SKITY_IOS)
+#if defined(VK_EXT_METAL_SURFACE_EXTENSION_NAME)
+  AddUniqueExtension(&requested_extensions,
+                     VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+#endif
+#if defined(VK_MVK_MACOS_SURFACE_EXTENSION_NAME)
+  AddUniqueExtension(&requested_extensions,
+                     VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+#endif
+#endif
+
+  skity::GPUContextInfoVK info = {};
+  info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  info.enabled_instance_extensions = requested_extensions.data();
+  info.enabled_instance_extension_count =
+      static_cast<uint32_t>(requested_extensions.size());
+  return skity::CreateGPUContextVK(&info);
+}
+
+void WindowVK::OnShow() {
+  if (!CreateNativeWindow()) {
+    std::cerr << "Failed to create Vulkan native window." << std::endl;
+    glfwSetWindowShouldClose(GetNativeWindow(), GLFW_TRUE);
+  }
+}
+
+skity::Canvas* WindowVK::AquireCanvas() {
+  if (native_window_vk_ == nullptr) {
+    return nullptr;
+  }
+
+  auto* presenter = native_window_vk_->GetPresenter();
+  if (presenter == nullptr) {
+    return nullptr;
+  }
+
+  const int32_t logical_width = std::max(GetWidth(), 1);
+  const int32_t logical_height = std::max(GetHeight(), 1);
+
+  int framebuffer_width = 0;
+  int framebuffer_height = 0;
+  glfwGetFramebufferSize(GetNativeWindow(), &framebuffer_width,
+                         &framebuffer_height);
+  const float density =
+      static_cast<float>(
+          std::max(framebuffer_width, 1) * std::max(framebuffer_width, 1) +
+          std::max(framebuffer_height, 1) * std::max(framebuffer_height, 1)) /
+      static_cast<float>(logical_width * logical_width +
+                         logical_height * logical_height);
+  skity::GPUSurfaceAcquireDescriptor acquire_desc = {};
+  acquire_desc.sample_count = 4;
+  acquire_desc.content_scale = std::sqrt(density);
+
+  auto acquire_result = presenter->AcquireNextSurface(acquire_desc);
+  if (acquire_result.status == skity::GPUPresenterStatus::kNeedRecreate) {
+    if (!ResizeNativeWindow()) {
+      glfwSetWindowShouldClose(GetNativeWindow(), GLFW_TRUE);
+      return nullptr;
+    }
+    acquire_result =
+        native_window_vk_->GetPresenter()->AcquireNextSurface(acquire_desc);
+  }
+
+  if (acquire_result.status != skity::GPUPresenterStatus::kSuccess ||
+      acquire_result.surface == nullptr) {
+    return nullptr;
+  }
+
+  surface_ = std::move(acquire_result.surface);
+  canvas_ = surface_->LockCanvas();
+  return canvas_;
+}
+
+void WindowVK::OnPresent() {
+  if (canvas_ == nullptr || surface_ == nullptr ||
+      native_window_vk_ == nullptr) {
+    return;
+  }
+
+  canvas_->Flush();
+  surface_->Flush();
+  canvas_ = nullptr;
+
+  const auto present_status =
+      native_window_vk_->GetPresenter()->Present(std::move(surface_));
+  if (present_status == skity::GPUPresenterStatus::kNeedRecreate &&
+      !ResizeNativeWindow()) {
+    glfwSetWindowShouldClose(GetNativeWindow(), GLFW_TRUE);
+  }
+}
+
+void WindowVK::OnTerminate() {
+  canvas_ = nullptr;
+  surface_.reset();
+  native_window_vk_.reset();
+  ResetGPUContext();
+}
+
+bool WindowVK::CreateNativeWindow() {
+  int framebuffer_width = 0;
+  int framebuffer_height = 0;
+  glfwGetFramebufferSize(GetNativeWindow(), &framebuffer_width,
+                         &framebuffer_height);
+
+  skity::GPUNativeWindowInfoVK info = {};
+  if (!BuildNativeWindowInfo(GetNativeWindow(), &info.native_window)) {
+    return false;
+  }
+
+  info.width = static_cast<uint32_t>(std::max(framebuffer_width, 1));
+  info.height = static_cast<uint32_t>(std::max(framebuffer_height, 1));
+  info.present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+
+  native_window_vk_ = skity::CreateGPUNativeWindowVK(GetGPUContext(), &info);
+  return native_window_vk_ != nullptr;
+}
+
+bool WindowVK::ResizeNativeWindow() {
+  if (native_window_vk_ == nullptr) {
+    return false;
+  }
+
+  int framebuffer_width = 0;
+  int framebuffer_height = 0;
+  glfwGetFramebufferSize(GetNativeWindow(), &framebuffer_width,
+                         &framebuffer_height);
+
+  return native_window_vk_->Resize(
+      static_cast<uint32_t>(std::max(framebuffer_width, 1)),
+      static_cast<uint32_t>(std::max(framebuffer_height, 1)));
+}
+
+}  // namespace example
+}  // namespace skity

--- a/example/common/vk/window_vk.hpp
+++ b/example/common/vk/window_vk.hpp
@@ -1,0 +1,52 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SKITY_EXAMPLE_COMMON_VK_WINDOW_VK_HPP
+#define SKITY_EXAMPLE_COMMON_VK_WINDOW_VK_HPP
+
+#include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
+
+#include "common/window.hpp"
+
+namespace skity {
+namespace example {
+
+class WindowVK : public Window {
+ public:
+  WindowVK(int width, int height, std::string title)
+      : Window(width, height, std::move(title)) {}
+
+  ~WindowVK() override = default;
+
+  Backend GetBackend() const override { return Backend::kVulkan; }
+
+ protected:
+  bool OnInit() override;
+
+  GLFWwindow* CreateWindowHandler() override;
+
+  std::unique_ptr<skity::GPUContext> CreateGPUContext() override;
+
+  void OnShow() override;
+
+  skity::Canvas* AquireCanvas() override;
+
+  void OnPresent() override;
+
+  void OnTerminate() override;
+
+ private:
+  bool CreateNativeWindow();
+  bool ResizeNativeWindow();
+
+  std::unique_ptr<skity::GPUSurface> surface_;
+  std::unique_ptr<skity::GPUNativeWindowVK> native_window_vk_;
+  skity::Canvas* canvas_ = nullptr;
+};
+
+}  // namespace example
+}  // namespace skity
+
+#endif  // SKITY_EXAMPLE_COMMON_VK_WINDOW_VK_HPP

--- a/example/common/vk/window_vk_native_macos.mm
+++ b/example/common/vk/window_vk_native_macos.mm
@@ -1,0 +1,76 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#if !__has_feature(objc_arc)
+#error ARC must be enabled!
+#endif
+
+#include <skity/macros.hpp>
+
+#if defined(SKITY_MACOS)
+
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
+#include <GLFW/glfw3.h>
+#define GLFW_EXPOSE_NATIVE_COCOA
+#include <GLFW/glfw3native.h>
+
+#include <QuartzCore/CAMetalLayer.h>
+
+namespace skity {
+namespace example {
+
+bool SetupCocoaVulkanWindow(GLFWwindow* window) {
+  if (window == nullptr) {
+    return false;
+  }
+
+  NSWindow* cocoa_window = glfwGetCocoaWindow(window);
+  if (cocoa_window == nil) {
+    return false;
+  }
+
+  CAMetalLayer* metal_layer = [CAMetalLayer layer];
+  metal_layer.opaque = YES;
+  metal_layer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+  metal_layer.framebufferOnly = NO;
+  metal_layer.frame = cocoa_window.contentView.bounds;
+  metal_layer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+
+  cocoa_window.contentView.layer = metal_layer;
+  cocoa_window.contentView.wantsLayer = YES;
+  return true;
+}
+
+void* GetCocoaVulkanLayer(GLFWwindow* window) {
+  if (window == nullptr) {
+    return nullptr;
+  }
+
+  NSWindow* cocoa_window = glfwGetCocoaWindow(window);
+  if (cocoa_window == nil) {
+    return nullptr;
+  }
+
+  return (__bridge void*)cocoa_window.contentView.layer;
+}
+
+void* GetCocoaVulkanView(GLFWwindow* window) {
+  if (window == nullptr) {
+    return nullptr;
+  }
+
+  NSWindow* cocoa_window = glfwGetCocoaWindow(window);
+  if (cocoa_window == nil) {
+    return nullptr;
+  }
+
+  return (__bridge void*)cocoa_window.contentView;
+}
+
+}  // namespace example
+}  // namespace skity
+
+#endif

--- a/example/common/window.cc
+++ b/example/common/window.cc
@@ -15,6 +15,10 @@
 #include "common/mtl/window_mtl.hpp"
 #endif
 
+#ifdef SKITY_EXAMPLE_VK_BACKEND
+#include "common/vk/window_vk.hpp"
+#endif
+
 #ifdef SKITY_EXAMPLE_SW_BACKEND
 #include "common/sw/window_sw.hpp"
 #endif
@@ -40,6 +44,12 @@ std::unique_ptr<Window> Window::CreateWindow(Backend backend, uint32_t width,
     window = std::make_unique<WindowMTL>(width, height, std::move(title));
 #else
     std::cerr << "Metal backend is not supported." << std::endl;
+#endif
+  } else if (backend == Backend::kVulkan) {
+#ifdef SKITY_EXAMPLE_VK_BACKEND
+    window = std::make_unique<WindowVK>(width, height, std::move(title));
+#else
+    std::cerr << "Vulkan backend is not supported." << std::endl;
 #endif
   } else if (backend == Backend::kSoftware) {
 #ifdef SKITY_EXAMPLE_SW_BACKEND
@@ -86,7 +96,7 @@ bool Window::Init() {
   return true;
 }
 
-void Window::Show(WindowClient &client) {
+void Window::Show(WindowClient& client) {
   skity::FontManager::RefDefault()->SetDefaultTypeface(
       skity::Typeface::MakeFromFile(EXAMPLE_DEFAULT_FONT));
 
@@ -120,7 +130,7 @@ void Window::Show(WindowClient &client) {
   glfwTerminate();
 }
 
-void Window::GetCursorPos(double &x, double &y) const {
+void Window::GetCursorPos(double& x, double& y) const {
   double mx, my;
 
   glfwGetCursorPos(native_window_, &mx, &my);

--- a/example/common/window.hpp
+++ b/example/common/window.hpp
@@ -73,6 +73,8 @@ class Window {
 
   skity::GPUContext* GetGPUContext() const { return gpu_context_.get(); }
 
+  void ResetGPUContext() { gpu_context_.reset(); }
+
   bool Init();
 
   virtual bool OnInit() = 0;

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -28,6 +28,7 @@ android {
                             "-DSKITY_EXAMPLE=OFF",
                             "-DSKITY_TEST=OFF",
                             "-DSKITY_LOG=ON",
+                            "-DSKITY_VK_BACKEND=ON",
                             "-DSKITY_CODEC_MODULE=ON",
                             "-DSKITY_IO_MODULE=ON",
                             "-DSKITY_BUILD_INSTALL=OFF"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -521,6 +521,8 @@ if(${SKITY_HW_RENDERER})
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_platform_extensions.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_context_state.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_context_state.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/render/hw/vk/vk_root_layer.cc
+      ${CMAKE_CURRENT_LIST_DIR}/render/hw/vk/vk_root_layer.hpp
     )
   endif()
 endif()

--- a/src/gpu/vk/gpu_surface_vk.cc
+++ b/src/gpu/vk/gpu_surface_vk.cc
@@ -4,6 +4,8 @@
 
 #include "src/gpu/vk/gpu_surface_vk.hpp"
 
+#include "src/render/hw/vk/vk_root_layer.hpp"
+
 namespace skity {
 
 std::shared_ptr<Pixmap> GPUSurfaceVK::ReadPixels(const Rect& rect) {
@@ -16,8 +18,13 @@ const GPUSubmitInfo* GPUSurfaceVK::GetSubmitInfo() const {
 }
 
 HWRootLayer* GPUSurfaceVK::OnBeginNextFrame(bool clear) {
-  // VKRootLayer integration will be added with the HW render layer PR
-  return nullptr;
+  auto root_layer = GetArenaAllocator()->Make<VKRootLayer>(
+      target_width_, target_height_, texture_,
+      Rect::MakeWH(GetWidth(), GetHeight()), GetGPUFormat());
+  root_layer->SetClearSurface(clear);
+  root_layer->SetSampleCount(GetSampleCount());
+  root_layer->SetArenaAllocator(GetArenaAllocator());
+  return root_layer;
 }
 
 }  // namespace skity

--- a/src/render/hw/draw/hw_draw_step.cc
+++ b/src/render/hw/draw/hw_draw_step.cc
@@ -26,6 +26,13 @@ void HWDrawStep::GenerateCommand(const HWDrawStepContext& ctx, Command* cmd,
 
   cmd->pipeline = GetPipeline(ctx.context, ctx.state, ctx.color_format,
                               ctx.sample_count, ctx.blend_mode);
+  if (RequireStencil()) {
+    const auto stencil_state = GetStencilState();
+    cmd->front_stencil_compare_mask = stencil_state.front.stencil_read_mask;
+    cmd->back_stencil_compare_mask = stencil_state.back.stencil_read_mask;
+    cmd->front_stencil_write_mask = stencil_state.front.stencil_write_mask;
+    cmd->back_stencil_write_mask = stencil_state.back.stencil_write_mask;
+  }
 
   geometry_->PrepareCMD(cmd, ctx.context, ctx.transform, ctx.clip_depth,
                         stencil_cmd);

--- a/src/render/hw/hw_canvas.cc
+++ b/src/render/hw/hw_canvas.cc
@@ -13,6 +13,7 @@
 
 #include "src/effect/image_filter_base.hpp"
 #include "src/gpu/gpu_surface_impl.hpp"
+#include "src/graphic/blend_mode_priv.hpp"
 #include "src/render/canvas_state.hpp"
 #include "src/render/hw/draw/hw_dynamic_path_clip.hpp"
 #include "src/render/hw/draw/hw_dynamic_path_draw.hpp"
@@ -659,9 +660,14 @@ void HWCanvas::OnFlush() {
 
     UploadMesh(cmd.get());
 
+    cmd->HoldResource(gpu_buffer_->GetGPUBufferOwner());
+    cmd->HoldResource(gpu_buffer_->GetGPUIndexBufferOwner());
+    cmd->HoldResource(static_buffer_->GetGPUBufferOwner());
+    cmd->HoldResource(static_buffer_->GetGPUIndexBufferOwner());
+
     root_layer_->Draw(nullptr, cmd.get());
 
-    cmd->Submit();
+    cmd->Submit(surface_->GetSubmitInfo());
   }
 
   layer_stack_.clear();

--- a/src/render/hw/hw_pipeline_lib.cc
+++ b/src/render/hw/hw_pipeline_lib.cc
@@ -48,8 +48,8 @@ static std::pair<GPUBlendFactor, GPUBlendFactor> get_gpu_blending(
   }
 }
 
-static void setup_blending_state(GPURenderPipelineDescriptor &gpu_desc,
-                                 const HWPipelineDescriptor &hw_desc) {
+static void setup_blending_state(GPURenderPipelineDescriptor& gpu_desc,
+                                 const HWPipelineDescriptor& hw_desc) {
   gpu_desc.target.format = hw_desc.color_format;
   gpu_desc.target.write_mask = hw_desc.color_mask;
 
@@ -60,14 +60,14 @@ static void setup_blending_state(GPURenderPipelineDescriptor &gpu_desc,
   // need to support other advance blending in the future
 }
 
-HWPipeline::HWPipeline(GPUDevice *device,
+HWPipeline::HWPipeline(GPUDevice* device, GPUBackendType backend,
                        std::unique_ptr<GPURenderPipeline> base_pipeline)
-    : gpu_device_(device), gpu_pipelines_() {
+    : gpu_device_(device), backend_(backend), gpu_pipelines_() {
   gpu_pipelines_.emplace_back(std::move(base_pipeline));
 }
 
-GPURenderPipeline *HWPipeline::GetPipeline(const HWPipelineDescriptor &desc) {
-  for (auto &pipeline : gpu_pipelines_) {
+GPURenderPipeline* HWPipeline::GetPipeline(const HWPipelineDescriptor& desc) {
+  for (auto& pipeline : gpu_pipelines_) {
     if (PipelineMatch(pipeline.get(), desc)) {
       return pipeline.get();
     }
@@ -92,13 +92,13 @@ GPURenderPipeline *HWPipeline::GetPipeline(const HWPipelineDescriptor &desc) {
   return gpu_pipelines_.back().get();
 }
 
-bool HWPipeline::PipelineMatch(GPURenderPipeline *pipeline,
-                               const HWPipelineDescriptor &desc) {
-  const auto &gpu_desc = pipeline->GetDescriptor();
-
-  if (gpu_desc.depth_stencil != desc.depth_stencil) {
+bool HWPipeline::PipelineMatch(GPURenderPipeline* pipeline,
+                               const HWPipelineDescriptor& desc) {
+  if (!DepthStencilStateMatch(pipeline, desc)) {
     return false;
   }
+
+  const auto& gpu_desc = pipeline->GetDescriptor();
 
   auto blend_function = get_gpu_blending(desc.blend_mode);
 
@@ -109,8 +109,36 @@ bool HWPipeline::PipelineMatch(GPURenderPipeline *pipeline,
          gpu_desc.target.format == desc.color_format;
 }
 
-GPURenderPipeline *HWPipelineLib::GetPipeline(
-    const HWPipelineKey &key, const HWPipelineDescriptor &desc) {
+bool HWPipeline::DepthStencilStateMatch(GPURenderPipeline* pipeline,
+                                        const HWPipelineDescriptor& desc) {
+  const auto& gpu_desc = pipeline->GetDescriptor();
+  if (backend_ != GPUBackendType::kVulkan) {
+    return gpu_desc.depth_stencil == desc.depth_stencil;
+  }
+
+  const auto& pipeline_ds = gpu_desc.depth_stencil;
+  const auto& request_ds = desc.depth_stencil;
+  if (pipeline_ds.format != request_ds.format ||
+      pipeline_ds.enable_stencil != request_ds.enable_stencil ||
+      pipeline_ds.enable_depth != request_ds.enable_depth ||
+      !(pipeline_ds.depth_state == request_ds.depth_state)) {
+    return false;
+  }
+
+  const auto stencil_face_match = [](const GPUStencilFaceState& lhs,
+                                     const GPUStencilFaceState& rhs) -> bool {
+    return lhs.compare == rhs.compare && lhs.fail_op == rhs.fail_op &&
+           lhs.depth_fail_op == rhs.depth_fail_op && lhs.pass_op == rhs.pass_op;
+  };
+
+  return stencil_face_match(pipeline_ds.stencil_state.front,
+                            request_ds.stencil_state.front) &&
+         stencil_face_match(pipeline_ds.stencil_state.back,
+                            request_ds.stencil_state.back);
+}
+
+GPURenderPipeline* HWPipelineLib::GetPipeline(
+    const HWPipelineKey& key, const HWPipelineDescriptor& desc) {
 #ifdef SKITY_ENABLE_TRACING
   uint64_t vs_key = (static_cast<uint64_t>(GPUShaderStage::kVertex) << 32) |
                     key.GetVertexBaseKey();
@@ -151,14 +179,14 @@ GPURenderPipeline *HWPipelineLib::GetPipeline(
 }
 
 std::unique_ptr<HWPipeline> HWPipelineLib::CreatePipeline(
-    const HWPipelineKey &key, const HWPipelineDescriptor &desc) {
+    const HWPipelineKey& key, const HWPipelineDescriptor& desc) {
   DEBUG_CHECK(desc.shader_generator);
   GPURenderPipelineDescriptor gpu_pso_desc{};
 
   gpu_pso_desc.buffers = desc.buffers;
   gpu_pso_desc.target.format = desc.color_format;
   gpu_pso_desc.sample_count = desc.sample_count;
-  gpu_pso_desc.error_callback = [this](char const *message) {
+  gpu_pso_desc.error_callback = [this](char const* message) {
     ctx_->TriggerErrorCallback(GPUError::kPipelineError, message);
   };
   gpu_pso_desc.label =
@@ -180,12 +208,13 @@ std::unique_ptr<HWPipeline> HWPipelineLib::CreatePipeline(
     return std::unique_ptr<HWPipeline>();
   }
 
-  return std::make_unique<HWPipeline>(gpu_device_, std::move(gpu_pipeline));
+  return std::make_unique<HWPipeline>(gpu_device_, backend_,
+                                      std::move(gpu_pipeline));
 }
 
-void HWPipelineLib::SetupShaderFunction(GPURenderPipelineDescriptor &desc,
-                                        const HWPipelineKey &key,
-                                        HWShaderGenerator *shader_generator) {
+void HWPipelineLib::SetupShaderFunction(GPURenderPipelineDescriptor& desc,
+                                        const HWPipelineKey& key,
+                                        HWShaderGenerator* shader_generator) {
   if (shader_generator == nullptr) {
     return;
   }
@@ -208,10 +237,10 @@ void HWPipelineLib::SetupShaderFunction(GPURenderPipelineDescriptor &desc,
 }
 
 std::shared_ptr<GPUShaderFunction> HWPipelineLib::GetShaderFunction(
-    const HWPipelineKey &pipeline_key, GPUShaderStage stage,
-    HWShaderGenerator *shader_generator,
-    const wgx::CompilerContext &wgx_context,
-    const GPUShaderFunctionErrorCallback &error_callback) {
+    const HWPipelineKey& pipeline_key, GPUShaderStage stage,
+    HWShaderGenerator* shader_generator,
+    const wgx::CompilerContext& wgx_context,
+    const GPUShaderFunctionErrorCallback& error_callback) {
   HWFunctionKey function_key = pipeline_key.GetFunctionKey(stage);
   if (shader_functions_.count(function_key)) {
     return shader_functions_[function_key];

--- a/src/render/hw/hw_pipeline_lib.hpp
+++ b/src/render/hw/hw_pipeline_lib.hpp
@@ -43,7 +43,7 @@ struct HWPipelineDescriptor {
 
 class HWPipeline {
  public:
-  HWPipeline(GPUDevice* device,
+  HWPipeline(GPUDevice* device, GPUBackendType backend,
              std::unique_ptr<GPURenderPipeline> base_pipeline);
 
   ~HWPipeline() = default;
@@ -55,7 +55,12 @@ class HWPipeline {
                      const HWPipelineDescriptor& desc);
 
  private:
+  bool DepthStencilStateMatch(GPURenderPipeline* pipeline,
+                              const HWPipelineDescriptor& desc);
+
+ private:
   GPUDevice* gpu_device_;
+  GPUBackendType backend_;
   std::vector<std::unique_ptr<GPURenderPipeline>> gpu_pipelines_;
 };
 

--- a/src/render/hw/hw_stage_buffer.hpp
+++ b/src/render/hw/hw_stage_buffer.hpp
@@ -70,7 +70,15 @@ class HWStageBuffer final {
 
   GPUBuffer* GetGPUBuffer() const { return gpu_buffer_.get(); }
 
+  const std::shared_ptr<GPUBuffer>& GetGPUBufferOwner() const {
+    return gpu_buffer_;
+  }
+
   GPUBuffer* GetGPUIndexBuffer() const { return gpu_index_buffer_.get(); }
+
+  const std::shared_ptr<GPUBuffer>& GetGPUIndexBufferOwner() const {
+    return gpu_index_buffer_;
+  }
 
  private:
   static void ResizeIfNeed(std::vector<uint8_t>& buffer, uint32_t curr_pos,
@@ -84,8 +92,8 @@ class HWStageBuffer final {
   uint32_t stage_pos_ = 0;
   std::vector<uint8_t> stage_index_buffer_;
   uint32_t stage_index_pos_ = 0;
-  std::unique_ptr<GPUBuffer> gpu_buffer_;
-  std::unique_ptr<GPUBuffer> gpu_index_buffer_;
+  std::shared_ptr<GPUBuffer> gpu_buffer_;
+  std::shared_ptr<GPUBuffer> gpu_index_buffer_;
   uint32_t ubo_alignment_;
   std::optional<uint32_t> writing_offset_ = std::nullopt;
 };

--- a/src/render/hw/hw_static_buffer.hpp
+++ b/src/render/hw/hw_static_buffer.hpp
@@ -40,6 +40,14 @@ class HWStaticBuffer final {
 
   GPUBufferView GetTextIndexBufferView();
 
+  const std::shared_ptr<GPUBuffer>& GetGPUBufferOwner() const {
+    return stage_buffer_->GetGPUBufferOwner();
+  }
+
+  const std::shared_ptr<GPUBuffer>& GetGPUIndexBufferOwner() const {
+    return stage_buffer_->GetGPUIndexBufferOwner();
+  }
+
  private:
   void Initialize();
 

--- a/src/render/hw/vk/vk_root_layer.cc
+++ b/src/render/hw/vk/vk_root_layer.cc
@@ -1,0 +1,43 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/hw/vk/vk_root_layer.hpp"
+
+#include "src/render/hw/hw_render_pass_builder.hpp"
+
+namespace skity {
+
+VKRootLayer::VKRootLayer(uint32_t width, uint32_t height,
+                         std::shared_ptr<GPUTexture> texture,
+                         const Rect& bounds, GPUTextureFormat format)
+    : HWRootLayer(width, height, bounds, format),
+      color_attachment_(std::move(texture)) {}
+
+HWDrawState VKRootLayer::OnPrepare(HWDrawContext* context) {
+  auto state = HWRootLayer::OnPrepare(context);
+
+  if (color_attachment_ == nullptr) {
+    return state;
+  }
+
+  HWRenderPassBuilder builder(context, color_attachment_);
+  builder.SetSampleCount(GetSampleCount())
+      .SetDrawState(GetLayerDrawState())
+      .SetLoadOp(NeedClearSurface() ? GPULoadOp::kClear : GPULoadOp::kLoad)
+      .SetStoreOp(GPUStoreOp::kStore)
+      .Build(render_pass_desc_);
+
+  return state;
+}
+
+std::shared_ptr<GPURenderPass> VKRootLayer::OnBeginRenderPass(
+    GPUCommandBuffer* cmd, bool force_load) {
+  if (force_load && GetSampleCount() == 1) {
+    render_pass_desc_.color_attachment.load_op = GPULoadOp::kLoad;
+  }
+
+  return cmd->BeginRenderPass(render_pass_desc_);
+}
+
+}  // namespace skity

--- a/src/render/hw/vk/vk_root_layer.hpp
+++ b/src/render/hw/vk/vk_root_layer.hpp
@@ -1,0 +1,39 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_HW_VK_VK_ROOT_LAYER_HPP
+#define SRC_RENDER_HW_VK_VK_ROOT_LAYER_HPP
+
+#include "src/render/hw/layer/hw_root_layer.hpp"
+
+namespace skity {
+
+class GPUTexture;
+
+class VKRootLayer : public HWRootLayer {
+ public:
+  VKRootLayer(uint32_t width, uint32_t height,
+              std::shared_ptr<GPUTexture> texture, const Rect& bounds,
+              GPUTextureFormat format);
+
+  ~VKRootLayer() override = default;
+
+ protected:
+  HWDrawState OnPrepare(HWDrawContext* context) override;
+
+  void OnPostDraw(GPURenderPass* render_pass, GPUCommandBuffer* cmd) override {}
+
+  std::shared_ptr<GPURenderPass> OnBeginRenderPass(GPUCommandBuffer* cmd,
+                                                   bool force_load) override;
+
+  bool IsValid() const override { return color_attachment_ != nullptr; }
+
+ private:
+  std::shared_ptr<GPUTexture> color_attachment_ = {};
+  GPURenderPassDescriptor render_pass_desc_ = {};
+};
+
+}  // namespace skity
+
+#endif  // SRC_RENDER_HW_VK_VK_ROOT_LAYER_HPP

--- a/tools/test-runner.py
+++ b/tools/test-runner.py
@@ -76,6 +76,44 @@ class TestRunner:
         env = os.environ.copy()
         env["AGENT_OUT_DIR"] = os.path.abspath(self.golden_failures_dir)
 
+        vk_test_loader = os.environ.get("SKITY_VK_TEST_USE_SYSTEM_LOADER", "")
+        use_vulkan_system_loader = vk_test_loader.upper() not in (
+            "",
+            "0",
+            "OFF",
+            "FALSE",
+            "NO",
+        )
+        if self.suite == "unit" and use_vulkan_system_loader:
+            if sys.platform == "linux":
+                swiftshader_icd = os.path.join(
+                    self.repo_root,
+                    "third_party",
+                    "libSwiftShader",
+                    "vk_swiftshader_icd.json",
+                )
+            else:
+                swiftshader_icd = os.path.join(
+                    self.repo_root,
+                    "third_party",
+                    "libSwAngle",
+                    "lib",
+                    "vk_swiftshader_icd.json",
+                )
+            if not os.path.isfile(swiftshader_icd):
+                return None, f"SwiftShader Vulkan ICD not found: {swiftshader_icd}"
+
+            # Unit tests are expected to run against bundled SwiftShader. Vulkan
+            # SDK setup-env.sh points these variables at MoltenVK on macOS.
+            env["VK_ICD_FILENAMES"] = swiftshader_icd
+            env["VK_DRIVER_FILES"] = swiftshader_icd
+
+            vulkan_sdk = env.get("VULKAN_SDK", "")
+            if vulkan_sdk:
+                layer_dir = os.path.join(vulkan_sdk, "share", "vulkan", "explicit_layer.d")
+                if os.path.isdir(layer_dir):
+                    self._prepend_env_path(env, "VK_ADD_LAYER_PATH", layer_dir)
+
         if not self.suite.startswith("golden"):
             return env, None
 
@@ -102,6 +140,11 @@ class TestRunner:
         self.print_status(Colors.YELLOW, "🔧 Configuring with CMake...")
         os.makedirs(self.build_dir, exist_ok=True)
         cmd = ["cmake", "-B", self.build_dir, "-DSKITY_TEST=ON", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
+        vk_test_loader = os.environ.get("SKITY_VK_TEST_USE_SYSTEM_LOADER", "")
+        if vk_test_loader.upper() not in ("", "0", "OFF", "FALSE", "NO"):
+            cmd.append("-DSKITY_VK_TEST_USE_SYSTEM_LOADER=ON")
+        else:
+            cmd.append("-DSKITY_VK_TEST_USE_SYSTEM_LOADER=OFF")
         
         if self.suite.startswith("golden"):
             cmd.extend([
@@ -152,47 +195,95 @@ class TestRunner:
                     return os.path.join(root, file)
         return None
 
-    def run_gtest_suite(self) -> Dict[str, Any]:
+    def find_test_executables(self) -> List[str]:
         test_executable = self.find_test_executable()
         if not test_executable:
+            return []
+
+        executables = [test_executable]
+        if self.suite == "unit":
+            vulkan_executable = self._find_named_test_executable("skity_vulkan_unit_test")
+            if vulkan_executable:
+                executables.append(vulkan_executable)
+        return executables
+
+    def _find_named_test_executable(self, target_exe: str) -> Optional[str]:
+        test_paths = [
+            os.path.join(self.build_dir, "test", "ut", target_exe),
+            os.path.join(self.build_dir, "test", target_exe),
+            os.path.join(self.build_dir, target_exe),
+        ]
+        for path in test_paths:
+            if os.path.exists(path) and os.access(path, os.X_OK):
+                return path
+
+        for root, dirs, files in os.walk(self.build_dir):
+            for file in files:
+                if file == target_exe and os.access(os.path.join(root, file), os.X_OK):
+                    return os.path.join(root, file)
+        return None
+
+    def run_gtest_suite(self) -> Dict[str, Any]:
+        test_executables = self.find_test_executables()
+        if not test_executables:
             return self._create_infra_error("missing_executable", "Test executable not found!")
 
         self.print_status(Colors.YELLOW, f"🚀 Running {self.suite} tests...")
-        
-        gtest_json_path = os.path.join(self.build_dir, "gtest_report.json")
-        if os.path.exists(gtest_json_path):
-            os.remove(gtest_json_path)
 
-        cmd = [test_executable, f"--gtest_output=json:{gtest_json_path}"]
         env, env_error = self.prepare_test_environment()
         if env_error:
             return self._create_infra_error("missing_runtime_dependency", env_error)
 
-        if self.suite.startswith("golden") and self.backend != "metal":
-            cmd.extend(["--backend", self.backend])
-        
-        if self.test_filter:
-            cmd.append(f"--gtest_filter={self.test_filter}")
-            self.print_status(Colors.YELLOW, f"🎯 Filter: {self.test_filter}")
-
-        try:
-            result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
-            
-            # Crash or abnormal exit without JSON generated
-            if result.returncode != 0 and not os.path.exists(gtest_json_path):
-                return self._create_infra_error(
-                    "runtime_crash", 
-                    f"Test process crashed with exit code {result.returncode}.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
-                )
-            
-            # Parse the JSON if it exists
+        reports = []
+        for index, test_executable in enumerate(test_executables):
+            gtest_json_path = os.path.join(self.build_dir, f"gtest_report_{index}.json")
             if os.path.exists(gtest_json_path):
-                return self._parse_gtest_json(gtest_json_path, result.returncode, result.stdout)
-            else:
-                return self._create_infra_error("missing_gtest_report", "Tests ran but gtest_report.json was not generated.")
+                os.remove(gtest_json_path)
 
-        except Exception as e:
-            return self._create_infra_error("infra_error", f"Failed to execute tests: {e}")
+            cmd = [test_executable, f"--gtest_output=json:{gtest_json_path}"]
+
+            if self.suite.startswith("golden") and self.backend != "metal":
+                cmd.extend(["--backend", self.backend])
+
+            if self.test_filter:
+                cmd.append(f"--gtest_filter={self.test_filter}")
+                if index == 0:
+                    self.print_status(Colors.YELLOW, f"🎯 Filter: {self.test_filter}")
+
+            try:
+                result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
+
+                # Crash or abnormal exit without JSON generated
+                if result.returncode != 0 and not os.path.exists(gtest_json_path):
+                    return self._create_infra_error(
+                        "runtime_crash",
+                        f"Test process crashed with exit code {result.returncode}.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+                    )
+
+                # Parse the JSON if it exists
+                if os.path.exists(gtest_json_path):
+                    reports.append(self._parse_gtest_json(gtest_json_path, result.returncode, result.stdout))
+                else:
+                    return self._create_infra_error("missing_gtest_report", "Tests ran but gtest_report.json was not generated.")
+
+            except Exception as e:
+                return self._create_infra_error("infra_error", f"Failed to execute tests: {e}")
+
+        if len(reports) == 1:
+            return reports[0]
+
+        merged_report = {
+            "summary": {
+                "total": sum(report["summary"]["total"] for report in reports),
+                "passed": sum(report["summary"]["passed"] for report in reports),
+                "failed": sum(report["summary"]["failed"] for report in reports),
+                "duration_ms": int((time.time() - self.started) * 1000),
+            },
+            "failures": [],
+        }
+        for report in reports:
+            merged_report["failures"].extend(report["failures"])
+        return merged_report
 
     def _parse_gtest_json(self, json_path: str, exit_code: int, stdout: str) -> Dict[str, Any]:
         try:


### PR DESCRIPTION
- Add VKRootLayer to connect Vulkan backend with render pipeline
- Enhance HWStageBuffer to use shared_ptr for GPU buffer ownership
- Add Vulkan-specific depth/stencil state matching in pipeline cache
- Add Vulkan example backend (WindowVK) with Win32/macOS/Linux support
- Enable Vulkan backend in Android build
- Enhance test-runner with improved capabilities