### PR TITLE
docs: add Vulkan backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 `Skity` is an open-source 2D graphics library developed in C++. 
 It focuses on GPU rendering, providing developers with efficient graphics drawing and rendering capabilities. 
-Currently, Skity supports mainstream graphics APIs such as OpenGL, OpenGL ES, and Metal. 
+Currently, Skity supports mainstream graphics APIs such as OpenGL, OpenGL ES, and Metal.
+Experimental Vulkan backend is also available.
 Meanwhile, it offers a functional working software rendering backend as a fallback solution, ensuring stable graphics rendering in various environments.
 
 ## Getting Started
@@ -159,6 +160,9 @@ We appreciate the efforts of the developers and the open-source community behind
 - [jsoncpp](https://github.com/open-source-parsers/jsoncpp) Used to parse json file.
 - [pugixml](https://github.com/zeux/pugixml) Used to parse xml file.
 - [fmt](https://github.com/fmtlib/fmt) Used for string formatting and logging.
+- [volk](https://github.com/zeux/volk) Used for dynamically loading Vulkan entrypoints in example and test.
+- [SPIRV-Headers](https://github.com/KhronosGroup/SPIRV-Headers) Used for SPIR-V instruction set headers.
+- [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) Used for Vulkan GPU memory allocation.
 - [GLFW](https://www.glfw.org/) Used for window and input in example and test.
 - [googletest](https://github.com/google/googletest) Used for testing.
 - [google/benchmark](https://github.com/google/benchmark) Used for testing benchmark.

--- a/docs/BUILD_AND_RUN.md
+++ b/docs/BUILD_AND_RUN.md
@@ -12,13 +12,13 @@ Although Skity supports CPU rendering, it is recommended to ensure that the GPU 
 This is the support GPU backends on different platforms:
 * Windows and Linux:
     * OpenGL at least version 3.3
-    * Vulkan in planning
+    * Vulkan (experimental) at least version 1.1
 * MacOS:
     * Metal (recommend to use Metal since OpenGL is deprecated by Apple)
     * OpenGL at least version 3.3
 * Android:
     * OpenGL ES at least version 3.0
-    * Vulkan in planning
+    * Vulkan (experimental) at least version 1.1
 * iOS (11.0 +):
     * Metal (recommend to use Metal since OpenGLES is deprecated by Apple)
     * OpenGL ES at least version 3.0
@@ -75,6 +75,7 @@ There are several options you can use to configure the build:
     * `SKITY_SW_RENDERER` - Option for CPU raster. Default is ON. Pass `-DSKITY_SW_RENDERER=OFF` in command line to disable it if does not needs the CPU raster pipeline.
     * `SKITY_GL_BACKEND` - Option for OpenGL backend. Default is ON. Pass `-DSKITY_GL_BACKEND=OFF` in command line to disable it. (OpenGL/GLES is almost supported by all platforms, so it is recommended not to turn this option off.)
     * `SKITY_MTL_BACKEND` - Option for Metal backend. Not available on Windows and Linux but open by default on Apple platform.
+    * `SKITY_VK_BACKEND` - Option for Vulkan backend (experimental). Default is OFF. Pass `-DSKITY_VK_BACKEND=ON` in command line to enable it. Requires Vulkan at least version 1.1. Skity will attempt to create the highest available Vulkan version and leverage extensions such as dynamic rendering when supported.
     * `SKITY_LOG` - Option for logging. Default is OFF since print log may slow down the performance. Pass `-DSKITY_LOG=ON` in command line to enable it.
 
 * Options for build optional modules:
@@ -104,6 +105,7 @@ You can run the example code like this:
 
 The available backend name for `<backend>` is:
 * `gl` - OpenGL backend
+* `vulkan` - Vulkan backend (experimental)
 * `metal` - Metal backend
 * `software` - Software renderer backend
 


### PR DESCRIPTION
Add Vulkan (experimental) support description to README and BUILD_AND_RUN. Includes GPU backend listing, CMake option (SKITY_VK_BACKEND), example backend name, version requirement (1.1+), and third-party credits for volk, SPIRV-Headers, and Vulkan Memory Allocator.