### PR TITLE
feat(vk): support Vulkan texture copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           - name: Build And Test
             run: |
                 export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
-                cmake -B out/cmake_golden_test -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DSKITY_MTL_BACKEND=ON -DSKITY_TEST=ON -DSKITY_GOLDEN_GUI=OFF
+                cmake -B out/cmake_golden_test -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DSKITY_MTL_BACKEND=ON -DSKITY_VK_BACKEND=ON -DSKITY_TEST=ON -DSKITY_GOLDEN_GUI=OFF -DSKITY_VK_TEST_USE_SYSTEM_LOADER=OFF
                 cmake --build out/cmake_golden_test --target skity_golden_test_shape skity_golden_test_text
                 export MTL_DEBUG_LAYER=1
                 export METAL_DEBUG_ERROR_MODE=1
@@ -213,6 +213,10 @@ jobs:
           - name: Run Experimental GL Golden Test
             run: |
                 ./out/cmake_golden_test/test/golden/skity_golden_test_shape --backend gl
+          - name: Run Vulkan Golden Test
+            run: |
+                ./out/cmake_golden_test/test/golden/skity_golden_test_shape --backend vulkan
+                ./out/cmake_golden_test/test/golden/skity_golden_test_text --backend vulkan
 
     osx_metal_golden_test_ct:
         runs-on: lynx-darwin-14-medium

--- a/example/common/CMakeLists.txt
+++ b/example/common/CMakeLists.txt
@@ -47,8 +47,12 @@ endif()
 
 if (${SKITY_VK_BACKEND})
   if (NOT TARGET volk::volk)
+    set(VULKAN_HEADERS_INSTALL_DIR ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers
+        CACHE PATH "Use bundled Vulkan headers for examples" FORCE)
     set(VOLK_PULL_IN_VULKAN OFF CACHE BOOL "Disable Volk Vulkan lookup" FORCE)
     add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/volk third_party/volk)
+    target_include_directories(volk PUBLIC
+      ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include)
   endif()
 
   target_compile_definitions(skity_example_common PUBLIC -DSKITY_EXAMPLE_VK_BACKEND=1)

