### PR TITLE
feat(gpu): add IsGPUBackendSupported() query API

### DIFF
--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -18,6 +18,20 @@
 namespace skity {
 
 /**
+ * Query whether a specific GPU backend type is supported by this build.
+ *
+ * This is a compile-time check based on CMake configuration options
+ * (SKITY_GL_BACKEND, SKITY_VK_BACKEND, SKITY_MTL_BACKEND). The result
+ * does not reflect runtime device capabilities — for example,
+ * IsGPUBackendSupported(GPUBackendType::kVulkan) may return true even
+ * if the device has no Vulkan driver installed.
+ *
+ * @param type  The GPU backend type to query
+ * @return      true if the backend was compiled into this build
+ */
+bool SKITY_API IsGPUBackendSupported(GPUBackendType type);
+
+/**
  * @enum GPUError indicate the internal state about Skity engine
  */
 enum class GPUError {

--- a/src/gpu/gpu_context_impl.cc
+++ b/src/gpu/gpu_context_impl.cc
@@ -128,4 +128,37 @@ void GPUContextImpl::ResetOwnedResources() {
   gpu_device_.reset();
 }
 
+bool IsGPUBackendSupported(GPUBackendType type) {
+  switch (type) {
+    case GPUBackendType::kOpenGL:
+    case GPUBackendType::kWebGL2:
+#if defined(SKITY_OPENGL)
+      return true;
+#else
+      return false;
+#endif
+    case GPUBackendType::kVulkan:
+#if defined(SKITY_VULKAN)
+      return true;
+#else
+      return false;
+#endif
+    case GPUBackendType::kMetal:
+#if defined(SKITY_METAL)
+      return true;
+#else
+      return false;
+#endif
+    case GPUBackendType::kWebGPU:
+#if defined(__EMSCRIPTEN__)
+      return true;
+#else
+      return false;
+#endif
+    case GPUBackendType::kNone:
+      return false;
+  }
+  return false;
+}
+
 }  // namespace skity


### PR DESCRIPTION
Add a runtime query function to check which GPU backends are compiled into the current build. This allows applications (especially on Android) to decide at runtime whether to attempt Vulkan context creation or fall back to OpenGL.

The check is compile-time based on CMake options:
- SKITY_OPENGL covers both OpenGL and WebGL2
- SKITY_VULKAN covers Vulkan
- SKITY_METAL covers Metal
- __EMSCRIPTEN__ covers WebGPU