### PR TITLE
fix(gpu): Fix new API cause external users compile error

### DIFF
--- a/include/skity/gpu/gpu_surface.hpp
+++ b/include/skity/gpu/gpu_surface.hpp
@@ -35,7 +35,12 @@ class SKITY_API GPUSurface {
  public:
   virtual ~GPUSurface() = default;
 
-  virtual GPUBackendType GetBackendType() const = 0;
+  virtual GPUBackendType GetBackendType() const {
+    // subclass should override this function to return the backend type
+    // Currently this function only used in vulkan backend to do extra command
+    // submission check
+    return GPUBackendType::kNone;
+  }
 
   virtual uint32_t GetWidth() const = 0;
 


### PR DESCRIPTION
The GPUSurface::GetBackendType() only used in vulkan backend to do some extra check in command submission. Now add default implementation to ensure that other subclasses do not need to implement this function.