--- a/example/common/vk/window_vk.cc
+++ b/example/common/vk/window_vk.cc
@@ -199,8 +199,8 @@ skity::Canvas* WindowVK::AquireCanvas() {
       static_cast<float>(logical_width * logical_width +
                          logical_height * logical_height);
   skity::GPUSurfaceAcquireDescriptor acquire_desc = {};
-  acquire_desc.sample_count = 4;
-  acquire_desc.content_scale = std::sqrt(density);
+  acquire_desc.sample_count = UseDebugAAPresent() ? GetAASampleCount() : 4;
+  acquire_desc.content_scale = UseDebugAAPresent() ? 1.f : std::sqrt(density);
 
   auto acquire_result = presenter->AcquireNextSurface(acquire_desc);
   if (acquire_result.status == skity::GPUPresenterStatus::kNeedRecreate) {

--- a/include/skity/gpu/gpu_context_vk.hpp
+++ b/include/skity/gpu/gpu_context_vk.hpp
@@ -249,6 +249,16 @@ struct GPUSurfaceDescriptorVK : public GPUSurfaceDescriptor {
   VkFormat format = VK_FORMAT_UNDEFINED;
 
   /**
+   * Usage flags that the user provided image was created with.
+   *
+   * Skity uses this to expose matching GPUTextureUsage capabilities for the
+   * wrapped image. For example, root-layer texture-copy dst read requires
+   * `VK_IMAGE_USAGE_TRANSFER_SRC_BIT`, and MSAA emulated load additionally
+   * requires `VK_IMAGE_USAGE_SAMPLED_BIT`.
+   */
+  VkImageUsageFlags image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+  /**
    * Optional pre-transform for the current frame target.
    *
    * This is especially useful when `image` comes from a swapchain image whose

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -136,6 +136,34 @@ bool ContainsExtension(const std::vector<std::string>& extensions,
   return false;
 }
 
+GPUTextureUsageMask ToGPUTextureUsageMask(VkImageUsageFlags image_usage) {
+  GPUTextureUsageMask usage = 0;
+
+  if ((image_usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) != 0) {
+    usage |=
+        static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment);
+  }
+
+  if ((image_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) != 0) {
+    usage |= static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc);
+  }
+
+  if ((image_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) != 0) {
+    usage |= static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopyDst);
+  }
+
+  if ((image_usage & VK_IMAGE_USAGE_SAMPLED_BIT) != 0) {
+    usage |= static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
+  }
+
+  if ((image_usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) {
+    usage |= static_cast<GPUTextureUsageMask>(GPUTextureUsage::kStorageBinding);
+  }
+
+  return usage;
+}
+
 bool QueryInstanceExtensions(const VulkanGlobalFns& global_fns,
                              std::vector<VkExtensionProperties>* extensions) {
   if (extensions == nullptr) {
@@ -723,8 +751,7 @@ std::unique_ptr<GPUSurface> GPUContextVK::CreateSurface(
   texture_desc.mip_level_count = 1;
   texture_desc.sample_count = 1;
   texture_desc.format = ToGPUTextureFormat(vk_desc->format);
-  texture_desc.usage =
-      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment);
+  texture_desc.usage = ToGPUTextureUsageMask(vk_desc->image_usage);
   texture_desc.storage_mode = GPUTextureStorageMode::kPrivate;
 
   if (texture_desc.format == GPUTextureFormat::kInvalid) {

--- a/src/gpu/vk/gpu_presenter_vk.cc
+++ b/src/gpu/vk/gpu_presenter_vk.cc
@@ -266,6 +266,7 @@ GPUSurfaceAcquireResult GPUPresenterVK::AcquireNextSurface(
   surface_desc.image = swapchain_images_[image_index];
   surface_desc.image_view = swapchain_image_views_[image_index];
   surface_desc.format = swapchain_format_;
+  surface_desc.image_usage = swapchain_image_usage_;
   surface_desc.pre_transform = swapchain_transform_;
   surface_desc.initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
   surface_desc.final_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
@@ -277,10 +278,18 @@ GPUSurfaceAcquireResult GPUPresenterVK::AcquireNextSurface(
   texture_desc.width = desc_.width;
   texture_desc.height = desc_.height;
   texture_desc.mip_level_count = 1;
-  texture_desc.sample_count = acquire_desc.sample_count;
+  texture_desc.sample_count = 1;
   texture_desc.format = ToGPUTextureFormat(swapchain_format_);
   texture_desc.usage =
       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment);
+  if ((swapchain_image_usage_ & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) != 0) {
+    texture_desc.usage |=
+        static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc);
+  }
+  if ((swapchain_image_usage_ & VK_IMAGE_USAGE_SAMPLED_BIT) != 0) {
+    texture_desc.usage |=
+        static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
+  }
   texture_desc.storage_mode = GPUTextureStorageMode::kPrivate;
   if (texture_desc.format == GPUTextureFormat::kInvalid) {
     LOGE("Failed to acquire Vulkan surface: unsupported swapchain format");
@@ -512,6 +521,13 @@ bool GPUPresenterVK::CreateSwapchain() {
   create_info.imageExtent = swapchain_extent_;
   create_info.imageArrayLayers = 1;
   create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  if ((capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) !=
+      0) {
+    create_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  }
+  if ((capabilities.supportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT) != 0) {
+    create_info.imageUsage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+  }
   create_info.imageSharingMode = shared_present_queue
                                      ? VK_SHARING_MODE_CONCURRENT
                                      : VK_SHARING_MODE_EXCLUSIVE;
@@ -535,6 +551,8 @@ bool GPUPresenterVK::CreateSwapchain() {
       static_cast<uint32_t>(create_info.preTransform),
       static_cast<uint32_t>(create_info.compositeAlpha),
       static_cast<uint32_t>(create_info.imageUsage));
+
+  swapchain_image_usage_ = create_info.imageUsage;
 
   const VkResult result = fns_.vkCreateSwapchainKHR(
       state_->GetLogicalDevice(), &create_info, nullptr, &swapchain_);

--- a/src/gpu/vk/gpu_presenter_vk.hpp
+++ b/src/gpu/vk/gpu_presenter_vk.hpp
@@ -87,6 +87,8 @@ class GPUPresenterVK : public GPUPresenter {
   VkSwapchainKHR swapchain_ = VK_NULL_HANDLE;
   VkExtent2D swapchain_extent_ = {};
   VkFormat swapchain_format_ = VK_FORMAT_UNDEFINED;
+  VkImageUsageFlags swapchain_image_usage_ =
+      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
   VkPresentModeKHR swapchain_present_mode_ = VK_PRESENT_MODE_FIFO_KHR;
   VkSurfaceTransformFlagBitsKHR swapchain_transform_ =
       VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;

--- a/src/gpu/vk/gpu_render_pass_vk.cc
+++ b/src/gpu/vk/gpu_render_pass_vk.cc
@@ -288,9 +288,18 @@ VulkanContextState::LegacyRenderPassKey BuildLegacyRenderPassKey(
 
 VkImageLayout GetSampledImageLayout(const GPUTextureVK& texture) {
   const auto current_layout = texture.GetCurrentLayout();
-  return current_layout != VK_IMAGE_LAYOUT_UNDEFINED
-             ? current_layout
-             : texture.GetPreferredLayout();
+  if (current_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL ||
+      current_layout == VK_IMAGE_LAYOUT_GENERAL) {
+    return current_layout;
+  }
+
+  const auto preferred_layout = texture.GetPreferredLayout();
+  if (preferred_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL ||
+      preferred_layout == VK_IMAGE_LAYOUT_GENERAL) {
+    return preferred_layout;
+  }
+
+  return VK_IMAGE_LAYOUT_GENERAL;
 }
 
 struct DescriptorPoolRequirements {
@@ -389,7 +398,7 @@ bool PrepareSampledTextures(const VulkanContextState& state,
       }
 
       if (!TransitionImageLayout(state, command_buffer.GetCommandBuffer(),
-                                 *texture, texture->GetPreferredLayout())) {
+                                 *texture, GetSampledImageLayout(*texture))) {
         return false;
       }
     }

--- a/src/render/hw/vk/vk_root_layer.cc
+++ b/src/render/hw/vk/vk_root_layer.cc
@@ -4,9 +4,18 @@
 
 #include "src/render/hw/vk/vk_root_layer.hpp"
 
+#include "src/gpu/gpu_texture.hpp"
 #include "src/render/hw/hw_render_pass_builder.hpp"
 
 namespace skity {
+
+namespace {
+
+bool HasTextureUsage(const GPUTextureDescriptor& desc, GPUTextureUsage usage) {
+  return (desc.usage & static_cast<GPUTextureUsageMask>(usage)) != 0;
+}
+
+}  // namespace
 
 VKRootLayer::VKRootLayer(uint32_t width, uint32_t height,
                          std::shared_ptr<GPUTexture> texture,
@@ -38,6 +47,29 @@ std::shared_ptr<GPURenderPass> VKRootLayer::OnBeginRenderPass(
   }
 
   return cmd->BeginRenderPass(render_pass_desc_);
+}
+
+bool VKRootLayer::OnCopyToDstTexture(GPUCommandBuffer* cmd,
+                                     std::shared_ptr<GPUTexture> dst_texture,
+                                     GPURegion copy_region) const {
+  return CopyRegionToDstTexture(cmd, color_attachment_, std::move(dst_texture),
+                                copy_region);
+}
+
+bool VKRootLayer::SupportsTextureCopyDstRead() const {
+  if (color_attachment_ == nullptr) {
+    return false;
+  }
+
+  const auto& desc = color_attachment_->GetDescriptor();
+  if (!HasTextureUsage(desc, GPUTextureUsage::kCopySrc)) {
+    return false;
+  }
+
+  // Texture-copy dst read itself only needs CopySrc, but MSAA split passes also
+  // run an emulated-load draw that samples the single-sample resolve target.
+  return GetSampleCount() == 1 ||
+         HasTextureUsage(desc, GPUTextureUsage::kTextureBinding);
 }
 
 }  // namespace skity

--- a/src/render/hw/vk/vk_root_layer.hpp
+++ b/src/render/hw/vk/vk_root_layer.hpp
@@ -27,7 +27,17 @@ class VKRootLayer : public HWRootLayer {
   std::shared_ptr<GPURenderPass> OnBeginRenderPass(GPUCommandBuffer* cmd,
                                                    bool force_load) override;
 
+  bool OnCopyToDstTexture(GPUCommandBuffer* cmd,
+                          std::shared_ptr<GPUTexture> dst_texture,
+                          GPURegion copy_region) const override;
+
   bool IsValid() const override { return color_attachment_ != nullptr; }
+
+  bool SupportsTextureCopyDstRead() const override;
+
+  std::shared_ptr<GPUTexture> GetResolveColorTexture() const override {
+    return color_attachment_;
+  }
 
  private:
   std::shared_ptr<GPUTexture> color_attachment_ = {};

--- a/test/golden/cases/blend_mode/blend_mode.cc
+++ b/test/golden/cases/blend_mode/blend_mode.cc
@@ -27,6 +27,12 @@ static bool IsGLBackend() {
   return env != nullptr && env->GetBackend() == skity::testing::Backend::kGL;
 }
 
+static bool IsFramebufferFetchUnsupported() {
+  auto* env = skity::testing::GoldenTestEnv::GetInstance();
+  return env != nullptr &&
+         env->GetBackend() == skity::testing::Backend::kVulkan;
+}
+
 static bool IsBasicSaveLayerBlendModeFileName(std::string_view file_name) {
   static constexpr std::array<std::string_view, 16> kSaveLayerBlendModeFiles = {
       "Modulate.png",  "Screen.png",     "Overlay.png",   "Darken.png",
@@ -461,11 +467,19 @@ static void RunBlendModeCompositeTest(
   RunBlendModeCompositeTest("blend_mode_composite_" path ".png", config)
 
 TEST(BlendModeGolden, CompositeFramebufferFetchSampleCount1) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   BLEND_MODE_COMPOSITE_TEST("framebuffer_fetch_sample_count_1",
                             FramebufferFetchConfig(1));
 }
 
 TEST(BlendModeGolden, CompositeFramebufferFetchSampleCount4) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   BLEND_MODE_COMPOSITE_TEST("framebuffer_fetch_sample_count_4",
                             FramebufferFetchConfig(4));
 }
@@ -686,12 +700,20 @@ static void RunBlendModeSaveLayerClipRectTest(
 }
 
 TEST(BlendModeGolden, ClipReplayFramebufferFetchSampleCount1) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeClipReplayTest(
       "blend_mode_clip_replay_framebuffer_fetch_sample_count_1.png",
       FramebufferFetchConfig(1));
 }
 
 TEST(BlendModeGolden, ClipReplayFramebufferFetchSampleCount4) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeClipReplayTest(
       "blend_mode_clip_replay_framebuffer_fetch_sample_count_4.png",
       FramebufferFetchConfig(4));
@@ -716,12 +738,20 @@ TEST(BlendModeGolden, RestoredClipPathTextureCopySampleCount1) {
 }
 
 TEST(BlendModeGolden, SaveLayerClipReplayFramebufferFetchSampleCount1) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeSaveLayerClipReplayTest(
       "blend_mode_savelayer_clip_replay_framebuffer_fetch_sample_count_1.png",
       FramebufferFetchConfig(1));
 }
 
 TEST(BlendModeGolden, SaveLayerClipReplayFramebufferFetchSampleCount4) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeSaveLayerClipReplayTest(
       "blend_mode_savelayer_clip_replay_framebuffer_fetch_sample_count_4.png",
       FramebufferFetchConfig(4));
@@ -740,12 +770,20 @@ TEST(BlendModeGolden, SaveLayerClipReplayTextureCopySampleCount4) {
 }
 
 TEST(BlendModeGolden, ClipRectFramebufferFetchSampleCount1) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeClipRectTest(
       "blend_mode_clip_rect_framebuffer_fetch_sample_count_1.png",
       FramebufferFetchConfig(1));
 }
 
 TEST(BlendModeGolden, ClipRectFramebufferFetchSampleCount4) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeClipRectTest(
       "blend_mode_clip_rect_framebuffer_fetch_sample_count_4.png",
       FramebufferFetchConfig(4));
@@ -764,12 +802,20 @@ TEST(BlendModeGolden, ClipRectTextureCopySampleCount4) {
 }
 
 TEST(BlendModeGolden, SaveLayerClipRectFramebufferFetchSampleCount1) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeSaveLayerClipRectTest(
       "blend_mode_savelayer_clip_rect_framebuffer_fetch_sample_count_1.png",
       FramebufferFetchConfig(1));
 }
 
 TEST(BlendModeGolden, SaveLayerClipRectFramebufferFetchSampleCount4) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP()
+        << "Framebuffer fetch golden cases are not supported on Vulkan";
+  }
   RunBlendModeSaveLayerClipRectTest(
       "blend_mode_savelayer_clip_rect_framebuffer_fetch_sample_count_4.png",
       FramebufferFetchConfig(4));

--- a/test/golden/common/vk/golden_test_env_vk.cc
+++ b/test/golden/common/vk/golden_test_env_vk.cc
@@ -190,7 +190,8 @@ std::shared_ptr<GoldenTexture> GoldenTestEnvVK::RenderToTexture(
   color_desc.format = GPUTextureFormat::kRGBA8Unorm;
   color_desc.usage =
       static_cast<GPUTextureUsageMask>(GPUTextureUsage::kRenderAttachment) |
-      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc);
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kCopySrc) |
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
   color_desc.storage_mode = GPUTextureStorageMode::kPrivate;
 
   auto color_texture = device->CreateTexture(color_desc);
@@ -226,8 +227,11 @@ std::shared_ptr<GoldenTexture> GoldenTestEnvVK::RenderToTexture(
   surface_desc.image = vk_texture->GetImage();
   surface_desc.image_view = vk_texture->GetImageView();
   surface_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+  surface_desc.image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                             VK_IMAGE_USAGE_SAMPLED_BIT;
   surface_desc.initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
-  surface_desc.final_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  surface_desc.final_layout = VK_IMAGE_LAYOUT_GENERAL;
   surface_desc.owns_image = false;
   surface_desc.owns_image_view = false;
 
@@ -248,7 +252,7 @@ std::shared_ptr<GoldenTexture> GoldenTestEnvVK::RenderToTexture(
   // Read pixels from the rendered texture
   std::vector<uint8_t> pixels;
   if (!ReadPixelsFromVulkanImage(state, vk_texture->GetImage(),
-                                 vk_texture->GetCurrentLayout(), width, height,
+                                 surface_desc.final_layout, width, height,
                                  &pixels)) {
     std::cerr << "Failed to read pixels from Vulkan texture" << std::endl;
     return {};


### PR DESCRIPTION
Support Vulkan texture copy across root layer and presenter paths.

Enable Vulkan golden tests in CI and skip unsupported framebuffer fetch golden cases on Vulkan.