### PR TITLE
feat(vk): add stub functions when Vulkan backend is disabled

### DIFF
--- a/cmake/ThirdPartyDep.cmake
+++ b/cmake/ThirdPartyDep.cmake
@@ -53,6 +53,9 @@ if(${SKITY_VK_BACKEND})
       target_compile_definitions(skity PRIVATE SKITY_VK_USE_WAYLAND)
     endif()
   endif()
+elseif(${SKITY_HW_RENDERER})
+  # Only Vulkan headers are needed for stub compilation when VK backend is off
+  target_include_directories(skity PRIVATE third_party/Vulkan-Headers/include)
 endif()
 
 # json parser

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -524,6 +524,14 @@ if(${SKITY_HW_RENDERER})
       ${CMAKE_CURRENT_LIST_DIR}/render/hw/vk/vk_root_layer.cc
       ${CMAKE_CURRENT_LIST_DIR}/render/hw/vk/vk_root_layer.hpp
     )
+  else()
+    # Stub implementations so Vulkan symbols remain available when the backend
+    # is disabled, preventing link errors and runtime SO loading failures.
+    target_sources(
+      skity
+      PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_context_vk_stub.cc
+    )
   endif()
 endif()
 

--- a/src/gpu/vk/gpu_context_vk_stub.cc
+++ b/src/gpu/vk/gpu_context_vk_stub.cc
@@ -1,0 +1,31 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Stub implementations for Vulkan GPU context functions.
+// These are compiled when SKITY_VK_BACKEND is OFF to provide linkable symbols
+// that return nullptr, preventing link errors and runtime SO loading failures.
+
+#include <skity/gpu/gpu_context_vk.hpp>
+
+namespace skity {
+
+std::unique_ptr<GPUContext> CreateGPUContextVK(const GPUContextInfoVK* info) {
+  (void)info;
+  return {};
+}
+
+std::unique_ptr<GPUContext> CreateGPUContextVK(
+    PFN_vkGetInstanceProcAddr get_instance_proc_addr) {
+  (void)get_instance_proc_addr;
+  return {};
+}
+
+std::unique_ptr<GPUNativeWindowVK> CreateGPUNativeWindowVK(
+    GPUContext* context, const GPUNativeWindowInfoVK* info) {
+  (void)context;
+  (void)info;
+  return {};
+}
+
+}  // namespace skity


### PR DESCRIPTION
When SKITY_VK_BACKEND is OFF, provide empty stub implementations for CreateGPUContextVK and CreateGPUNativeWindowVK that return nullptr. This prevents link errors and runtime SO loading failures for users who reference these symbols conditionally.