### PR TITLE
chore(ci): optimize Android WGX build

### DIFF
--- a/module/wgx/CMakeLists.txt
+++ b/module/wgx/CMakeLists.txt
@@ -74,7 +74,19 @@ target_compile_options(wgsl-cross PRIVATE -fno-rtti)
 set_property(TARGET wgsl-cross PROPERTY CXX_STANDARD 17)
 
 if (ANDROID)
-    if (${SKITY_USE_ASAN})
+    if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        if (NOT SKITY_USE_ASAN)
+            target_compile_options(wgsl-cross PRIVATE
+                "-Oz"
+                "-flto"
+                "-fomit-frame-pointer"
+                "-fvisibility=hidden"
+                "-fvisibility-inlines-hidden"
+            )
+        endif()
+    endif()
+
+    if (SKITY_USE_ASAN)
        target_compile_options(wgsl-cross PRIVATE -fsanitize=address -fno-omit-frame-pointer)
        target_link_options(wgsl-cross PRIVATE -fsanitize=address)
     endif()

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -30,6 +30,8 @@ android {
                             "-DSKITY_LOG=ON",
                             "-DSKITY_CODEC_MODULE=ON",
                             "-DSKITY_IO_MODULE=ON",
+                            "-DWGX_GLSL_BACKEND=ON",
+                            "-DWGX_MSL_BACKEND=OFF",
                             "-DSKITY_BUILD_INSTALL=OFF"
             }
         }


### PR DESCRIPTION
Compile wgsl-cross with size flags on Android and disable the unused MSL backend for Android release builds.