### PR TITLE
feat(harness): add macOS CoreText font harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,10 @@ if(${SKITY_EXAMPLE})
   add_subdirectory(example)
 endif()
 
+if(${SKITY_ENABLE_FONT_HARNESS})
+  add_subdirectory(harness/font)
+endif()
+
 if(${SKITY_TEST})
   add_subdirectory(test)
 endif()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -75,6 +75,8 @@ cmake_dependent_option(
 option(SKITY_LOG "option for logging" OFF)
 option(SKITY_CT_FONT "option for open CoreText font backend on Darwin" OFF)
 
+option(SKITY_ENABLE_FONT_HARNESS "option for building font harness CLI and tests" OFF)
+
 option(SKITY_USE_SELF_LIBCXX "option to force skity use self libcxx" OFF)
 option(SKITY_TRACE "option for enable skity tracing" OFF)
 option(SKITY_BENCH_ENABLE_PERFETTO "option for enable perfetto tracing for benchmark" OFF)

--- a/harness/font/CMakeLists.txt
+++ b/harness/font/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+if(NOT TARGET jsoncpp_static AND NOT TARGET jsoncpp_lib)
+  set(JSONCPP_WITH_TESTS OFF CACHE BOOL "disable jsoncpp tests" FORCE)
+  add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/third_party/jsoncpp
+    ${CMAKE_CURRENT_BINARY_DIR}/third_party/jsoncpp
+  )
+endif()
+
+if(TARGET jsoncpp_static)
+  set(SKITY_FONT_HARNESS_JSONCPP_TARGET jsoncpp_static)
+elseif(TARGET jsoncpp_lib)
+  set(SKITY_FONT_HARNESS_JSONCPP_TARGET jsoncpp_lib)
+else()
+  message(FATAL_ERROR "jsoncpp target is required for skity_font_harness")
+endif()
+
+add_library(skity_font_harness STATIC
+  ${CMAKE_CURRENT_LIST_DIR}/artifact/artifact_validator.cc
+  ${CMAKE_CURRENT_LIST_DIR}/artifact/artifact_writer.cc
+  ${CMAKE_CURRENT_LIST_DIR}/artifact/json_io.cc
+  ${CMAKE_CURRENT_LIST_DIR}/case/case_document.cc
+  ${CMAKE_CURRENT_LIST_DIR}/case/manifest_document.cc
+  ${CMAKE_CURRENT_LIST_DIR}/case/repo_uri.cc
+  ${CMAKE_CURRENT_LIST_DIR}/case/validation.cc
+  ${CMAKE_CURRENT_LIST_DIR}/compare/compare_engine.cc
+  ${CMAKE_CURRENT_LIST_DIR}/compare/path/path_normalizer.cc
+  ${CMAKE_CURRENT_LIST_DIR}/platform/coretext/env_info.cc
+  ${CMAKE_CURRENT_LIST_DIR}/probe/font_manager_probe.cc
+  ${CMAKE_CURRENT_LIST_DIR}/probe/glyph_path_probe.cc
+  ${CMAKE_CURRENT_LIST_DIR}/probe/metrics_probe.cc
+  ${CMAKE_CURRENT_LIST_DIR}/probe/typeface_probe.cc
+  ${CMAKE_SOURCE_DIR}/src/render/text/text_transform.cc
+  ${CMAKE_SOURCE_DIR}/src/base/hash.cc
+  ${CMAKE_SOURCE_DIR}/src/text/scaler_context.cc
+  ${CMAKE_SOURCE_DIR}/src/text/scaler_context_desc.cc
+)
+
+set(SKITY_FONT_HARNESS_HAS_CORETEXT 0)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND SKITY_CT_FONT)
+  set(SKITY_FONT_HARNESS_HAS_CORETEXT 1)
+endif()
+
+target_include_directories(
+  skity_font_harness
+  PUBLIC
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_compile_features(skity_font_harness PUBLIC cxx_std_17)
+target_compile_definitions(
+  skity_font_harness
+  PUBLIC
+  SKITY_FONT_HARNESS_REPO_ROOT="${CMAKE_SOURCE_DIR}"
+  SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME="${CMAKE_SYSTEM_NAME}"
+  SKITY_FONT_HARNESS_SKITY_CT_FONT=$<BOOL:${SKITY_CT_FONT}>
+  SKITY_FONT_HARNESS_ENABLE_FONT_HARNESS=$<BOOL:${SKITY_ENABLE_FONT_HARNESS}>
+  SKITY_FONT_HARNESS_HAS_CORETEXT=${SKITY_FONT_HARNESS_HAS_CORETEXT}
+)
+target_link_libraries(
+  skity_font_harness
+  PUBLIC
+  skity::skity
+  PRIVATE
+  glm::glm-header-only
+  ${SKITY_FONT_HARNESS_JSONCPP_TARGET}
+)
+
+if(SKITY_FONT_HARNESS_HAS_CORETEXT)
+  target_link_libraries(
+    skity_font_harness
+    PRIVATE
+    "-framework CoreText"
+    "-framework CoreFoundation"
+  )
+endif()
+
+add_executable(skity-font
+  ${CMAKE_CURRENT_LIST_DIR}/cli/skity-font/main.cc
+)
+
+target_link_libraries(skity-font PRIVATE skity_font_harness)
+target_compile_features(skity-font PRIVATE cxx_std_17)
+
+if(${SKITY_TEST})
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  enable_testing()
+  add_test(
+    NAME font_harness_cli_smoke
+    COMMAND
+      ${Python3_EXECUTABLE}
+      ${CMAKE_CURRENT_LIST_DIR}/tests/smoke/skity_font_cli_smoke.py
+      $<TARGET_FILE:skity-font>
+  )
+  set_tests_properties(font_harness_cli_smoke PROPERTIES LABELS font_harness)
+endif()

--- a/harness/font/artifact/artifact_validator.cc
+++ b/harness/font/artifact/artifact_validator.cc
@@ -1,0 +1,59 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/artifact/artifact_validator.hpp"
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+ArtifactValidationResult ValidateBaseArtifact(
+    const Json::Value& root, const std::string& expected_type) {
+  ArtifactValidationResult result;
+  if (!RequireObject(root, "$", &result.errors)) {
+    result.valid = false;
+    return result;
+  }
+
+  int schema_version = 0;
+  if (RequireIntField(root, "schema_version", "$", &result.errors,
+                      &schema_version) &&
+      schema_version != 1) {
+    result.errors.AddError("$.schema_version", "expected schema_version 1");
+  }
+
+  RequireStringField(root, "artifact_type", "$", &result.errors,
+                     &result.artifact_type);
+  RequireStringField(root, "case_id", "$", &result.errors, &result.case_id);
+  ValidateNonEmptyString(result.case_id, "$.case_id", &result.errors);
+  if (result.artifact_type != expected_type) {
+    result.errors.AddError("$.artifact_type",
+                           "expected artifact_type " + expected_type);
+  }
+  return result;
+}
+
+}  // namespace
+
+ArtifactValidationResult ValidateProbeResultDocument(const Json::Value& root) {
+  ArtifactValidationResult result =
+      ValidateBaseArtifact(root, "font_probe_result");
+  RequireStringField(root, "backend", "$", &result.errors, nullptr);
+  result.valid = result.errors.IsValid();
+  return result;
+}
+
+ArtifactValidationResult ValidateCompareReportDocument(
+    const Json::Value& root) {
+  ArtifactValidationResult result =
+      ValidateBaseArtifact(root, "font_compare_report");
+  RequireStringField(root, "stage", "$", &result.errors, nullptr);
+  RequireStringField(root, "reason_code", "$", &result.errors, nullptr);
+  result.valid = result.errors.IsValid();
+  return result;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/artifact/artifact_validator.hpp
+++ b/harness/font/artifact/artifact_validator.hpp
@@ -1,0 +1,28 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_ARTIFACT_ARTIFACT_VALIDATOR_HPP
+#define HARNESS_FONT_ARTIFACT_ARTIFACT_VALIDATOR_HPP
+
+#include <string>
+
+#include "harness/font/case/validation.hpp"
+
+namespace skity {
+namespace font_harness {
+
+struct ArtifactValidationResult {
+  bool valid = false;
+  std::string artifact_type;
+  std::string case_id;
+  ValidationContext errors;
+};
+
+ArtifactValidationResult ValidateProbeResultDocument(const Json::Value& root);
+ArtifactValidationResult ValidateCompareReportDocument(const Json::Value& root);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_ARTIFACT_ARTIFACT_VALIDATOR_HPP

--- a/harness/font/artifact/artifact_writer.cc
+++ b/harness/font/artifact/artifact_writer.cc
@@ -1,0 +1,334 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/artifact/artifact_writer.hpp"
+
+#include <cctype>
+#include <sstream>
+#include <system_error>
+
+#include "harness/font/artifact/json_io.hpp"
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+std::filesystem::path NormalizeRepoRoot(const std::filesystem::path& repo_root,
+                                        std::string* error) {
+  std::error_code ec;
+  std::filesystem::path normalized =
+      std::filesystem::weakly_canonical(repo_root, ec);
+  if (!ec) {
+    return normalized;
+  }
+  if (error != nullptr) {
+    *error = "failed to resolve repository root: " + ec.message();
+  }
+  return {};
+}
+
+bool IsSafeFileChar(char value) {
+  return std::isalnum(static_cast<unsigned char>(value)) || value == '-' ||
+         value == '_' || value == '.';
+}
+
+std::string SanitizeFileComponent(std::string value,
+                                  const std::string& fallback) {
+  if (value.empty()) {
+    return fallback;
+  }
+  for (char& c : value) {
+    if (!IsSafeFileChar(c)) {
+      c = '_';
+    }
+  }
+  while (!value.empty() && value.front() == '.') {
+    value.erase(value.begin());
+  }
+  if (value.empty()) {
+    return fallback;
+  }
+  return value;
+}
+
+std::string StemFromPath(const std::filesystem::path& path,
+                         const std::string& fallback) {
+  std::string stem = path.stem().string();
+  if (stem.empty()) {
+    return fallback;
+  }
+  return SanitizeFileComponent(stem, fallback);
+}
+
+std::string ArtifactBaseName(const ArtifactDescriptor& descriptor) {
+  if (!descriptor.case_id.empty()) {
+    return SanitizeFileComponent(descriptor.case_id, "case");
+  }
+  if (!descriptor.manifest_id.empty()) {
+    return SanitizeFileComponent(descriptor.manifest_id, "manifest");
+  }
+  return StemFromPath(descriptor.input_path, "artifact");
+}
+
+std::string BackendSuffix(const ArtifactDescriptor& descriptor) {
+  if (descriptor.backend.empty()) {
+    return "";
+  }
+  return "." + SanitizeFileComponent(descriptor.backend, "backend");
+}
+
+std::filesystem::path DefaultArtifactPath(
+    const std::filesystem::path& repo_root,
+    const ArtifactDescriptor& descriptor) {
+  const std::filesystem::path local_root = repo_root / "local" / "font-harness";
+  const std::string name = ArtifactBaseName(descriptor);
+  const std::string backend = BackendSuffix(descriptor);
+
+  switch (descriptor.kind) {
+    case ArtifactKind::kCaseInfo:
+      return local_root / "artifacts" / "compare" /
+             (name + backend + ".case-info.json");
+    case ArtifactKind::kEnvInfo:
+      return local_root / "artifacts" / "env" /
+             (SanitizeFileComponent(descriptor.backend, "backend") +
+              ".env-info.json");
+    case ArtifactKind::kFontList:
+      return local_root / "artifacts" / "env" /
+             (SanitizeFileComponent(descriptor.backend, "backend") +
+              ".fonts.json");
+    case ArtifactKind::kSkityResult:
+      return local_root / "artifacts" / "skity" / (name + backend + ".json");
+    case ArtifactKind::kCompareReport:
+      return local_root / "artifacts" / "compare" /
+             (name + backend + ".compare.json");
+    case ArtifactKind::kRunSummary:
+      return local_root / "reports" / (name + backend + ".run.json");
+    case ArtifactKind::kPathDump:
+      return local_root / "artifacts" / "path" /
+             (name + backend + ".path.json");
+  }
+  return local_root / "artifacts" / (name + backend + ".json");
+}
+
+std::string StablePathFor(const std::filesystem::path& absolute_path,
+                          const std::filesystem::path& repo_root) {
+  std::error_code ec;
+  auto relative = std::filesystem::relative(absolute_path, repo_root, ec);
+  if (!ec && !relative.empty()) {
+    bool escapes_repo = false;
+    for (const auto& part : relative) {
+      if (part == "..") {
+        escapes_repo = true;
+        break;
+      }
+    }
+    if (!escapes_repo) {
+      return relative.generic_string();
+    }
+  }
+  return absolute_path.lexically_normal().string();
+}
+
+std::string QuoteArg(const std::string& arg) {
+  if (arg.empty()) {
+    return "''";
+  }
+
+  bool needs_quote = false;
+  for (char c : arg) {
+    if (std::isspace(static_cast<unsigned char>(c)) || c == '\'' || c == '"' ||
+        c == '\\') {
+      needs_quote = true;
+      break;
+    }
+  }
+  if (!needs_quote) {
+    return arg;
+  }
+
+  std::string quoted = "'";
+  for (char c : arg) {
+    if (c == '\'') {
+      quoted += "'\\''";
+    } else {
+      quoted += c;
+    }
+  }
+  quoted += "'";
+  return quoted;
+}
+
+std::string BuildMinimalRepro(const ArtifactDescriptor& descriptor,
+                              const std::string& stable_path) {
+  std::vector<std::string> args = {"skity-font", descriptor.command};
+  args.insert(args.end(), descriptor.repro_args.begin(),
+              descriptor.repro_args.end());
+  if (!descriptor.output_flag.empty()) {
+    args.push_back(descriptor.output_flag);
+    args.push_back(stable_path);
+  }
+
+  std::ostringstream stream;
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i > 0) {
+      stream << ' ';
+    }
+    stream << QuoteArg(args[i]);
+  }
+  return stream.str();
+}
+
+void FillCommonFields(const ArtifactDescriptor& descriptor,
+                      const ArtifactWriteResult& write_result,
+                      Json::Value* report) {
+  if (!descriptor.case_id.empty() && !report->isMember("case_id")) {
+    (*report)["case_id"] = descriptor.case_id;
+  }
+  if (!descriptor.manifest_id.empty() && !report->isMember("manifest_id")) {
+    (*report)["manifest_id"] = descriptor.manifest_id;
+  }
+  if (!descriptor.backend.empty() && !report->isMember("backend")) {
+    (*report)["backend"] = descriptor.backend;
+  }
+  (*report)["artifact_path"] = write_result.stable_path;
+  (*report)["minimal_repro_command"] = write_result.minimal_repro_command;
+}
+
+std::string ReportStatus(const Json::Value& report, int exit_code) {
+  if (exit_code == 0) {
+    if (report.isMember("valid") && !report["valid"].asBool()) {
+      return "invalid";
+    }
+    return "ok";
+  }
+  if (report.isMember("reason_code")) {
+    return report["reason_code"].asString();
+  }
+  if (report.isMember("valid") && !report["valid"].asBool()) {
+    return "schema_validation_failed";
+  }
+  return "failed";
+}
+
+void AppendIfPresent(std::ostringstream* stream, const Json::Value& report,
+                     const std::string& field) {
+  if (report.isMember(field) && report[field].isString() &&
+      !report[field].asString().empty()) {
+    *stream << ' ' << field << '=' << report[field].asString();
+  }
+}
+
+}  // namespace
+
+std::filesystem::path ResolveArtifactPath(
+    const std::filesystem::path& repo_root,
+    const ArtifactDescriptor& descriptor) {
+  if (!descriptor.explicit_output_path.empty()) {
+    if (descriptor.explicit_output_path.is_absolute()) {
+      return descriptor.explicit_output_path.lexically_normal();
+    }
+    return (repo_root / descriptor.explicit_output_path).lexically_normal();
+  }
+  return DefaultArtifactPath(repo_root, descriptor).lexically_normal();
+}
+
+bool WriteStableArtifact(const std::filesystem::path& repo_root,
+                         const ArtifactDescriptor& descriptor,
+                         Json::Value* report, ArtifactWriteResult* result,
+                         std::string* error) {
+  if (report == nullptr || result == nullptr) {
+    if (error != nullptr) {
+      *error = "artifact writer requires report and result";
+    }
+    return false;
+  }
+
+  const std::filesystem::path normalized_repo =
+      NormalizeRepoRoot(repo_root, error);
+  if (normalized_repo.empty()) {
+    return false;
+  }
+
+  result->absolute_path = ResolveArtifactPath(normalized_repo, descriptor);
+  result->stable_path = StablePathFor(result->absolute_path, normalized_repo);
+  result->minimal_repro_command =
+      BuildMinimalRepro(descriptor, result->stable_path);
+  FillCommonFields(descriptor, *result, report);
+
+  return WriteJsonFile(result->absolute_path, *report, error);
+}
+
+std::string BuildHumanSummary(const std::string& command,
+                              const Json::Value& report, int exit_code) {
+  std::ostringstream stream;
+  stream << "font-harness command=" << command << " exit_code=" << exit_code
+         << " status=" << ReportStatus(report, exit_code);
+  AppendIfPresent(&stream, report, "case_id");
+  AppendIfPresent(&stream, report, "manifest_id");
+  AppendIfPresent(&stream, report, "backend");
+  AppendIfPresent(&stream, report, "artifact_path");
+  return stream.str();
+}
+
+Json::Value BuildProbeResultReport(const std::string& case_id,
+                                   const std::string& backend,
+                                   const std::string& reason_code) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_probe_result";
+  report["runner"] = "skity";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  report["reason_code"] = reason_code;
+  return report;
+}
+
+Json::Value BuildCompareReport(const std::string& case_id,
+                               const std::string& backend,
+                               const std::string& stage,
+                               const std::string& reason_code) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_compare_report";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["stage"] = stage;
+  report["reason_code"] = reason_code;
+  report["passed"] = false;
+  report["diff_path"] = "";
+  report["artifacts"] = Json::Value(Json::objectValue);
+  return report;
+}
+
+Json::Value BuildRunSummaryReport(const std::string& manifest_id,
+                                  const std::string& backend,
+                                  const std::string& reason_code) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_run_summary";
+  report["manifest_id"] = manifest_id;
+  report["backend"] = backend;
+  report["status"] = "not_run";
+  report["reason_code"] = reason_code;
+  report["cases"] = Json::Value(Json::arrayValue);
+  return report;
+}
+
+Json::Value BuildPathDumpReport(const std::string& case_id,
+                                const std::string& backend,
+                                const std::string& reason_code) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_path_dump";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  report["reason_code"] = reason_code;
+  return report;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/artifact/artifact_writer.hpp
+++ b/harness/font/artifact/artifact_writer.hpp
@@ -1,0 +1,74 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_ARTIFACT_ARTIFACT_WRITER_HPP
+#define HARNESS_FONT_ARTIFACT_ARTIFACT_WRITER_HPP
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class ArtifactKind {
+  kCaseInfo,
+  kEnvInfo,
+  kFontList,
+  kSkityResult,
+  kCompareReport,
+  kRunSummary,
+  kPathDump,
+};
+
+struct ArtifactDescriptor {
+  ArtifactKind kind = ArtifactKind::kCaseInfo;
+  std::string command;
+  std::string output_flag = "--report";
+  std::string case_id;
+  std::string manifest_id;
+  std::string backend;
+  std::filesystem::path input_path;
+  std::filesystem::path explicit_output_path;
+  std::vector<std::string> repro_args;
+};
+
+struct ArtifactWriteResult {
+  std::filesystem::path absolute_path;
+  std::string stable_path;
+  std::string minimal_repro_command;
+};
+
+std::filesystem::path ResolveArtifactPath(
+    const std::filesystem::path& repo_root,
+    const ArtifactDescriptor& descriptor);
+
+bool WriteStableArtifact(const std::filesystem::path& repo_root,
+                         const ArtifactDescriptor& descriptor,
+                         Json::Value* report, ArtifactWriteResult* result,
+                         std::string* error);
+
+std::string BuildHumanSummary(const std::string& command,
+                              const Json::Value& report, int exit_code);
+
+Json::Value BuildProbeResultReport(const std::string& case_id,
+                                   const std::string& backend,
+                                   const std::string& reason_code);
+Json::Value BuildCompareReport(const std::string& case_id,
+                               const std::string& backend,
+                               const std::string& stage,
+                               const std::string& reason_code);
+Json::Value BuildRunSummaryReport(const std::string& manifest_id,
+                                  const std::string& backend,
+                                  const std::string& reason_code);
+Json::Value BuildPathDumpReport(const std::string& case_id,
+                                const std::string& backend,
+                                const std::string& reason_code);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_ARTIFACT_ARTIFACT_WRITER_HPP

--- a/harness/font/artifact/json_io.cc
+++ b/harness/font/artifact/json_io.cc
@@ -1,0 +1,74 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/artifact/json_io.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <system_error>
+
+namespace skity {
+namespace font_harness {
+
+bool LoadJsonFile(const std::filesystem::path& path, Json::Value* root,
+                  std::string* error) {
+  std::ifstream input(path);
+  if (!input.is_open()) {
+    if (error != nullptr) {
+      *error = "failed to open JSON file: " + path.string();
+    }
+    return false;
+  }
+
+  Json::CharReaderBuilder builder;
+  builder["collectComments"] = false;
+  std::string parse_errors;
+  if (!Json::parseFromStream(builder, input, root, &parse_errors)) {
+    if (error != nullptr) {
+      *error = parse_errors;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool WriteJsonFile(const std::filesystem::path& path, const Json::Value& root,
+                   std::string* error) {
+  std::error_code ec;
+  auto parent = path.parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      if (error != nullptr) {
+        *error = "failed to create report directory: " + ec.message();
+      }
+      return false;
+    }
+  }
+
+  std::ofstream output(path);
+  if (!output.is_open()) {
+    if (error != nullptr) {
+      *error = "failed to open output JSON file: " + path.string();
+    }
+    return false;
+  }
+  output << WriteJsonString(root);
+  if (!output.good()) {
+    if (error != nullptr) {
+      *error = "failed to write output JSON file: " + path.string();
+    }
+    return false;
+  }
+  return true;
+}
+
+std::string WriteJsonString(const Json::Value& root) {
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "  ";
+  return Json::writeString(builder, root);
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/artifact/json_io.hpp
+++ b/harness/font/artifact/json_io.hpp
@@ -1,0 +1,25 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_ARTIFACT_JSON_IO_HPP
+#define HARNESS_FONT_ARTIFACT_JSON_IO_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+bool LoadJsonFile(const std::filesystem::path& path, Json::Value* root,
+                  std::string* error);
+bool WriteJsonFile(const std::filesystem::path& path, const Json::Value& root,
+                   std::string* error);
+std::string WriteJsonString(const Json::Value& root);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_ARTIFACT_JSON_IO_HPP

--- a/harness/font/case/case_document.cc
+++ b/harness/font/case/case_document.cc
@@ -1,0 +1,433 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/case/case_document.hpp"
+
+#include <cctype>
+#include <set>
+#include <unordered_map>
+#include <utility>
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+const std::vector<std::string>& AllowedCategories() {
+  static const std::vector<std::string> values = {
+      "typeface_probe", "system_match",        "family_style_set",
+      "fallback_match", "typeface_descriptor", "font_metrics",
+      "glyph_mapping",  "glyph_metrics",       "glyph_path",
+      "variation",      "font_tables",         "scaler_context",
+      "font_manager",
+  };
+  return values;
+}
+
+const std::vector<std::string>& AllowedStatuses() {
+  static const std::vector<std::string> values = {
+      "active", "skity_gap", "expected_diff", "platform_unstable", "blocked"};
+  return values;
+}
+
+const std::vector<std::string>& AllowedBackends() {
+  static const std::vector<std::string> values = {"coretext", "directwrite",
+                                                  "host-ft"};
+  return values;
+}
+
+const std::vector<std::string>& AllowedTypefaceEntries() {
+  static const std::vector<std::string> values = {
+      "MakeFromFile", "MakeFromData", "MakeVariation",
+      "MakeFromPlatformDescriptor"};
+  return values;
+}
+
+const std::vector<std::string>& AllowedHinting() {
+  static const std::vector<std::string> values = {"none", "slight", "normal",
+                                                  "full"};
+  return values;
+}
+
+bool BackendMatchesPlatforms(const std::string& backend,
+                             const Json::Value& platforms) {
+  for (const auto& platform : platforms) {
+    if (!platform.isString()) {
+      continue;
+    }
+    const std::string value = platform.asString();
+    if (backend == "coretext" && value == "darwin-ct") {
+      return true;
+    }
+    if (backend == "directwrite" && value == "windows-dwrite") {
+      return true;
+    }
+    if (backend == "host-ft" && value == "host-ft") {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ValidateGlyphChar(const std::string& value) {
+  if (value.size() < 3 || value.rfind("U+", 0) != 0) {
+    return false;
+  }
+  for (size_t i = 2; i < value.size(); ++i) {
+    if (!std::isxdigit(static_cast<unsigned char>(value[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool RequiresTypefaceRequest(const std::string& category) {
+  static const std::set<std::string> values = {
+      "typeface_probe", "typeface_descriptor", "font_metrics",
+      "glyph_mapping",  "glyph_metrics",       "glyph_path",
+      "variation",      "font_tables",         "scaler_context",
+  };
+  return values.find(category) != values.end();
+}
+
+void ValidatePlatforms(const Json::Value& root, const std::string& backend,
+                       ValidationContext* context) {
+  const Json::Value* platforms = nullptr;
+  if (!RequireArrayField(root, "platforms", "$", context, &platforms)) {
+    return;
+  }
+  if (platforms->empty()) {
+    context->AddError("$.platforms", "platforms must not be empty");
+  }
+  for (Json::ArrayIndex i = 0; i < platforms->size(); ++i) {
+    const Json::Value& platform = (*platforms)[i];
+    const std::string path = IndexPath("$.platforms", i);
+    if (!platform.isString()) {
+      context->AddError(path, "expected string");
+      continue;
+    }
+    ValidateNonEmptyString(platform.asString(), path, context);
+  }
+  if (!backend.empty() && !BackendMatchesPlatforms(backend, *platforms)) {
+    context->AddError("$.platforms",
+                      "platforms do not match backend: " + backend);
+  }
+}
+
+void ValidateFontRequest(const Json::Value& root, ValidationContext* context) {
+  if (!root.isMember("font_request")) {
+    return;
+  }
+  const Json::Value& request = root["font_request"];
+  const std::string path = "$.font_request";
+  if (!RequireObject(request, path, context)) {
+    return;
+  }
+
+  double number = 0.0;
+  if (OptionalNumberField(request, "size", path, context, &number)) {
+    ValidatePositiveNumber(number, ChildPath(path, "size"), context);
+  }
+  if (OptionalNumberField(request, "scale_x", path, context, &number)) {
+    ValidatePositiveNumber(number, ChildPath(path, "scale_x"), context);
+  }
+  OptionalNumberField(request, "skew_x", path, context, nullptr);
+  bool bool_value = false;
+  OptionalBoolField(request, "linear_metrics", path, context, &bool_value);
+  OptionalBoolField(request, "subpixel", path, context, &bool_value);
+  OptionalBoolField(request, "embolden", path, context, &bool_value);
+
+  std::string hinting;
+  if (OptionalStringField(request, "hinting", path, context, &hinting)) {
+    ValidateStringEnum(hinting, ChildPath(path, "hinting"), AllowedHinting(),
+                       context);
+  }
+}
+
+void ValidateGlyphs(const Json::Value& root, ValidationContext* context) {
+  if (!root.isMember("glyphs")) {
+    return;
+  }
+  const Json::Value& glyphs = root["glyphs"];
+  const std::string path = "$.glyphs";
+  if (!RequireObject(glyphs, path, context)) {
+    return;
+  }
+
+  bool has_chars = false;
+  bool has_glyph_ids = false;
+  if (glyphs.isMember("chars")) {
+    const Json::Value& chars = glyphs["chars"];
+    const std::string chars_path = ChildPath(path, "chars");
+    if (!chars.isArray()) {
+      context->AddError(chars_path, "expected array");
+    } else {
+      has_chars = !chars.empty();
+      for (Json::ArrayIndex i = 0; i < chars.size(); ++i) {
+        const std::string item_path = IndexPath(chars_path, i);
+        if (!chars[i].isString()) {
+          context->AddError(item_path, "expected string");
+          continue;
+        }
+        if (!ValidateGlyphChar(chars[i].asString())) {
+          context->AddError(item_path, "expected U+XXXX code point string");
+        }
+      }
+    }
+  }
+  if (glyphs.isMember("glyph_ids")) {
+    const Json::Value& ids = glyphs["glyph_ids"];
+    const std::string ids_path = ChildPath(path, "glyph_ids");
+    if (!ids.isArray()) {
+      context->AddError(ids_path, "expected array");
+    } else {
+      has_glyph_ids = !ids.empty();
+      for (Json::ArrayIndex i = 0; i < ids.size(); ++i) {
+        const std::string item_path = IndexPath(ids_path, i);
+        if (!ids[i].isInt()) {
+          context->AddError(item_path, "expected integer");
+          continue;
+        }
+        ValidateNonNegativeInt(ids[i].asInt(), item_path, context);
+      }
+    }
+  }
+  if (!has_chars && !has_glyph_ids) {
+    context->AddError(path,
+                      "chars or glyph_ids must contain at least one item");
+  }
+}
+
+void ValidateCompareModeObject(const Json::Value& value,
+                               const std::string& path,
+                               const std::vector<std::string>& modes,
+                               ValidationContext* context) {
+  if (!RequireObject(value, path, context)) {
+    return;
+  }
+  std::string mode;
+  if (OptionalStringField(value, "mode", path, context, &mode)) {
+    ValidateStringEnum(mode, ChildPath(path, "mode"), modes, context);
+  }
+  double epsilon = 0.0;
+  if (OptionalNumberField(value, "epsilon", path, context, &epsilon) &&
+      epsilon < 0.0) {
+    context->AddError(ChildPath(path, "epsilon"),
+                      "epsilon must be non-negative");
+  }
+}
+
+void ValidateCompare(const Json::Value& root, ValidationContext* context) {
+  const Json::Value* compare = nullptr;
+  if (!RequireObjectField(root, "compare", "$", context, &compare)) {
+    return;
+  }
+
+  std::string value;
+  if (OptionalStringField(*compare, "typeface_identity", "$.compare", context,
+                          &value)) {
+    ValidateStringEnum(value, "$.compare.typeface_identity",
+                       {"normalized_descriptor", "exact", "none"}, context);
+  }
+  if (OptionalStringField(*compare, "font_style", "$.compare", context,
+                          &value)) {
+    ValidateStringEnum(value, "$.compare.font_style", {"exact", "none"},
+                       context);
+  }
+
+  if (compare->isMember("font_metrics")) {
+    ValidateCompareModeObject((*compare)["font_metrics"],
+                              "$.compare.font_metrics",
+                              {"exact", "epsilon", "ignore"}, context);
+  }
+  if (compare->isMember("glyph_metrics")) {
+    ValidateCompareModeObject((*compare)["glyph_metrics"],
+                              "$.compare.glyph_metrics",
+                              {"exact", "epsilon", "ignore"}, context);
+  }
+  if (compare->isMember("glyph_path")) {
+    ValidateCompareModeObject((*compare)["glyph_path"], "$.compare.glyph_path",
+                              {"backend_default", "path_exact",
+                               "path_normalized", "path_geometry", "ignore"},
+                              context);
+  }
+}
+
+std::unordered_map<std::string, ResolvedFontFile> ValidateFontFiles(
+    const Json::Value& root, const RepoUriResolver& resolver,
+    CaseValidationResult* result) {
+  std::unordered_map<std::string, ResolvedFontFile> font_files;
+  if (!root.isMember("font_files")) {
+    return font_files;
+  }
+
+  const Json::Value& files = root["font_files"];
+  if (!files.isArray()) {
+    result->errors.AddError("$.font_files", "expected array");
+    return font_files;
+  }
+
+  std::set<std::string> ids;
+  for (Json::ArrayIndex i = 0; i < files.size(); ++i) {
+    const Json::Value& file = files[i];
+    const std::string path = IndexPath("$.font_files", i);
+    if (!RequireObject(file, path, &result->errors)) {
+      continue;
+    }
+
+    std::string id;
+    std::string uri;
+    RequireStringField(file, "id", path, &result->errors, &id);
+    RequireStringField(file, "uri", path, &result->errors, &uri);
+    ValidateNonEmptyString(id, ChildPath(path, "id"), &result->errors);
+    if (!id.empty() && !ids.insert(id).second) {
+      result->errors.AddError(ChildPath(path, "id"),
+                              "font file id must be unique");
+    }
+
+    int collection_index = 0;
+    if (OptionalIntField(file, "collection_index", path, &result->errors,
+                         &collection_index)) {
+      ValidateNonNegativeInt(collection_index,
+                             ChildPath(path, "collection_index"),
+                             &result->errors);
+    }
+    std::string sha256;
+    if (OptionalStringField(file, "sha256", path, &result->errors, &sha256)) {
+      ValidateSha256String(sha256, ChildPath(path, "sha256"), &result->errors);
+    }
+
+    ResolvedFontFile file_record;
+    file_record.id = id;
+    file_record.uri = uri;
+    file_record.collection_index = collection_index;
+
+    ResolvedRepoFile resolved;
+    if (!uri.empty() &&
+        resolver.ResolveExistingFile(uri, ChildPath(path, "uri"),
+                                     &result->errors, &resolved)) {
+      file_record.absolute_path = resolved.absolute_path;
+      result->resolved_font_files.push_back(file_record);
+    }
+    if (!id.empty()) {
+      font_files.emplace(id, std::move(file_record));
+    }
+  }
+
+  return font_files;
+}
+
+void ValidateTypefaceRequest(
+    const Json::Value& root, const std::string& category,
+    const std::unordered_map<std::string, ResolvedFontFile>& font_files,
+    ValidationContext* context) {
+  const Json::Value* request = nullptr;
+  if (!root.isMember("typeface_request")) {
+    if (RequiresTypefaceRequest(category)) {
+      context->AddError("$.typeface_request", "required field is missing");
+    }
+    return;
+  }
+  if (!RequireObjectField(root, "typeface_request", "$", context, &request)) {
+    return;
+  }
+
+  std::string entry;
+  if (!RequireStringField(*request, "entry", "$.typeface_request", context,
+                          &entry)) {
+    return;
+  }
+  ValidateStringEnum(entry, "$.typeface_request.entry",
+                     AllowedTypefaceEntries(), context);
+
+  std::string font_file;
+  if (OptionalStringField(*request, "font_file", "$.typeface_request", context,
+                          &font_file) &&
+      !font_file.empty() && font_files.find(font_file) == font_files.end()) {
+    context->AddError("$.typeface_request.font_file",
+                      "font_file does not reference font_files[].id");
+  }
+
+  if ((entry == "MakeFromFile" || entry == "MakeFromData") &&
+      font_file.empty()) {
+    context->AddError("$.typeface_request.font_file",
+                      "font_file is required for " + entry);
+  }
+}
+
+}  // namespace
+
+CaseValidationResult ValidateCaseDocument(const Json::Value& root,
+                                          const RepoUriResolver& resolver) {
+  CaseValidationResult result;
+  result.normalized_case = root;
+
+  if (!RequireObject(root, "$", &result.errors)) {
+    result.valid = false;
+    return result;
+  }
+
+  int schema_version = 0;
+  if (RequireIntField(root, "schema_version", "$", &result.errors,
+                      &schema_version) &&
+      schema_version != 1) {
+    result.errors.AddError("$.schema_version", "expected schema_version 1");
+  }
+
+  std::string category;
+  std::string status;
+  RequireStringField(root, "id", "$", &result.errors, &result.case_id);
+  RequireStringField(root, "category", "$", &result.errors, &category);
+  RequireStringField(root, "status", "$", &result.errors, &status);
+  RequireStringField(root, "backend", "$", &result.errors, &result.backend);
+
+  ValidateNonEmptyString(result.case_id, "$.id", &result.errors);
+  if (!category.empty()) {
+    ValidateStringEnum(category, "$.category", AllowedCategories(),
+                       &result.errors);
+  }
+  if (!status.empty()) {
+    ValidateStringEnum(status, "$.status", AllowedStatuses(), &result.errors);
+  }
+  if (!result.backend.empty()) {
+    ValidateStringEnum(result.backend, "$.backend", AllowedBackends(),
+                       &result.errors);
+  }
+  ValidatePlatforms(root, result.backend, &result.errors);
+
+  const auto font_files = ValidateFontFiles(root, resolver, &result);
+  ValidateTypefaceRequest(root, category, font_files, &result.errors);
+  ValidateFontRequest(root, &result.errors);
+  ValidateGlyphs(root, &result.errors);
+  ValidateCompare(root, &result.errors);
+
+  result.valid = result.errors.IsValid();
+  return result;
+}
+
+Json::Value BuildCaseInfoReport(const CaseValidationResult& result) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_case_info";
+  report["valid"] = result.valid;
+  report["case_id"] = result.case_id;
+  report["backend"] = result.backend;
+  report["normalized_case"] = result.normalized_case;
+
+  Json::Value resolved_files(Json::arrayValue);
+  for (const auto& file : result.resolved_font_files) {
+    Json::Value item(Json::objectValue);
+    item["id"] = file.id;
+    item["uri"] = file.uri;
+    item["absolute_path"] = file.absolute_path.string();
+    item["collection_index"] = file.collection_index;
+    resolved_files.append(std::move(item));
+  }
+  report["resolved_font_files"] = std::move(resolved_files);
+  report["errors"] = result.errors.ToJson();
+  return report;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/case/case_document.hpp
+++ b/harness/font/case/case_document.hpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_CASE_CASE_DOCUMENT_HPP
+#define HARNESS_FONT_CASE_CASE_DOCUMENT_HPP
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "harness/font/case/repo_uri.hpp"
+#include "harness/font/case/validation.hpp"
+
+namespace skity {
+namespace font_harness {
+
+struct ResolvedFontFile {
+  std::string id;
+  std::string uri;
+  std::filesystem::path absolute_path;
+  int collection_index = 0;
+};
+
+struct CaseValidationResult {
+  bool valid = false;
+  std::string case_id;
+  std::string backend;
+  Json::Value normalized_case;
+  std::vector<ResolvedFontFile> resolved_font_files;
+  ValidationContext errors;
+};
+
+CaseValidationResult ValidateCaseDocument(const Json::Value& root,
+                                          const RepoUriResolver& resolver);
+Json::Value BuildCaseInfoReport(const CaseValidationResult& result);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_CASE_CASE_DOCUMENT_HPP

--- a/harness/font/case/manifest_document.cc
+++ b/harness/font/case/manifest_document.cc
@@ -1,0 +1,93 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/case/manifest_document.hpp"
+
+#include <filesystem>
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+bool IsSafeRelativePath(const std::string& value) {
+  if (value.empty()) {
+    return false;
+  }
+  std::filesystem::path path(value);
+  if (path.is_absolute()) {
+    return false;
+  }
+  for (const auto& part : path) {
+    if (part == "." || part == "..") {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+ManifestValidationResult ValidateManifestDocument(const Json::Value& root,
+                                                  const RepoUriResolver&) {
+  ManifestValidationResult result;
+  result.normalized_manifest = root;
+
+  if (!RequireObject(root, "$", &result.errors)) {
+    result.valid = false;
+    return result;
+  }
+
+  int schema_version = 0;
+  if (RequireIntField(root, "schema_version", "$", &result.errors,
+                      &schema_version) &&
+      schema_version != 1) {
+    result.errors.AddError("$.schema_version", "expected schema_version 1");
+  }
+
+  RequireStringField(root, "id", "$", &result.errors, &result.manifest_id);
+  RequireStringField(root, "backend", "$", &result.errors, &result.backend);
+  ValidateNonEmptyString(result.manifest_id, "$.id", &result.errors);
+  ValidateStringEnum(result.backend, "$.backend",
+                     {"coretext", "directwrite", "host-ft"}, &result.errors);
+
+  const Json::Value* platforms = nullptr;
+  if (RequireArrayField(root, "platforms", "$", &result.errors, &platforms) &&
+      platforms->empty()) {
+    result.errors.AddError("$.platforms", "platforms must not be empty");
+  }
+
+  std::string case_root;
+  if (RequireStringField(root, "case_root", "$", &result.errors, &case_root) &&
+      !IsSafeRelativePath(case_root)) {
+    result.errors.AddError("$.case_root",
+                           "case_root must be a safe relative path");
+  }
+
+  const Json::Value* cases = nullptr;
+  if (RequireArrayField(root, "cases", "$", &result.errors, &cases)) {
+    if (cases->empty()) {
+      result.errors.AddError("$.cases", "cases must not be empty");
+    }
+    for (Json::ArrayIndex i = 0; i < cases->size(); ++i) {
+      const std::string path = IndexPath("$.cases", i);
+      if (!(*cases)[i].isString()) {
+        result.errors.AddError(path, "expected string");
+        continue;
+      }
+      if (!IsSafeRelativePath((*cases)[i].asString())) {
+        result.errors.AddError(path, "case path must be relative to case_root");
+      }
+    }
+  }
+
+  const Json::Value* artifacts = nullptr;
+  RequireObjectField(root, "artifacts", "$", &result.errors, &artifacts);
+
+  result.valid = result.errors.IsValid();
+  return result;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/case/manifest_document.hpp
+++ b/harness/font/case/manifest_document.hpp
@@ -1,0 +1,28 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_CASE_MANIFEST_DOCUMENT_HPP
+#define HARNESS_FONT_CASE_MANIFEST_DOCUMENT_HPP
+
+#include "harness/font/case/repo_uri.hpp"
+#include "harness/font/case/validation.hpp"
+
+namespace skity {
+namespace font_harness {
+
+struct ManifestValidationResult {
+  bool valid = false;
+  std::string manifest_id;
+  std::string backend;
+  Json::Value normalized_manifest;
+  ValidationContext errors;
+};
+
+ManifestValidationResult ValidateManifestDocument(
+    const Json::Value& root, const RepoUriResolver& resolver);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_CASE_MANIFEST_DOCUMENT_HPP

--- a/harness/font/case/repo_uri.cc
+++ b/harness/font/case/repo_uri.cc
@@ -1,0 +1,107 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/case/repo_uri.hpp"
+
+#include <system_error>
+#include <utility>
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+constexpr char kRepoScheme[] = "repo://";
+
+bool StartsWith(const std::string& value, const std::string& prefix) {
+  return value.rfind(prefix, 0) == 0;
+}
+
+bool HasForbiddenRelativeSegment(const std::filesystem::path& path) {
+  for (const auto& part : path) {
+    if (part == "." || part == "..") {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsInside(const std::filesystem::path& path,
+              const std::filesystem::path& root) {
+  std::error_code ec;
+  auto relative = std::filesystem::relative(path, root, ec);
+  if (ec || relative.empty()) {
+    return false;
+  }
+  for (const auto& part : relative) {
+    if (part == "..") {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+RepoUriResolver::RepoUriResolver(std::filesystem::path repo_root) {
+  std::error_code ec;
+  repo_root_ = std::filesystem::weakly_canonical(std::move(repo_root), ec);
+  if (ec) {
+    repo_root_ = std::filesystem::absolute(repo_root_);
+  }
+}
+
+bool RepoUriResolver::ResolveExistingFile(const std::string& uri,
+                                          const std::string& path,
+                                          ValidationContext* context,
+                                          ResolvedRepoFile* resolved) const {
+  if (uri.empty()) {
+    context->AddError(path, "uri must not be empty");
+    return false;
+  }
+  if (!StartsWith(uri, kRepoScheme)) {
+    if (!uri.empty() && std::filesystem::path(uri).is_absolute()) {
+      context->AddError(path,
+                        "absolute paths are not allowed in repository cases");
+    } else {
+      context->AddError(path, "uri must use repo:// scheme");
+    }
+    return false;
+  }
+
+  std::string relative_text = uri.substr(std::string(kRepoScheme).size());
+  std::filesystem::path relative_path(relative_text);
+  if (relative_text.empty() || relative_path.is_absolute() ||
+      HasForbiddenRelativeSegment(relative_path)) {
+    context->AddError(path,
+                      "repo:// uri must be a non-empty in-repository path");
+    return false;
+  }
+
+  std::filesystem::path absolute_path =
+      (repo_root_ / relative_path).lexically_normal();
+  if (!IsInside(absolute_path, repo_root_)) {
+    context->AddError(path, "repo:// uri escapes repository root");
+    return false;
+  }
+
+  std::error_code ec;
+  if (!std::filesystem::exists(absolute_path, ec) || ec) {
+    context->AddError(path, "repo:// target does not exist");
+    return false;
+  }
+  if (!std::filesystem::is_regular_file(absolute_path, ec) || ec) {
+    context->AddError(path, "repo:// target is not a regular file");
+    return false;
+  }
+
+  if (resolved != nullptr) {
+    resolved->uri = uri;
+    resolved->absolute_path = std::move(absolute_path);
+  }
+  return true;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/case/repo_uri.hpp
+++ b/harness/font/case/repo_uri.hpp
@@ -1,0 +1,38 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_CASE_REPO_URI_HPP
+#define HARNESS_FONT_CASE_REPO_URI_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "harness/font/case/validation.hpp"
+
+namespace skity {
+namespace font_harness {
+
+struct ResolvedRepoFile {
+  std::string uri;
+  std::filesystem::path absolute_path;
+};
+
+class RepoUriResolver {
+ public:
+  explicit RepoUriResolver(std::filesystem::path repo_root);
+
+  const std::filesystem::path& RepoRoot() const { return repo_root_; }
+
+  bool ResolveExistingFile(const std::string& uri, const std::string& path,
+                           ValidationContext* context,
+                           ResolvedRepoFile* resolved) const;
+
+ private:
+  std::filesystem::path repo_root_;
+};
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_CASE_REPO_URI_HPP

--- a/harness/font/case/validation.cc
+++ b/harness/font/case/validation.cc
@@ -1,0 +1,259 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/case/validation.hpp"
+
+#include <cctype>
+#include <utility>
+
+namespace skity {
+namespace font_harness {
+
+void ValidationContext::AddError(std::string path, std::string message) {
+  errors_.push_back({std::move(path), std::move(message)});
+}
+
+Json::Value ValidationContext::ToJson() const {
+  Json::Value errors(Json::arrayValue);
+  for (const auto& error : errors_) {
+    Json::Value item(Json::objectValue);
+    item["path"] = error.path;
+    item["message"] = error.message;
+    errors.append(std::move(item));
+  }
+  return errors;
+}
+
+std::string ChildPath(const std::string& path, const std::string& field) {
+  if (path.empty() || path == "$") {
+    return "$." + field;
+  }
+  return path + "." + field;
+}
+
+std::string IndexPath(const std::string& path, Json::ArrayIndex index) {
+  return path + "[" + std::to_string(index) + "]";
+}
+
+bool RequireObject(const Json::Value& value, const std::string& path,
+                   ValidationContext* context) {
+  if (value.isObject()) {
+    return true;
+  }
+  context->AddError(path, "expected object");
+  return false;
+}
+
+bool RequireArrayField(const Json::Value& value, const std::string& field,
+                       const std::string& path, ValidationContext* context,
+                       const Json::Value** out) {
+  const std::string field_path = ChildPath(path, field);
+  if (!value.isMember(field)) {
+    context->AddError(field_path, "required field is missing");
+    return false;
+  }
+  const Json::Value& member = value[field];
+  if (!member.isArray()) {
+    context->AddError(field_path, "expected array");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = &member;
+  }
+  return true;
+}
+
+bool RequireObjectField(const Json::Value& value, const std::string& field,
+                        const std::string& path, ValidationContext* context,
+                        const Json::Value** out) {
+  const std::string field_path = ChildPath(path, field);
+  if (!value.isMember(field)) {
+    context->AddError(field_path, "required field is missing");
+    return false;
+  }
+  const Json::Value& member = value[field];
+  if (!member.isObject()) {
+    context->AddError(field_path, "expected object");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = &member;
+  }
+  return true;
+}
+
+bool RequireStringField(const Json::Value& value, const std::string& field,
+                        const std::string& path, ValidationContext* context,
+                        std::string* out) {
+  const std::string field_path = ChildPath(path, field);
+  if (!value.isMember(field)) {
+    context->AddError(field_path, "required field is missing");
+    return false;
+  }
+  const Json::Value& member = value[field];
+  if (!member.isString()) {
+    context->AddError(field_path, "expected string");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asString();
+  }
+  return true;
+}
+
+bool RequireIntField(const Json::Value& value, const std::string& field,
+                     const std::string& path, ValidationContext* context,
+                     int* out) {
+  const std::string field_path = ChildPath(path, field);
+  if (!value.isMember(field)) {
+    context->AddError(field_path, "required field is missing");
+    return false;
+  }
+  const Json::Value& member = value[field];
+  if (!member.isInt()) {
+    context->AddError(field_path, "expected integer");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asInt();
+  }
+  return true;
+}
+
+bool OptionalStringField(const Json::Value& value, const std::string& field,
+                         const std::string& path, ValidationContext* context,
+                         std::string* out) {
+  if (!value.isMember(field)) {
+    return false;
+  }
+  const std::string field_path = ChildPath(path, field);
+  const Json::Value& member = value[field];
+  if (!member.isString()) {
+    context->AddError(field_path, "expected string");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asString();
+  }
+  return true;
+}
+
+bool OptionalIntField(const Json::Value& value, const std::string& field,
+                      const std::string& path, ValidationContext* context,
+                      int* out) {
+  if (!value.isMember(field)) {
+    return false;
+  }
+  const std::string field_path = ChildPath(path, field);
+  const Json::Value& member = value[field];
+  if (!member.isInt()) {
+    context->AddError(field_path, "expected integer");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asInt();
+  }
+  return true;
+}
+
+bool OptionalNumberField(const Json::Value& value, const std::string& field,
+                         const std::string& path, ValidationContext* context,
+                         double* out) {
+  if (!value.isMember(field)) {
+    return false;
+  }
+  const std::string field_path = ChildPath(path, field);
+  const Json::Value& member = value[field];
+  if (!member.isNumeric()) {
+    context->AddError(field_path, "expected number");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asDouble();
+  }
+  return true;
+}
+
+bool OptionalBoolField(const Json::Value& value, const std::string& field,
+                       const std::string& path, ValidationContext* context,
+                       bool* out) {
+  if (!value.isMember(field)) {
+    return false;
+  }
+  const std::string field_path = ChildPath(path, field);
+  const Json::Value& member = value[field];
+  if (!member.isBool()) {
+    context->AddError(field_path, "expected bool");
+    return false;
+  }
+  if (out != nullptr) {
+    *out = member.asBool();
+  }
+  return true;
+}
+
+bool IsOneOf(const std::string& value,
+             const std::vector<std::string>& allowed_values) {
+  for (const auto& allowed_value : allowed_values) {
+    if (value == allowed_value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ValidateStringEnum(const std::string& value, const std::string& path,
+                        const std::vector<std::string>& allowed_values,
+                        ValidationContext* context) {
+  if (IsOneOf(value, allowed_values)) {
+    return true;
+  }
+  context->AddError(path, "unknown enum value: " + value);
+  return false;
+}
+
+bool ValidateNonEmptyString(const std::string& value, const std::string& path,
+                            ValidationContext* context) {
+  if (!value.empty()) {
+    return true;
+  }
+  context->AddError(path, "string must not be empty");
+  return false;
+}
+
+bool ValidateNonNegativeInt(int value, const std::string& path,
+                            ValidationContext* context) {
+  if (value >= 0) {
+    return true;
+  }
+  context->AddError(path, "integer must be non-negative");
+  return false;
+}
+
+bool ValidatePositiveNumber(double value, const std::string& path,
+                            ValidationContext* context) {
+  if (value > 0.0) {
+    return true;
+  }
+  context->AddError(path, "number must be positive");
+  return false;
+}
+
+bool ValidateSha256String(const std::string& value, const std::string& path,
+                          ValidationContext* context) {
+  if (value.size() != 64) {
+    context->AddError(path, "sha256 must be 64 hex characters");
+    return false;
+  }
+  for (char c : value) {
+    if (!std::isxdigit(static_cast<unsigned char>(c))) {
+      context->AddError(path, "sha256 must be 64 hex characters");
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/case/validation.hpp
+++ b/harness/font/case/validation.hpp
@@ -1,0 +1,80 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_CASE_VALIDATION_HPP
+#define HARNESS_FONT_CASE_VALIDATION_HPP
+
+#include <string>
+#include <vector>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+struct ValidationError {
+  std::string path;
+  std::string message;
+};
+
+class ValidationContext {
+ public:
+  void AddError(std::string path, std::string message);
+
+  bool IsValid() const { return errors_.empty(); }
+  const std::vector<ValidationError>& Errors() const { return errors_; }
+  Json::Value ToJson() const;
+
+ private:
+  std::vector<ValidationError> errors_;
+};
+
+std::string ChildPath(const std::string& path, const std::string& field);
+std::string IndexPath(const std::string& path, Json::ArrayIndex index);
+
+bool RequireObject(const Json::Value& value, const std::string& path,
+                   ValidationContext* context);
+bool RequireArrayField(const Json::Value& value, const std::string& field,
+                       const std::string& path, ValidationContext* context,
+                       const Json::Value** out = nullptr);
+bool RequireObjectField(const Json::Value& value, const std::string& field,
+                        const std::string& path, ValidationContext* context,
+                        const Json::Value** out = nullptr);
+bool RequireStringField(const Json::Value& value, const std::string& field,
+                        const std::string& path, ValidationContext* context,
+                        std::string* out = nullptr);
+bool RequireIntField(const Json::Value& value, const std::string& field,
+                     const std::string& path, ValidationContext* context,
+                     int* out = nullptr);
+bool OptionalStringField(const Json::Value& value, const std::string& field,
+                         const std::string& path, ValidationContext* context,
+                         std::string* out = nullptr);
+bool OptionalIntField(const Json::Value& value, const std::string& field,
+                      const std::string& path, ValidationContext* context,
+                      int* out = nullptr);
+bool OptionalNumberField(const Json::Value& value, const std::string& field,
+                         const std::string& path, ValidationContext* context,
+                         double* out = nullptr);
+bool OptionalBoolField(const Json::Value& value, const std::string& field,
+                       const std::string& path, ValidationContext* context,
+                       bool* out = nullptr);
+
+bool IsOneOf(const std::string& value,
+             const std::vector<std::string>& allowed_values);
+bool ValidateStringEnum(const std::string& value, const std::string& path,
+                        const std::vector<std::string>& allowed_values,
+                        ValidationContext* context);
+bool ValidateNonEmptyString(const std::string& value, const std::string& path,
+                            ValidationContext* context);
+bool ValidateNonNegativeInt(int value, const std::string& path,
+                            ValidationContext* context);
+bool ValidatePositiveNumber(double value, const std::string& path,
+                            ValidationContext* context);
+bool ValidateSha256String(const std::string& value, const std::string& path,
+                          ValidationContext* context);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_CASE_VALIDATION_HPP

--- a/harness/font/cases/family_style_set/helvetica_coretext.json
+++ b/harness/font/cases/family_style_set/helvetica_coretext.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "font.family_style_set.coretext.helvetica",
+  "category": "family_style_set",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_manager_request": {
+    "entry": "CreateStyleSet",
+    "family_name": "Helvetica",
+    "style": {
+      "weight": 400,
+      "width": 5,
+      "slant": "upright"
+    },
+    "sample_limit": 8
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact",
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/font_manager/css_generic_sans_serif_coretext.json
+++ b/harness/font/cases/font_manager/css_generic_sans_serif_coretext.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "category": "font_manager",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_manager_request": {
+    "entry": "MatchFamilyStyle",
+    "family_name": "sans-serif",
+    "style": {
+      "weight": 400,
+      "width": 5,
+      "slant": "upright"
+    },
+    "sample_limit": 8
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact",
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/font_manager/default_typeface_coretext.json
+++ b/harness/font/cases/font_manager/default_typeface_coretext.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "id": "font.font_manager.coretext.default_typeface",
+  "category": "font_manager",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_manager_request": {
+    "entry": "GetDefaultTypeface",
+    "style": {
+      "weight": 400,
+      "width": 5,
+      "slant": "upright"
+    },
+    "sample_limit": 8
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact",
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/font_manager/match_family_style_character_cjk_coretext.json
+++ b/harness/font/cases/font_manager/match_family_style_character_cjk_coretext.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "id": "font.font_manager.coretext.match_family_style_character_cjk",
+  "category": "font_manager",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_manager_request": {
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": "Helvetica",
+    "style": {
+      "weight": 400,
+      "width": 5,
+      "slant": "upright"
+    },
+    "character": "U+4E00",
+    "bcp47": [
+      "zh-Hans"
+    ],
+    "sample_limit": 8
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+4E00"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact",
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/font_manager/match_family_style_helvetica_regular_coretext.json
+++ b/harness/font/cases/font_manager/match_family_style_helvetica_regular_coretext.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "font.font_manager.coretext.match_family_style_helvetica_regular",
+  "category": "font_manager",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_manager_request": {
+    "entry": "MatchFamilyStyle",
+    "family_name": "Helvetica",
+    "style": {
+      "weight": 400,
+      "width": 5,
+      "slant": "upright"
+    },
+    "sample_limit": 8
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact",
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/font_metrics/roboto_regular_64_coretext.json
+++ b/harness/font/cases/font_metrics/roboto_regular_64_coretext.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "id": "font.font_metrics.coretext.roboto_regular_64",
+  "category": "font_metrics",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+0061"
+    ],
+    "glyph_ids": [
+      0
+    ]
+  },
+  "compare": {
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/glyph_metrics/roboto_regular_latin_coretext.json
+++ b/harness/font/cases/glyph_metrics/roboto_regular_latin_coretext.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "id": "font.glyph_metrics.coretext.roboto_regular_latin",
+  "category": "glyph_metrics",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+0061"
+    ],
+    "glyph_ids": [
+      0
+    ]
+  },
+  "compare": {
+    "glyph_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/glyph_path/roboto_regular_latin_A_coretext.json
+++ b/harness/font/cases/glyph_path/roboto_regular_latin_A_coretext.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "id": "font.glyph_path.coretext.roboto_regular_latin_A",
+  "category": "glyph_path",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041"
+    ]
+  },
+  "path_expectation": {
+    "empty": false
+  },
+  "compare": {
+    "glyph_path": {
+      "mode": "path_normalized",
+      "epsilon": 0.0001
+    }
+  }
+}

--- a/harness/font/cases/glyph_path/roboto_regular_missing_glyph_coretext.json
+++ b/harness/font/cases/glyph_path/roboto_regular_missing_glyph_coretext.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "id": "font.glyph_path.coretext.roboto_regular_missing_glyph",
+  "category": "glyph_path",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "glyph_ids": [
+      65535
+    ]
+  },
+  "path_expectation": {
+    "empty": true
+  },
+  "compare": {
+    "glyph_path": {
+      "mode": "path_normalized",
+      "epsilon": 0.0001
+    }
+  }
+}

--- a/harness/font/cases/scaler_context/roboto_regular_64_coretext.json
+++ b/harness/font/cases/scaler_context/roboto_regular_64_coretext.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "id": "font.scaler_context.coretext.roboto_regular_64",
+  "category": "scaler_context",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "font_request": {
+    "size": 64,
+    "scale_x": 1,
+    "skew_x": 0,
+    "linear_metrics": false,
+    "subpixel": true,
+    "embolden": false,
+    "hinting": "normal"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+0061"
+    ],
+    "glyph_ids": [
+      0
+    ]
+  },
+  "compare": {
+    "font_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    },
+    "glyph_metrics": {
+      "mode": "epsilon",
+      "epsilon": 0.001
+    }
+  }
+}

--- a/harness/font/cases/typeface_probe/roboto_regular_data_coretext.json
+++ b/harness/font/cases/typeface_probe/roboto_regular_data_coretext.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "font.typeface_probe.coretext.roboto_regular_data",
+  "category": "typeface_probe",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromData",
+    "font_file": "roboto_regular"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+0061",
+      "U+0030"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact"
+  }
+}

--- a/harness/font/cases/typeface_probe/roboto_regular_file_coretext.json
+++ b/harness/font/cases/typeface_probe/roboto_regular_file_coretext.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "font.typeface_probe.coretext.roboto_regular_file",
+  "category": "typeface_probe",
+  "status": "active",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "font_files": [
+    {
+      "id": "roboto_regular",
+      "uri": "repo://test/fonts/resources/Roboto-Regular.ttf",
+      "collection_index": 0
+    }
+  ],
+  "typeface_request": {
+    "entry": "MakeFromFile",
+    "font_file": "roboto_regular"
+  },
+  "glyphs": {
+    "chars": [
+      "U+0041",
+      "U+0061",
+      "U+0030"
+    ]
+  },
+  "compare": {
+    "typeface_identity": "normalized_descriptor",
+    "font_style": "exact"
+  }
+}

--- a/harness/font/cli/skity-font/main.cc
+++ b/harness/font/cli/skity-font/main.cc
@@ -1,0 +1,1292 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <cctype>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/artifact_writer.hpp"
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "harness/font/case/manifest_document.hpp"
+#include "harness/font/compare/compare_engine.hpp"
+#include "harness/font/platform/coretext/env_info.hpp"
+#include "harness/font/probe/font_manager_probe.hpp"
+#include "harness/font/probe/glyph_path_probe.hpp"
+#include "harness/font/probe/metrics_probe.hpp"
+#include "harness/font/probe/typeface_probe.hpp"
+
+#ifndef SKITY_FONT_HARNESS_REPO_ROOT
+#define SKITY_FONT_HARNESS_REPO_ROOT "."
+#endif
+
+namespace {
+
+constexpr int kExitSuccess = 0;
+constexpr int kExitCompareMismatch = 1;
+constexpr int kExitUsageError = 2;
+constexpr int kExitSchemaValidationFailed = 3;
+constexpr int kExitIOFailure = 4;
+constexpr int kExitBackendUnavailable = 5;
+constexpr int kExitCompareInputFailure = 6;
+constexpr int kExitSkityProbeFailure = 7;
+
+struct CaseMetadata {
+  std::string case_id;
+  std::string backend;
+};
+
+struct ManifestMetadata {
+  std::string manifest_id;
+  std::string backend;
+};
+
+struct ProbeInvocationResult {
+  Json::Value report;
+  int exit_code = kExitSkityProbeFailure;
+  std::string case_id;
+  std::string backend;
+};
+
+struct CompareInvocationResult {
+  Json::Value report;
+  int exit_code = kExitCompareInputFailure;
+  std::string case_id;
+  std::string backend;
+};
+
+void PrintUsage(std::ostream& out) {
+  out << "skity-font - Skity font harness CLI\n"
+      << "\n"
+      << "Usage:\n"
+      << "  skity-font --help\n"
+      << "  skity-font <command> [options]\n"
+      << "\n"
+      << "Commands planned for the font harness:\n"
+      << "  env-info      collect platform and backend information\n"
+      << "  case-info     validate and normalize a case file\n"
+      << "  probe         run a Skity font probe and write result JSON\n"
+      << "  compare       compare Skia oracle and Skity result JSON\n"
+      << "  run           run a manifest with existing Skia oracle data\n"
+      << "  dump-path     dump one normalized glyph path\n"
+      << "  list-fonts    list visible families and styles for a backend\n"
+      << "\n"
+      << "case-info options:\n"
+      << "  --case <path>       input case JSON\n"
+      << "  --report <path>     optional output report JSON\n"
+      << "  --repo-root <path>  optional repository root override\n"
+      << "\n"
+      << "env-info/list-fonts options:\n"
+      << "  --backend coretext  backend to inspect\n"
+      << "  --report <path>     optional output JSON\n"
+      << "  --repo-root <path>  optional repository root override\n"
+      << "\n"
+      << "probe/dump-path options:\n"
+      << "  --case <path>       input case JSON\n"
+      << "  --backend <name>    backend to use\n"
+      << "  --out <path>        optional output JSON\n"
+      << "  --repo-root <path>  optional repository root override\n"
+      << "\n"
+      << "compare options:\n"
+      << "  --case <path>       input case JSON\n"
+      << "  --expected <path>   Skia oracle JSON\n"
+      << "  --actual <path>     Skity result JSON\n"
+      << "  --report <path>     optional output report JSON\n"
+      << "  --backend <name>    optional backend override\n"
+      << "  --repo-root <path>  optional repository root override\n"
+      << "\n"
+      << "run options:\n"
+      << "  --manifest <path>   input manifest JSON\n"
+      << "  --backend <name>    backend to use\n"
+      << "  --skia-dir <path>   existing Skia oracle directory\n"
+      << "  --skity-dir <path>  Skity result directory\n"
+      << "  --report <path>     optional output report JSON\n"
+      << "  --repo-root <path>  optional repository root override\n";
+}
+
+bool IsHelpArgument(const std::string& arg) {
+  return arg == "--help" || arg == "-h" || arg == "help";
+}
+
+std::string PathArg(const std::filesystem::path& path) {
+  return path.generic_string();
+}
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+std::string StablePathForRun(const std::filesystem::path& path,
+                             const std::filesystem::path& repo_root) {
+  std::error_code ec;
+  std::filesystem::path relative =
+      std::filesystem::relative(path, repo_root, ec);
+  if (!ec && !relative.empty()) {
+    bool escapes_repo = false;
+    for (const auto& part : relative) {
+      if (part == "..") {
+        escapes_repo = true;
+        break;
+      }
+    }
+    if (!escapes_repo) {
+      return relative.generic_string();
+    }
+  }
+  return path.lexically_normal().generic_string();
+}
+
+std::filesystem::path ResolveRunPath(const std::filesystem::path& repo_root,
+                                     const std::filesystem::path& path) {
+  if (path.is_absolute()) {
+    return path.lexically_normal();
+  }
+  return (repo_root / path).lexically_normal();
+}
+
+bool IsSafeFileChar(char value) {
+  return std::isalnum(static_cast<unsigned char>(value)) || value == '-' ||
+         value == '_' || value == '.';
+}
+
+std::string SanitizeFileComponent(std::string value,
+                                  const std::string& fallback) {
+  if (value.empty()) {
+    return fallback;
+  }
+  for (char& c : value) {
+    if (!IsSafeFileChar(c)) {
+      c = '_';
+    }
+  }
+  while (!value.empty() && value.front() == '.') {
+    value.erase(value.begin());
+  }
+  return value.empty() ? fallback : value;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* value) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *value = root[field].asString();
+  return true;
+}
+
+CaseMetadata ReadCaseMetadata(const std::filesystem::path& case_path) {
+  CaseMetadata metadata;
+  metadata.case_id = StemOrFallback(case_path, "case");
+
+  Json::Value root;
+  std::string error;
+  if (!skity::font_harness::LoadJsonFile(case_path, &root, &error)) {
+    return metadata;
+  }
+  ReadStringField(root, "id", &metadata.case_id);
+  ReadStringField(root, "backend", &metadata.backend);
+  return metadata;
+}
+
+ManifestMetadata ReadManifestMetadata(
+    const std::filesystem::path& manifest_path) {
+  ManifestMetadata metadata;
+  metadata.manifest_id = StemOrFallback(manifest_path, "manifest");
+
+  Json::Value root;
+  std::string error;
+  if (!skity::font_harness::LoadJsonFile(manifest_path, &root, &error)) {
+    return metadata;
+  }
+  ReadStringField(root, "id", &metadata.manifest_id);
+  ReadStringField(root, "backend", &metadata.backend);
+  return metadata;
+}
+
+Json::Value BuildCaseLoadErrorReport(const std::string& message) {
+  skity::font_harness::ValidationContext errors;
+  errors.AddError("--case", message);
+
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_case_info";
+  report["valid"] = false;
+  report["case_id"] = "";
+  report["backend"] = "";
+  report["reason_code"] = "schema_validation_failed";
+  report["errors"] = errors.ToJson();
+  return report;
+}
+
+int WriteCommandReport(
+    Json::Value report, const std::filesystem::path& repo_root,
+    const skity::font_harness::ArtifactDescriptor& descriptor, int exit_code) {
+  skity::font_harness::ArtifactWriteResult write_result;
+  std::string error;
+  if (!skity::font_harness::WriteStableArtifact(repo_root, descriptor, &report,
+                                                &write_result, &error)) {
+    std::cerr << error << "\n";
+    return kExitIOFailure;
+  }
+
+  std::cout << skity::font_harness::BuildHumanSummary(descriptor.command,
+                                                      report, exit_code)
+            << "\n";
+  return exit_code;
+}
+
+std::vector<std::string> BackendReproArgs(const std::string& backend) {
+  return {"--backend", backend};
+}
+
+bool IsMetricsProbeCategory(const std::string& category) {
+  return category == "font_metrics" || category == "glyph_metrics" ||
+         category == "scaler_context";
+}
+
+bool IsGlyphPathProbeCategory(const std::string& category) {
+  return category == "glyph_path";
+}
+
+bool IsFontManagerProbeCategory(const std::string& category) {
+  return category == "font_manager" || category == "family_style_set";
+}
+
+std::string ReadCaseCategory(const std::filesystem::path& case_path) {
+  Json::Value root;
+  std::string error;
+  if (!skity::font_harness::LoadJsonFile(case_path, &root, &error)) {
+    return "";
+  }
+
+  std::string category;
+  ReadStringField(root, "category", &category);
+  return category;
+}
+
+int ExitCodeForProbeStatus(skity::font_harness::TypefaceProbeStatus status) {
+  switch (status) {
+    case skity::font_harness::TypefaceProbeStatus::kSuccess:
+      return kExitSuccess;
+    case skity::font_harness::TypefaceProbeStatus::kSchemaValidationFailed:
+      return kExitSchemaValidationFailed;
+    case skity::font_harness::TypefaceProbeStatus::kBackendUnavailable:
+      return kExitBackendUnavailable;
+    case skity::font_harness::TypefaceProbeStatus::kProbeFailed:
+      return kExitSkityProbeFailure;
+  }
+  return kExitSkityProbeFailure;
+}
+
+int ExitCodeForProbeStatus(skity::font_harness::MetricsProbeStatus status) {
+  switch (status) {
+    case skity::font_harness::MetricsProbeStatus::kSuccess:
+      return kExitSuccess;
+    case skity::font_harness::MetricsProbeStatus::kSchemaValidationFailed:
+      return kExitSchemaValidationFailed;
+    case skity::font_harness::MetricsProbeStatus::kBackendUnavailable:
+      return kExitBackendUnavailable;
+    case skity::font_harness::MetricsProbeStatus::kProbeFailed:
+      return kExitSkityProbeFailure;
+  }
+  return kExitSkityProbeFailure;
+}
+
+int ExitCodeForProbeStatus(skity::font_harness::GlyphPathProbeStatus status) {
+  switch (status) {
+    case skity::font_harness::GlyphPathProbeStatus::kSuccess:
+      return kExitSuccess;
+    case skity::font_harness::GlyphPathProbeStatus::kSchemaValidationFailed:
+      return kExitSchemaValidationFailed;
+    case skity::font_harness::GlyphPathProbeStatus::kBackendUnavailable:
+      return kExitBackendUnavailable;
+    case skity::font_harness::GlyphPathProbeStatus::kProbeFailed:
+      return kExitSkityProbeFailure;
+  }
+  return kExitSkityProbeFailure;
+}
+
+int ExitCodeForProbeStatus(skity::font_harness::FontManagerProbeStatus status) {
+  switch (status) {
+    case skity::font_harness::FontManagerProbeStatus::kSuccess:
+      return kExitSuccess;
+    case skity::font_harness::FontManagerProbeStatus::kSchemaValidationFailed:
+      return kExitSchemaValidationFailed;
+    case skity::font_harness::FontManagerProbeStatus::kBackendUnavailable:
+      return kExitBackendUnavailable;
+    case skity::font_harness::FontManagerProbeStatus::kProbeFailed:
+      return kExitSkityProbeFailure;
+  }
+  return kExitSkityProbeFailure;
+}
+
+int ExitCodeForCompareStatus(skity::font_harness::CompareStatus status) {
+  switch (status) {
+    case skity::font_harness::CompareStatus::kPass:
+      return kExitSuccess;
+    case skity::font_harness::CompareStatus::kMismatch:
+      return kExitCompareMismatch;
+    case skity::font_harness::CompareStatus::kInputFailed:
+      return kExitCompareInputFailure;
+  }
+  return kExitCompareInputFailure;
+}
+
+ProbeInvocationResult RunSkityProbeForCase(
+    const std::filesystem::path& repo_root,
+    const std::filesystem::path& case_path, const std::string& backend) {
+  ProbeInvocationResult invocation;
+  const std::string category = ReadCaseCategory(case_path);
+  if (IsMetricsProbeCategory(category)) {
+    skity::font_harness::MetricsProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = backend;
+    skity::font_harness::MetricsProbeResult result =
+        skity::font_harness::RunMetricsProbe(request);
+    invocation.report = std::move(result.report);
+    invocation.exit_code = ExitCodeForProbeStatus(result.status);
+    invocation.case_id = std::move(result.case_id);
+    invocation.backend = std::move(result.backend);
+  } else if (IsGlyphPathProbeCategory(category)) {
+    skity::font_harness::GlyphPathProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = backend;
+    skity::font_harness::GlyphPathProbeResult result =
+        skity::font_harness::RunGlyphPathProbe(request);
+    invocation.report = std::move(result.report);
+    invocation.exit_code = ExitCodeForProbeStatus(result.status);
+    invocation.case_id = std::move(result.case_id);
+    invocation.backend = std::move(result.backend);
+  } else if (IsFontManagerProbeCategory(category)) {
+    skity::font_harness::FontManagerProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = backend;
+    skity::font_harness::FontManagerProbeResult result =
+        skity::font_harness::RunFontManagerProbe(request);
+    invocation.report = std::move(result.report);
+    invocation.exit_code = ExitCodeForProbeStatus(result.status);
+    invocation.case_id = std::move(result.case_id);
+    invocation.backend = std::move(result.backend);
+  } else {
+    skity::font_harness::TypefaceProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = backend;
+    skity::font_harness::TypefaceProbeResult result =
+        skity::font_harness::RunTypefaceProbe(request);
+    invocation.report = std::move(result.report);
+    invocation.exit_code = ExitCodeForProbeStatus(result.status);
+    invocation.case_id = std::move(result.case_id);
+    invocation.backend = std::move(result.backend);
+  }
+  return invocation;
+}
+
+CompareInvocationResult RunCompareForArtifacts(
+    const std::filesystem::path& repo_root,
+    const std::filesystem::path& case_path,
+    const std::filesystem::path& expected_path,
+    const std::filesystem::path& actual_path, const std::string& backend) {
+  CompareInvocationResult invocation;
+  skity::font_harness::CompareRequest request;
+  request.repo_root = repo_root;
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = backend;
+  skity::font_harness::CompareResult result =
+      skity::font_harness::RunCompare(request);
+  invocation.report = std::move(result.report);
+  invocation.exit_code = ExitCodeForCompareStatus(result.status);
+  invocation.case_id = std::move(result.case_id);
+  invocation.backend = std::move(result.backend);
+  return invocation;
+}
+
+std::filesystem::path ReadManifestArtifactDir(const Json::Value& manifest,
+                                              const std::string& field,
+                                              const std::string& fallback) {
+  if (manifest.isObject() && manifest.isMember("artifacts") &&
+      manifest["artifacts"].isObject()) {
+    std::string value;
+    if (ReadStringField(manifest["artifacts"], field, &value) &&
+        !value.empty()) {
+      return value;
+    }
+  }
+  return fallback;
+}
+
+bool WriteArtifactSilently(
+    const std::filesystem::path& repo_root,
+    const skity::font_harness::ArtifactDescriptor& descriptor,
+    Json::Value* report, std::string* stable_path, std::string* error) {
+  skity::font_harness::ArtifactWriteResult write_result;
+  if (!skity::font_harness::WriteStableArtifact(repo_root, descriptor, report,
+                                                &write_result, error)) {
+    return false;
+  }
+  if (stable_path != nullptr) {
+    *stable_path = write_result.stable_path;
+  }
+  return true;
+}
+
+int RunCaseInfo(int argc, char** argv) {
+  std::filesystem::path case_path;
+  std::filesystem::path report_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--case") {
+      if (i + 1 >= argc) {
+        std::cerr << "--case requires a path\n";
+        return kExitUsageError;
+      }
+      case_path = argv[++i];
+    } else if (arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << "--report requires a path\n";
+        return kExitUsageError;
+      }
+      report_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown case-info option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (case_path.empty()) {
+    std::cerr << "case-info requires --case <path>\n";
+    return kExitUsageError;
+  }
+
+  Json::Value root;
+  std::string error;
+  Json::Value report;
+  int exit_code = kExitSuccess;
+  if (!skity::font_harness::LoadJsonFile(case_path, &root, &error)) {
+    report = BuildCaseLoadErrorReport(error);
+    exit_code = kExitSchemaValidationFailed;
+  } else {
+    skity::font_harness::RepoUriResolver resolver(repo_root);
+    auto result = skity::font_harness::ValidateCaseDocument(root, resolver);
+    report = skity::font_harness::BuildCaseInfoReport(result);
+    exit_code = result.valid ? kExitSuccess : kExitSchemaValidationFailed;
+  }
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kCaseInfo;
+  descriptor.command = "case-info";
+  descriptor.case_id = report["case_id"].asString();
+  descriptor.backend = report["backend"].asString();
+  descriptor.input_path = case_path;
+  descriptor.explicit_output_path = report_path;
+  descriptor.repro_args = {"--case", PathArg(case_path)};
+  return WriteCommandReport(std::move(report), repo_root, descriptor,
+                            exit_code);
+}
+
+Json::Value BuildUnsupportedBackendReport(const std::string& backend,
+                                          const std::string& artifact_type) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = artifact_type;
+  report["backend"] = backend;
+  report["backend_available"] = false;
+  report["reason_code"] = "backend_unavailable";
+  report["message"] = "backend is not supported by this harness command";
+  return report;
+}
+
+int RunPlatformInfoCommand(int argc, char** argv, const std::string& command) {
+  std::string backend;
+  std::filesystem::path report_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << "--report requires a path\n";
+        return kExitUsageError;
+      }
+      report_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown " << command << " option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (backend.empty()) {
+    std::cerr << command << " requires --backend <backend>\n";
+    return kExitUsageError;
+  }
+
+  Json::Value report;
+  if (backend == "coretext") {
+    skity::font_harness::CoreTextEnvRequest request;
+    request.repo_root = repo_root;
+    report = command == "list-fonts"
+                 ? skity::font_harness::BuildCoreTextFontList(request)
+                 : skity::font_harness::BuildCoreTextEnvInfo(request);
+  } else {
+    report = BuildUnsupportedBackendReport(
+        backend, command == "list-fonts" ? "font_list_fonts" : "font_env_info");
+  }
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = command == "list-fonts"
+                        ? skity::font_harness::ArtifactKind::kFontList
+                        : skity::font_harness::ArtifactKind::kEnvInfo;
+  descriptor.command = command;
+  descriptor.backend = backend;
+  descriptor.explicit_output_path = report_path;
+  descriptor.repro_args = BackendReproArgs(backend);
+
+  int exit_code = report["backend_available"].asBool()
+                      ? kExitSuccess
+                      : kExitBackendUnavailable;
+  return WriteCommandReport(std::move(report), repo_root, descriptor,
+                            exit_code);
+}
+
+int RunDumpPathCommand(int argc, char** argv) {
+  std::filesystem::path case_path;
+  std::filesystem::path output_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+  std::string backend;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--case") {
+      if (i + 1 >= argc) {
+        std::cerr << "--case requires a path\n";
+        return kExitUsageError;
+      }
+      case_path = argv[++i];
+    } else if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--out" || arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << arg << " requires a path\n";
+        return kExitUsageError;
+      }
+      output_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown dump-path option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (case_path.empty()) {
+    std::cerr << "dump-path requires --case <path>\n";
+    return kExitUsageError;
+  }
+  if (backend.empty()) {
+    std::cerr << "dump-path requires --backend <backend>\n";
+    return kExitUsageError;
+  }
+
+  skity::font_harness::GlyphPathProbeRequest request;
+  request.repo_root = repo_root;
+  request.case_path = case_path;
+  request.backend = backend;
+  skity::font_harness::GlyphPathProbeResult result =
+      skity::font_harness::RunGlyphPathDump(request);
+  Json::Value report = std::move(result.report);
+  const int exit_code = ExitCodeForProbeStatus(result.status);
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kPathDump;
+  descriptor.command = "dump-path";
+  descriptor.output_flag = "--out";
+  descriptor.case_id = result.case_id.empty()
+                           ? StemOrFallback(case_path, "case")
+                           : result.case_id;
+  descriptor.backend = result.backend.empty() ? backend : result.backend;
+  descriptor.input_path = case_path;
+  descriptor.explicit_output_path = output_path;
+  descriptor.repro_args = {"--case", PathArg(case_path), "--backend", backend};
+
+  return WriteCommandReport(std::move(report), repo_root, descriptor,
+                            exit_code);
+}
+
+int RunProbeCommand(int argc, char** argv) {
+  std::filesystem::path case_path;
+  std::filesystem::path output_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+  std::string backend;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--case") {
+      if (i + 1 >= argc) {
+        std::cerr << "--case requires a path\n";
+        return kExitUsageError;
+      }
+      case_path = argv[++i];
+    } else if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--out" || arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << arg << " requires a path\n";
+        return kExitUsageError;
+      }
+      output_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown probe option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (case_path.empty()) {
+    std::cerr << "probe requires --case <path>\n";
+    return kExitUsageError;
+  }
+  if (backend.empty()) {
+    std::cerr << "probe requires --backend <backend>\n";
+    return kExitUsageError;
+  }
+
+  ProbeInvocationResult invocation =
+      RunSkityProbeForCase(repo_root, case_path, backend);
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kSkityResult;
+  descriptor.command = "probe";
+  descriptor.output_flag = "--out";
+  descriptor.case_id = invocation.case_id.empty()
+                           ? StemOrFallback(case_path, "case")
+                           : invocation.case_id;
+  descriptor.backend =
+      invocation.backend.empty() ? backend : invocation.backend;
+  descriptor.input_path = case_path;
+  descriptor.explicit_output_path = output_path;
+  descriptor.repro_args = {"--case", PathArg(case_path), "--backend", backend};
+
+  return WriteCommandReport(std::move(invocation.report), repo_root, descriptor,
+                            invocation.exit_code);
+}
+
+int RunCompareCommand(int argc, char** argv) {
+  std::filesystem::path case_path;
+  std::filesystem::path expected_path;
+  std::filesystem::path actual_path;
+  std::filesystem::path report_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+  std::string backend;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--case") {
+      if (i + 1 >= argc) {
+        std::cerr << "--case requires a path\n";
+        return kExitUsageError;
+      }
+      case_path = argv[++i];
+    } else if (arg == "--expected") {
+      if (i + 1 >= argc) {
+        std::cerr << "--expected requires a path\n";
+        return kExitUsageError;
+      }
+      expected_path = argv[++i];
+    } else if (arg == "--actual") {
+      if (i + 1 >= argc) {
+        std::cerr << "--actual requires a path\n";
+        return kExitUsageError;
+      }
+      actual_path = argv[++i];
+    } else if (arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << "--report requires a path\n";
+        return kExitUsageError;
+      }
+      report_path = argv[++i];
+    } else if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown compare option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (case_path.empty() || expected_path.empty() || actual_path.empty()) {
+    std::cerr << "compare requires --case, --expected, and --actual\n";
+    return kExitUsageError;
+  }
+
+  const CaseMetadata metadata = ReadCaseMetadata(case_path);
+  const std::string case_id = metadata.case_id.empty()
+                                  ? StemOrFallback(case_path, "case")
+                                  : metadata.case_id;
+  if (backend.empty()) {
+    backend = metadata.backend.empty() ? "unknown" : metadata.backend;
+  }
+
+  CompareInvocationResult invocation =
+      RunCompareForArtifacts(repo_root, case_path, expected_path, actual_path,
+                             backend == "unknown" ? "" : backend);
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kCompareReport;
+  descriptor.command = "compare";
+  descriptor.case_id =
+      invocation.case_id.empty() ? case_id : invocation.case_id;
+  descriptor.backend =
+      invocation.backend.empty() ? backend : invocation.backend;
+  descriptor.input_path = case_path;
+  descriptor.explicit_output_path = report_path;
+  descriptor.repro_args = {"--case",     PathArg(case_path),
+                           "--expected", PathArg(expected_path),
+                           "--actual",   PathArg(actual_path)};
+  if (descriptor.backend != "unknown") {
+    descriptor.repro_args.push_back("--backend");
+    descriptor.repro_args.push_back(descriptor.backend);
+  }
+
+  return WriteCommandReport(std::move(invocation.report), repo_root, descriptor,
+                            invocation.exit_code);
+}
+
+int RunManifestCommand(int argc, char** argv) {
+  std::filesystem::path manifest_path;
+  std::filesystem::path skia_dir;
+  std::filesystem::path skity_dir;
+  std::filesystem::path report_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+  std::string backend;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--manifest") {
+      if (i + 1 >= argc) {
+        std::cerr << "--manifest requires a path\n";
+        return kExitUsageError;
+      }
+      manifest_path = argv[++i];
+    } else if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--skia-dir") {
+      if (i + 1 >= argc) {
+        std::cerr << "--skia-dir requires a path\n";
+        return kExitUsageError;
+      }
+      skia_dir = argv[++i];
+    } else if (arg == "--skity-dir") {
+      if (i + 1 >= argc) {
+        std::cerr << "--skity-dir requires a path\n";
+        return kExitUsageError;
+      }
+      skity_dir = argv[++i];
+    } else if (arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << "--report requires a path\n";
+        return kExitUsageError;
+      }
+      report_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown run option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (manifest_path.empty() || backend.empty()) {
+    std::cerr << "run requires --manifest and --backend\n";
+    return kExitUsageError;
+  }
+
+  const ManifestMetadata metadata = ReadManifestMetadata(manifest_path);
+  std::string manifest_id = metadata.manifest_id.empty()
+                                ? StemOrFallback(manifest_path, "manifest")
+                                : metadata.manifest_id;
+
+  Json::Value manifest_root;
+  std::string load_error;
+  if (!skity::font_harness::LoadJsonFile(manifest_path, &manifest_root,
+                                         &load_error)) {
+    Json::Value report = skity::font_harness::BuildRunSummaryReport(
+        manifest_id, backend, "schema_validation_failed");
+    report["status"] = "invalid";
+    report["passed"] = false;
+    report["message"] = load_error;
+
+    skity::font_harness::ArtifactDescriptor descriptor;
+    descriptor.kind = skity::font_harness::ArtifactKind::kRunSummary;
+    descriptor.command = "run";
+    descriptor.case_id = "";
+    descriptor.manifest_id = manifest_id;
+    descriptor.backend = backend;
+    descriptor.input_path = manifest_path;
+    descriptor.explicit_output_path = report_path;
+    descriptor.repro_args = {"--manifest", PathArg(manifest_path), "--backend",
+                             backend};
+    return WriteCommandReport(std::move(report), repo_root, descriptor,
+                              kExitSchemaValidationFailed);
+  }
+
+  skity::font_harness::RepoUriResolver resolver(repo_root);
+  skity::font_harness::ManifestValidationResult manifest_validation =
+      skity::font_harness::ValidateManifestDocument(manifest_root, resolver);
+  if (!manifest_validation.manifest_id.empty()) {
+    manifest_id = manifest_validation.manifest_id;
+  }
+
+  if (!manifest_validation.valid || manifest_validation.backend != backend) {
+    Json::Value report = skity::font_harness::BuildRunSummaryReport(
+        manifest_id, backend, "schema_validation_failed");
+    report["status"] = "invalid";
+    report["passed"] = false;
+    report["normalized_manifest"] = manifest_validation.normalized_manifest;
+    report["validation_errors"] = manifest_validation.errors.ToJson();
+    if (manifest_validation.valid && manifest_validation.backend != backend) {
+      report["reason_code"] = "backend_mismatch";
+      report["message"] = "manifest backend does not match --backend";
+    }
+
+    skity::font_harness::ArtifactDescriptor descriptor;
+    descriptor.kind = skity::font_harness::ArtifactKind::kRunSummary;
+    descriptor.command = "run";
+    descriptor.case_id = "";
+    descriptor.manifest_id = manifest_id;
+    descriptor.backend = backend;
+    descriptor.input_path = manifest_path;
+    descriptor.explicit_output_path = report_path;
+    descriptor.repro_args = {"--manifest", PathArg(manifest_path), "--backend",
+                             backend};
+    return WriteCommandReport(std::move(report), repo_root, descriptor,
+                              kExitSchemaValidationFailed);
+  }
+
+  if (skia_dir.empty()) {
+    skia_dir = ReadManifestArtifactDir(manifest_root, "skia_dir",
+                                       "local/font-harness/artifacts/skia");
+  }
+  if (skity_dir.empty()) {
+    skity_dir = ReadManifestArtifactDir(manifest_root, "skity_dir",
+                                        "local/font-harness/artifacts/skity");
+  }
+  std::filesystem::path compare_dir = ReadManifestArtifactDir(
+      manifest_root, "compare_dir", "local/font-harness/artifacts/compare");
+
+  const std::filesystem::path resolved_skia_dir =
+      ResolveRunPath(repo_root, skia_dir);
+  const std::filesystem::path resolved_skity_dir =
+      ResolveRunPath(repo_root, skity_dir);
+  const std::filesystem::path resolved_compare_dir =
+      ResolveRunPath(repo_root, compare_dir);
+
+  Json::Value report =
+      skity::font_harness::BuildRunSummaryReport(manifest_id, backend, "pass");
+  report["status"] = "running";
+  report["passed"] = false;
+  report["artifacts"] = Json::Value(Json::objectValue);
+  report["artifacts"]["manifest"] =
+      StablePathForRun(ResolveRunPath(repo_root, manifest_path), repo_root);
+  report["artifacts"]["skia_dir"] =
+      StablePathForRun(resolved_skia_dir, repo_root);
+  report["artifacts"]["skity_dir"] =
+      StablePathForRun(resolved_skity_dir, repo_root);
+  report["artifacts"]["compare_dir"] =
+      StablePathForRun(resolved_compare_dir, repo_root);
+
+  const std::string case_root_value = manifest_root["case_root"].asString();
+  const std::filesystem::path case_root =
+      ResolveRunPath(repo_root, case_root_value);
+  const Json::Value& cases = manifest_root["cases"];
+  int pass_count = 0;
+  int mismatch_count = 0;
+  int input_failure_count = 0;
+  int probe_failure_count = 0;
+  int schema_failure_count = 0;
+  int backend_unavailable_count = 0;
+  int io_failure_count = 0;
+
+  Json::Value case_reports(Json::arrayValue);
+  for (Json::ArrayIndex i = 0; i < cases.size(); ++i) {
+    const std::string case_relative_path = cases[i].asString();
+    const std::filesystem::path case_path =
+        (case_root / case_relative_path).lexically_normal();
+
+    Json::Value item(Json::objectValue);
+    item["index"] = i;
+    item["case"] = case_relative_path;
+    item["case_path"] = StablePathForRun(case_path, repo_root);
+    item["backend"] = backend;
+    item["status"] = "running";
+    item["artifacts"] = Json::Value(Json::objectValue);
+
+    Json::Value case_root_json;
+    std::string case_error;
+    if (!skity::font_harness::LoadJsonFile(case_path, &case_root_json,
+                                           &case_error)) {
+      item["status"] = "schema_validation_failed";
+      item["reason_code"] = "schema_validation_failed";
+      item["message"] = case_error;
+      schema_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+
+    skity::font_harness::CaseValidationResult case_validation =
+        skity::font_harness::ValidateCaseDocument(case_root_json, resolver);
+    const std::string case_id = case_validation.case_id.empty()
+                                    ? StemOrFallback(case_path, "case")
+                                    : case_validation.case_id;
+    item["case_id"] = case_id;
+    std::string category;
+    std::string status;
+    ReadStringField(case_root_json, "category", &category);
+    ReadStringField(case_root_json, "status", &status);
+    item["category"] = category;
+    item["case_status"] = status;
+
+    if (!case_validation.valid) {
+      item["status"] = "schema_validation_failed";
+      item["reason_code"] = "schema_validation_failed";
+      item["validation_errors"] = case_validation.errors.ToJson();
+      schema_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+    if (case_validation.backend != backend) {
+      item["status"] = "schema_validation_failed";
+      item["reason_code"] = "backend_mismatch";
+      item["message"] = "case backend does not match manifest run backend";
+      schema_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+    if (status != "active") {
+      item["status"] = "schema_validation_failed";
+      item["reason_code"] = "non_active_case_in_smoke";
+      item["message"] = "smoke manifest entries must be active cases";
+      schema_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+
+    const std::string safe_case_id = SanitizeFileComponent(case_id, "case");
+    const std::string safe_backend = SanitizeFileComponent(backend, "backend");
+    const std::filesystem::path expected_path =
+        resolved_skia_dir / (safe_case_id + ".skia.json");
+    const std::filesystem::path actual_path =
+        resolved_skity_dir / (safe_case_id + "." + safe_backend + ".json");
+    const std::filesystem::path compare_path =
+        resolved_compare_dir /
+        (safe_case_id + "." + safe_backend + ".compare.json");
+
+    item["artifacts"]["expected"] = StablePathForRun(expected_path, repo_root);
+    item["artifacts"]["actual"] = StablePathForRun(actual_path, repo_root);
+    item["artifacts"]["compare"] = StablePathForRun(compare_path, repo_root);
+
+    std::error_code exists_error;
+    if (!std::filesystem::is_regular_file(expected_path, exists_error)) {
+      item["status"] = "input_failed";
+      item["reason_code"] = "missing_oracle";
+      item["message"] = "Skia oracle is missing for manifest case";
+      item["compare_exit_code"] = kExitCompareInputFailure;
+      input_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+
+    ProbeInvocationResult probe_invocation =
+        RunSkityProbeForCase(repo_root, case_path, backend);
+    item["probe_exit_code"] = probe_invocation.exit_code;
+    skity::font_harness::ArtifactDescriptor probe_descriptor;
+    probe_descriptor.kind = skity::font_harness::ArtifactKind::kSkityResult;
+    probe_descriptor.command = "probe";
+    probe_descriptor.output_flag = "--out";
+    probe_descriptor.case_id =
+        probe_invocation.case_id.empty() ? case_id : probe_invocation.case_id;
+    probe_descriptor.backend =
+        probe_invocation.backend.empty() ? backend : probe_invocation.backend;
+    probe_descriptor.input_path = case_path;
+    probe_descriptor.explicit_output_path = actual_path;
+    probe_descriptor.repro_args = {
+        "--case", StablePathForRun(case_path, repo_root), "--backend", backend};
+
+    std::string write_error;
+    std::string stable_probe_path;
+    if (!WriteArtifactSilently(repo_root, probe_descriptor,
+                               &probe_invocation.report, &stable_probe_path,
+                               &write_error)) {
+      item["status"] = "io_failure";
+      item["reason_code"] = "io_failure";
+      item["message"] = write_error;
+      io_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+    item["artifacts"]["actual"] = stable_probe_path;
+
+    if (probe_invocation.exit_code != kExitSuccess) {
+      item["status"] = probe_invocation.exit_code == kExitBackendUnavailable
+                           ? "backend_unavailable"
+                           : "probe_failed";
+      item["reason_code"] =
+          probe_invocation.report.isMember("reason_code")
+              ? probe_invocation.report["reason_code"].asString()
+              : "probe_failed";
+      if (probe_invocation.exit_code == kExitBackendUnavailable) {
+        backend_unavailable_count += 1;
+      } else {
+        probe_failure_count += 1;
+      }
+      case_reports.append(std::move(item));
+      continue;
+    }
+
+    CompareInvocationResult compare_invocation = RunCompareForArtifacts(
+        repo_root, case_path, expected_path, actual_path, backend);
+    item["compare_exit_code"] = compare_invocation.exit_code;
+
+    skity::font_harness::ArtifactDescriptor compare_descriptor;
+    compare_descriptor.kind = skity::font_harness::ArtifactKind::kCompareReport;
+    compare_descriptor.command = "compare";
+    compare_descriptor.case_id = compare_invocation.case_id.empty()
+                                     ? case_id
+                                     : compare_invocation.case_id;
+    compare_descriptor.backend = compare_invocation.backend.empty()
+                                     ? backend
+                                     : compare_invocation.backend;
+    compare_descriptor.input_path = case_path;
+    compare_descriptor.explicit_output_path = compare_path;
+    compare_descriptor.repro_args = {
+        "--case",     StablePathForRun(case_path, repo_root),
+        "--expected", StablePathForRun(expected_path, repo_root),
+        "--actual",   StablePathForRun(actual_path, repo_root),
+        "--backend",  backend};
+
+    std::string stable_compare_path;
+    if (!WriteArtifactSilently(repo_root, compare_descriptor,
+                               &compare_invocation.report, &stable_compare_path,
+                               &write_error)) {
+      item["status"] = "io_failure";
+      item["reason_code"] = "io_failure";
+      item["message"] = write_error;
+      io_failure_count += 1;
+      case_reports.append(std::move(item));
+      continue;
+    }
+    item["artifacts"]["compare"] = stable_compare_path;
+    item["diff_count"] = compare_invocation.report.isMember("diff_count")
+                             ? compare_invocation.report["diff_count"].asInt()
+                             : 0;
+
+    if (compare_invocation.exit_code == kExitSuccess) {
+      item["status"] = "pass";
+      item["reason_code"] = "pass";
+      item["passed"] = true;
+      pass_count += 1;
+    } else if (compare_invocation.exit_code == kExitCompareMismatch) {
+      item["status"] = "mismatch";
+      item["reason_code"] =
+          compare_invocation.report.isMember("reason_code")
+              ? compare_invocation.report["reason_code"].asString()
+              : "compare_mismatch";
+      item["passed"] = false;
+      mismatch_count += 1;
+    } else {
+      item["status"] = "input_failed";
+      item["reason_code"] =
+          compare_invocation.report.isMember("reason_code")
+              ? compare_invocation.report["reason_code"].asString()
+              : "compare_input_failed";
+      item["passed"] = false;
+      input_failure_count += 1;
+    }
+    case_reports.append(std::move(item));
+  }
+
+  report["cases"] = std::move(case_reports);
+  report["case_count"] = static_cast<int>(cases.size());
+  report["pass_count"] = pass_count;
+  report["mismatch_count"] = mismatch_count;
+  report["input_failure_count"] = input_failure_count;
+  report["probe_failure_count"] = probe_failure_count;
+  report["schema_failure_count"] = schema_failure_count;
+  report["backend_unavailable_count"] = backend_unavailable_count;
+  report["io_failure_count"] = io_failure_count;
+
+  int exit_code = kExitSuccess;
+  std::string run_status = "pass";
+  std::string reason_code = "pass";
+  if (schema_failure_count > 0) {
+    exit_code = kExitSchemaValidationFailed;
+    run_status = "failed";
+    reason_code = "schema_validation_failed";
+  } else if (io_failure_count > 0) {
+    exit_code = kExitIOFailure;
+    run_status = "failed";
+    reason_code = "io_failure";
+  } else if (backend_unavailable_count > 0) {
+    exit_code = kExitBackendUnavailable;
+    run_status = "failed";
+    reason_code = "backend_unavailable";
+  } else if (input_failure_count > 0) {
+    exit_code = kExitCompareInputFailure;
+    run_status = "failed";
+    reason_code = "compare_input_failed";
+  } else if (probe_failure_count > 0) {
+    exit_code = kExitSkityProbeFailure;
+    run_status = "failed";
+    reason_code = "probe_failed";
+  } else if (mismatch_count > 0) {
+    exit_code = kExitCompareMismatch;
+    run_status = "mismatch";
+    reason_code = "compare_mismatch";
+  }
+  report["status"] = run_status;
+  report["reason_code"] = reason_code;
+  report["passed"] = exit_code == kExitSuccess;
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kRunSummary;
+  descriptor.command = "run";
+  descriptor.case_id = "";
+  descriptor.manifest_id = manifest_id;
+  descriptor.backend = backend;
+  descriptor.input_path = manifest_path;
+  descriptor.explicit_output_path = report_path;
+  descriptor.repro_args = {"--manifest", PathArg(manifest_path), "--backend",
+                           backend};
+  if (!skia_dir.empty()) {
+    descriptor.repro_args.push_back("--skia-dir");
+    descriptor.repro_args.push_back(PathArg(skia_dir));
+  }
+  if (!skity_dir.empty()) {
+    descriptor.repro_args.push_back("--skity-dir");
+    descriptor.repro_args.push_back(PathArg(skity_dir));
+  }
+
+  return WriteCommandReport(std::move(report), repo_root, descriptor,
+                            exit_code);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc <= 1 || IsHelpArgument(argv[1])) {
+    PrintUsage(std::cout);
+    return kExitSuccess;
+  }
+
+  const std::string command = argv[1];
+  if (!command.empty() && command[0] == '-') {
+    std::cerr << "Unknown option: " << command << "\n\n";
+    PrintUsage(std::cerr);
+    return kExitUsageError;
+  }
+
+  if (command == "case-info") {
+    return RunCaseInfo(argc, argv);
+  }
+  if (command == "env-info" || command == "list-fonts") {
+    return RunPlatformInfoCommand(argc, argv, command);
+  }
+  if (command == "probe") {
+    return RunProbeCommand(argc, argv);
+  }
+  if (command == "dump-path") {
+    return RunDumpPathCommand(argc, argv);
+  }
+  if (command == "compare") {
+    return RunCompareCommand(argc, argv);
+  }
+  if (command == "run") {
+    return RunManifestCommand(argc, argv);
+  }
+
+  std::cerr << "Unknown command: " << command << "\n";
+  return kExitUsageError;
+}

--- a/harness/font/compare/compare_engine.cc
+++ b/harness/font/compare/compare_engine.cc
@@ -1,0 +1,1139 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/compare/compare_engine.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/artifact_validator.hpp"
+#include "harness/font/artifact/artifact_writer.hpp"
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "harness/font/case/validation.hpp"
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+constexpr double kDefaultMetricEpsilon = 0.001;
+constexpr double kDefaultPathEpsilon = 0.0001;
+constexpr size_t kMaxDiffs = 64;
+
+struct CompareConfig {
+  std::string category;
+  std::string typeface_identity = "normalized_descriptor";
+  std::string font_style = "exact";
+  std::string font_metrics_mode = "epsilon";
+  std::string glyph_metrics_mode = "epsilon";
+  std::string glyph_path_mode = "path_normalized";
+  double font_metrics_epsilon = kDefaultMetricEpsilon;
+  double glyph_metrics_epsilon = kDefaultMetricEpsilon;
+  double glyph_path_epsilon = kDefaultPathEpsilon;
+};
+
+struct Diff {
+  std::string path;
+  std::string reason_code;
+  std::string rule;
+  std::string message;
+  Json::Value expected;
+  Json::Value actual;
+};
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *out = root[field].asString();
+  return true;
+}
+
+std::string PathArg(const std::filesystem::path& path) {
+  return path.generic_string();
+}
+
+std::string TrimNullPadding(std::string value) {
+  while (!value.empty() && value.back() == '\0') {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::string ChildJsonPath(const std::string& path, const std::string& field) {
+  return path.empty() ? field : path + "." + field;
+}
+
+std::string IndexJsonPath(const std::string& path, Json::ArrayIndex index) {
+  return path + "[" + std::to_string(index) + "]";
+}
+
+const Json::Value* ObjectMember(const Json::Value& root,
+                                const std::string& field) {
+  if (!root.isObject() || !root.isMember(field)) {
+    return nullptr;
+  }
+  return &root[field];
+}
+
+bool IsIgnoreMode(const std::string& mode) { return mode == "ignore"; }
+
+void AddDiff(std::vector<Diff>* diffs, const std::string& path,
+             const std::string& reason_code, const std::string& rule,
+             const std::string& message, const Json::Value& expected,
+             const Json::Value& actual) {
+  if (diffs->size() >= kMaxDiffs) {
+    return;
+  }
+  Diff diff;
+  diff.path = path;
+  diff.reason_code = reason_code;
+  diff.rule = rule;
+  diff.message = message;
+  diff.expected = expected;
+  diff.actual = actual;
+  diffs->push_back(std::move(diff));
+}
+
+Json::Value MissingValue() {
+  Json::Value value(Json::objectValue);
+  value["missing"] = true;
+  return value;
+}
+
+Json::Value ToDiffsJson(const std::vector<Diff>& diffs) {
+  Json::Value value(Json::arrayValue);
+  for (const auto& diff : diffs) {
+    Json::Value item(Json::objectValue);
+    item["path"] = diff.path;
+    item["reason_code"] = diff.reason_code;
+    item["rule"] = diff.rule;
+    item["message"] = diff.message;
+    item["expected"] = diff.expected;
+    item["actual"] = diff.actual;
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+bool SameJsonScalar(const Json::Value& expected, const Json::Value& actual) {
+  if (expected.isString() && actual.isString()) {
+    return TrimNullPadding(expected.asString()) ==
+           TrimNullPadding(actual.asString());
+  }
+  if (expected.isBool() && actual.isBool()) {
+    return expected.asBool() == actual.asBool();
+  }
+  if (expected.isNull() && actual.isNull()) {
+    return true;
+  }
+  if (expected.isIntegral() && actual.isIntegral()) {
+    return expected.asLargestInt() == actual.asLargestInt();
+  }
+  return expected == actual;
+}
+
+void CompareNumber(const Json::Value& expected, const Json::Value& actual,
+                   const std::string& path, double epsilon,
+                   const std::string& reason_code, const std::string& rule,
+                   std::vector<Diff>* diffs) {
+  if (!expected.isNumeric() || !actual.isNumeric()) {
+    AddDiff(diffs, path, reason_code, rule, "expected numeric values", expected,
+            actual);
+    return;
+  }
+  const double lhs = expected.asDouble();
+  const double rhs = actual.asDouble();
+  if (!std::isfinite(lhs) || !std::isfinite(rhs) ||
+      std::fabs(lhs - rhs) > epsilon) {
+    AddDiff(diffs, path, reason_code, rule,
+            "numeric values differ beyond "
+            "epsilon",
+            expected, actual);
+  }
+}
+
+void CompareJsonSubset(const Json::Value& expected, const Json::Value& actual,
+                       const std::string& path, const std::string& reason_code,
+                       const std::string& rule, double epsilon,
+                       bool use_epsilon, std::vector<Diff>* diffs) {
+  if (diffs->size() >= kMaxDiffs) {
+    return;
+  }
+
+  if (expected.isNumeric()) {
+    if (use_epsilon) {
+      CompareNumber(expected, actual, path, epsilon, reason_code, rule, diffs);
+    } else if (!expected.isNumeric() || !actual.isNumeric() ||
+               expected.asDouble() != actual.asDouble()) {
+      AddDiff(diffs, path, reason_code, rule, "numeric values differ", expected,
+              actual);
+    }
+    return;
+  }
+
+  if (expected.isObject()) {
+    if (!actual.isObject()) {
+      AddDiff(diffs, path, reason_code, rule, "expected object", expected,
+              actual);
+      return;
+    }
+    std::vector<std::string> names;
+    names.reserve(expected.size());
+    for (const auto& name : expected.getMemberNames()) {
+      names.push_back(name);
+    }
+    std::sort(names.begin(), names.end());
+    for (const auto& name : names) {
+      const std::string child_path = ChildJsonPath(path, name);
+      if (!actual.isMember(name)) {
+        AddDiff(diffs, child_path, reason_code, rule, "field is missing",
+                expected[name], MissingValue());
+        continue;
+      }
+      CompareJsonSubset(expected[name], actual[name], child_path, reason_code,
+                        rule, epsilon, use_epsilon, diffs);
+    }
+    return;
+  }
+
+  if (expected.isArray()) {
+    if (!actual.isArray()) {
+      AddDiff(diffs, path, reason_code, rule, "expected array", expected,
+              actual);
+      return;
+    }
+    if (expected.size() != actual.size()) {
+      AddDiff(diffs, path, reason_code, rule, "array sizes differ", expected,
+              actual);
+      return;
+    }
+    for (Json::ArrayIndex i = 0; i < expected.size(); ++i) {
+      CompareJsonSubset(expected[i], actual[i], IndexJsonPath(path, i),
+                        reason_code, rule, epsilon, use_epsilon, diffs);
+    }
+    return;
+  }
+
+  if (!SameJsonScalar(expected, actual)) {
+    AddDiff(diffs, path, reason_code, rule, "values differ", expected, actual);
+  }
+}
+
+Json::Value OptionalStringValue(const Json::Value& root,
+                                const std::string& field) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return Json::Value(Json::nullValue);
+  }
+  return Json::Value(TrimNullPadding(root[field].asString()));
+}
+
+Json::Value OptionalValue(const Json::Value& root, const std::string& field) {
+  if (!root.isObject() || !root.isMember(field)) {
+    return Json::Value(Json::nullValue);
+  }
+  return root[field];
+}
+
+void AddIfPresent(Json::Value* target, const std::string& field,
+                  const Json::Value& value) {
+  if (!value.isNull()) {
+    (*target)[field] = value;
+  }
+}
+
+Json::Value NormalizeStyle(const Json::Value& style) {
+  Json::Value value(Json::objectValue);
+  if (!style.isObject()) {
+    return value;
+  }
+  AddIfPresent(&value, "weight", OptionalValue(style, "weight"));
+  AddIfPresent(&value, "width", OptionalValue(style, "width"));
+  AddIfPresent(&value, "slant", OptionalStringValue(style, "slant"));
+  return value;
+}
+
+Json::Value NormalizeDescriptor(const Json::Value& descriptor,
+                                const Json::Value* owner = nullptr) {
+  Json::Value value(Json::objectValue);
+  if (!descriptor.isObject()) {
+    value["available"] = false;
+    return value;
+  }
+
+  AddIfPresent(&value, "family_name",
+               OptionalStringValue(descriptor, "family_name"));
+  AddIfPresent(&value, "post_script_name",
+               OptionalStringValue(descriptor, "post_script_name"));
+  AddIfPresent(&value, "full_name",
+               OptionalStringValue(descriptor, "full_name"));
+  AddIfPresent(&value, "collection_index",
+               OptionalValue(descriptor, "collection_index"));
+  if (!value.isMember("collection_index") && owner != nullptr) {
+    AddIfPresent(&value, "collection_index",
+                 OptionalValue(*owner, "collection_index"));
+  }
+  if (descriptor.isMember("style")) {
+    value["style"] = NormalizeStyle(descriptor["style"]);
+  }
+  return value;
+}
+
+const Json::Value* FindTypefaceDescriptor(const Json::Value& root) {
+  const Json::Value* typeface_result = ObjectMember(root, "typeface_result");
+  if (typeface_result == nullptr || !typeface_result->isObject()) {
+    return nullptr;
+  }
+  return ObjectMember(*typeface_result, "typeface");
+}
+
+Json::Value NormalizeTypefaceDescriptor(const Json::Value& root) {
+  const Json::Value* typeface_result = ObjectMember(root, "typeface_result");
+  const Json::Value* descriptor = FindTypefaceDescriptor(root);
+  if (descriptor == nullptr) {
+    return Json::Value(Json::objectValue);
+  }
+  return NormalizeDescriptor(*descriptor, typeface_result);
+}
+
+Json::Value NormalizeGlyphItem(const Json::Value& item) {
+  Json::Value value(Json::objectValue);
+  if (!item.isObject()) {
+    return value;
+  }
+  if (item.isMember("label")) {
+    AddIfPresent(&value, "label", OptionalStringValue(item, "label"));
+  } else {
+    AddIfPresent(&value, "label", OptionalStringValue(item, "char"));
+  }
+  AddIfPresent(&value, "code_point", OptionalValue(item, "code_point"));
+  AddIfPresent(&value, "glyph_id", OptionalValue(item, "glyph_id"));
+  return value;
+}
+
+Json::Value NormalizeGlyphArray(const Json::Value& glyphs) {
+  Json::Value value(Json::arrayValue);
+  if (!glyphs.isArray()) {
+    return value;
+  }
+  for (const auto& glyph : glyphs) {
+    value.append(NormalizeGlyphItem(glyph));
+  }
+  return value;
+}
+
+Json::Value NormalizeTableArray(const Json::Value& tables) {
+  Json::Value normalized(Json::arrayValue);
+  if (!tables.isArray()) {
+    return normalized;
+  }
+
+  std::vector<Json::Value> items;
+  for (const auto& table : tables) {
+    if (!table.isObject()) {
+      continue;
+    }
+    Json::Value item(Json::objectValue);
+    AddIfPresent(&item, "tag", OptionalStringValue(table, "tag"));
+    AddIfPresent(&item, "tag_value", OptionalValue(table, "tag_value"));
+    AddIfPresent(&item, "size", OptionalValue(table, "size"));
+    AddIfPresent(&item, "digest", OptionalStringValue(table, "digest"));
+    items.push_back(std::move(item));
+  }
+  std::sort(items.begin(), items.end(),
+            [](const Json::Value& lhs, const Json::Value& rhs) {
+              return lhs["tag"].asString() < rhs["tag"].asString();
+            });
+  for (auto& item : items) {
+    normalized.append(std::move(item));
+  }
+  return normalized;
+}
+
+Json::Value NormalizeFontMetrics(const Json::Value& metrics) {
+  static const std::vector<std::string> fields = {
+      "top",
+      "ascent",
+      "descent",
+      "bottom",
+      "leading",
+      "avg_char_width",
+      "max_char_width",
+      "x_min",
+      "x_max",
+      "x_height",
+      "cap_height",
+      "underline_thickness",
+      "underline_position",
+      "strikeout_thickness",
+      "strikeout_position",
+  };
+
+  Json::Value value(Json::objectValue);
+  if (!metrics.isObject()) {
+    return value;
+  }
+  for (const auto& field : fields) {
+    AddIfPresent(&value, field, OptionalValue(metrics, field));
+  }
+  return value;
+}
+
+Json::Value BoundsFromGlyphData(const Json::Value& glyph_data) {
+  Json::Value bounds(Json::objectValue);
+  if (!glyph_data.isObject() || !glyph_data.isMember("left") ||
+      !glyph_data.isMember("top") || !glyph_data.isMember("width") ||
+      !glyph_data.isMember("height")) {
+    return bounds;
+  }
+  const double left = glyph_data["left"].asDouble();
+  const double top = -glyph_data["top"].asDouble();
+  const double width = glyph_data["width"].asDouble();
+  const double height = glyph_data["height"].asDouble();
+  bounds["left"] = left;
+  bounds["top"] = top;
+  bounds["right"] = left + width;
+  bounds["bottom"] = top + height;
+  bounds["width"] = width;
+  bounds["height"] = height;
+  bounds["empty"] = width <= 0.0 || height <= 0.0;
+  return bounds;
+}
+
+Json::Value NormalizeBounds(const Json::Value& bounds) {
+  static const std::vector<std::string> fields = {
+      "left", "top", "right", "bottom", "width", "height", "empty"};
+  Json::Value value(Json::objectValue);
+  if (!bounds.isObject()) {
+    return value;
+  }
+  for (const auto& field : fields) {
+    AddIfPresent(&value, field, OptionalValue(bounds, field));
+  }
+  return value;
+}
+
+Json::Value NormalizeGlyphMetricsItem(const Json::Value& item) {
+  Json::Value value = NormalizeGlyphItem(item);
+  if (!item.isObject()) {
+    return value;
+  }
+
+  const Json::Value* glyph_data = ObjectMember(item, "glyph_data");
+  const Json::Value* source = glyph_data != nullptr ? glyph_data : &item;
+  AddIfPresent(&value, "advance_x", OptionalValue(*source, "advance_x"));
+  AddIfPresent(&value, "advance_y", OptionalValue(*source, "advance_y"));
+  AddIfPresent(&value, "width", OptionalValue(*source, "width"));
+  AddIfPresent(&value, "height", OptionalValue(*source, "height"));
+
+  if (item.isMember("bounds")) {
+    value["bounds"] = NormalizeBounds(item["bounds"]);
+  } else if (glyph_data != nullptr) {
+    Json::Value bounds = BoundsFromGlyphData(*glyph_data);
+    if (!bounds.empty()) {
+      value["bounds"] = NormalizeBounds(bounds);
+    }
+  }
+  return value;
+}
+
+Json::Value NormalizeGlyphMetricsArray(const Json::Value& glyphs) {
+  Json::Value value(Json::arrayValue);
+  if (!glyphs.isArray()) {
+    return value;
+  }
+  for (const auto& glyph : glyphs) {
+    value.append(NormalizeGlyphMetricsItem(glyph));
+  }
+  return value;
+}
+
+Json::Value NormalizeMetricsProbe(const Json::Value& root) {
+  Json::Value value(Json::objectValue);
+  const Json::Value* probe = ObjectMember(root, "metrics_probe");
+  if (probe == nullptr || !probe->isObject()) {
+    return value;
+  }
+
+  const Json::Value* font_result = ObjectMember(*probe, "font_result");
+  if (font_result != nullptr) {
+    Json::Value font(Json::objectValue);
+    font["font_metrics"] =
+        NormalizeFontMetrics(OptionalValue(*font_result, "font_metrics"));
+    font["glyph_metrics"] = NormalizeGlyphMetricsArray(
+        OptionalValue(*font_result, "glyph_metrics"));
+    value["font_result"] = std::move(font);
+  }
+
+  const Json::Value* scaler = ObjectMember(*probe, "scaler_context_result");
+  if (scaler != nullptr) {
+    Json::Value scaler_result(Json::objectValue);
+    scaler_result["font_metrics"] =
+        NormalizeFontMetrics(OptionalValue(*scaler, "font_metrics"));
+    scaler_result["glyph_metrics"] =
+        NormalizeGlyphMetricsArray(OptionalValue(*scaler, "glyph_metrics"));
+    value["scaler_context_result"] = std::move(scaler_result);
+  }
+  return value;
+}
+
+Json::Value NormalizeTypefaceProbe(const Json::Value& root) {
+  Json::Value value(Json::objectValue);
+  value["descriptor"] = NormalizeTypefaceDescriptor(root);
+
+  const Json::Value* probe = ObjectMember(root, "typeface_probe");
+  if (probe == nullptr || !probe->isObject()) {
+    return value;
+  }
+  AddIfPresent(&value, "units_per_em", OptionalValue(*probe, "units_per_em"));
+  AddIfPresent(&value, "table_count", OptionalValue(*probe, "table_count"));
+  value["glyphs"] = NormalizeGlyphArray(OptionalValue(*probe, "glyphs"));
+  value["tables"] = NormalizeTableArray(OptionalValue(*probe, "tables"));
+  return value;
+}
+
+Json::Value NormalizePathGlyphItem(const Json::Value& item) {
+  Json::Value value = NormalizeGlyphItem(item);
+  if (item.isObject() && item.isMember("path")) {
+    value["path"] = item["path"];
+  }
+  return value;
+}
+
+Json::Value NormalizePathGlyphArray(const Json::Value& glyphs) {
+  Json::Value value(Json::arrayValue);
+  if (!glyphs.isArray()) {
+    return value;
+  }
+  for (const auto& glyph : glyphs) {
+    value.append(NormalizePathGlyphItem(glyph));
+  }
+  return value;
+}
+
+Json::Value NormalizePathProbe(const Json::Value& root) {
+  Json::Value value(Json::objectValue);
+  const Json::Value* probe = ObjectMember(root, "glyph_path_probe");
+  if (probe == nullptr || !probe->isObject()) {
+    return value;
+  }
+
+  const Json::Value* font_result = ObjectMember(*probe, "font_result");
+  if (font_result != nullptr) {
+    Json::Value font(Json::objectValue);
+    font["glyph_paths"] =
+        NormalizePathGlyphArray(OptionalValue(*font_result, "glyph_paths"));
+    value["font_result"] = std::move(font);
+  }
+
+  const Json::Value* scaler = ObjectMember(*probe, "scaler_context_result");
+  if (scaler != nullptr) {
+    Json::Value scaler_result(Json::objectValue);
+    scaler_result["glyph_paths"] =
+        NormalizePathGlyphArray(OptionalValue(*scaler, "glyph_paths"));
+    value["scaler_context_result"] = std::move(scaler_result);
+  }
+  return value;
+}
+
+Json::Value NormalizeMatchedTypeface(const Json::Value& typeface) {
+  Json::Value value(Json::objectValue);
+  if (!typeface.isObject()) {
+    return value;
+  }
+  AddIfPresent(&value, "available", OptionalValue(typeface, "available"));
+  value["descriptor"] =
+      NormalizeDescriptor(OptionalValue(typeface, "descriptor"), &typeface);
+  if (typeface.isMember("font_style")) {
+    value["font_style"] = NormalizeStyle(typeface["font_style"]);
+  }
+  AddIfPresent(&value, "units_per_em", OptionalValue(typeface, "units_per_em"));
+
+  const Json::Value* summary = ObjectMember(typeface, "probe_summary");
+  if (summary != nullptr) {
+    Json::Value probe_summary(Json::objectValue);
+    const Json::Value* font_result = ObjectMember(*summary, "font_result");
+    if (font_result != nullptr) {
+      probe_summary["font_metrics"] =
+          NormalizeFontMetrics(OptionalValue(*font_result, "font_metrics"));
+    }
+    const Json::Value* scaler = ObjectMember(*summary, "scaler_context_result");
+    if (scaler != nullptr) {
+      probe_summary["scaler_font_metrics"] =
+          NormalizeFontMetrics(OptionalValue(*scaler, "font_metrics"));
+    }
+    probe_summary["glyphs"] =
+        NormalizeGlyphArray(OptionalValue(*summary, "glyphs"));
+    value["probe_summary"] = std::move(probe_summary);
+  }
+  return value;
+}
+
+Json::Value NormalizeTypefaceSelection(const Json::Value& typeface) {
+  Json::Value value(Json::objectValue);
+  if (!typeface.isObject()) {
+    return value;
+  }
+  AddIfPresent(&value, "available", OptionalValue(typeface, "available"));
+  value["descriptor"] =
+      NormalizeDescriptor(OptionalValue(typeface, "descriptor"), &typeface);
+  if (typeface.isMember("font_style")) {
+    value["font_style"] = NormalizeStyle(typeface["font_style"]);
+  }
+  AddIfPresent(&value, "units_per_em", OptionalValue(typeface, "units_per_em"));
+  return value;
+}
+
+Json::Value NormalizeMatchedTypefaces(const Json::Value& root) {
+  Json::Value value(Json::arrayValue);
+  const Json::Value* probe = ObjectMember(root, "font_manager_probe");
+  if (probe == nullptr || !probe->isObject() ||
+      !probe->isMember("matched_typefaces") ||
+      !(*probe)["matched_typefaces"].isArray()) {
+    return value;
+  }
+
+  for (const auto& typeface : (*probe)["matched_typefaces"]) {
+    value.append(NormalizeMatchedTypeface(typeface));
+  }
+  return value;
+}
+
+Json::Value NormalizeStyleSet(const Json::Value& style_set) {
+  Json::Value value(Json::objectValue);
+  if (!style_set.isObject()) {
+    return value;
+  }
+  AddIfPresent(&value, "available", OptionalValue(style_set, "available"));
+  AddIfPresent(&value, "style_count", OptionalValue(style_set, "style_count"));
+  if (style_set.isMember("match_style")) {
+    value["match_style"]["typeface"] =
+        NormalizeTypefaceSelection(style_set["match_style"]["typeface"]);
+  }
+  return value;
+}
+
+Json::Value NormalizeFontManagerProbe(const Json::Value& root) {
+  Json::Value value(Json::objectValue);
+  const Json::Value* probe = ObjectMember(root, "font_manager_probe");
+  if (probe == nullptr || !probe->isObject()) {
+    return value;
+  }
+
+  const Json::Value* operation = ObjectMember(*probe, "operation");
+  if (operation != nullptr) {
+    AddIfPresent(&value, "entry", OptionalStringValue(*operation, "entry"));
+    if (operation->isMember("create_style_set")) {
+      value["create_style_set"] =
+          NormalizeStyleSet((*operation)["create_style_set"]);
+    }
+    if (operation->isMember("style_set")) {
+      value["style_set"] = NormalizeStyleSet((*operation)["style_set"]);
+    }
+    if (operation->isMember("match_family")) {
+      value["match_family"] = NormalizeStyleSet((*operation)["match_family"]);
+    }
+  }
+  value["matched_typefaces"] = NormalizeMatchedTypefaces(root);
+  return value;
+}
+
+double ReadCompareEpsilon(const Json::Value& compare, const std::string& field,
+                          double fallback) {
+  if (!compare.isObject() || !compare.isMember(field) ||
+      !compare[field].isObject() || !compare[field].isMember("epsilon") ||
+      !compare[field]["epsilon"].isNumeric()) {
+    return fallback;
+  }
+  return compare[field]["epsilon"].asDouble();
+}
+
+std::string ReadCompareMode(const Json::Value& compare,
+                            const std::string& field,
+                            const std::string& fallback) {
+  if (!compare.isObject() || !compare.isMember(field)) {
+    return fallback;
+  }
+  if (compare[field].isString()) {
+    return compare[field].asString();
+  }
+  if (compare[field].isObject() && compare[field].isMember("mode") &&
+      compare[field]["mode"].isString()) {
+    return compare[field]["mode"].asString();
+  }
+  return fallback;
+}
+
+CompareConfig ParseCompareConfig(const Json::Value& case_root) {
+  CompareConfig config;
+  ReadStringField(case_root, "category", &config.category);
+
+  const Json::Value& compare = case_root["compare"];
+  config.typeface_identity =
+      ReadCompareMode(compare, "typeface_identity", config.typeface_identity);
+  config.font_style = ReadCompareMode(compare, "font_style", config.font_style);
+  config.font_metrics_mode =
+      ReadCompareMode(compare, "font_metrics", config.font_metrics_mode);
+  config.glyph_metrics_mode =
+      ReadCompareMode(compare, "glyph_metrics", config.glyph_metrics_mode);
+  config.glyph_path_mode =
+      ReadCompareMode(compare, "glyph_path", config.glyph_path_mode);
+  config.font_metrics_epsilon =
+      ReadCompareEpsilon(compare, "font_metrics", kDefaultMetricEpsilon);
+  config.glyph_metrics_epsilon =
+      ReadCompareEpsilon(compare, "glyph_metrics", kDefaultMetricEpsilon);
+  config.glyph_path_epsilon =
+      ReadCompareEpsilon(compare, "glyph_path", kDefaultPathEpsilon);
+  return config;
+}
+
+Json::Value CompareConfigToJson(const CompareConfig& config) {
+  Json::Value value(Json::objectValue);
+  value["category"] = config.category;
+  value["typeface_identity"] = config.typeface_identity;
+  value["font_style"] = config.font_style;
+  value["font_metrics_mode"] = config.font_metrics_mode;
+  value["glyph_metrics_mode"] = config.glyph_metrics_mode;
+  value["glyph_path_mode"] = config.glyph_path_mode;
+  value["font_metrics_epsilon"] = config.font_metrics_epsilon;
+  value["glyph_metrics_epsilon"] = config.glyph_metrics_epsilon;
+  value["glyph_path_epsilon"] = config.glyph_path_epsilon;
+  return value;
+}
+
+Json::Value BuildReport(const std::string& case_id, const std::string& backend,
+                        const std::string& stage,
+                        const std::string& reason_code,
+                        const CompareRequest& request) {
+  Json::Value report = BuildCompareReport(case_id, backend, stage, reason_code);
+  report["artifacts"]["case"] = PathArg(request.case_path);
+  report["artifacts"]["expected"] = PathArg(request.expected_path);
+  report["artifacts"]["actual"] = PathArg(request.actual_path);
+  return report;
+}
+
+CompareResult BuildInputFailure(const std::string& case_id,
+                                const std::string& backend,
+                                const CompareRequest& request,
+                                const std::string& stage,
+                                const std::string& reason_code,
+                                const std::string& message) {
+  CompareResult result;
+  result.status = CompareStatus::kInputFailed;
+  result.case_id = case_id;
+  result.backend = backend;
+  result.report = BuildReport(case_id, backend, stage, reason_code, request);
+  result.report["message"] = message;
+  return result;
+}
+
+void AddArtifactValidationReport(Json::Value* report, const std::string& field,
+                                 const ArtifactValidationResult& validation) {
+  (*report)["artifact_validation"][field]["valid"] = validation.valid;
+  (*report)["artifact_validation"][field]["artifact_type"] =
+      validation.artifact_type;
+  (*report)["artifact_validation"][field]["case_id"] = validation.case_id;
+  (*report)["artifact_validation"][field]["errors"] =
+      validation.errors.ToJson();
+}
+
+std::string FirstDiffReason(const std::vector<Diff>& diffs,
+                            const std::string& fallback) {
+  if (diffs.empty() || diffs.front().reason_code.empty()) {
+    return fallback;
+  }
+  return diffs.front().reason_code;
+}
+
+void CompareDescriptor(const Json::Value& expected, const Json::Value& actual,
+                       const std::string& path, const std::string& reason_code,
+                       const CompareConfig& config, std::vector<Diff>* diffs) {
+  if (config.typeface_identity == "none") {
+    return;
+  }
+  CompareJsonSubset(expected, actual, path, reason_code,
+                    "normalized_descriptor", 0.0, false, diffs);
+}
+
+void CompareFontStyle(const Json::Value& expected, const Json::Value& actual,
+                      const std::string& path, const CompareConfig& config,
+                      std::vector<Diff>* diffs) {
+  if (config.font_style == "none") {
+    return;
+  }
+  CompareJsonSubset(expected, actual, path, "font_style_mismatch",
+                    "font_style_exact", 0.0, false, diffs);
+}
+
+void CompareGlyphIds(const Json::Value& expected, const Json::Value& actual,
+                     const std::string& path, std::vector<Diff>* diffs) {
+  if (!expected.isArray() || !actual.isArray()) {
+    CompareJsonSubset(expected, actual, path, "glyph_id_mismatch",
+                      "glyph_id_exact", 0.0, false, diffs);
+    return;
+  }
+  if (expected.size() != actual.size()) {
+    AddDiff(diffs, path, "glyph_id_mismatch", "glyph_id_exact",
+            "glyph array sizes differ", expected, actual);
+    return;
+  }
+  for (Json::ArrayIndex i = 0; i < expected.size(); ++i) {
+    const std::string item_path = IndexJsonPath(path, i);
+    CompareJsonSubset(OptionalValue(expected[i], "label"),
+                      OptionalValue(actual[i], "label"),
+                      ChildJsonPath(item_path, "label"), "glyph_id_mismatch",
+                      "glyph_id_exact", 0.0, false, diffs);
+    if (expected[i].isMember("code_point")) {
+      CompareJsonSubset(
+          expected[i]["code_point"], OptionalValue(actual[i], "code_point"),
+          ChildJsonPath(item_path, "code_point"), "glyph_id_mismatch",
+          "glyph_id_exact", 0.0, false, diffs);
+    }
+    CompareJsonSubset(OptionalValue(expected[i], "glyph_id"),
+                      OptionalValue(actual[i], "glyph_id"),
+                      ChildJsonPath(item_path, "glyph_id"), "glyph_id_mismatch",
+                      "glyph_id_exact", 0.0, false, diffs);
+  }
+}
+
+void CompareMetricSet(const Json::Value& expected, const Json::Value& actual,
+                      const std::string& path, double epsilon,
+                      const std::string& rule, std::vector<Diff>* diffs) {
+  CompareJsonSubset(expected, actual, path, "metrics_mismatch", rule, epsilon,
+                    true, diffs);
+}
+
+void CompareGlyphMetricSet(const Json::Value& expected,
+                           const Json::Value& actual, const std::string& path,
+                           double epsilon, std::vector<Diff>* diffs) {
+  CompareJsonSubset(expected, actual, path, "metrics_mismatch",
+                    "glyph_metrics_epsilon", epsilon, true, diffs);
+}
+
+void ComparePathSet(const Json::Value& expected, const Json::Value& actual,
+                    const std::string& path, double epsilon,
+                    std::vector<Diff>* diffs) {
+  CompareJsonSubset(expected, actual, path, "path_mismatch", "path_normalized",
+                    epsilon, true, diffs);
+}
+
+void CompareTypefaceProbe(const Json::Value& expected_root,
+                          const Json::Value& actual_root,
+                          const CompareConfig& config,
+                          std::vector<Diff>* diffs) {
+  Json::Value expected = NormalizeTypefaceProbe(expected_root);
+  Json::Value actual = NormalizeTypefaceProbe(actual_root);
+  CompareDescriptor(expected["descriptor"], actual["descriptor"],
+                    "typeface_result.typeface", "descriptor_mismatch", config,
+                    diffs);
+
+  if (expected["descriptor"].isMember("style") &&
+      actual["descriptor"].isMember("style")) {
+    CompareFontStyle(expected["descriptor"]["style"],
+                     actual["descriptor"]["style"],
+                     "typeface_result.typeface.style", config, diffs);
+  }
+  CompareJsonSubset(OptionalValue(expected, "units_per_em"),
+                    OptionalValue(actual, "units_per_em"),
+                    "typeface_probe.units_per_em", "descriptor_mismatch",
+                    "exact", 0.0, false, diffs);
+  CompareJsonSubset(OptionalValue(expected, "table_count"),
+                    OptionalValue(actual, "table_count"),
+                    "typeface_probe.table_count", "table_mismatch", "exact",
+                    0.0, false, diffs);
+  CompareGlyphIds(expected["glyphs"], actual["glyphs"], "typeface_probe.glyphs",
+                  diffs);
+  CompareJsonSubset(expected["tables"], actual["tables"],
+                    "typeface_probe.tables", "table_mismatch", "table_exact",
+                    0.0, false, diffs);
+}
+
+void CompareMetricsProbe(const Json::Value& expected_root,
+                         const Json::Value& actual_root,
+                         const CompareConfig& config,
+                         std::vector<Diff>* diffs) {
+  Json::Value expected = NormalizeMetricsProbe(expected_root);
+  Json::Value actual = NormalizeMetricsProbe(actual_root);
+
+  if (!IsIgnoreMode(config.font_metrics_mode)) {
+    CompareMetricSet(expected["font_result"]["font_metrics"],
+                     actual["font_result"]["font_metrics"],
+                     "metrics_probe.font_result.font_metrics",
+                     config.font_metrics_epsilon, "font_metrics_epsilon",
+                     diffs);
+    CompareMetricSet(expected["scaler_context_result"]["font_metrics"],
+                     actual["scaler_context_result"]["font_metrics"],
+                     "metrics_probe.scaler_context_result.font_metrics",
+                     config.font_metrics_epsilon, "font_metrics_epsilon",
+                     diffs);
+  }
+
+  if (!IsIgnoreMode(config.glyph_metrics_mode)) {
+    CompareGlyphMetricSet(expected["font_result"]["glyph_metrics"],
+                          actual["font_result"]["glyph_metrics"],
+                          "metrics_probe.font_result.glyph_metrics",
+                          config.glyph_metrics_epsilon, diffs);
+    CompareGlyphMetricSet(expected["scaler_context_result"]["glyph_metrics"],
+                          actual["scaler_context_result"]["glyph_metrics"],
+                          "metrics_probe.scaler_context_result.glyph_metrics",
+                          config.glyph_metrics_epsilon, diffs);
+  }
+}
+
+void CompareGlyphPathProbe(const Json::Value& expected_root,
+                           const Json::Value& actual_root,
+                           const CompareConfig& config,
+                           std::vector<Diff>* diffs) {
+  if (IsIgnoreMode(config.glyph_path_mode)) {
+    return;
+  }
+  Json::Value expected = NormalizePathProbe(expected_root);
+  Json::Value actual = NormalizePathProbe(actual_root);
+  ComparePathSet(expected["font_result"]["glyph_paths"],
+                 actual["font_result"]["glyph_paths"],
+                 "glyph_path_probe.font_result.glyph_paths",
+                 config.glyph_path_epsilon, diffs);
+  ComparePathSet(expected["scaler_context_result"]["glyph_paths"],
+                 actual["scaler_context_result"]["glyph_paths"],
+                 "glyph_path_probe.scaler_context_result.glyph_paths",
+                 config.glyph_path_epsilon, diffs);
+}
+
+void CompareFontManagerProbe(const Json::Value& expected_root,
+                             const Json::Value& actual_root,
+                             const CompareConfig& config,
+                             std::vector<Diff>* diffs) {
+  Json::Value expected = NormalizeFontManagerProbe(expected_root);
+  Json::Value actual = NormalizeFontManagerProbe(actual_root);
+  CompareJsonSubset(OptionalValue(expected, "entry"),
+                    OptionalValue(actual, "entry"),
+                    "font_manager_probe.operation.entry", "selection_mismatch",
+                    "exact", 0.0, false, diffs);
+
+  CompareJsonSubset(OptionalValue(expected, "create_style_set"),
+                    OptionalValue(actual, "create_style_set"),
+                    "font_manager_probe.operation.create_style_set",
+                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
+  CompareJsonSubset(OptionalValue(expected, "style_set"),
+                    OptionalValue(actual, "style_set"),
+                    "font_manager_probe.operation.style_set",
+                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
+  CompareJsonSubset(OptionalValue(expected, "match_family"),
+                    OptionalValue(actual, "match_family"),
+                    "font_manager_probe.operation.match_family",
+                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
+
+  const Json::Value& expected_typefaces = expected["matched_typefaces"];
+  const Json::Value& actual_typefaces = actual["matched_typefaces"];
+  if (!expected_typefaces.isArray() || !actual_typefaces.isArray() ||
+      expected_typefaces.size() != actual_typefaces.size()) {
+    AddDiff(diffs, "font_manager_probe.matched_typefaces", "selection_mismatch",
+            "selection_exact", "matched typeface array sizes differ",
+            expected_typefaces, actual_typefaces);
+    return;
+  }
+
+  for (Json::ArrayIndex i = 0; i < expected_typefaces.size(); ++i) {
+    const std::string path =
+        IndexJsonPath("font_manager_probe.matched_typefaces", i);
+    CompareDescriptor(
+        expected_typefaces[i]["descriptor"], actual_typefaces[i]["descriptor"],
+        ChildJsonPath(path, "descriptor"), "selection_mismatch", config, diffs);
+    if (expected_typefaces[i].isMember("font_style") &&
+        actual_typefaces[i].isMember("font_style")) {
+      CompareFontStyle(expected_typefaces[i]["font_style"],
+                       actual_typefaces[i]["font_style"],
+                       ChildJsonPath(path, "font_style"), config, diffs);
+    }
+    CompareGlyphIds(expected_typefaces[i]["probe_summary"]["glyphs"],
+                    actual_typefaces[i]["probe_summary"]["glyphs"],
+                    ChildJsonPath(path, "probe_summary.glyphs"), diffs);
+    if (!IsIgnoreMode(config.font_metrics_mode)) {
+      CompareMetricSet(expected_typefaces[i]["probe_summary"]["font_metrics"],
+                       actual_typefaces[i]["probe_summary"]["font_metrics"],
+                       ChildJsonPath(path, "probe_summary.font_metrics"),
+                       config.font_metrics_epsilon, "font_metrics_epsilon",
+                       diffs);
+      CompareMetricSet(
+          expected_typefaces[i]["probe_summary"]["scaler_font_metrics"],
+          actual_typefaces[i]["probe_summary"]["scaler_font_metrics"],
+          ChildJsonPath(path, "probe_summary.scaler_font_metrics"),
+          config.font_metrics_epsilon, "font_metrics_epsilon", diffs);
+    }
+  }
+}
+
+void RunCategoryCompare(const Json::Value& expected, const Json::Value& actual,
+                        const CompareConfig& config, std::vector<Diff>* diffs) {
+  if (config.category == "typeface_probe" ||
+      config.category == "typeface_descriptor" ||
+      config.category == "font_tables" || config.category == "variation" ||
+      config.category == "glyph_mapping") {
+    CompareTypefaceProbe(expected, actual, config, diffs);
+    return;
+  }
+
+  if (config.category == "font_metrics" || config.category == "glyph_metrics" ||
+      config.category == "scaler_context") {
+    CompareMetricsProbe(expected, actual, config, diffs);
+    return;
+  }
+
+  if (config.category == "glyph_path") {
+    CompareGlyphPathProbe(expected, actual, config, diffs);
+    return;
+  }
+
+  if (config.category == "font_manager" ||
+      config.category == "family_style_set") {
+    CompareFontManagerProbe(expected, actual, config, diffs);
+    return;
+  }
+
+  AddDiff(diffs, "category", "schema_mismatch", "category_supported",
+          "compare category is not implemented", Json::Value(config.category),
+          Json::Value(Json::nullValue));
+}
+
+bool LoadJsonInput(const std::filesystem::path& path, Json::Value* root,
+                   std::string* error) {
+  return LoadJsonFile(path, root, error);
+}
+
+}  // namespace
+
+CompareResult RunCompare(const CompareRequest& request) {
+  const std::string fallback_case_id =
+      StemOrFallback(request.case_path, "case");
+  std::string backend = request.backend.empty() ? "unknown" : request.backend;
+
+  Json::Value case_root;
+  std::string error;
+  if (!LoadJsonInput(request.case_path, &case_root, &error)) {
+    return BuildInputFailure(fallback_case_id, backend, request, "case_load",
+                             "schema_mismatch", error);
+  }
+
+  RepoUriResolver resolver(request.repo_root);
+  CaseValidationResult case_validation =
+      ValidateCaseDocument(case_root, resolver);
+  if (case_validation.case_id.empty()) {
+    case_validation.case_id = fallback_case_id;
+  }
+  if (case_validation.backend.empty()) {
+    case_validation.backend = backend;
+  }
+  if (backend == "unknown") {
+    backend =
+        case_validation.backend.empty() ? "unknown" : case_validation.backend;
+  }
+
+  if (!case_validation.valid) {
+    CompareResult result = BuildInputFailure(
+        case_validation.case_id, backend, request, "case_schema",
+        "schema_mismatch", "case document is invalid");
+    result.report["case_validation_errors"] = case_validation.errors.ToJson();
+    return result;
+  }
+
+  if (!request.backend.empty() && case_validation.backend != request.backend) {
+    CompareResult result = BuildInputFailure(
+        case_validation.case_id, backend, request, "case_schema",
+        "schema_mismatch", "case backend does not match --backend");
+    result.report["case_validation_errors"] = Json::Value(Json::arrayValue);
+    Json::Value item(Json::objectValue);
+    item["path"] = "$.backend";
+    item["message"] = "case backend does not match --backend";
+    result.report["case_validation_errors"].append(std::move(item));
+    return result;
+  }
+
+  Json::Value expected_root;
+  if (!LoadJsonInput(request.expected_path, &expected_root, &error)) {
+    return BuildInputFailure(case_validation.case_id, backend, request,
+                             "expected_load", "oracle_unavailable", error);
+  }
+
+  Json::Value actual_root;
+  if (!LoadJsonInput(request.actual_path, &actual_root, &error)) {
+    return BuildInputFailure(case_validation.case_id, backend, request,
+                             "actual_load", "schema_mismatch", error);
+  }
+
+  ArtifactValidationResult expected_validation =
+      ValidateProbeResultDocument(expected_root);
+  ArtifactValidationResult actual_validation =
+      ValidateProbeResultDocument(actual_root);
+  if (!expected_validation.valid || !actual_validation.valid) {
+    CompareResult result = BuildInputFailure(
+        case_validation.case_id, backend, request, "artifact_schema",
+        "schema_mismatch", "probe result artifact schema is invalid");
+    AddArtifactValidationReport(&result.report, "expected",
+                                expected_validation);
+    AddArtifactValidationReport(&result.report, "actual", actual_validation);
+    return result;
+  }
+
+  if (expected_validation.case_id != case_validation.case_id ||
+      actual_validation.case_id != case_validation.case_id) {
+    CompareResult result = BuildInputFailure(
+        case_validation.case_id, backend, request, "artifact_schema",
+        "schema_mismatch", "probe result case_id does not match case");
+    result.report["expected_case_id"] = expected_validation.case_id;
+    result.report["actual_case_id"] = actual_validation.case_id;
+    return result;
+  }
+
+  if (!expected_root.isMember("ok") || !expected_root["ok"].asBool() ||
+      !actual_root.isMember("ok") || !actual_root["ok"].asBool()) {
+    CompareResult result = BuildInputFailure(
+        case_validation.case_id, backend, request, "artifact_schema",
+        "schema_mismatch", "probe result is not ok");
+    result.report["expected_ok"] =
+        expected_root.isMember("ok") && expected_root["ok"].asBool();
+    result.report["actual_ok"] =
+        actual_root.isMember("ok") && actual_root["ok"].asBool();
+    return result;
+  }
+
+  CompareConfig config = ParseCompareConfig(case_root);
+  std::vector<Diff> diffs;
+  RunCategoryCompare(expected_root, actual_root, config, &diffs);
+
+  CompareResult result;
+  result.case_id = case_validation.case_id;
+  result.backend = backend;
+  if (diffs.empty()) {
+    result.status = CompareStatus::kPass;
+    result.report = BuildReport(case_validation.case_id, backend, "compare",
+                                "pass", request);
+    result.report["passed"] = true;
+  } else {
+    result.status = CompareStatus::kMismatch;
+    result.report =
+        BuildReport(case_validation.case_id, backend, "compare",
+                    FirstDiffReason(diffs, "compare_mismatch"), request);
+    result.report["passed"] = false;
+    result.report["diff_path"] = diffs.front().path;
+    result.report["diff_count"] = static_cast<Json::UInt64>(diffs.size());
+    result.report["diffs"] = ToDiffsJson(diffs);
+  }
+  result.report["compare_config"] = CompareConfigToJson(config);
+  return result;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/compare/compare_engine.hpp
+++ b/harness/font/compare/compare_engine.hpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_COMPARE_COMPARE_ENGINE_HPP
+#define HARNESS_FONT_COMPARE_COMPARE_ENGINE_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class CompareStatus {
+  kPass,
+  kMismatch,
+  kInputFailed,
+};
+
+struct CompareRequest {
+  std::filesystem::path repo_root;
+  std::filesystem::path case_path;
+  std::filesystem::path expected_path;
+  std::filesystem::path actual_path;
+  std::string backend;
+};
+
+struct CompareResult {
+  CompareStatus status = CompareStatus::kInputFailed;
+  std::string case_id;
+  std::string backend;
+  Json::Value report;
+};
+
+CompareResult RunCompare(const CompareRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_COMPARE_COMPARE_ENGINE_HPP

--- a/harness/font/compare/path/path_normalizer.cc
+++ b/harness/font/compare/path/path_normalizer.cc
@@ -1,0 +1,332 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/compare/path/path_normalizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <skity/geometry/point.hpp>
+#include <skity/geometry/rect.hpp>
+#include <string>
+#include <vector>
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+struct NormalizedPoint {
+  double x = 0.0;
+  double y = 0.0;
+  bool finite = true;
+};
+
+struct ContourState {
+  bool active = false;
+  bool closed = false;
+  bool has_bounds = false;
+  Json::UInt64 index = 0;
+  Json::UInt64 start_verb_index = 0;
+  Json::UInt64 end_verb_index = 0;
+  Json::UInt64 verb_count = 0;
+  double left = 0.0;
+  double top = 0.0;
+  double right = 0.0;
+  double bottom = 0.0;
+};
+
+double NormalizeScalar(double value, double epsilon) {
+  if (!std::isfinite(value)) {
+    return value;
+  }
+  if (epsilon > 0.0) {
+    value = std::round(value / epsilon) * epsilon;
+  }
+  const double zero_epsilon = epsilon > 0.0 ? epsilon : kDefaultPathEpsilon;
+  if (value == 0.0 || std::fabs(value) < zero_epsilon * 0.5) {
+    return 0.0;
+  }
+  return value;
+}
+
+Json::Value ScalarToJson(double value, double epsilon) {
+  if (!std::isfinite(value)) {
+    return Json::Value(Json::nullValue);
+  }
+  return Json::Value(NormalizeScalar(value, epsilon));
+}
+
+std::string FillTypeToString(Path::PathFillType fill_type) {
+  switch (fill_type) {
+    case Path::PathFillType::kWinding:
+      return "winding";
+    case Path::PathFillType::kEvenOdd:
+      return "even_odd";
+  }
+  return "unknown";
+}
+
+std::string VerbToString(Path::Verb verb) {
+  switch (verb) {
+    case Path::Verb::kMove:
+      return "move";
+    case Path::Verb::kLine:
+      return "line";
+    case Path::Verb::kQuad:
+      return "quad";
+    case Path::Verb::kConic:
+      return "conic";
+    case Path::Verb::kCubic:
+      return "cubic";
+    case Path::Verb::kClose:
+      return "close";
+    case Path::Verb::kDone:
+      return "done";
+  }
+  return "unknown";
+}
+
+int SerializedPointCount(Path::Verb verb) {
+  switch (verb) {
+    case Path::Verb::kMove:
+      return 1;
+    case Path::Verb::kLine:
+      return 2;
+    case Path::Verb::kQuad:
+    case Path::Verb::kConic:
+      return 3;
+    case Path::Verb::kCubic:
+      return 4;
+    case Path::Verb::kClose:
+    case Path::Verb::kDone:
+      return 0;
+  }
+  return 0;
+}
+
+bool IsSegmentVerb(Path::Verb verb) {
+  return verb == Path::Verb::kLine || verb == Path::Verb::kQuad ||
+         verb == Path::Verb::kConic || verb == Path::Verb::kCubic;
+}
+
+NormalizedPoint NormalizePoint(const Point& point, double epsilon) {
+  NormalizedPoint value;
+  value.finite = std::isfinite(point.x) && std::isfinite(point.y);
+  value.x = NormalizeScalar(point.x, epsilon);
+  value.y = NormalizeScalar(point.y, epsilon);
+  return value;
+}
+
+Json::Value PointToJson(const NormalizedPoint& point, double epsilon) {
+  Json::Value value(Json::objectValue);
+  value["x"] = ScalarToJson(point.x, epsilon);
+  value["y"] = ScalarToJson(point.y, epsilon);
+  return value;
+}
+
+bool SamePoint(const NormalizedPoint& lhs, const NormalizedPoint& rhs) {
+  return lhs.finite && rhs.finite && lhs.x == rhs.x && lhs.y == rhs.y;
+}
+
+bool IsZeroLengthSegment(Path::Verb verb,
+                         const std::vector<NormalizedPoint>& points) {
+  if (!IsSegmentVerb(verb) || points.empty()) {
+    return false;
+  }
+  const NormalizedPoint& first = points.front();
+  for (const auto& point : points) {
+    if (!SamePoint(first, point)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Json::Value BoundsToJson(double left, double top, double right, double bottom,
+                         bool has_bounds, double epsilon) {
+  Json::Value value(Json::objectValue);
+  value["left"] = ScalarToJson(has_bounds ? left : 0.0, epsilon);
+  value["top"] = ScalarToJson(has_bounds ? top : 0.0, epsilon);
+  value["right"] = ScalarToJson(has_bounds ? right : 0.0, epsilon);
+  value["bottom"] = ScalarToJson(has_bounds ? bottom : 0.0, epsilon);
+  value["width"] = ScalarToJson(has_bounds ? right - left : 0.0, epsilon);
+  value["height"] = ScalarToJson(has_bounds ? bottom - top : 0.0, epsilon);
+  value["empty"] = !has_bounds || !(left < right && top < bottom);
+  return value;
+}
+
+Json::Value RectToJson(const Rect& rect, double epsilon) {
+  return BoundsToJson(rect.Left(), rect.Top(), rect.Right(), rect.Bottom(),
+                      rect.IsFinite(), epsilon);
+}
+
+void AddPointToContour(const NormalizedPoint& point, ContourState* contour) {
+  if (!point.finite) {
+    return;
+  }
+  if (!contour->has_bounds) {
+    contour->left = point.x;
+    contour->right = point.x;
+    contour->top = point.y;
+    contour->bottom = point.y;
+    contour->has_bounds = true;
+    return;
+  }
+  contour->left = std::min(contour->left, point.x);
+  contour->right = std::max(contour->right, point.x);
+  contour->top = std::min(contour->top, point.y);
+  contour->bottom = std::max(contour->bottom, point.y);
+}
+
+Json::Value ContourToJson(const ContourState& contour, double epsilon) {
+  Json::Value value(Json::objectValue);
+  value["index"] = contour.index;
+  value["start_verb_index"] = contour.start_verb_index;
+  value["end_verb_index"] = contour.end_verb_index;
+  value["verb_count"] = contour.verb_count;
+  value["closed"] = contour.closed;
+  value["bounds"] = BoundsToJson(contour.left, contour.top, contour.right,
+                                 contour.bottom, contour.has_bounds, epsilon);
+  return value;
+}
+
+void FinishContour(ContourState* contour, Json::Value* contours,
+                   double epsilon) {
+  if (!contour->active) {
+    return;
+  }
+  contours->append(ContourToJson(*contour, epsilon));
+  *contour = ContourState{};
+}
+
+void AddVerbToContour(Path::Verb verb,
+                      const std::vector<NormalizedPoint>& points,
+                      Json::UInt64 verb_index, Json::Value* contours,
+                      ContourState* contour, double epsilon) {
+  if (verb == Path::Verb::kMove) {
+    FinishContour(contour, contours, epsilon);
+    contour->active = true;
+    contour->index = contours->size();
+    contour->start_verb_index = verb_index;
+  } else if (!contour->active && verb != Path::Verb::kClose) {
+    contour->active = true;
+    contour->index = contours->size();
+    contour->start_verb_index = verb_index;
+  }
+
+  if (!contour->active) {
+    return;
+  }
+
+  contour->end_verb_index = verb_index;
+  contour->verb_count += 1;
+  for (const auto& point : points) {
+    AddPointToContour(point, contour);
+  }
+
+  if (verb == Path::Verb::kClose) {
+    contour->closed = true;
+    FinishContour(contour, contours, epsilon);
+  }
+}
+
+Json::Value SegmentMasksToJson(uint32_t masks) {
+  Json::Value value(Json::objectValue);
+  value["line"] = (masks & Path::SegmentMask::kLine) != 0;
+  value["quad"] = (masks & Path::SegmentMask::kQuad) != 0;
+  value["conic"] = (masks & Path::SegmentMask::kConic) != 0;
+  value["cubic"] = (masks & Path::SegmentMask::kCubic) != 0;
+  return value;
+}
+
+}  // namespace
+
+Json::Value BuildNormalizedPathJson(const Path& path,
+                                    const PathNormalizeOptions& options) {
+  Json::Value result(Json::objectValue);
+  result["mode"] = "path_normalized";
+  result["epsilon"] = options.epsilon;
+  result["fill_type"] = FillTypeToString(path.GetFillType());
+  result["empty"] = path.IsEmpty();
+  result["finite"] = path.IsFinite();
+  result["source_point_count"] = static_cast<Json::UInt64>(path.CountPoints());
+  result["source_verb_count"] = static_cast<Json::UInt64>(path.CountVerbs());
+  Json::Value bounds = RectToJson(path.GetBounds(), options.epsilon);
+  result["bounds"] = bounds;
+  result["source_bounds"] = std::move(bounds);
+  result["segment_masks"] = SegmentMasksToJson(path.GetSegmentMasks());
+
+  Json::Value normalization(Json::objectValue);
+  normalization["drop_zero_length_segments"] =
+      options.drop_zero_length_segments;
+  normalization["normalize_negative_zero"] = true;
+
+  Json::Value verbs(Json::arrayValue);
+  Json::Value contours(Json::arrayValue);
+  Json::Value sequence(Json::arrayValue);
+  ContourState contour;
+  Path::RawIter iter(path);
+  Point points[4];
+  const float* conic_weights = path.ConicWeights();
+  Json::UInt64 serialized_point_count = 0;
+  Json::UInt64 dropped_zero_length_segments = 0;
+
+  for (Path::Verb verb = iter.Next(points); verb != Path::Verb::kDone;
+       verb = iter.Next(points)) {
+    const int point_count = SerializedPointCount(verb);
+    std::vector<NormalizedPoint> normalized_points;
+    normalized_points.reserve(point_count);
+    for (int i = 0; i < point_count; ++i) {
+      normalized_points.push_back(NormalizePoint(points[i], options.epsilon));
+    }
+
+    double conic_weight = 0.0;
+    if (verb == Path::Verb::kConic) {
+      conic_weight = *conic_weights++;
+    }
+
+    if (options.drop_zero_length_segments &&
+        IsZeroLengthSegment(verb, normalized_points)) {
+      dropped_zero_length_segments += 1;
+      continue;
+    }
+
+    const Json::UInt64 verb_index = verbs.size();
+    Json::Value item(Json::objectValue);
+    item["index"] = verb_index;
+    item["verb"] = VerbToString(verb);
+    item["point_count"] = point_count;
+
+    Json::Value json_points(Json::arrayValue);
+    for (const auto& point : normalized_points) {
+      json_points.append(PointToJson(point, options.epsilon));
+    }
+    item["points"] = std::move(json_points);
+    serialized_point_count += static_cast<Json::UInt64>(point_count);
+
+    if (verb == Path::Verb::kConic) {
+      item["weight"] = ScalarToJson(conic_weight, options.epsilon);
+    }
+
+    AddVerbToContour(verb, normalized_points, verb_index, &contours, &contour,
+                     options.epsilon);
+    sequence.append(VerbToString(verb));
+    verbs.append(std::move(item));
+  }
+  FinishContour(&contour, &contours, options.epsilon);
+
+  normalization["dropped_zero_length_segments"] = dropped_zero_length_segments;
+  result["normalization"] = std::move(normalization);
+  result["verb_count"] = static_cast<Json::UInt64>(verbs.size());
+  result["point_count"] = serialized_point_count;
+  result["contour_count"] = static_cast<Json::UInt64>(contours.size());
+  result["verb_sequence"] = std::move(sequence);
+  result["verbs"] = std::move(verbs);
+  result["contours"] = std::move(contours);
+  return result;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/compare/path/path_normalizer.hpp
+++ b/harness/font/compare/path/path_normalizer.hpp
@@ -1,0 +1,29 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_COMPARE_PATH_PATH_NORMALIZER_HPP
+#define HARNESS_FONT_COMPARE_PATH_PATH_NORMALIZER_HPP
+
+#include <skity/graphic/path.hpp>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+inline constexpr double kDefaultPathEpsilon = 0.0001;
+
+struct PathNormalizeOptions {
+  double epsilon = kDefaultPathEpsilon;
+  bool drop_zero_length_segments = true;
+};
+
+Json::Value BuildNormalizedPathJson(
+    const Path& path,
+    const PathNormalizeOptions& options = PathNormalizeOptions{});
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_COMPARE_PATH_PATH_NORMALIZER_HPP

--- a/harness/font/manifests/pc_macos_coretext_smoke.json
+++ b/harness/font/manifests/pc_macos_coretext_smoke.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "id": "pc_macos_coretext_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "case_root": "harness/font/cases",
+  "cases": [
+    "typeface_probe/roboto_regular_file_coretext.json",
+    "typeface_probe/roboto_regular_data_coretext.json",
+    "font_metrics/roboto_regular_64_coretext.json",
+    "glyph_metrics/roboto_regular_latin_coretext.json",
+    "glyph_path/roboto_regular_latin_A_coretext.json",
+    "scaler_context/roboto_regular_64_coretext.json",
+    "family_style_set/helvetica_coretext.json",
+    "font_manager/default_typeface_coretext.json",
+    "font_manager/match_family_style_helvetica_regular_coretext.json"
+  ],
+  "artifacts": {
+    "skia_dir": "local/font-harness/artifacts/skia",
+    "skity_dir": "local/font-harness/artifacts/skity",
+    "compare_dir": "local/font-harness/artifacts/compare"
+  }
+}

--- a/harness/font/platform/coretext/env_info.cc
+++ b/harness/font/platform/coretext/env_info.cc
@@ -1,0 +1,410 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/platform/coretext/env_info.hpp"
+
+#include <sys/utsname.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
+#if SKITY_FONT_HARNESS_HAS_CORETEXT
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreText/CoreText.h>
+#endif
+
+#ifndef SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME
+#define SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME "unknown"
+#endif
+
+#ifndef SKITY_FONT_HARNESS_SKITY_CT_FONT
+#define SKITY_FONT_HARNESS_SKITY_CT_FONT 0
+#endif
+
+#ifndef SKITY_FONT_HARNESS_ENABLE_FONT_HARNESS
+#define SKITY_FONT_HARNESS_ENABLE_FONT_HARNESS 0
+#endif
+
+#ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
+#define SKITY_FONT_HARNESS_HAS_CORETEXT 0
+#endif
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+constexpr const char* kBackend = "coretext";
+constexpr const char* kPlatformId = "darwin-ct";
+
+std::string Trim(std::string value) {
+  while (!value.empty() && (value.back() == '\n' || value.back() == '\r' ||
+                            value.back() == '\0' || value.back() == ' ' ||
+                            value.back() == '\t')) {
+    value.pop_back();
+  }
+  size_t start = 0;
+  while (start < value.size() &&
+         (value[start] == ' ' || value[start] == '\t')) {
+    ++start;
+  }
+  if (start > 0) {
+    value.erase(0, start);
+  }
+  return value;
+}
+
+std::string ReadFirstLine(const std::filesystem::path& path) {
+  std::ifstream input(path);
+  std::string line;
+  if (!std::getline(input, line)) {
+    return {};
+  }
+  return Trim(std::move(line));
+}
+
+std::filesystem::path ResolveGitDir(const std::filesystem::path& repo_root) {
+  const auto dot_git = repo_root / ".git";
+  if (std::filesystem::is_directory(dot_git)) {
+    return dot_git;
+  }
+
+  const std::string git_file = ReadFirstLine(dot_git);
+  constexpr const char* kGitDirPrefix = "gitdir:";
+  if (git_file.rfind(kGitDirPrefix, 0) != 0) {
+    return {};
+  }
+
+  std::filesystem::path git_dir = Trim(git_file.substr(strlen(kGitDirPrefix)));
+  if (git_dir.is_absolute()) {
+    return git_dir;
+  }
+  return (repo_root / git_dir).lexically_normal();
+}
+
+std::string ReadPackedRef(const std::filesystem::path& git_dir,
+                          const std::string& ref_name) {
+  std::ifstream input(git_dir / "packed-refs");
+  std::string line;
+  while (std::getline(input, line)) {
+    if (line.empty() || line[0] == '#' || line[0] == '^') {
+      continue;
+    }
+    std::istringstream stream(line);
+    std::string sha;
+    std::string ref;
+    stream >> sha >> ref;
+    if (ref == ref_name) {
+      return sha;
+    }
+  }
+  return {};
+}
+
+std::string ResolveSkityCommit(const std::filesystem::path& repo_root) {
+  const auto git_dir = ResolveGitDir(repo_root);
+  if (git_dir.empty()) {
+    return {};
+  }
+
+  const std::string head = ReadFirstLine(git_dir / "HEAD");
+  constexpr const char* kRefPrefix = "ref:";
+  if (head.rfind(kRefPrefix, 0) != 0) {
+    return head;
+  }
+
+  const std::string ref_name = Trim(head.substr(strlen(kRefPrefix)));
+  std::string sha = ReadFirstLine(git_dir / ref_name);
+  if (!sha.empty()) {
+    return sha;
+  }
+  return ReadPackedRef(git_dir, ref_name);
+}
+
+std::string DetectPlatformName() {
+  const std::string system_name = SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME;
+  if (system_name == "Darwin") {
+    return "macOS";
+  }
+  return system_name.empty() ? "unknown" : system_name;
+}
+
+std::string DetectOSVersion() {
+#if defined(__APPLE__)
+  size_t size = 0;
+  if (sysctlbyname("kern.osproductversion", nullptr, &size, nullptr, 0) == 0 &&
+      size > 0) {
+    std::string version(size, '\0');
+    if (sysctlbyname("kern.osproductversion", version.data(), &size, nullptr,
+                     0) == 0) {
+      return Trim(std::move(version));
+    }
+  }
+#endif
+
+  struct utsname value;
+  if (uname(&value) == 0) {
+    return value.release;
+  }
+  return "unknown";
+}
+
+Json::Value BuildCMakeOptions() {
+  Json::Value options(Json::objectValue);
+  options["CMAKE_SYSTEM_NAME"] = SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME;
+  options["SKITY_CT_FONT"] =
+      static_cast<bool>(SKITY_FONT_HARNESS_SKITY_CT_FONT);
+  options["SKITY_ENABLE_FONT_HARNESS"] =
+      static_cast<bool>(SKITY_FONT_HARNESS_ENABLE_FONT_HARNESS);
+  options["SKITY_FONT_HARNESS_HAS_CORETEXT"] =
+      static_cast<bool>(SKITY_FONT_HARNESS_HAS_CORETEXT);
+  return options;
+}
+
+Json::Value BuildBaseReport(const CoreTextEnvRequest& request,
+                            const std::string& artifact_type) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = artifact_type;
+  report["platform"] = DetectPlatformName();
+  report["platform_id"] = kPlatformId;
+  report["backend"] = kBackend;
+  report["os_version"] = DetectOSVersion();
+  const std::string commit = ResolveSkityCommit(request.repo_root);
+  report["skity_commit"] = commit.empty() ? "unknown" : commit;
+  report["cmake_options"] = BuildCMakeOptions();
+  report["backend_available"] =
+      static_cast<bool>(SKITY_FONT_HARNESS_HAS_CORETEXT);
+  if (!static_cast<bool>(SKITY_FONT_HARNESS_HAS_CORETEXT)) {
+    report["reason_code"] = "backend_unavailable";
+    report["message"] =
+        "CoreText backend is unavailable; build on macOS with SKITY_CT_FONT=ON";
+  }
+  return report;
+}
+
+#if SKITY_FONT_HARNESS_HAS_CORETEXT
+
+struct CFReleaseDeleter {
+  void operator()(const void* ref) const {
+    if (ref != nullptr) {
+      CFRelease(ref);
+    }
+  }
+};
+
+template <typename T>
+using ScopedCFRef = std::unique_ptr<std::remove_pointer_t<T>, CFReleaseDeleter>;
+
+std::string CFStringToStdString(CFStringRef value) {
+  if (value == nullptr) {
+    return {};
+  }
+  CFIndex length = CFStringGetLength(value);
+  CFIndex max_size =
+      CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+  std::string result(static_cast<size_t>(max_size), '\0');
+  if (!CFStringGetCString(value, result.data(), max_size,
+                          kCFStringEncodingUTF8)) {
+    return {};
+  }
+  return Trim(std::move(result));
+}
+
+ScopedCFRef<CFStringRef> MakeCFString(const std::string& value) {
+  return ScopedCFRef<CFStringRef>(CFStringCreateWithCString(
+      kCFAllocatorDefault, value.c_str(), kCFStringEncodingUTF8));
+}
+
+std::string CopyDescriptorString(CTFontDescriptorRef descriptor,
+                                 CFStringRef attribute) {
+  ScopedCFRef<CFStringRef> value(static_cast<CFStringRef>(
+      CTFontDescriptorCopyAttribute(descriptor, attribute)));
+  return CFStringToStdString(value.get());
+}
+
+std::vector<std::string> CopyAvailableFamilies() {
+  std::vector<std::string> families;
+  ScopedCFRef<CFArrayRef> array(CTFontManagerCopyAvailableFontFamilyNames());
+  if (!array) {
+    return families;
+  }
+
+  CFIndex count = CFArrayGetCount(array.get());
+  families.reserve(static_cast<size_t>(count));
+  for (CFIndex i = 0; i < count; ++i) {
+    CFStringRef family =
+        static_cast<CFStringRef>(CFArrayGetValueAtIndex(array.get(), i));
+    std::string name = CFStringToStdString(family);
+    if (!name.empty()) {
+      families.push_back(std::move(name));
+    }
+  }
+
+  std::sort(families.begin(), families.end());
+  families.erase(std::unique(families.begin(), families.end()), families.end());
+  return families;
+}
+
+Json::Value CopyStylesForFamily(const std::string& family_name) {
+  Json::Value styles(Json::arrayValue);
+  ScopedCFRef<CFStringRef> family = MakeCFString(family_name);
+  if (!family) {
+    return styles;
+  }
+
+  ScopedCFRef<CFMutableDictionaryRef> attributes(CFDictionaryCreateMutable(
+      kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks));
+  CFDictionarySetValue(attributes.get(), kCTFontFamilyNameAttribute,
+                       family.get());
+  ScopedCFRef<CTFontDescriptorRef> descriptor(
+      CTFontDescriptorCreateWithAttributes(attributes.get()));
+  if (!descriptor) {
+    return styles;
+  }
+
+  ScopedCFRef<CFArrayRef> matches(
+      CTFontDescriptorCreateMatchingFontDescriptors(descriptor.get(), nullptr));
+  if (!matches) {
+    return styles;
+  }
+
+  std::vector<Json::Value> style_values;
+  CFIndex count = CFArrayGetCount(matches.get());
+  style_values.reserve(static_cast<size_t>(count));
+  for (CFIndex i = 0; i < count; ++i) {
+    CTFontDescriptorRef match = static_cast<CTFontDescriptorRef>(
+        CFArrayGetValueAtIndex(matches.get(), i));
+    Json::Value style(Json::objectValue);
+    style["style_name"] =
+        CopyDescriptorString(match, kCTFontStyleNameAttribute);
+    style["postscript_name"] =
+        CopyDescriptorString(match, kCTFontNameAttribute);
+    style_values.push_back(std::move(style));
+  }
+
+  std::sort(style_values.begin(), style_values.end(),
+            [](const Json::Value& lhs, const Json::Value& rhs) {
+              return lhs["postscript_name"].asString() <
+                     rhs["postscript_name"].asString();
+            });
+  for (auto& style : style_values) {
+    styles.append(std::move(style));
+  }
+  return styles;
+}
+
+bool CanResolveFamilyDescriptor(const std::string& family_name) {
+  ScopedCFRef<CFStringRef> family = MakeCFString(family_name);
+  if (!family) {
+    return false;
+  }
+
+  ScopedCFRef<CFMutableDictionaryRef> attributes(CFDictionaryCreateMutable(
+      kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks));
+  CFDictionarySetValue(attributes.get(), kCTFontFamilyNameAttribute,
+                       family.get());
+  ScopedCFRef<CTFontDescriptorRef> descriptor(
+      CTFontDescriptorCreateWithAttributes(attributes.get()));
+  if (!descriptor) {
+    return false;
+  }
+
+  const void* required_values[] = {kCTFontFamilyNameAttribute};
+  ScopedCFRef<CFSetRef> required(CFSetCreate(
+      kCFAllocatorDefault, required_values, 1, &kCFTypeSetCallBacks));
+  ScopedCFRef<CTFontDescriptorRef> resolved(
+      CTFontDescriptorCreateMatchingFontDescriptor(descriptor.get(),
+                                                   required.get()));
+  return resolved != nullptr;
+}
+
+#endif
+
+}  // namespace
+
+Json::Value BuildCoreTextEnvInfo(const CoreTextEnvRequest& request) {
+  Json::Value report = BuildBaseReport(request, "font_env_info");
+  if (!report["backend_available"].asBool()) {
+    return report;
+  }
+
+#if SKITY_FONT_HARNESS_HAS_CORETEXT
+  const auto families = CopyAvailableFamilies();
+  report["family_count"] = static_cast<Json::UInt64>(families.size());
+
+  Json::Value key_families(Json::objectValue);
+  const std::set<std::string> family_set(families.begin(), families.end());
+  for (const auto& family :
+       std::array<const char*, 3>{"Helvetica", "Times", "Courier"}) {
+    key_families[family] = family_set.find(family) != family_set.end();
+  }
+  report["key_families"] = std::move(key_families);
+
+  Json::Value css_aliases(Json::objectValue);
+  const std::array<std::pair<const char*, const char*>, 3> aliases = {
+      {{"sans-serif", "Helvetica"},
+       {"serif", "Times"},
+       {"monospace", "Courier"}}};
+  for (const auto& alias : aliases) {
+    Json::Value item(Json::objectValue);
+    item["mapped_family"] = alias.second;
+    item["visible_family"] = family_set.find(alias.second) != family_set.end();
+    item["descriptor_match"] = CanResolveFamilyDescriptor(alias.second);
+    css_aliases[alias.first] = std::move(item);
+  }
+  report["css_alias_families"] = std::move(css_aliases);
+
+  Json::Value sample(Json::arrayValue);
+  const size_t sample_count = std::min<size_t>(families.size(), 16);
+  for (size_t i = 0; i < sample_count; ++i) {
+    sample.append(families[i]);
+  }
+  report["sample_families"] = std::move(sample);
+#endif
+
+  return report;
+}
+
+Json::Value BuildCoreTextFontList(const CoreTextEnvRequest& request) {
+  Json::Value report = BuildBaseReport(request, "font_list_fonts");
+  if (!report["backend_available"].asBool()) {
+    return report;
+  }
+
+#if SKITY_FONT_HARNESS_HAS_CORETEXT
+  const auto families = CopyAvailableFamilies();
+  report["family_count"] = static_cast<Json::UInt64>(families.size());
+  Json::Value family_list(Json::arrayValue);
+  for (const auto& family_name : families) {
+    Json::Value family(Json::objectValue);
+    family["family_name"] = family_name;
+    Json::Value styles = CopyStylesForFamily(family_name);
+    family["style_count"] = static_cast<Json::UInt64>(styles.size());
+    family["styles"] = std::move(styles);
+    family_list.append(std::move(family));
+  }
+  report["families"] = std::move(family_list);
+#endif
+
+  return report;
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/platform/coretext/env_info.hpp
+++ b/harness/font/platform/coretext/env_info.hpp
@@ -1,0 +1,25 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PLATFORM_CORETEXT_ENV_INFO_HPP
+#define HARNESS_FONT_PLATFORM_CORETEXT_ENV_INFO_HPP
+
+#include <filesystem>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+struct CoreTextEnvRequest {
+  std::filesystem::path repo_root;
+};
+
+Json::Value BuildCoreTextEnvInfo(const CoreTextEnvRequest& request);
+Json::Value BuildCoreTextFontList(const CoreTextEnvRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PLATFORM_CORETEXT_ENV_INFO_HPP

--- a/harness/font/probe/font_manager_probe.cc
+++ b/harness/font/probe/font_manager_probe.cc
@@ -1,0 +1,959 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/probe/font_manager_probe.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+#include <skity/graphic/paint.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/glyph.hpp>
+#include <skity/text/typeface.hpp>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "src/render/text/text_transform.hpp"
+#include "src/text/scaler_context.hpp"
+#include "src/text/scaler_context_desc.hpp"
+
+#ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
+#define SKITY_FONT_HARNESS_HAS_CORETEXT 0
+#endif
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+constexpr int kDefaultSampleLimit = 8;
+constexpr int kMaxSampleLimit = 32;
+constexpr float kDefaultProbeSize = 64.0f;
+
+struct GlyphProbeRequest {
+  std::string label;
+  uint32_t code_point = 0;
+};
+
+struct FontProbeRequest {
+  float size = kDefaultProbeSize;
+  float scale_x = 1.0f;
+  float skew_x = 0.0f;
+  bool linear_metrics = false;
+  bool subpixel = true;
+  bool embolden = false;
+  Font::FontHinting hinting = Font::FontHinting::kNormal;
+};
+
+struct ParsedFontManagerRequest {
+  std::string entry;
+  std::string family_name;
+  FontStyle style = FontStyle::Normal();
+  bool has_character = false;
+  uint32_t character = 0;
+  std::string character_label;
+  std::vector<std::string> bcp47;
+  int sample_limit = kDefaultSampleLimit;
+  FontProbeRequest font_request;
+};
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *out = root[field].asString();
+  return true;
+}
+
+bool ReadIntField(const Json::Value& root, const std::string& field, int* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isInt()) {
+    return false;
+  }
+  *out = root[field].asInt();
+  return true;
+}
+
+bool ReadNumberField(const Json::Value& root, const std::string& field,
+                     float* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isNumeric()) {
+    return false;
+  }
+  *out = root[field].asFloat();
+  return true;
+}
+
+bool ReadBoolField(const Json::Value& root, const std::string& field,
+                   bool* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isBool()) {
+    return false;
+  }
+  *out = root[field].asBool();
+  return true;
+}
+
+std::string TagToString(uint32_t tag) {
+  std::string value;
+  value.push_back(static_cast<char>((tag >> 24) & 0xFF));
+  value.push_back(static_cast<char>((tag >> 16) & 0xFF));
+  value.push_back(static_cast<char>((tag >> 8) & 0xFF));
+  value.push_back(static_cast<char>(tag & 0xFF));
+  for (char c : value) {
+    if (!std::isprint(static_cast<unsigned char>(c))) {
+      std::ostringstream stream;
+      stream << "0x" << std::hex << std::setw(8) << std::setfill('0') << tag;
+      return stream.str();
+    }
+  }
+  return value;
+}
+
+std::string TrimNullPadding(std::string value) {
+  while (!value.empty() && value.back() == '\0') {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::string CodePointToLabel(uint32_t code_point) {
+  std::ostringstream stream;
+  stream << "U+" << std::uppercase << std::hex
+         << std::setw(code_point <= 0xFFFF ? 4 : 6) << std::setfill('0')
+         << code_point;
+  return stream.str();
+}
+
+bool ParseCodePoint(const std::string& value, uint32_t* code_point) {
+  if (value.size() < 3 || value.rfind("U+", 0) != 0) {
+    return false;
+  }
+  try {
+    size_t consumed = 0;
+    unsigned long parsed = std::stoul(value.substr(2), &consumed, 16);
+    if (consumed != value.size() - 2 || parsed > 0x10FFFFul) {
+      return false;
+    }
+    *code_point = static_cast<uint32_t>(parsed);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::string SlantToString(FontStyle::Slant slant) {
+  switch (slant) {
+    case FontStyle::kUpright_Slant:
+      return "upright";
+    case FontStyle::kItalic_Slant:
+      return "italic";
+    case FontStyle::kOblique_Slant:
+      return "oblique";
+  }
+  return "unknown";
+}
+
+bool SlantFromString(const std::string& value, FontStyle::Slant* slant) {
+  if (value == "upright") {
+    *slant = FontStyle::kUpright_Slant;
+    return true;
+  }
+  if (value == "italic") {
+    *slant = FontStyle::kItalic_Slant;
+    return true;
+  }
+  if (value == "oblique") {
+    *slant = FontStyle::kOblique_Slant;
+    return true;
+  }
+  return false;
+}
+
+std::string HintingToString(Font::FontHinting hinting) {
+  switch (hinting) {
+    case Font::FontHinting::kNone:
+      return "none";
+    case Font::FontHinting::kSlight:
+      return "slight";
+    case Font::FontHinting::kNormal:
+      return "normal";
+    case Font::FontHinting::kFull:
+      return "full";
+  }
+  return "unknown";
+}
+
+Font::FontHinting HintingFromString(const std::string& value) {
+  if (value == "none") {
+    return Font::FontHinting::kNone;
+  }
+  if (value == "slight") {
+    return Font::FontHinting::kSlight;
+  }
+  if (value == "full") {
+    return Font::FontHinting::kFull;
+  }
+  return Font::FontHinting::kNormal;
+}
+
+Json::Value FontStyleToJson(const FontStyle& style) {
+  Json::Value value(Json::objectValue);
+  value["weight"] = style.weight();
+  value["width"] = style.width();
+  value["slant"] = SlantToString(style.slant());
+  return value;
+}
+
+Json::Value FontProbeRequestToJson(const FontProbeRequest& request) {
+  Json::Value value(Json::objectValue);
+  value["size"] = request.size;
+  value["scale_x"] = request.scale_x;
+  value["skew_x"] = request.skew_x;
+  value["linear_metrics"] = request.linear_metrics;
+  value["subpixel"] = request.subpixel;
+  value["embolden"] = request.embolden;
+  value["hinting"] = HintingToString(request.hinting);
+  return value;
+}
+
+Json::Value ParsedRequestToJson(const ParsedFontManagerRequest& request) {
+  Json::Value value(Json::objectValue);
+  value["entry"] = request.entry;
+  if (!request.family_name.empty()) {
+    value["family_name"] = request.family_name;
+  }
+  value["style"] = FontStyleToJson(request.style);
+  if (request.has_character) {
+    value["character"] = request.character_label;
+    value["code_point"] = static_cast<Json::UInt64>(request.character);
+  }
+  Json::Value bcp47(Json::arrayValue);
+  for (const auto& tag : request.bcp47) {
+    bcp47.append(tag);
+  }
+  value["bcp47"] = std::move(bcp47);
+  value["sample_limit"] = request.sample_limit;
+  value["font_request"] = FontProbeRequestToJson(request.font_request);
+  return value;
+}
+
+Json::Value BuildBaseProbeReport(const std::string& case_id,
+                                 const std::string& backend) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_probe_result";
+  report["runner"] = "skity";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  return report;
+}
+
+FontManagerProbeResult BuildFailure(FontManagerProbeStatus status,
+                                    const std::string& case_id,
+                                    const std::string& backend,
+                                    const std::string& reason_code,
+                                    const std::string& message = {}) {
+  FontManagerProbeResult result;
+  result.status = status;
+  result.case_id = case_id;
+  result.backend = backend;
+  result.report = BuildBaseProbeReport(case_id, backend);
+  result.report["reason_code"] = reason_code;
+  if (!message.empty()) {
+    result.report["message"] = message;
+  }
+  return result;
+}
+
+void AddValidationError(Json::Value* report, const std::string& path,
+                        const std::string& message) {
+  Json::Value error(Json::objectValue);
+  error["path"] = path;
+  error["message"] = message;
+  if (!report->isMember("validation_errors")) {
+    (*report)["validation_errors"] = Json::Value(Json::arrayValue);
+  }
+  (*report)["validation_errors"].append(std::move(error));
+}
+
+bool PutFinite(Json::Value* object, const std::string& field, float value,
+               const std::string& path, std::vector<std::string>* errors) {
+  if (!std::isfinite(value)) {
+    errors->push_back(path + "." + field + " is not finite");
+    return false;
+  }
+  (*object)[field] = value;
+  return true;
+}
+
+Json::Value FontMetricsToJson(const FontMetrics& metrics,
+                              const std::string& path,
+                              std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  PutFinite(&value, "top", metrics.top_, path, errors);
+  PutFinite(&value, "ascent", metrics.ascent_, path, errors);
+  PutFinite(&value, "descent", metrics.descent_, path, errors);
+  PutFinite(&value, "bottom", metrics.bottom_, path, errors);
+  PutFinite(&value, "leading", metrics.leading_, path, errors);
+  PutFinite(&value, "avg_char_width", metrics.avg_char_width_, path, errors);
+  PutFinite(&value, "max_char_width", metrics.max_char_width_, path, errors);
+  PutFinite(&value, "x_min", metrics.x_min_, path, errors);
+  PutFinite(&value, "x_max", metrics.x_max_, path, errors);
+  PutFinite(&value, "x_height", metrics.x_height_, path, errors);
+  PutFinite(&value, "cap_height", metrics.cap_height_, path, errors);
+  PutFinite(&value, "underline_thickness", metrics.underline_thickness_, path,
+            errors);
+  PutFinite(&value, "underline_position", metrics.underline_position_, path,
+            errors);
+  PutFinite(&value, "strikeout_thickness", metrics.strikeout_thickness_, path,
+            errors);
+  PutFinite(&value, "strikeout_position", metrics.strikeout_position_, path,
+            errors);
+  return value;
+}
+
+Json::Value Matrix22ToJson(const Matrix22& matrix) {
+  Json::Value value(Json::objectValue);
+  value["scale_x"] = matrix.GetScaleX();
+  value["skew_x"] = matrix.GetSkewX();
+  value["skew_y"] = matrix.GetSkewY();
+  value["scale_y"] = matrix.GetScaleY();
+  return value;
+}
+
+Json::Value ScalerContextDescToJson(const ScalerContextDesc& desc) {
+  Json::Value value(Json::objectValue);
+  value["typeface_id"] = static_cast<Json::UInt64>(desc.typeface_id);
+  value["text_size"] = desc.text_size;
+  value["scale_x"] = desc.scale_x;
+  value["skew_x"] = desc.skew_x;
+  value["transform"] = Matrix22ToJson(desc.transform);
+  value["context_scale"] = desc.context_scale;
+  value["foreground_color"] = static_cast<Json::UInt64>(desc.foreground_color);
+  value["stroke_width"] = desc.stroke_width;
+  value["miter_limit"] = desc.miter_limit;
+  value["cap"] = static_cast<int>(desc.cap);
+  value["join"] = static_cast<int>(desc.join);
+  value["fake_bold"] = desc.fake_bold != 0;
+  value["hinting"] = HintingToString(desc.GetHinting());
+  value["hash"] = static_cast<Json::UInt64>(desc.hash());
+  return value;
+}
+
+Font MakeFont(const std::shared_ptr<Typeface>& typeface,
+              const FontProbeRequest& request) {
+  Font font(typeface, request.size, request.scale_x, request.skew_x);
+  font.SetLinearMetrics(request.linear_metrics);
+  font.SetSubpixel(request.subpixel);
+  font.SetEmbolden(request.embolden);
+  font.SetHinting(request.hinting);
+  return font;
+}
+
+Json::Value FontDescriptorToJson(const FontDescriptor& descriptor) {
+  Json::Value value(Json::objectValue);
+  value["family_name"] = TrimNullPadding(descriptor.family_name);
+  value["post_script_name"] = TrimNullPadding(descriptor.post_script_name);
+  value["full_name"] = TrimNullPadding(descriptor.full_name);
+  value["style"] = FontStyleToJson(descriptor.style);
+  value["collection_index"] = descriptor.collection_index;
+  value["factory_id"] = TagToString(descriptor.factory_id);
+  value["factory_id_value"] = static_cast<Json::UInt64>(descriptor.factory_id);
+  return value;
+}
+
+void AppendGlyphIfMissing(std::vector<GlyphProbeRequest>* glyphs,
+                          const std::string& label, uint32_t code_point) {
+  for (const auto& glyph : *glyphs) {
+    if (glyph.code_point == code_point) {
+      return;
+    }
+  }
+  GlyphProbeRequest glyph;
+  glyph.label = label;
+  glyph.code_point = code_point;
+  glyphs->push_back(std::move(glyph));
+}
+
+std::vector<GlyphProbeRequest> BuildGlyphProbeRequests(
+    const Json::Value& root, const ParsedFontManagerRequest& request) {
+  std::vector<GlyphProbeRequest> glyphs;
+  if (root.isMember("glyphs") && root["glyphs"].isObject() &&
+      root["glyphs"].isMember("chars") && root["glyphs"]["chars"].isArray()) {
+    for (const auto& item : root["glyphs"]["chars"]) {
+      if (!item.isString()) {
+        continue;
+      }
+      uint32_t code_point = 0;
+      const std::string label = item.asString();
+      if (ParseCodePoint(label, &code_point)) {
+        AppendGlyphIfMissing(&glyphs, label, code_point);
+      }
+    }
+  }
+
+  if (glyphs.empty()) {
+    AppendGlyphIfMissing(&glyphs, "U+0041", 0x0041);
+  }
+  if (request.has_character) {
+    AppendGlyphIfMissing(&glyphs, request.character_label, request.character);
+  }
+  return glyphs;
+}
+
+Json::Value GlyphProbeToJson(const std::shared_ptr<Typeface>& typeface,
+                             const std::vector<GlyphProbeRequest>& glyphs) {
+  Json::Value value(Json::arrayValue);
+  for (const auto& glyph : glyphs) {
+    const GlyphID glyph_id = typeface->UnicharToGlyph(glyph.code_point);
+    Json::Value item(Json::objectValue);
+    item["char"] = glyph.label;
+    item["code_point"] = static_cast<Json::UInt64>(glyph.code_point);
+    item["glyph_id"] = static_cast<Json::UInt64>(glyph_id);
+    item["contains"] =
+        typeface->ContainGlyph(static_cast<Unichar>(glyph.code_point));
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+Json::Value BuildProbeSummary(const std::shared_ptr<Typeface>& typeface,
+                              const FontProbeRequest& request,
+                              const std::vector<GlyphProbeRequest>& glyphs,
+                              const std::string& path,
+                              std::vector<std::string>* errors) {
+  Json::Value summary(Json::objectValue);
+  summary["font_request"] = FontProbeRequestToJson(request);
+
+  Font font = MakeFont(typeface, request);
+  Json::Value font_result(Json::objectValue);
+  FontMetrics public_metrics{};
+  font.GetMetrics(&public_metrics);
+  font_result["font_metrics"] = FontMetricsToJson(
+      public_metrics, path + ".font_result.font_metrics", errors);
+  summary["font_result"] = std::move(font_result);
+
+  ScalerContextDesc desc = ScalerContextDesc::MakeCanonicalized(font, Paint());
+  auto scaler_context = typeface->CreateScalerContext(&desc);
+  Json::Value scaler_result(Json::objectValue);
+  scaler_result["desc"] = ScalerContextDescToJson(desc);
+  if (scaler_context == nullptr) {
+    scaler_result["available"] = false;
+    errors->push_back(path + ".scaler_context_result.context is missing");
+  } else {
+    scaler_result["available"] = true;
+    FontMetrics scaler_metrics{};
+    scaler_context->GetFontMetrics(&scaler_metrics);
+    scaler_result["font_metrics"] = FontMetricsToJson(
+        scaler_metrics, path + ".scaler_context_result.font_metrics", errors);
+  }
+  summary["scaler_context_result"] = std::move(scaler_result);
+  summary["glyphs"] = GlyphProbeToJson(typeface, glyphs);
+  return summary;
+}
+
+Json::Value BuildTypefaceSummary(const std::string& label,
+                                 const std::shared_ptr<Typeface>& typeface,
+                                 const FontProbeRequest& request,
+                                 const std::vector<GlyphProbeRequest>& glyphs,
+                                 const std::string& path,
+                                 std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  value["label"] = label;
+  value["available"] = typeface != nullptr;
+  if (typeface == nullptr) {
+    errors->push_back(path + ".typeface is missing");
+    return value;
+  }
+
+  value["typeface_id"] = static_cast<Json::UInt64>(typeface->TypefaceId());
+  value["font_style"] = FontStyleToJson(typeface->GetFontStyle());
+  value["descriptor"] = FontDescriptorToJson(typeface->GetFontDescriptor());
+  value["units_per_em"] = static_cast<Json::UInt64>(typeface->GetUnitsPerEm());
+  value["contains_color_table"] = typeface->ContainsColorTable();
+  value["table_count"] = typeface->CountTables();
+  value["probe_summary"] = BuildProbeSummary(typeface, request, glyphs,
+                                             path + ".probe_summary", errors);
+  return value;
+}
+
+Json::Value BuildFamilySamples(FontManager* font_manager, int family_count,
+                               int sample_limit) {
+  Json::Value samples(Json::arrayValue);
+  const int count = std::min(family_count, sample_limit);
+  for (int i = 0; i < count; ++i) {
+    Json::Value item(Json::objectValue);
+    item["index"] = i;
+    item["family_name"] = font_manager->GetFamilyName(i);
+    samples.append(std::move(item));
+  }
+  return samples;
+}
+
+int FindFamilyIndex(FontManager* font_manager, int family_count,
+                    const std::string& family_name) {
+  if (family_name.empty()) {
+    return -1;
+  }
+  for (int i = 0; i < family_count; ++i) {
+    if (font_manager->GetFamilyName(i) == family_name) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+Json::Value BuildFontManagerState(FontManager* font_manager,
+                                  const ParsedFontManagerRequest& request) {
+  Json::Value state(Json::objectValue);
+  const int family_count = font_manager->CountFamilies();
+  state["family_count"] = family_count;
+  state["family_samples"] =
+      BuildFamilySamples(font_manager, family_count, request.sample_limit);
+
+  if (!request.family_name.empty()) {
+    const int family_index =
+        FindFamilyIndex(font_manager, family_count, request.family_name);
+    state["requested_family_name"] = request.family_name;
+    state["requested_family_found"] = family_index >= 0;
+    state["requested_family_index"] = family_index;
+    if (family_index >= 0) {
+      state["resolved_family_name"] = font_manager->GetFamilyName(family_index);
+    }
+  }
+  return state;
+}
+
+Json::Value BuildStyleSetSummary(const std::string& label,
+                                 const std::shared_ptr<FontStyleSet>& style_set,
+                                 const ParsedFontManagerRequest& request,
+                                 const std::vector<GlyphProbeRequest>& glyphs,
+                                 const std::string& path,
+                                 Json::Value* matched_typefaces,
+                                 std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  value["label"] = label;
+  value["available"] = style_set != nullptr;
+  if (style_set == nullptr) {
+    errors->push_back(path + ".style_set is missing");
+    return value;
+  }
+
+  const int style_count = style_set->Count();
+  value["style_count"] = style_count;
+  if (style_count <= 0) {
+    errors->push_back(path + ".style_count is zero");
+  }
+
+  Json::Value styles(Json::arrayValue);
+  const int sample_count = std::min(style_count, request.sample_limit);
+  for (int i = 0; i < sample_count; ++i) {
+    FontStyle style;
+    std::string style_name;
+    style_set->GetStyle(i, &style, &style_name);
+
+    Json::Value item(Json::objectValue);
+    item["index"] = i;
+    item["style_name"] = style_name;
+    item["style"] = FontStyleToJson(style);
+    item["create_typeface"] = BuildTypefaceSummary(
+        label + ".CreateTypeface", style_set->CreateTypeface(i),
+        request.font_request, glyphs,
+        path + ".styles[" + std::to_string(i) + "].create_typeface", errors);
+    styles.append(std::move(item));
+  }
+  value["styles"] = std::move(styles);
+
+  Json::Value match_style(Json::objectValue);
+  match_style["pattern"] = FontStyleToJson(request.style);
+  Json::Value matched = BuildTypefaceSummary(
+      label + ".MatchStyle", style_set->MatchStyle(request.style),
+      request.font_request, glyphs, path + ".match_style.typeface", errors);
+  match_style["typeface"] = matched;
+  matched_typefaces->append(std::move(matched));
+  value["match_style"] = std::move(match_style);
+  return value;
+}
+
+void ParseFontProbeRequest(const Json::Value& root, FontProbeRequest* request) {
+  if (!root.isMember("font_request") || !root["font_request"].isObject()) {
+    return;
+  }
+  const Json::Value& value = root["font_request"];
+  ReadNumberField(value, "size", &request->size);
+  ReadNumberField(value, "scale_x", &request->scale_x);
+  ReadNumberField(value, "skew_x", &request->skew_x);
+  ReadBoolField(value, "linear_metrics", &request->linear_metrics);
+  ReadBoolField(value, "subpixel", &request->subpixel);
+  ReadBoolField(value, "embolden", &request->embolden);
+
+  std::string hinting;
+  if (ReadStringField(value, "hinting", &hinting)) {
+    request->hinting = HintingFromString(hinting);
+  }
+}
+
+bool ParseStyle(const Json::Value& request, const std::string& path,
+                FontStyle* style, Json::Value* report) {
+  if (!request.isMember("style")) {
+    *style = FontStyle::Normal();
+    return true;
+  }
+  const Json::Value& value = request["style"];
+  if (!value.isObject()) {
+    AddValidationError(report, path + ".style", "expected object");
+    return false;
+  }
+
+  int weight = FontStyle::kNormal_Weight;
+  int width = FontStyle::kNormal_Width;
+  FontStyle::Slant slant = FontStyle::kUpright_Slant;
+  bool valid = true;
+
+  if (value.isMember("weight")) {
+    if (!ReadIntField(value, "weight", &weight) || weight < 0 ||
+        weight > FontStyle::kExtraBlack_Weight) {
+      AddValidationError(report, path + ".style.weight",
+                         "weight must be an integer in [0, 1000]");
+      valid = false;
+    }
+  }
+
+  if (value.isMember("width")) {
+    if (!ReadIntField(value, "width", &width) ||
+        width < FontStyle::kUltraCondensed_Width ||
+        width > FontStyle::kUltraExpanded_Width) {
+      AddValidationError(report, path + ".style.width",
+                         "width must be an integer in [1, 9]");
+      valid = false;
+    }
+  }
+
+  if (value.isMember("slant")) {
+    std::string slant_value;
+    if (!ReadStringField(value, "slant", &slant_value) ||
+        !SlantFromString(slant_value, &slant)) {
+      AddValidationError(report, path + ".style.slant",
+                         "slant must be upright, italic, or oblique");
+      valid = false;
+    }
+  }
+
+  *style = FontStyle(weight, width, slant);
+  return valid;
+}
+
+bool IsKnownEntry(const std::string& entry) {
+  return entry == "GetDefaultTypeface" || entry == "MatchFamily" ||
+         entry == "MatchFamilyStyle" || entry == "MatchFamilyStyleCharacter" ||
+         entry == "CreateStyleSet";
+}
+
+bool RequiresFamilyName(const std::string& entry) {
+  return entry == "MatchFamily" || entry == "MatchFamilyStyle" ||
+         entry == "MatchFamilyStyleCharacter" || entry == "CreateStyleSet";
+}
+
+bool ParseFontManagerRequest(const Json::Value& root,
+                             const std::string& category,
+                             ParsedFontManagerRequest* request,
+                             Json::Value* report) {
+  if (!root.isMember("font_manager_request") ||
+      !root["font_manager_request"].isObject()) {
+    AddValidationError(report, "$.font_manager_request",
+                       "font_manager_request is required");
+    return false;
+  }
+
+  const Json::Value& value = root["font_manager_request"];
+  bool valid = true;
+  if (!ReadStringField(value, "entry", &request->entry) ||
+      !IsKnownEntry(request->entry)) {
+    AddValidationError(report, "$.font_manager_request.entry",
+                       "unsupported FontManager entry");
+    valid = false;
+  }
+
+  if (category == "family_style_set" && request->entry != "CreateStyleSet" &&
+      request->entry != "MatchFamily") {
+    AddValidationError(report, "$.font_manager_request.entry",
+                       "family_style_set supports CreateStyleSet or "
+                       "MatchFamily");
+    valid = false;
+  }
+
+  ReadStringField(value, "family_name", &request->family_name);
+  if (RequiresFamilyName(request->entry) && request->family_name.empty()) {
+    AddValidationError(report, "$.font_manager_request.family_name",
+                       "family_name is required for this entry");
+    valid = false;
+  }
+
+  valid =
+      ParseStyle(value, "$.font_manager_request", &request->style, report) &&
+      valid;
+
+  if (value.isMember("character")) {
+    if (!value["character"].isString() ||
+        !ParseCodePoint(value["character"].asString(), &request->character)) {
+      AddValidationError(report, "$.font_manager_request.character",
+                         "character must be a U+XXXX code point string");
+      valid = false;
+    } else {
+      request->has_character = true;
+      request->character_label = value["character"].asString();
+    }
+  }
+
+  if (request->entry == "MatchFamilyStyleCharacter" &&
+      !request->has_character) {
+    AddValidationError(report, "$.font_manager_request.character",
+                       "character is required for MatchFamilyStyleCharacter");
+    valid = false;
+  }
+
+  if (value.isMember("bcp47")) {
+    if (!value["bcp47"].isArray()) {
+      AddValidationError(report, "$.font_manager_request.bcp47",
+                         "expected array");
+      valid = false;
+    } else {
+      for (Json::ArrayIndex i = 0; i < value["bcp47"].size(); ++i) {
+        if (!value["bcp47"][i].isString()) {
+          AddValidationError(report, "$.font_manager_request.bcp47",
+                             "bcp47 items must be strings");
+          valid = false;
+          continue;
+        }
+        request->bcp47.push_back(value["bcp47"][i].asString());
+      }
+    }
+  }
+
+  if (value.isMember("sample_limit")) {
+    if (!ReadIntField(value, "sample_limit", &request->sample_limit) ||
+        request->sample_limit <= 0) {
+      AddValidationError(report, "$.font_manager_request.sample_limit",
+                         "sample_limit must be a positive integer");
+      valid = false;
+    } else {
+      request->sample_limit = std::min(request->sample_limit, kMaxSampleLimit);
+    }
+  }
+
+  ParseFontProbeRequest(root, &request->font_request);
+  if (!request->has_character && request->character_label.empty()) {
+    request->character_label = CodePointToLabel(request->character);
+  }
+  return valid;
+}
+
+Json::Value BuildFontManagerProbeReport(const Json::Value& root,
+                                        const CaseValidationResult& validation,
+                                        const std::string& category,
+                                        const ParsedFontManagerRequest& request,
+                                        std::vector<std::string>* errors) {
+  Json::Value report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  report["ok"] = true;
+
+  auto font_manager = FontManager::RefDefault();
+  const std::vector<GlyphProbeRequest> glyphs =
+      BuildGlyphProbeRequests(root, request);
+
+  Json::Value probe(Json::objectValue);
+  probe["category"] = category;
+  probe["request"] = ParsedRequestToJson(request);
+  probe["font_manager"] = BuildFontManagerState(font_manager.get(), request);
+  Json::Value matched_typefaces(Json::arrayValue);
+
+  Json::Value operation(Json::objectValue);
+  operation["entry"] = request.entry;
+  if (request.entry == "GetDefaultTypeface") {
+    Json::Value matched = BuildTypefaceSummary(
+        "FontManager.GetDefaultTypeface",
+        font_manager->GetDefaultTypeface(request.style), request.font_request,
+        glyphs, "$.font_manager_probe.operation.matched_typeface", errors);
+    operation["matched_typeface"] = matched;
+    matched_typefaces.append(std::move(matched));
+  } else if (request.entry == "MatchFamily") {
+    operation["style_set"] = BuildStyleSetSummary(
+        "FontManager.MatchFamily",
+        font_manager->MatchFamily(request.family_name.c_str()), request, glyphs,
+        "$.font_manager_probe.operation.style_set", &matched_typefaces, errors);
+  } else if (request.entry == "MatchFamilyStyle") {
+    Json::Value matched = BuildTypefaceSummary(
+        "FontManager.MatchFamilyStyle",
+        font_manager->MatchFamilyStyle(request.family_name.c_str(),
+                                       request.style),
+        request.font_request, glyphs,
+        "$.font_manager_probe.operation.matched_typeface", errors);
+    operation["matched_typeface"] = matched;
+    matched_typefaces.append(std::move(matched));
+  } else if (request.entry == "MatchFamilyStyleCharacter") {
+    std::vector<const char*> bcp47;
+    bcp47.reserve(request.bcp47.size());
+    for (const auto& tag : request.bcp47) {
+      bcp47.push_back(tag.c_str());
+    }
+    Json::Value matched = BuildTypefaceSummary(
+        "FontManager.MatchFamilyStyleCharacter",
+        font_manager->MatchFamilyStyleCharacter(
+            request.family_name.c_str(), request.style,
+            bcp47.empty() ? nullptr : bcp47.data(),
+            static_cast<int>(bcp47.size()),
+            static_cast<Unichar>(request.character)),
+        request.font_request, glyphs,
+        "$.font_manager_probe.operation.matched_typeface", errors);
+    operation["matched_typeface"] = matched;
+    matched_typefaces.append(std::move(matched));
+  } else if (request.entry == "CreateStyleSet") {
+    const int family_count = font_manager->CountFamilies();
+    const int family_index =
+        FindFamilyIndex(font_manager.get(), family_count, request.family_name);
+    operation["requested_family_index"] = family_index;
+    if (family_index < 0) {
+      errors->push_back(
+          "$.font_manager_probe.operation.family_index is "
+          "missing for CreateStyleSet");
+    } else {
+      operation["create_style_set"] = BuildStyleSetSummary(
+          "FontManager.CreateStyleSet",
+          font_manager->CreateStyleSet(family_index), request, glyphs,
+          "$.font_manager_probe.operation.create_style_set", &matched_typefaces,
+          errors);
+    }
+    operation["match_family"] = BuildStyleSetSummary(
+        "FontManager.MatchFamily",
+        font_manager->MatchFamily(request.family_name.c_str()), request, glyphs,
+        "$.font_manager_probe.operation.match_family", &matched_typefaces,
+        errors);
+  } else {
+    errors->push_back("$.font_manager_probe.operation.entry is unsupported");
+  }
+
+  probe["operation"] = std::move(operation);
+  probe["matched_typefaces"] = std::move(matched_typefaces);
+  report["font_manager_probe"] = std::move(probe);
+  return report;
+}
+
+bool IsFontManagerCategory(const std::string& category) {
+  return category == "font_manager" || category == "family_style_set";
+}
+
+}  // namespace
+
+FontManagerProbeResult RunFontManagerProbe(
+    const FontManagerProbeRequest& request) {
+  const std::string fallback_case_id =
+      StemOrFallback(request.case_path, "case");
+  if (request.backend != "coretext") {
+    return BuildFailure(
+        FontManagerProbeStatus::kBackendUnavailable, fallback_case_id,
+        request.backend, "backend_unavailable",
+        "font manager probe supports only the coretext backend");
+  }
+#if !SKITY_FONT_HARNESS_HAS_CORETEXT
+  return BuildFailure(FontManagerProbeStatus::kBackendUnavailable,
+                      fallback_case_id, request.backend, "backend_unavailable",
+                      "CoreText backend is unavailable; build on macOS with "
+                      "SKITY_CT_FONT=ON");
+#else
+  Json::Value root;
+  std::string error;
+  if (!LoadJsonFile(request.case_path, &root, &error)) {
+    return BuildFailure(FontManagerProbeStatus::kSchemaValidationFailed,
+                        fallback_case_id, request.backend,
+                        "schema_validation_failed", error);
+  }
+
+  RepoUriResolver resolver(request.repo_root);
+  CaseValidationResult validation = ValidateCaseDocument(root, resolver);
+  if (validation.case_id.empty()) {
+    validation.case_id = fallback_case_id;
+  }
+  if (validation.backend.empty()) {
+    validation.backend = request.backend;
+  }
+
+  if (!validation.valid) {
+    FontManagerProbeResult result = BuildFailure(
+        FontManagerProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    result.report["validation_errors"] = validation.errors.ToJson();
+    result.report["normalized_case"] = validation.normalized_case;
+    return result;
+  }
+
+  if (validation.backend != request.backend) {
+    FontManagerProbeResult result = BuildFailure(
+        FontManagerProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    AddValidationError(&result.report, "$.backend",
+                       "case backend does not match --backend");
+    return result;
+  }
+
+  std::string category;
+  ReadStringField(root, "category", &category);
+  if (!IsFontManagerCategory(category)) {
+    return BuildFailure(FontManagerProbeStatus::kProbeFailed,
+                        validation.case_id, validation.backend,
+                        "probe_category_unimplemented",
+                        "unsupported case category for font manager probe");
+  }
+
+  Json::Value scratch_report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  ParsedFontManagerRequest font_manager_request;
+  if (!ParseFontManagerRequest(root, category, &font_manager_request,
+                               &scratch_report)) {
+    FontManagerProbeResult result = BuildFailure(
+        FontManagerProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    result.report["validation_errors"] = scratch_report["validation_errors"];
+    return result;
+  }
+
+  std::vector<std::string> probe_errors;
+  FontManagerProbeResult result;
+  result.case_id = validation.case_id;
+  result.backend = validation.backend;
+  result.report = BuildFontManagerProbeReport(
+      root, validation, category, font_manager_request, &probe_errors);
+
+  if (!probe_errors.empty()) {
+    result.status = FontManagerProbeStatus::kProbeFailed;
+    result.report["ok"] = false;
+    result.report["reason_code"] = "font_manager_probe_invalid";
+    Json::Value errors(Json::arrayValue);
+    for (const auto& probe_error : probe_errors) {
+      errors.append(probe_error);
+    }
+    result.report["probe_errors"] = std::move(errors);
+    return result;
+  }
+
+  result.status = FontManagerProbeStatus::kSuccess;
+  return result;
+#endif
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/probe/font_manager_probe.hpp
+++ b/harness/font/probe/font_manager_probe.hpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PROBE_FONT_MANAGER_PROBE_HPP
+#define HARNESS_FONT_PROBE_FONT_MANAGER_PROBE_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class FontManagerProbeStatus {
+  kSuccess,
+  kSchemaValidationFailed,
+  kBackendUnavailable,
+  kProbeFailed,
+};
+
+struct FontManagerProbeRequest {
+  std::filesystem::path repo_root;
+  std::filesystem::path case_path;
+  std::string backend;
+};
+
+struct FontManagerProbeResult {
+  FontManagerProbeStatus status = FontManagerProbeStatus::kProbeFailed;
+  std::string case_id;
+  std::string backend;
+  Json::Value report;
+};
+
+FontManagerProbeResult RunFontManagerProbe(
+    const FontManagerProbeRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PROBE_FONT_MANAGER_PROBE_HPP

--- a/harness/font/probe/glyph_path_probe.cc
+++ b/harness/font/probe/glyph_path_probe.cc
@@ -1,0 +1,760 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/probe/glyph_path_probe.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <skity/graphic/path.hpp>
+#include <skity/io/data.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/glyph.hpp>
+#include <skity/text/typeface.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "harness/font/compare/path/path_normalizer.hpp"
+#include "src/render/text/text_transform.hpp"
+#include "src/text/scaler_context.hpp"
+#include "src/text/scaler_context_desc.hpp"
+
+#ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
+#define SKITY_FONT_HARNESS_HAS_CORETEXT 0
+#endif
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+struct GlyphRequest {
+  std::string source;
+  std::string label;
+  bool has_code_point = false;
+  uint32_t code_point = 0;
+  GlyphID glyph_id = 0;
+};
+
+struct FontRequest {
+  float size = 0.0f;
+  float scale_x = 1.0f;
+  float skew_x = 0.0f;
+  bool linear_metrics = false;
+  bool subpixel = false;
+  bool embolden = false;
+  Font::FontHinting hinting = Font::FontHinting::kNormal;
+};
+
+struct PathExpectation {
+  bool has_empty = false;
+  bool empty = false;
+};
+
+struct PathCompareConfig {
+  std::string mode = "path_normalized";
+  double epsilon = kDefaultPathEpsilon;
+};
+
+enum class GlyphPathOutputMode {
+  kProbe,
+  kDump,
+};
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *out = root[field].asString();
+  return true;
+}
+
+bool ReadNumberField(const Json::Value& root, const std::string& field,
+                     float* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isNumeric()) {
+    return false;
+  }
+  *out = root[field].asFloat();
+  return true;
+}
+
+bool ReadDoubleField(const Json::Value& root, const std::string& field,
+                     double* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isNumeric()) {
+    return false;
+  }
+  *out = root[field].asDouble();
+  return true;
+}
+
+bool ReadBoolField(const Json::Value& root, const std::string& field,
+                   bool* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isBool()) {
+    return false;
+  }
+  *out = root[field].asBool();
+  return true;
+}
+
+uint32_t ParseCodePoint(const std::string& value) {
+  if (value.rfind("U+", 0) != 0) {
+    return 0;
+  }
+  try {
+    return static_cast<uint32_t>(std::stoul(value.substr(2), nullptr, 16));
+  } catch (...) {
+    return 0;
+  }
+}
+
+std::string HintingToString(Font::FontHinting hinting) {
+  switch (hinting) {
+    case Font::FontHinting::kNone:
+      return "none";
+    case Font::FontHinting::kSlight:
+      return "slight";
+    case Font::FontHinting::kNormal:
+      return "normal";
+    case Font::FontHinting::kFull:
+      return "full";
+  }
+  return "unknown";
+}
+
+Font::FontHinting HintingFromString(const std::string& value) {
+  if (value == "none") {
+    return Font::FontHinting::kNone;
+  }
+  if (value == "slight") {
+    return Font::FontHinting::kSlight;
+  }
+  if (value == "full") {
+    return Font::FontHinting::kFull;
+  }
+  return Font::FontHinting::kNormal;
+}
+
+Json::Value BuildBaseReport(const std::string& case_id,
+                            const std::string& backend,
+                            GlyphPathOutputMode output_mode) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = output_mode == GlyphPathOutputMode::kDump
+                                ? "font_path_dump"
+                                : "font_probe_result";
+  report["runner"] = "skity";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  return report;
+}
+
+GlyphPathProbeResult BuildFailure(GlyphPathProbeStatus status,
+                                  const std::string& case_id,
+                                  const std::string& backend,
+                                  const std::string& reason_code,
+                                  GlyphPathOutputMode output_mode,
+                                  const std::string& message = {}) {
+  GlyphPathProbeResult result;
+  result.status = status;
+  result.case_id = case_id;
+  result.backend = backend;
+  result.report = BuildBaseReport(case_id, backend, output_mode);
+  result.report["reason_code"] = reason_code;
+  if (!message.empty()) {
+    result.report["message"] = message;
+  }
+  return result;
+}
+
+void AddValidationError(Json::Value* report, const std::string& path,
+                        const std::string& message) {
+  Json::Value error(Json::objectValue);
+  error["path"] = path;
+  error["message"] = message;
+  if (!report->isMember("validation_errors")) {
+    (*report)["validation_errors"] = Json::Value(Json::arrayValue);
+  }
+  (*report)["validation_errors"].append(std::move(error));
+}
+
+const ResolvedFontFile* FindResolvedFont(
+    const std::vector<ResolvedFontFile>& files, const std::string& id) {
+  for (const auto& file : files) {
+    if (file.id == id) {
+      return &file;
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<Typeface> MakeTypeface(const std::string& entry,
+                                       const ResolvedFontFile& font_file,
+                                       Json::Value* report) {
+  auto font_manager = FontManager::RefDefault();
+  if (entry == "MakeFromFile") {
+    return font_manager->MakeFromFile(font_file.absolute_path.string().c_str(),
+                                      font_file.collection_index);
+  }
+  if (entry == "MakeFromData") {
+    auto data =
+        Data::MakeFromFileName(font_file.absolute_path.string().c_str());
+    Json::Value source(Json::objectValue);
+    source["data_size"] =
+        data ? static_cast<Json::UInt64>(data->Size()) : Json::UInt64(0);
+    (*report)["source_data"] = std::move(source);
+    if (!data || data->IsEmpty()) {
+      return nullptr;
+    }
+    return font_manager->MakeFromData(data, font_file.collection_index);
+  }
+  return nullptr;
+}
+
+Json::Value GlyphRequestToJson(const GlyphRequest& glyph) {
+  Json::Value value(Json::objectValue);
+  value["source"] = glyph.source;
+  value["label"] = glyph.label;
+  if (glyph.has_code_point) {
+    value["code_point"] = static_cast<Json::UInt64>(glyph.code_point);
+  }
+  value["glyph_id"] = static_cast<Json::UInt64>(glyph.glyph_id);
+  return value;
+}
+
+Json::Value Matrix22ToJson(const Matrix22& matrix) {
+  Json::Value value(Json::objectValue);
+  value["scale_x"] = matrix.GetScaleX();
+  value["skew_x"] = matrix.GetSkewX();
+  value["skew_y"] = matrix.GetSkewY();
+  value["scale_y"] = matrix.GetScaleY();
+  return value;
+}
+
+Json::Value ScalerContextDescToJson(const ScalerContextDesc& desc) {
+  Json::Value value(Json::objectValue);
+  value["typeface_id"] = static_cast<Json::UInt64>(desc.typeface_id);
+  value["text_size"] = desc.text_size;
+  value["scale_x"] = desc.scale_x;
+  value["skew_x"] = desc.skew_x;
+  value["transform"] = Matrix22ToJson(desc.transform);
+  value["context_scale"] = desc.context_scale;
+  value["foreground_color"] = static_cast<Json::UInt64>(desc.foreground_color);
+  value["stroke_width"] = desc.stroke_width;
+  value["miter_limit"] = desc.miter_limit;
+  value["cap"] = static_cast<int>(desc.cap);
+  value["join"] = static_cast<int>(desc.join);
+  value["fake_bold"] = desc.fake_bold != 0;
+  value["hinting"] = HintingToString(desc.GetHinting());
+  value["hash"] = static_cast<Json::UInt64>(desc.hash());
+  return value;
+}
+
+Json::Value FontRequestToJson(const FontRequest& request) {
+  Json::Value value(Json::objectValue);
+  value["size"] = request.size;
+  value["scale_x"] = request.scale_x;
+  value["skew_x"] = request.skew_x;
+  value["linear_metrics"] = request.linear_metrics;
+  value["subpixel"] = request.subpixel;
+  value["embolden"] = request.embolden;
+  value["hinting"] = HintingToString(request.hinting);
+  return value;
+}
+
+Font MakeFont(const std::shared_ptr<Typeface>& typeface,
+              const FontRequest& request) {
+  Font font(typeface, request.size, request.scale_x, request.skew_x);
+  font.SetLinearMetrics(request.linear_metrics);
+  font.SetSubpixel(request.subpixel);
+  font.SetEmbolden(request.embolden);
+  font.SetHinting(request.hinting);
+  return font;
+}
+
+bool ParseFontRequest(const Json::Value& root, FontRequest* request,
+                      Json::Value* report) {
+  if (!root.isMember("font_request") || !root["font_request"].isObject()) {
+    AddValidationError(report, "$.font_request",
+                       "font_request is required for glyph path probe");
+    return false;
+  }
+
+  const Json::Value& font_request = root["font_request"];
+  if (!ReadNumberField(font_request, "size", &request->size)) {
+    AddValidationError(report, "$.font_request.size",
+                       "size is required for glyph path probe");
+    return false;
+  }
+  ReadNumberField(font_request, "scale_x", &request->scale_x);
+  ReadNumberField(font_request, "skew_x", &request->skew_x);
+  ReadBoolField(font_request, "linear_metrics", &request->linear_metrics);
+  ReadBoolField(font_request, "subpixel", &request->subpixel);
+  ReadBoolField(font_request, "embolden", &request->embolden);
+
+  std::string hinting;
+  if (ReadStringField(font_request, "hinting", &hinting)) {
+    request->hinting = HintingFromString(hinting);
+  }
+  return true;
+}
+
+std::vector<GlyphRequest> BuildGlyphRequests(
+    const Json::Value& root, const std::shared_ptr<Typeface>& typeface,
+    Json::Value* report) {
+  std::vector<GlyphRequest> glyphs;
+  if (!root.isMember("glyphs") || !root["glyphs"].isObject()) {
+    return glyphs;
+  }
+
+  const Json::Value& glyph_spec = root["glyphs"];
+  if (glyph_spec.isMember("chars") && glyph_spec["chars"].isArray()) {
+    std::vector<uint32_t> code_points;
+    std::vector<std::string> labels;
+    for (const auto& item : glyph_spec["chars"]) {
+      if (!item.isString()) {
+        continue;
+      }
+      labels.push_back(item.asString());
+      code_points.push_back(ParseCodePoint(labels.back()));
+    }
+
+    std::vector<GlyphID> glyph_ids(code_points.size());
+    if (!code_points.empty()) {
+      typeface->UnicharsToGlyphs(code_points.data(),
+                                 static_cast<int>(code_points.size()),
+                                 glyph_ids.data());
+    }
+
+    for (size_t i = 0; i < code_points.size(); ++i) {
+      GlyphRequest glyph;
+      glyph.source = "char";
+      glyph.label = labels[i];
+      glyph.has_code_point = true;
+      glyph.code_point = code_points[i];
+      glyph.glyph_id = glyph_ids[i];
+      glyphs.push_back(std::move(glyph));
+    }
+  }
+
+  if (glyph_spec.isMember("glyph_ids") && glyph_spec["glyph_ids"].isArray()) {
+    for (Json::ArrayIndex i = 0; i < glyph_spec["glyph_ids"].size(); ++i) {
+      const Json::Value& item = glyph_spec["glyph_ids"][i];
+      if (!item.isInt()) {
+        continue;
+      }
+      const int glyph_id = item.asInt();
+      if (glyph_id < 0 || glyph_id > std::numeric_limits<GlyphID>::max()) {
+        AddValidationError(report, "$.glyphs.glyph_ids",
+                           "glyph id must fit uint16_t");
+        continue;
+      }
+      GlyphRequest glyph;
+      glyph.source = "glyph_id";
+      glyph.label = "gid:" + std::to_string(glyph_id);
+      glyph.glyph_id = static_cast<GlyphID>(glyph_id);
+      glyphs.push_back(std::move(glyph));
+    }
+  }
+
+  return glyphs;
+}
+
+PathCompareConfig ParsePathCompareConfig(const Json::Value& root) {
+  PathCompareConfig config;
+  const Json::Value& compare = root["compare"];
+  if (!compare.isObject() || !compare["glyph_path"].isObject()) {
+    return config;
+  }
+
+  const Json::Value& glyph_path = compare["glyph_path"];
+  std::string mode;
+  if (ReadStringField(glyph_path, "mode", &mode) && mode != "backend_default") {
+    config.mode = mode;
+  }
+  ReadDoubleField(glyph_path, "epsilon", &config.epsilon);
+  return config;
+}
+
+bool ParsePathExpectation(const Json::Value& root, PathExpectation* expectation,
+                          Json::Value* report) {
+  if (!root.isMember("path_expectation")) {
+    return true;
+  }
+
+  const Json::Value& path_expectation = root["path_expectation"];
+  if (!path_expectation.isObject()) {
+    AddValidationError(report, "$.path_expectation", "expected object");
+    return false;
+  }
+  if (path_expectation.isMember("empty") &&
+      !path_expectation["empty"].isBool()) {
+    AddValidationError(report, "$.path_expectation.empty", "expected bool");
+    return false;
+  }
+  if (ReadBoolField(path_expectation, "empty", &expectation->empty)) {
+    expectation->has_empty = true;
+  }
+  return true;
+}
+
+Json::Value PathExpectationToJson(const PathExpectation& expectation) {
+  Json::Value value(Json::objectValue);
+  value["has_empty"] = expectation.has_empty;
+  if (expectation.has_empty) {
+    value["empty"] = expectation.empty;
+  }
+  return value;
+}
+
+Json::Value BuildPathItem(const GlyphRequest& glyph, const Path& path,
+                          const std::string& path_prefix,
+                          const PathExpectation& expectation,
+                          const PathNormalizeOptions& normalize_options,
+                          std::vector<std::string>* errors) {
+  Json::Value item = GlyphRequestToJson(glyph);
+  const bool path_empty = path.IsEmpty();
+  const bool path_finite = path.IsFinite();
+  item["path_empty"] = path_empty;
+  item["path_finite"] = path_finite;
+  item["expectation"] = PathExpectationToJson(expectation);
+  item["normalized_path"] = BuildNormalizedPathJson(path, normalize_options);
+
+  if (!path_finite) {
+    errors->push_back(path_prefix + ".path is not finite");
+  }
+  if (expectation.has_empty && expectation.empty != path_empty) {
+    errors->push_back(path_prefix + ".path_empty expected " +
+                      std::string(expectation.empty ? "true" : "false"));
+  }
+  return item;
+}
+
+Json::Value BuildFontGlyphPaths(const Font& font,
+                                const std::vector<GlyphRequest>& glyphs,
+                                const PathExpectation& expectation,
+                                const PathNormalizeOptions& normalize_options,
+                                std::vector<std::string>* errors) {
+  Json::Value value(Json::arrayValue);
+  if (glyphs.empty()) {
+    return value;
+  }
+
+  std::vector<GlyphID> glyph_ids;
+  glyph_ids.reserve(glyphs.size());
+  for (const auto& glyph : glyphs) {
+    glyph_ids.push_back(glyph.glyph_id);
+  }
+
+  std::vector<const GlyphData*> glyph_data(glyphs.size(), nullptr);
+  font.LoadGlyphPath(glyph_ids.data(), static_cast<uint32_t>(glyph_ids.size()),
+                     glyph_data.data());
+
+  for (size_t i = 0; i < glyphs.size(); ++i) {
+    const std::string item_path =
+        "$.glyph_path_probe.font_result.glyph_paths[" + std::to_string(i) + "]";
+    if (glyph_data[i] == nullptr) {
+      Json::Value item = GlyphRequestToJson(glyphs[i]);
+      item["path_empty"] = true;
+      item["path_finite"] = false;
+      item["expectation"] = PathExpectationToJson(expectation);
+      errors->push_back(item_path + ".glyph_data is missing");
+      value.append(std::move(item));
+      continue;
+    }
+    value.append(BuildPathItem(glyphs[i], glyph_data[i]->GetPath(), item_path,
+                               expectation, normalize_options, errors));
+  }
+  return value;
+}
+
+Json::Value BuildScalerGlyphPaths(ScalerContext* scaler_context,
+                                  const std::vector<GlyphRequest>& glyphs,
+                                  const PathExpectation& expectation,
+                                  const PathNormalizeOptions& normalize_options,
+                                  std::vector<std::string>* errors) {
+  Json::Value value(Json::arrayValue);
+  for (size_t i = 0; i < glyphs.size(); ++i) {
+    const std::string item_path =
+        "$.glyph_path_probe.scaler_context_result.glyph_paths[" +
+        std::to_string(i) + "]";
+    GlyphData glyph_data(glyphs[i].glyph_id);
+    scaler_context->MakeGlyph(&glyph_data);
+    scaler_context->GetPath(&glyph_data);
+    value.append(BuildPathItem(glyphs[i], glyph_data.GetPath(), item_path,
+                               expectation, normalize_options, errors));
+  }
+  return value;
+}
+
+Json::Value BuildGlyphPathBody(
+    const Json::Value& root, const std::string& entry,
+    const std::string& font_file_id, const ResolvedFontFile& font_file,
+    const FontRequest& font_request, const std::shared_ptr<Typeface>& typeface,
+    const PathCompareConfig& compare_config, const PathExpectation& expectation,
+    const PathNormalizeOptions& normalize_options,
+    std::vector<std::string>* errors) {
+  Json::Value probe(Json::objectValue);
+  probe["category"] = "glyph_path";
+  probe["path_compare_mode"] = compare_config.mode;
+  probe["path_epsilon"] = compare_config.epsilon;
+  probe["typeface_source"]["entry"] = entry;
+  probe["typeface_source"]["font_file_id"] = font_file_id;
+  probe["typeface_source"]["font_file_uri"] = font_file.uri;
+  probe["typeface_source"]["collection_index"] = font_file.collection_index;
+  probe["font_request"] = FontRequestToJson(font_request);
+  probe["path_expectation"] = PathExpectationToJson(expectation);
+
+  Font font = MakeFont(typeface, font_request);
+  const std::vector<GlyphRequest> glyphs =
+      BuildGlyphRequests(root, typeface, &probe);
+
+  Json::Value glyph_requests(Json::arrayValue);
+  for (const auto& glyph : glyphs) {
+    glyph_requests.append(GlyphRequestToJson(glyph));
+  }
+  probe["glyph_requests"] = std::move(glyph_requests);
+
+  Json::Value font_result(Json::objectValue);
+  font_result["load_path_entry"] = "Font::LoadGlyphPath";
+  font_result["glyph_paths"] =
+      BuildFontGlyphPaths(font, glyphs, expectation, normalize_options, errors);
+  probe["font_result"] = std::move(font_result);
+
+  ScalerContextDesc desc = ScalerContextDesc::MakeCanonicalized(font, Paint());
+  auto scaler_context = typeface->CreateScalerContext(&desc);
+  if (scaler_context == nullptr) {
+    errors->push_back(
+        "$.glyph_path_probe.scaler_context_result.context is "
+        "missing");
+  } else {
+    Json::Value scaler_result(Json::objectValue);
+    scaler_result["desc"] = ScalerContextDescToJson(desc);
+    scaler_result["load_path_entry"] = "ScalerContext::GetPath";
+    scaler_result["glyph_paths"] = BuildScalerGlyphPaths(
+        scaler_context.get(), glyphs, expectation, normalize_options, errors);
+    probe["scaler_context_result"] = std::move(scaler_result);
+  }
+
+  return probe;
+}
+
+Json::Value BuildProbeReport(
+    const Json::Value& root, const CaseValidationResult& validation,
+    const std::string& entry, const std::string& font_file_id,
+    const ResolvedFontFile& font_file, const FontRequest& font_request,
+    const std::shared_ptr<Typeface>& typeface,
+    const PathCompareConfig& compare_config, const PathExpectation& expectation,
+    const PathNormalizeOptions& normalize_options,
+    std::vector<std::string>* errors) {
+  Json::Value report = BuildBaseReport(validation.case_id, validation.backend,
+                                       GlyphPathOutputMode::kProbe);
+  report["ok"] = true;
+  report["glyph_path_probe"] = BuildGlyphPathBody(
+      root, entry, font_file_id, font_file, font_request, typeface,
+      compare_config, expectation, normalize_options, errors);
+  return report;
+}
+
+Json::Value BuildDumpReport(
+    const Json::Value& root, const CaseValidationResult& validation,
+    const std::string& entry, const std::string& font_file_id,
+    const ResolvedFontFile& font_file, const FontRequest& font_request,
+    const std::shared_ptr<Typeface>& typeface,
+    const PathCompareConfig& compare_config, const PathExpectation& expectation,
+    const PathNormalizeOptions& normalize_options,
+    std::vector<std::string>* errors) {
+  Json::Value report = BuildBaseReport(validation.case_id, validation.backend,
+                                       GlyphPathOutputMode::kDump);
+  report["ok"] = true;
+  report["path_dump"] = BuildGlyphPathBody(
+      root, entry, font_file_id, font_file, font_request, typeface,
+      compare_config, expectation, normalize_options, errors);
+  return report;
+}
+
+GlyphPathProbeResult RunGlyphPathInternal(const GlyphPathProbeRequest& request,
+                                          GlyphPathOutputMode output_mode) {
+  const std::string fallback_case_id =
+      StemOrFallback(request.case_path, "case");
+  if (request.backend != "coretext") {
+    return BuildFailure(GlyphPathProbeStatus::kBackendUnavailable,
+                        fallback_case_id, request.backend,
+                        "backend_unavailable", output_mode,
+                        "glyph path probe supports only the coretext backend");
+  }
+#if !SKITY_FONT_HARNESS_HAS_CORETEXT
+  return BuildFailure(GlyphPathProbeStatus::kBackendUnavailable,
+                      fallback_case_id, request.backend, "backend_unavailable",
+                      output_mode,
+                      "CoreText backend is unavailable; build on macOS with "
+                      "SKITY_CT_FONT=ON");
+#else
+  Json::Value root;
+  std::string error;
+  if (!LoadJsonFile(request.case_path, &root, &error)) {
+    return BuildFailure(GlyphPathProbeStatus::kSchemaValidationFailed,
+                        fallback_case_id, request.backend,
+                        "schema_validation_failed", output_mode, error);
+  }
+
+  RepoUriResolver resolver(request.repo_root);
+  CaseValidationResult validation = ValidateCaseDocument(root, resolver);
+  if (validation.case_id.empty()) {
+    validation.case_id = fallback_case_id;
+  }
+  if (validation.backend.empty()) {
+    validation.backend = request.backend;
+  }
+
+  if (!validation.valid) {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    result.report["validation_errors"] = validation.errors.ToJson();
+    result.report["normalized_case"] = validation.normalized_case;
+    return result;
+  }
+
+  if (validation.backend != request.backend) {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    AddValidationError(&result.report, "$.backend",
+                       "case backend does not match --backend");
+    return result;
+  }
+
+  std::string category;
+  ReadStringField(root, "category", &category);
+  if (category != "glyph_path") {
+    return BuildFailure(GlyphPathProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "probe_category_unimplemented",
+                        output_mode,
+                        "unsupported case category for glyph path probe");
+  }
+
+  const Json::Value& typeface_request = root["typeface_request"];
+  std::string entry;
+  std::string font_file_id;
+  ReadStringField(typeface_request, "entry", &entry);
+  ReadStringField(typeface_request, "font_file", &font_file_id);
+
+  if (entry != "MakeFromFile" && entry != "MakeFromData") {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    AddValidationError(&result.report, "$.typeface_request.entry",
+                       "glyph path probe supports only MakeFromFile and "
+                       "MakeFromData");
+    return result;
+  }
+
+  const ResolvedFontFile* font_file =
+      FindResolvedFont(validation.resolved_font_files, font_file_id);
+  if (font_file == nullptr) {
+    return BuildFailure(GlyphPathProbeStatus::kSchemaValidationFailed,
+                        validation.case_id, validation.backend,
+                        "schema_validation_failed", output_mode,
+                        "typeface_request.font_file was not resolved");
+  }
+
+  Json::Value scratch_report =
+      BuildBaseReport(validation.case_id, validation.backend, output_mode);
+  FontRequest font_request;
+  if (!ParseFontRequest(root, &font_request, &scratch_report)) {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    result.report["validation_errors"] = scratch_report["validation_errors"];
+    return result;
+  }
+
+  PathExpectation expectation;
+  if (!ParsePathExpectation(root, &expectation, &scratch_report)) {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    result.report["validation_errors"] = scratch_report["validation_errors"];
+    return result;
+  }
+
+  PathCompareConfig compare_config = ParsePathCompareConfig(root);
+  PathNormalizeOptions normalize_options;
+  normalize_options.epsilon = compare_config.epsilon;
+
+  if (compare_config.mode != "path_normalized") {
+    GlyphPathProbeResult result = BuildFailure(
+        GlyphPathProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed", output_mode);
+    AddValidationError(&result.report, "$.compare.glyph_path.mode",
+                       "glyph path probe supports only path_normalized");
+    return result;
+  }
+
+  auto typeface = MakeTypeface(entry, *font_file, &scratch_report);
+  if (typeface == nullptr) {
+    return BuildFailure(GlyphPathProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "typeface_create_failed",
+                        output_mode,
+                        "failed to create typeface from explicit font source");
+  }
+
+  std::vector<std::string> path_errors;
+  GlyphPathProbeResult result;
+  result.case_id = validation.case_id;
+  result.backend = validation.backend;
+  if (output_mode == GlyphPathOutputMode::kDump) {
+    result.report = BuildDumpReport(
+        root, validation, entry, font_file_id, *font_file, font_request,
+        typeface, compare_config, expectation, normalize_options, &path_errors);
+  } else {
+    result.report = BuildProbeReport(
+        root, validation, entry, font_file_id, *font_file, font_request,
+        typeface, compare_config, expectation, normalize_options, &path_errors);
+  }
+  if (scratch_report.isMember("source_data")) {
+    result.report["source_data"] = scratch_report["source_data"];
+  }
+
+  if (!path_errors.empty()) {
+    result.status = GlyphPathProbeStatus::kProbeFailed;
+    result.report["ok"] = false;
+    result.report["reason_code"] = "path_invalid";
+    Json::Value errors(Json::arrayValue);
+    for (const auto& path_error : path_errors) {
+      errors.append(path_error);
+    }
+    result.report["path_errors"] = std::move(errors);
+    return result;
+  }
+
+  result.status = GlyphPathProbeStatus::kSuccess;
+  return result;
+#endif
+}
+
+}  // namespace
+
+GlyphPathProbeResult RunGlyphPathProbe(const GlyphPathProbeRequest& request) {
+  return RunGlyphPathInternal(request, GlyphPathOutputMode::kProbe);
+}
+
+GlyphPathProbeResult RunGlyphPathDump(const GlyphPathProbeRequest& request) {
+  return RunGlyphPathInternal(request, GlyphPathOutputMode::kDump);
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/probe/glyph_path_probe.hpp
+++ b/harness/font/probe/glyph_path_probe.hpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PROBE_GLYPH_PATH_PROBE_HPP
+#define HARNESS_FONT_PROBE_GLYPH_PATH_PROBE_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class GlyphPathProbeStatus {
+  kSuccess,
+  kSchemaValidationFailed,
+  kBackendUnavailable,
+  kProbeFailed,
+};
+
+struct GlyphPathProbeRequest {
+  std::filesystem::path repo_root;
+  std::filesystem::path case_path;
+  std::string backend;
+};
+
+struct GlyphPathProbeResult {
+  GlyphPathProbeStatus status = GlyphPathProbeStatus::kProbeFailed;
+  std::string case_id;
+  std::string backend;
+  Json::Value report;
+};
+
+GlyphPathProbeResult RunGlyphPathProbe(const GlyphPathProbeRequest& request);
+GlyphPathProbeResult RunGlyphPathDump(const GlyphPathProbeRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PROBE_GLYPH_PATH_PROBE_HPP

--- a/harness/font/probe/metrics_probe.cc
+++ b/harness/font/probe/metrics_probe.cc
@@ -1,0 +1,672 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/probe/metrics_probe.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <skity/geometry/rect.hpp>
+#include <skity/io/data.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/glyph.hpp>
+#include <skity/text/typeface.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "src/render/text/text_transform.hpp"
+#include "src/text/scaler_context.hpp"
+#include "src/text/scaler_context_desc.hpp"
+
+#ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
+#define SKITY_FONT_HARNESS_HAS_CORETEXT 0
+#endif
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+struct GlyphRequest {
+  std::string source;
+  std::string label;
+  bool has_code_point = false;
+  uint32_t code_point = 0;
+  GlyphID glyph_id = 0;
+};
+
+struct FontRequest {
+  float size = 0.0f;
+  float scale_x = 1.0f;
+  float skew_x = 0.0f;
+  bool linear_metrics = false;
+  bool subpixel = false;
+  bool embolden = false;
+  Font::FontHinting hinting = Font::FontHinting::kNormal;
+};
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *out = root[field].asString();
+  return true;
+}
+
+bool ReadNumberField(const Json::Value& root, const std::string& field,
+                     float* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isNumeric()) {
+    return false;
+  }
+  *out = root[field].asFloat();
+  return true;
+}
+
+bool ReadBoolField(const Json::Value& root, const std::string& field,
+                   bool* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isBool()) {
+    return false;
+  }
+  *out = root[field].asBool();
+  return true;
+}
+
+uint32_t ParseCodePoint(const std::string& value) {
+  if (value.rfind("U+", 0) != 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(std::stoul(value.substr(2), nullptr, 16));
+}
+
+std::string HintingToString(Font::FontHinting hinting) {
+  switch (hinting) {
+    case Font::FontHinting::kNone:
+      return "none";
+    case Font::FontHinting::kSlight:
+      return "slight";
+    case Font::FontHinting::kNormal:
+      return "normal";
+    case Font::FontHinting::kFull:
+      return "full";
+  }
+  return "unknown";
+}
+
+Font::FontHinting HintingFromString(const std::string& value) {
+  if (value == "none") {
+    return Font::FontHinting::kNone;
+  }
+  if (value == "slight") {
+    return Font::FontHinting::kSlight;
+  }
+  if (value == "full") {
+    return Font::FontHinting::kFull;
+  }
+  return Font::FontHinting::kNormal;
+}
+
+Json::Value BuildBaseProbeReport(const std::string& case_id,
+                                 const std::string& backend) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_probe_result";
+  report["runner"] = "skity";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  return report;
+}
+
+MetricsProbeResult BuildFailure(MetricsProbeStatus status,
+                                const std::string& case_id,
+                                const std::string& backend,
+                                const std::string& reason_code,
+                                const std::string& message = {}) {
+  MetricsProbeResult result;
+  result.status = status;
+  result.case_id = case_id;
+  result.backend = backend;
+  result.report = BuildBaseProbeReport(case_id, backend);
+  result.report["reason_code"] = reason_code;
+  if (!message.empty()) {
+    result.report["message"] = message;
+  }
+  return result;
+}
+
+void AddValidationError(Json::Value* report, const std::string& path,
+                        const std::string& message) {
+  Json::Value error(Json::objectValue);
+  error["path"] = path;
+  error["message"] = message;
+  if (!report->isMember("validation_errors")) {
+    (*report)["validation_errors"] = Json::Value(Json::arrayValue);
+  }
+  (*report)["validation_errors"].append(std::move(error));
+}
+
+const ResolvedFontFile* FindResolvedFont(
+    const std::vector<ResolvedFontFile>& files, const std::string& id) {
+  for (const auto& file : files) {
+    if (file.id == id) {
+      return &file;
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<Typeface> MakeTypeface(const std::string& entry,
+                                       const ResolvedFontFile& font_file,
+                                       Json::Value* report) {
+  auto font_manager = FontManager::RefDefault();
+  if (entry == "MakeFromFile") {
+    return font_manager->MakeFromFile(font_file.absolute_path.string().c_str(),
+                                      font_file.collection_index);
+  }
+  if (entry == "MakeFromData") {
+    auto data =
+        Data::MakeFromFileName(font_file.absolute_path.string().c_str());
+    Json::Value source(Json::objectValue);
+    source["data_size"] =
+        data ? static_cast<Json::UInt64>(data->Size()) : Json::UInt64(0);
+    (*report)["source_data"] = std::move(source);
+    if (!data || data->IsEmpty()) {
+      return nullptr;
+    }
+    return font_manager->MakeFromData(data, font_file.collection_index);
+  }
+  return nullptr;
+}
+
+bool PutFinite(Json::Value* object, const std::string& field, float value,
+               const std::string& path, std::vector<std::string>* errors) {
+  if (!std::isfinite(value)) {
+    errors->push_back(path + "." + field + " is not finite");
+    return false;
+  }
+  (*object)[field] = value;
+  return true;
+}
+
+Json::Value FontMetricsToJson(const FontMetrics& metrics,
+                              const std::string& path,
+                              std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  PutFinite(&value, "top", metrics.top_, path, errors);
+  PutFinite(&value, "ascent", metrics.ascent_, path, errors);
+  PutFinite(&value, "descent", metrics.descent_, path, errors);
+  PutFinite(&value, "bottom", metrics.bottom_, path, errors);
+  PutFinite(&value, "leading", metrics.leading_, path, errors);
+  PutFinite(&value, "avg_char_width", metrics.avg_char_width_, path, errors);
+  PutFinite(&value, "max_char_width", metrics.max_char_width_, path, errors);
+  PutFinite(&value, "x_min", metrics.x_min_, path, errors);
+  PutFinite(&value, "x_max", metrics.x_max_, path, errors);
+  PutFinite(&value, "x_height", metrics.x_height_, path, errors);
+  PutFinite(&value, "cap_height", metrics.cap_height_, path, errors);
+  PutFinite(&value, "underline_thickness", metrics.underline_thickness_, path,
+            errors);
+  PutFinite(&value, "underline_position", metrics.underline_position_, path,
+            errors);
+  PutFinite(&value, "strikeout_thickness", metrics.strikeout_thickness_, path,
+            errors);
+  PutFinite(&value, "strikeout_position", metrics.strikeout_position_, path,
+            errors);
+  return value;
+}
+
+Json::Value RectToJson(const Rect& rect, const std::string& path,
+                       std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  PutFinite(&value, "left", rect.Left(), path, errors);
+  PutFinite(&value, "top", rect.Top(), path, errors);
+  PutFinite(&value, "right", rect.Right(), path, errors);
+  PutFinite(&value, "bottom", rect.Bottom(), path, errors);
+  PutFinite(&value, "width", rect.Width(), path, errors);
+  PutFinite(&value, "height", rect.Height(), path, errors);
+  value["empty"] = rect.IsEmpty();
+  return value;
+}
+
+Json::Value GlyphDataToJson(const GlyphData& glyph, const std::string& path,
+                            std::vector<std::string>* errors) {
+  Json::Value value(Json::objectValue);
+  value["glyph_id"] = static_cast<Json::UInt64>(glyph.Id());
+  PutFinite(&value, "advance_x", glyph.AdvanceX(), path, errors);
+  PutFinite(&value, "advance_y", glyph.AdvanceY(), path, errors);
+  PutFinite(&value, "width", glyph.GetWidth(), path, errors);
+  PutFinite(&value, "height", glyph.GetHeight(), path, errors);
+  PutFinite(&value, "left", glyph.GetLeft(), path, errors);
+  PutFinite(&value, "top", glyph.GetTop(), path, errors);
+  PutFinite(&value, "hori_bearing_x", glyph.GetHoriBearingX(), path, errors);
+  PutFinite(&value, "hori_bearing_y", glyph.GetHoriBearingY(), path, errors);
+  PutFinite(&value, "y_min", glyph.GetYMin(), path, errors);
+  PutFinite(&value, "y_max", glyph.GetYMax(), path, errors);
+  PutFinite(&value, "font_size", glyph.FontSize(), path, errors);
+  PutFinite(&value, "fixed_size", glyph.FixedSize(), path, errors);
+  value["empty"] = glyph.IsEmpty();
+  value["color"] = glyph.IsColor();
+  value["has_format"] = glyph.GetFormat().has_value();
+  if (glyph.GetFormat().has_value()) {
+    value["format"] = static_cast<int>(*glyph.GetFormat());
+  }
+  return value;
+}
+
+Json::Value GlyphRequestToJson(const GlyphRequest& glyph) {
+  Json::Value value(Json::objectValue);
+  value["source"] = glyph.source;
+  value["label"] = glyph.label;
+  if (glyph.has_code_point) {
+    value["code_point"] = static_cast<Json::UInt64>(glyph.code_point);
+  }
+  value["glyph_id"] = static_cast<Json::UInt64>(glyph.glyph_id);
+  return value;
+}
+
+Json::Value Matrix22ToJson(const Matrix22& matrix) {
+  Json::Value value(Json::objectValue);
+  value["scale_x"] = matrix.GetScaleX();
+  value["skew_x"] = matrix.GetSkewX();
+  value["skew_y"] = matrix.GetSkewY();
+  value["scale_y"] = matrix.GetScaleY();
+  return value;
+}
+
+Json::Value ScalerContextDescToJson(const ScalerContextDesc& desc) {
+  Json::Value value(Json::objectValue);
+  value["typeface_id"] = static_cast<Json::UInt64>(desc.typeface_id);
+  value["text_size"] = desc.text_size;
+  value["scale_x"] = desc.scale_x;
+  value["skew_x"] = desc.skew_x;
+  value["transform"] = Matrix22ToJson(desc.transform);
+  value["context_scale"] = desc.context_scale;
+  value["foreground_color"] = static_cast<Json::UInt64>(desc.foreground_color);
+  value["stroke_width"] = desc.stroke_width;
+  value["miter_limit"] = desc.miter_limit;
+  value["cap"] = static_cast<int>(desc.cap);
+  value["join"] = static_cast<int>(desc.join);
+  value["fake_bold"] = desc.fake_bold != 0;
+  value["hinting"] = HintingToString(desc.GetHinting());
+  value["hash"] = static_cast<Json::UInt64>(desc.hash());
+  return value;
+}
+
+Json::Value FontRequestToJson(const FontRequest& request) {
+  Json::Value value(Json::objectValue);
+  value["size"] = request.size;
+  value["scale_x"] = request.scale_x;
+  value["skew_x"] = request.skew_x;
+  value["linear_metrics"] = request.linear_metrics;
+  value["subpixel"] = request.subpixel;
+  value["embolden"] = request.embolden;
+  value["hinting"] = HintingToString(request.hinting);
+  return value;
+}
+
+Font MakeFont(const std::shared_ptr<Typeface>& typeface,
+              const FontRequest& request) {
+  Font font(typeface, request.size, request.scale_x, request.skew_x);
+  font.SetLinearMetrics(request.linear_metrics);
+  font.SetSubpixel(request.subpixel);
+  font.SetEmbolden(request.embolden);
+  font.SetHinting(request.hinting);
+  return font;
+}
+
+bool ParseFontRequest(const Json::Value& root, FontRequest* request,
+                      Json::Value* report) {
+  if (!root.isMember("font_request") || !root["font_request"].isObject()) {
+    AddValidationError(report, "$.font_request",
+                       "font_request is required for metrics probe");
+    return false;
+  }
+
+  const Json::Value& font_request = root["font_request"];
+  if (!ReadNumberField(font_request, "size", &request->size)) {
+    AddValidationError(report, "$.font_request.size",
+                       "size is required for metrics probe");
+    return false;
+  }
+  ReadNumberField(font_request, "scale_x", &request->scale_x);
+  ReadNumberField(font_request, "skew_x", &request->skew_x);
+  ReadBoolField(font_request, "linear_metrics", &request->linear_metrics);
+  ReadBoolField(font_request, "subpixel", &request->subpixel);
+  ReadBoolField(font_request, "embolden", &request->embolden);
+
+  std::string hinting;
+  if (ReadStringField(font_request, "hinting", &hinting)) {
+    request->hinting = HintingFromString(hinting);
+  }
+  return true;
+}
+
+std::vector<GlyphRequest> BuildGlyphRequests(
+    const Json::Value& root, const std::shared_ptr<Typeface>& typeface,
+    Json::Value* report) {
+  std::vector<GlyphRequest> glyphs;
+  if (!root.isMember("glyphs") || !root["glyphs"].isObject()) {
+    return glyphs;
+  }
+
+  const Json::Value& glyph_spec = root["glyphs"];
+  if (glyph_spec.isMember("chars") && glyph_spec["chars"].isArray()) {
+    std::vector<uint32_t> code_points;
+    std::vector<std::string> labels;
+    for (const auto& item : glyph_spec["chars"]) {
+      if (!item.isString()) {
+        continue;
+      }
+      labels.push_back(item.asString());
+      code_points.push_back(ParseCodePoint(labels.back()));
+    }
+
+    std::vector<GlyphID> glyph_ids(code_points.size());
+    if (!code_points.empty()) {
+      typeface->UnicharsToGlyphs(code_points.data(),
+                                 static_cast<int>(code_points.size()),
+                                 glyph_ids.data());
+    }
+
+    for (size_t i = 0; i < code_points.size(); ++i) {
+      GlyphRequest glyph;
+      glyph.source = "char";
+      glyph.label = labels[i];
+      glyph.has_code_point = true;
+      glyph.code_point = code_points[i];
+      glyph.glyph_id = glyph_ids[i];
+      glyphs.push_back(std::move(glyph));
+    }
+  }
+
+  if (glyph_spec.isMember("glyph_ids") && glyph_spec["glyph_ids"].isArray()) {
+    for (Json::ArrayIndex i = 0; i < glyph_spec["glyph_ids"].size(); ++i) {
+      const Json::Value& item = glyph_spec["glyph_ids"][i];
+      if (!item.isInt()) {
+        continue;
+      }
+      const int glyph_id = item.asInt();
+      if (glyph_id < 0 || glyph_id > std::numeric_limits<GlyphID>::max()) {
+        AddValidationError(report, "$.glyphs.glyph_ids",
+                           "glyph id must fit uint16_t");
+        continue;
+      }
+      GlyphRequest glyph;
+      glyph.source = "glyph_id";
+      glyph.label = "gid:" + std::to_string(glyph_id);
+      glyph.glyph_id = static_cast<GlyphID>(glyph_id);
+      glyphs.push_back(std::move(glyph));
+    }
+  }
+
+  return glyphs;
+}
+
+Json::Value BuildFontGlyphMetrics(const Font& font,
+                                  const std::vector<GlyphRequest>& glyphs,
+                                  std::vector<std::string>* errors) {
+  Json::Value value(Json::arrayValue);
+  if (glyphs.empty()) {
+    return value;
+  }
+
+  std::vector<GlyphID> glyph_ids;
+  glyph_ids.reserve(glyphs.size());
+  for (const auto& glyph : glyphs) {
+    glyph_ids.push_back(glyph.glyph_id);
+  }
+
+  std::vector<float> widths(glyphs.size());
+  std::vector<Rect> bounds(glyphs.size());
+  font.GetWidthsBounds(glyph_ids.data(), static_cast<int>(glyph_ids.size()),
+                       widths.data(), bounds.data(), Paint());
+
+  std::vector<const GlyphData*> glyph_data(glyphs.size(), nullptr);
+  font.LoadGlyphMetrics(glyph_ids.data(),
+                        static_cast<uint32_t>(glyph_ids.size()),
+                        glyph_data.data(), Paint());
+
+  for (size_t i = 0; i < glyphs.size(); ++i) {
+    const std::string item_path =
+        "$.font_result.glyph_metrics[" + std::to_string(i) + "]";
+    Json::Value item = GlyphRequestToJson(glyphs[i]);
+    PutFinite(&item, "width", widths[i], item_path, errors);
+    item["bounds"] = RectToJson(bounds[i], item_path + ".bounds", errors);
+    if (glyph_data[i] == nullptr) {
+      errors->push_back(item_path + ".glyph_data is missing");
+    } else {
+      item["glyph_data"] =
+          GlyphDataToJson(*glyph_data[i], item_path + ".glyph_data", errors);
+    }
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+Json::Value BuildScalerGlyphMetrics(ScalerContext* scaler_context,
+                                    const std::vector<GlyphRequest>& glyphs,
+                                    std::vector<std::string>* errors) {
+  Json::Value value(Json::arrayValue);
+  for (size_t i = 0; i < glyphs.size(); ++i) {
+    const std::string item_path =
+        "$.scaler_context_result.glyph_metrics[" + std::to_string(i) + "]";
+    GlyphData glyph_data(glyphs[i].glyph_id);
+    scaler_context->MakeGlyph(&glyph_data);
+
+    Json::Value item = GlyphRequestToJson(glyphs[i]);
+    item["glyph_data"] =
+        GlyphDataToJson(glyph_data, item_path + ".glyph_data", errors);
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+Json::Value BuildMetricsReport(
+    const Json::Value& root, const CaseValidationResult& validation,
+    const std::string& category, const std::string& entry,
+    const std::string& font_file_id, const ResolvedFontFile& font_file,
+    const FontRequest& font_request, const std::shared_ptr<Typeface>& typeface,
+    std::vector<std::string>* errors) {
+  Json::Value report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  report["ok"] = true;
+
+  Json::Value probe(Json::objectValue);
+  probe["category"] = category;
+  probe["typeface_source"]["entry"] = entry;
+  probe["typeface_source"]["font_file_id"] = font_file_id;
+  probe["typeface_source"]["font_file_uri"] = font_file.uri;
+  probe["typeface_source"]["collection_index"] = font_file.collection_index;
+  probe["font_request"] = FontRequestToJson(font_request);
+
+  Font font = MakeFont(typeface, font_request);
+  const std::vector<GlyphRequest> glyphs =
+      BuildGlyphRequests(root, typeface, &report);
+
+  Json::Value glyph_requests(Json::arrayValue);
+  for (const auto& glyph : glyphs) {
+    glyph_requests.append(GlyphRequestToJson(glyph));
+  }
+  probe["glyph_requests"] = std::move(glyph_requests);
+
+  FontMetrics public_metrics{};
+  font.GetMetrics(&public_metrics);
+  Json::Value font_result(Json::objectValue);
+  font_result["font_metrics"] =
+      FontMetricsToJson(public_metrics, "$.font_result.font_metrics", errors);
+  font_result["glyph_metrics"] = BuildFontGlyphMetrics(font, glyphs, errors);
+  probe["font_result"] = std::move(font_result);
+
+  ScalerContextDesc desc = ScalerContextDesc::MakeCanonicalized(font, Paint());
+  auto scaler_context = typeface->CreateScalerContext(&desc);
+  if (scaler_context == nullptr) {
+    errors->push_back("$.scaler_context_result.context is missing");
+  } else {
+    Json::Value scaler_result(Json::objectValue);
+    scaler_result["desc"] = ScalerContextDescToJson(desc);
+    scaler_result["generate_metrics_entry"] =
+        "ScalerContext::MakeGlyph -> GenerateMetrics";
+
+    FontMetrics scaler_metrics{};
+    scaler_context->GetFontMetrics(&scaler_metrics);
+    scaler_result["font_metrics"] = FontMetricsToJson(
+        scaler_metrics, "$.scaler_context_result.font_metrics", errors);
+    scaler_result["glyph_metrics"] =
+        BuildScalerGlyphMetrics(scaler_context.get(), glyphs, errors);
+    probe["scaler_context_result"] = std::move(scaler_result);
+  }
+
+  report["metrics_probe"] = std::move(probe);
+  return report;
+}
+
+bool IsMetricsCategory(const std::string& category) {
+  return category == "font_metrics" || category == "glyph_metrics" ||
+         category == "scaler_context";
+}
+
+}  // namespace
+
+MetricsProbeResult RunMetricsProbe(const MetricsProbeRequest& request) {
+  const std::string fallback_case_id =
+      StemOrFallback(request.case_path, "case");
+  if (request.backend != "coretext") {
+    return BuildFailure(MetricsProbeStatus::kBackendUnavailable,
+                        fallback_case_id, request.backend,
+                        "backend_unavailable",
+                        "metrics probe supports only the coretext backend");
+  }
+#if !SKITY_FONT_HARNESS_HAS_CORETEXT
+  return BuildFailure(MetricsProbeStatus::kBackendUnavailable, fallback_case_id,
+                      request.backend, "backend_unavailable",
+                      "CoreText backend is unavailable; build on macOS with "
+                      "SKITY_CT_FONT=ON");
+#else
+  Json::Value root;
+  std::string error;
+  if (!LoadJsonFile(request.case_path, &root, &error)) {
+    return BuildFailure(MetricsProbeStatus::kSchemaValidationFailed,
+                        fallback_case_id, request.backend,
+                        "schema_validation_failed", error);
+  }
+
+  RepoUriResolver resolver(request.repo_root);
+  CaseValidationResult validation = ValidateCaseDocument(root, resolver);
+  if (validation.case_id.empty()) {
+    validation.case_id = fallback_case_id;
+  }
+  if (validation.backend.empty()) {
+    validation.backend = request.backend;
+  }
+
+  if (!validation.valid) {
+    MetricsProbeResult result = BuildFailure(
+        MetricsProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    result.report["validation_errors"] = validation.errors.ToJson();
+    result.report["normalized_case"] = validation.normalized_case;
+    return result;
+  }
+
+  if (validation.backend != request.backend) {
+    MetricsProbeResult result = BuildFailure(
+        MetricsProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    AddValidationError(&result.report, "$.backend",
+                       "case backend does not match --backend");
+    return result;
+  }
+
+  std::string category;
+  ReadStringField(root, "category", &category);
+  if (!IsMetricsCategory(category)) {
+    return BuildFailure(MetricsProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "probe_category_unimplemented",
+                        "unsupported case category for metrics probe");
+  }
+
+  const Json::Value& typeface_request = root["typeface_request"];
+  std::string entry;
+  std::string font_file_id;
+  ReadStringField(typeface_request, "entry", &entry);
+  ReadStringField(typeface_request, "font_file", &font_file_id);
+
+  if (entry != "MakeFromFile" && entry != "MakeFromData") {
+    MetricsProbeResult result = BuildFailure(
+        MetricsProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    AddValidationError(&result.report, "$.typeface_request.entry",
+                       "metrics probe supports only MakeFromFile and "
+                       "MakeFromData");
+    return result;
+  }
+
+  const ResolvedFontFile* font_file =
+      FindResolvedFont(validation.resolved_font_files, font_file_id);
+  if (font_file == nullptr) {
+    return BuildFailure(MetricsProbeStatus::kSchemaValidationFailed,
+                        validation.case_id, validation.backend,
+                        "schema_validation_failed",
+                        "typeface_request.font_file was not resolved");
+  }
+
+  Json::Value scratch_report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  FontRequest font_request;
+  if (!ParseFontRequest(root, &font_request, &scratch_report)) {
+    MetricsProbeResult result = BuildFailure(
+        MetricsProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    result.report["validation_errors"] = scratch_report["validation_errors"];
+    return result;
+  }
+
+  auto typeface = MakeTypeface(entry, *font_file, &scratch_report);
+  if (typeface == nullptr) {
+    return BuildFailure(MetricsProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "typeface_create_failed",
+                        "failed to create typeface from explicit font source");
+  }
+
+  std::vector<std::string> metrics_errors;
+  MetricsProbeResult result;
+  result.case_id = validation.case_id;
+  result.backend = validation.backend;
+  result.report =
+      BuildMetricsReport(root, validation, category, entry, font_file_id,
+                         *font_file, font_request, typeface, &metrics_errors);
+  if (scratch_report.isMember("source_data")) {
+    result.report["source_data"] = scratch_report["source_data"];
+  }
+
+  if (!metrics_errors.empty()) {
+    result.status = MetricsProbeStatus::kProbeFailed;
+    result.report["ok"] = false;
+    result.report["reason_code"] = "metrics_invalid";
+    Json::Value errors(Json::arrayValue);
+    for (const auto& metric_error : metrics_errors) {
+      errors.append(metric_error);
+    }
+    result.report["metrics_errors"] = std::move(errors);
+    return result;
+  }
+
+  result.status = MetricsProbeStatus::kSuccess;
+  return result;
+#endif
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/probe/metrics_probe.hpp
+++ b/harness/font/probe/metrics_probe.hpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PROBE_METRICS_PROBE_HPP
+#define HARNESS_FONT_PROBE_METRICS_PROBE_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class MetricsProbeStatus {
+  kSuccess,
+  kSchemaValidationFailed,
+  kBackendUnavailable,
+  kProbeFailed,
+};
+
+struct MetricsProbeRequest {
+  std::filesystem::path repo_root;
+  std::filesystem::path case_path;
+  std::string backend;
+};
+
+struct MetricsProbeResult {
+  MetricsProbeStatus status = MetricsProbeStatus::kProbeFailed;
+  std::string case_id;
+  std::string backend;
+  Json::Value report;
+};
+
+MetricsProbeResult RunMetricsProbe(const MetricsProbeRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PROBE_METRICS_PROBE_HPP

--- a/harness/font/probe/typeface_probe.cc
+++ b/harness/font/probe/typeface_probe.cc
@@ -1,0 +1,444 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/probe/typeface_probe.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+#include <skity/io/data.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/typeface.hpp>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+
+#ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
+#define SKITY_FONT_HARNESS_HAS_CORETEXT 0
+#endif
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+constexpr size_t kMaxTableSampleBytes = 4096;
+
+std::string StemOrFallback(const std::filesystem::path& path,
+                           const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool ReadStringField(const Json::Value& root, const std::string& field,
+                     std::string* out) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *out = root[field].asString();
+  return true;
+}
+
+std::string TagToString(uint32_t tag) {
+  std::string value;
+  value.push_back(static_cast<char>((tag >> 24) & 0xFF));
+  value.push_back(static_cast<char>((tag >> 16) & 0xFF));
+  value.push_back(static_cast<char>((tag >> 8) & 0xFF));
+  value.push_back(static_cast<char>(tag & 0xFF));
+  for (char c : value) {
+    if (!std::isprint(static_cast<unsigned char>(c))) {
+      std::ostringstream stream;
+      stream << "0x" << std::hex << std::setw(8) << std::setfill('0') << tag;
+      return stream.str();
+    }
+  }
+  return value;
+}
+
+std::string SlantToString(FontStyle::Slant slant) {
+  switch (slant) {
+    case FontStyle::kUpright_Slant:
+      return "upright";
+    case FontStyle::kItalic_Slant:
+      return "italic";
+    case FontStyle::kOblique_Slant:
+      return "oblique";
+  }
+  return "unknown";
+}
+
+Json::Value FontStyleToJson(const FontStyle& style) {
+  Json::Value value(Json::objectValue);
+  value["weight"] = style.weight();
+  value["width"] = style.width();
+  value["slant"] = SlantToString(style.slant());
+  return value;
+}
+
+Json::Value VariationPositionToJson(const VariationPosition& position) {
+  std::vector<VariationPosition::Coordinate> coordinates(
+      position.GetCoordinates().begin(), position.GetCoordinates().end());
+  std::sort(coordinates.begin(), coordinates.end(),
+            [](const auto& lhs, const auto& rhs) {
+              if (lhs.axis != rhs.axis) {
+                return lhs.axis < rhs.axis;
+              }
+              return lhs.value < rhs.value;
+            });
+
+  Json::Value value(Json::arrayValue);
+  for (const auto& coordinate : coordinates) {
+    Json::Value item(Json::objectValue);
+    item["axis"] = TagToString(coordinate.axis);
+    item["axis_value"] = static_cast<Json::UInt64>(coordinate.axis);
+    item["value"] = coordinate.value;
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+Json::Value VariationAxesToJson(std::vector<VariationAxis> axes) {
+  std::sort(axes.begin(), axes.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.tag < rhs.tag; });
+
+  Json::Value value(Json::arrayValue);
+  for (const auto& axis : axes) {
+    Json::Value item(Json::objectValue);
+    item["tag"] = TagToString(axis.tag);
+    item["tag_value"] = static_cast<Json::UInt64>(axis.tag);
+    item["min"] = axis.min;
+    item["default"] = axis.def;
+    item["max"] = axis.max;
+    item["hidden"] = axis.hidden;
+    value.append(std::move(item));
+  }
+  return value;
+}
+
+Json::Value FontDescriptorToJson(const FontDescriptor& descriptor,
+                                 const std::string& font_uri) {
+  Json::Value value(Json::objectValue);
+  value["family_name"] = descriptor.family_name;
+  value["post_script_name"] = descriptor.post_script_name;
+  value["full_name"] = descriptor.full_name;
+  value["style"] = FontStyleToJson(descriptor.style);
+  value["collection_index"] = descriptor.collection_index;
+  value["font_file"] = font_uri;
+  value["variation_position"] =
+      VariationPositionToJson(descriptor.variation_position);
+  value["factory_id"] = TagToString(descriptor.factory_id);
+  value["factory_id_value"] = static_cast<Json::UInt64>(descriptor.factory_id);
+  return value;
+}
+
+uint32_t ParseCodePoint(const std::string& value) {
+  if (value.rfind("U+", 0) != 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(std::stoul(value.substr(2), nullptr, 16));
+}
+
+Json::Value GlyphsToJson(const Json::Value& root,
+                         const std::shared_ptr<Typeface>& typeface) {
+  Json::Value glyphs(Json::arrayValue);
+  if (!root.isMember("glyphs") || !root["glyphs"].isObject() ||
+      !root["glyphs"].isMember("chars") || !root["glyphs"]["chars"].isArray()) {
+    return glyphs;
+  }
+
+  std::vector<uint32_t> code_points;
+  std::vector<std::string> labels;
+  for (const auto& item : root["glyphs"]["chars"]) {
+    if (!item.isString()) {
+      continue;
+    }
+    labels.push_back(item.asString());
+    code_points.push_back(ParseCodePoint(labels.back()));
+  }
+
+  std::vector<GlyphID> sequence_glyphs(code_points.size());
+  if (!code_points.empty()) {
+    typeface->UnicharsToGlyphs(code_points.data(),
+                               static_cast<int>(code_points.size()),
+                               sequence_glyphs.data());
+  }
+
+  for (size_t i = 0; i < code_points.size(); ++i) {
+    const GlyphID single_glyph = typeface->UnicharToGlyph(code_points[i]);
+    Json::Value glyph(Json::objectValue);
+    glyph["char"] = labels[i];
+    glyph["code_point"] = static_cast<Json::UInt64>(code_points[i]);
+    glyph["glyph_id"] = static_cast<Json::UInt64>(single_glyph);
+    glyph["sequence_glyph_id"] = static_cast<Json::UInt64>(sequence_glyphs[i]);
+    glyph["contains"] = typeface->ContainGlyph(code_points[i]);
+    glyphs.append(std::move(glyph));
+  }
+  return glyphs;
+}
+
+Json::Value TablesToJson(const std::shared_ptr<Typeface>& typeface,
+                         int* table_count, int* copied_tag_count) {
+  *table_count = typeface->CountTables();
+  *copied_tag_count = 0;
+  Json::Value tables(Json::arrayValue);
+  if (*table_count <= 0) {
+    return tables;
+  }
+
+  std::vector<FontTableTag> tags(static_cast<size_t>(*table_count));
+  *copied_tag_count = typeface->GetTableTags(tags.data());
+  tags.resize(static_cast<size_t>(*copied_tag_count));
+  std::sort(tags.begin(), tags.end());
+
+  for (FontTableTag tag : tags) {
+    const size_t table_size = typeface->GetTableSize(tag);
+    const size_t sample_size = std::min(table_size, kMaxTableSampleBytes);
+    std::vector<uint8_t> sample(sample_size);
+    const size_t copied_size =
+        sample_size == 0
+            ? 0
+            : typeface->GetTableData(tag, 0, sample_size, sample.data());
+
+    Json::Value table(Json::objectValue);
+    table["tag"] = TagToString(tag);
+    table["tag_value"] = static_cast<Json::UInt64>(tag);
+    table["size"] = static_cast<Json::UInt64>(table_size);
+    table["sample_size"] = static_cast<Json::UInt64>(sample_size);
+    table["copied_size"] = static_cast<Json::UInt64>(copied_size);
+    tables.append(std::move(table));
+  }
+  return tables;
+}
+
+Json::Value BuildBaseProbeReport(const std::string& case_id,
+                                 const std::string& backend) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_probe_result";
+  report["runner"] = "skity";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  return report;
+}
+
+TypefaceProbeResult BuildFailure(TypefaceProbeStatus status,
+                                 const std::string& case_id,
+                                 const std::string& backend,
+                                 const std::string& reason_code,
+                                 const std::string& message = {}) {
+  TypefaceProbeResult result;
+  result.status = status;
+  result.case_id = case_id;
+  result.backend = backend;
+  result.report = BuildBaseProbeReport(case_id, backend);
+  result.report["reason_code"] = reason_code;
+  if (!message.empty()) {
+    result.report["message"] = message;
+  }
+  return result;
+}
+
+void AddValidationError(Json::Value* report, const std::string& path,
+                        const std::string& message) {
+  Json::Value error(Json::objectValue);
+  error["path"] = path;
+  error["message"] = message;
+  if (!report->isMember("validation_errors")) {
+    (*report)["validation_errors"] = Json::Value(Json::arrayValue);
+  }
+  (*report)["validation_errors"].append(std::move(error));
+}
+
+const ResolvedFontFile* FindResolvedFont(
+    const std::vector<ResolvedFontFile>& files, const std::string& id) {
+  for (const auto& file : files) {
+    if (file.id == id) {
+      return &file;
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<Typeface> MakeTypeface(const std::string& entry,
+                                       const ResolvedFontFile& font_file,
+                                       Json::Value* report) {
+  auto font_manager = FontManager::RefDefault();
+  if (entry == "MakeFromFile") {
+    return font_manager->MakeFromFile(font_file.absolute_path.string().c_str(),
+                                      font_file.collection_index);
+  }
+  if (entry == "MakeFromData") {
+    auto data =
+        Data::MakeFromFileName(font_file.absolute_path.string().c_str());
+    Json::Value source(Json::objectValue);
+    source["data_size"] =
+        data ? static_cast<Json::UInt64>(data->Size()) : Json::UInt64(0);
+    (*report)["source_data"] = std::move(source);
+    if (!data || data->IsEmpty()) {
+      return nullptr;
+    }
+    return font_manager->MakeFromData(data, font_file.collection_index);
+  }
+  return nullptr;
+}
+
+Json::Value BuildSuccessReport(const Json::Value& root,
+                               const CaseValidationResult& validation,
+                               const std::string& entry,
+                               const std::string& font_file_id,
+                               const ResolvedFontFile& font_file,
+                               const std::shared_ptr<Typeface>& typeface) {
+  Json::Value report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  report["ok"] = true;
+
+  Json::Value typeface_result(Json::objectValue);
+  typeface_result["ok"] = true;
+  typeface_result["request_entry"] = entry;
+  typeface_result["font_file_id"] = font_file_id;
+  typeface_result["font_file_uri"] = font_file.uri;
+  typeface_result["collection_index"] = font_file.collection_index;
+  typeface_result["typeface"] =
+      FontDescriptorToJson(typeface->GetFontDescriptor(), font_file.uri);
+  report["typeface_result"] = std::move(typeface_result);
+
+  Json::Value probe(Json::objectValue);
+  probe["units_per_em"] = static_cast<Json::UInt64>(typeface->GetUnitsPerEm());
+  probe["contains_color_table"] = typeface->ContainsColorTable();
+
+  auto data = typeface->GetData();
+  probe["data_size"] =
+      data ? static_cast<Json::UInt64>(data->Size()) : Json::UInt64(0);
+
+  int table_count = 0;
+  int copied_tag_count = 0;
+  probe["tables"] = TablesToJson(typeface, &table_count, &copied_tag_count);
+  probe["table_count"] = table_count;
+  probe["copied_table_tag_count"] = copied_tag_count;
+  probe["variation_position"] =
+      VariationPositionToJson(typeface->GetVariationDesignPosition());
+  probe["variation_axes"] =
+      VariationAxesToJson(typeface->GetVariationDesignParameters());
+  probe["glyphs"] = GlyphsToJson(root, typeface);
+  report["typeface_probe"] = std::move(probe);
+
+  return report;
+}
+
+}  // namespace
+
+TypefaceProbeResult RunTypefaceProbe(const TypefaceProbeRequest& request) {
+  const std::string fallback_case_id =
+      StemOrFallback(request.case_path, "case");
+  if (request.backend != "coretext") {
+    return BuildFailure(TypefaceProbeStatus::kBackendUnavailable,
+                        fallback_case_id, request.backend,
+                        "backend_unavailable",
+                        "typeface probe supports only the coretext backend");
+  }
+#if !SKITY_FONT_HARNESS_HAS_CORETEXT
+  return BuildFailure(TypefaceProbeStatus::kBackendUnavailable,
+                      fallback_case_id, request.backend, "backend_unavailable",
+                      "CoreText backend is unavailable; build on macOS with "
+                      "SKITY_CT_FONT=ON");
+#else
+  Json::Value root;
+  std::string error;
+  if (!LoadJsonFile(request.case_path, &root, &error)) {
+    return BuildFailure(TypefaceProbeStatus::kSchemaValidationFailed,
+                        fallback_case_id, request.backend,
+                        "schema_validation_failed", error);
+  }
+
+  RepoUriResolver resolver(request.repo_root);
+  CaseValidationResult validation = ValidateCaseDocument(root, resolver);
+  if (validation.case_id.empty()) {
+    validation.case_id = fallback_case_id;
+  }
+  if (validation.backend.empty()) {
+    validation.backend = request.backend;
+  }
+
+  if (!validation.valid) {
+    TypefaceProbeResult result = BuildFailure(
+        TypefaceProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    result.report["validation_errors"] = validation.errors.ToJson();
+    result.report["normalized_case"] = validation.normalized_case;
+    return result;
+  }
+
+  if (validation.backend != request.backend) {
+    TypefaceProbeResult result = BuildFailure(
+        TypefaceProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    AddValidationError(&result.report, "$.backend",
+                       "case backend does not match --backend");
+    return result;
+  }
+
+  std::string category;
+  ReadStringField(root, "category", &category);
+  if (category != "typeface_probe") {
+    return BuildFailure(TypefaceProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "probe_category_unimplemented",
+                        "unsupported case category for typeface probe");
+  }
+
+  const Json::Value& typeface_request = root["typeface_request"];
+  std::string entry;
+  std::string font_file_id;
+  ReadStringField(typeface_request, "entry", &entry);
+  ReadStringField(typeface_request, "font_file", &font_file_id);
+
+  if (entry != "MakeFromFile" && entry != "MakeFromData") {
+    TypefaceProbeResult result = BuildFailure(
+        TypefaceProbeStatus::kSchemaValidationFailed, validation.case_id,
+        validation.backend, "schema_validation_failed");
+    AddValidationError(&result.report, "$.typeface_request.entry",
+                       "typeface probe supports only MakeFromFile and "
+                       "MakeFromData");
+    return result;
+  }
+
+  const ResolvedFontFile* font_file =
+      FindResolvedFont(validation.resolved_font_files, font_file_id);
+  if (font_file == nullptr) {
+    return BuildFailure(TypefaceProbeStatus::kSchemaValidationFailed,
+                        validation.case_id, validation.backend,
+                        "schema_validation_failed",
+                        "typeface_request.font_file was not resolved");
+  }
+
+  Json::Value report =
+      BuildBaseProbeReport(validation.case_id, validation.backend);
+  auto typeface = MakeTypeface(entry, *font_file, &report);
+  if (typeface == nullptr) {
+    return BuildFailure(TypefaceProbeStatus::kProbeFailed, validation.case_id,
+                        validation.backend, "typeface_create_failed",
+                        "failed to create typeface from explicit font source");
+  }
+
+  TypefaceProbeResult result;
+  result.status = TypefaceProbeStatus::kSuccess;
+  result.case_id = validation.case_id;
+  result.backend = validation.backend;
+  result.report = BuildSuccessReport(root, validation, entry, font_file_id,
+                                     *font_file, typeface);
+  if (report.isMember("source_data")) {
+    result.report["source_data"] = report["source_data"];
+  }
+  return result;
+#endif
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/probe/typeface_probe.hpp
+++ b/harness/font/probe/typeface_probe.hpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PROBE_TYPEFACE_PROBE_HPP
+#define HARNESS_FONT_PROBE_TYPEFACE_PROBE_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+enum class TypefaceProbeStatus {
+  kSuccess,
+  kSchemaValidationFailed,
+  kBackendUnavailable,
+  kProbeFailed,
+};
+
+struct TypefaceProbeRequest {
+  std::filesystem::path repo_root;
+  std::filesystem::path case_path;
+  std::string backend;
+};
+
+struct TypefaceProbeResult {
+  TypefaceProbeStatus status = TypefaceProbeStatus::kProbeFailed;
+  std::string case_id;
+  std::string backend;
+  Json::Value report;
+};
+
+TypefaceProbeResult RunTypefaceProbe(const TypefaceProbeRequest& request);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PROBE_TYPEFACE_PROBE_HPP

--- a/harness/font/tests/smoke/skity_font_cli_smoke.py
+++ b/harness/font/tests/smoke/skity_font_cli_smoke.py
@@ -1,0 +1,294 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+CASE_ID = "font.synthetic.typeface"
+BACKEND = "coretext"
+
+
+def write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def read_json(path):
+    return json.loads(path.read_text())
+
+
+def make_case():
+    return {
+        "schema_version": 1,
+        "id": CASE_ID,
+        "category": "typeface_probe",
+        "status": "active",
+        "backend": BACKEND,
+        "platforms": ["darwin-ct"],
+        "font_files": [
+            {
+                "id": "synthetic",
+                "uri": "repo://fonts/synthetic.ttf",
+                "collection_index": 0,
+            }
+        ],
+        "typeface_request": {
+            "entry": "MakeFromFile",
+            "font_file": "synthetic",
+        },
+        "glyphs": {"chars": ["U+0041"]},
+        "compare": {
+            "typeface_identity": "normalized_descriptor",
+            "font_style": "exact",
+        },
+    }
+
+
+def make_manifest():
+    return {
+        "schema_version": 1,
+        "id": "font.synthetic.smoke",
+        "backend": BACKEND,
+        "platforms": ["darwin-ct"],
+        "case_root": "cases",
+        "cases": ["typeface.json"],
+        "artifacts": {
+            "skia_dir": "artifacts/skia",
+            "skity_dir": "artifacts/skity",
+            "compare_dir": "artifacts/compare",
+        },
+    }
+
+
+def make_probe_artifact(glyph_id):
+    return {
+        "schema_version": 1,
+        "artifact_type": "font_probe_result",
+        "case_id": CASE_ID,
+        "backend": BACKEND,
+        "ok": True,
+        "typeface_result": {
+            "typeface": {
+                "family_name": "Synthetic",
+                "post_script_name": "Synthetic-Regular",
+                "collection_index": 0,
+                "style": {
+                    "weight": 400,
+                    "width": 5,
+                    "slant": "upright",
+                },
+            }
+        },
+        "typeface_probe": {
+            "units_per_em": 1000,
+            "table_count": 1,
+            "glyphs": [
+                {
+                    "label": "U+0041",
+                    "code_point": 65,
+                    "glyph_id": glyph_id,
+                }
+            ],
+            "tables": [
+                {
+                    "tag": "head",
+                    "tag_value": 1751474532,
+                    "size": 54,
+                }
+            ],
+        },
+    }
+
+
+def run_command(args):
+    return subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def fail(label, result):
+    print(f"{label} failed", file=sys.stderr)
+    print("command:", " ".join(str(arg) for arg in result.args), file=sys.stderr)
+    print("exit:", result.returncode, file=sys.stderr)
+    print("stdout:", result.stdout, file=sys.stderr)
+    print("stderr:", result.stderr, file=sys.stderr)
+    return 1
+
+
+def expect_exit(label, result, expected_exit):
+    if result.returncode != expected_exit:
+        return fail(label, result)
+    return 0
+
+
+def expect_report_field(path, field, expected):
+    report = read_json(path)
+    value = report
+    for part in field.split("."):
+        if isinstance(value, list):
+            value = value[int(part)]
+        else:
+            value = value[part]
+    if value != expected:
+        print(
+            f"{path}: expected {field}={expected!r}, got {value!r}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: skity_font_cli_smoke.py <skity-font>", file=sys.stderr)
+        return 2
+
+    skity_font = Path(sys.argv[1])
+    if not skity_font.is_file():
+        print(f"skity-font binary does not exist: {skity_font}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="skity-font-cli-smoke-") as tmp:
+        tmp_dir = Path(tmp)
+        repo_root = tmp_dir / "repo"
+        case_path = repo_root / "cases/typeface.json"
+        manifest_path = repo_root / "manifests/smoke.json"
+        expected_path = tmp_dir / "expected.skia.json"
+        actual_path = tmp_dir / "actual.skity.json"
+        mismatch_path = tmp_dir / "actual-mismatch.skity.json"
+        report_dir = tmp_dir / "reports"
+
+        (repo_root / "fonts").mkdir(parents=True)
+        (repo_root / "fonts/synthetic.ttf").write_bytes(b"synthetic font bytes")
+        write_json(case_path, make_case())
+        write_json(manifest_path, make_manifest())
+        write_json(expected_path, make_probe_artifact(1))
+        write_json(actual_path, make_probe_artifact(1))
+        write_json(mismatch_path, make_probe_artifact(2))
+
+        case_info_report = report_dir / "case-info.json"
+        result = run_command(
+            [
+                skity_font,
+                "case-info",
+                "--case",
+                case_path,
+                "--repo-root",
+                repo_root,
+                "--report",
+                case_info_report,
+            ]
+        )
+        if expect_exit("case-info", result, 0):
+            return 1
+        if expect_report_field(case_info_report, "valid", True):
+            return 1
+
+        compare_report = report_dir / "compare-pass.json"
+        result = run_command(
+            [
+                skity_font,
+                "compare",
+                "--case",
+                case_path,
+                "--expected",
+                expected_path,
+                "--actual",
+                actual_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--report",
+                compare_report,
+            ]
+        )
+        if expect_exit("compare pass", result, 0):
+            return 1
+        if expect_report_field(compare_report, "passed", True):
+            return 1
+
+        mismatch_report = report_dir / "compare-mismatch.json"
+        result = run_command(
+            [
+                skity_font,
+                "compare",
+                "--case",
+                case_path,
+                "--expected",
+                expected_path,
+                "--actual",
+                mismatch_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--report",
+                mismatch_report,
+            ]
+        )
+        if expect_exit("compare mismatch", result, 1):
+            return 1
+        if expect_report_field(mismatch_report, "reason_code", "glyph_id_mismatch"):
+            return 1
+
+        missing_oracle_report = report_dir / "compare-missing-oracle.json"
+        result = run_command(
+            [
+                skity_font,
+                "compare",
+                "--case",
+                case_path,
+                "--expected",
+                tmp_dir / "missing.skia.json",
+                "--actual",
+                actual_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--report",
+                missing_oracle_report,
+            ]
+        )
+        if expect_exit("compare missing oracle", result, 6):
+            return 1
+        if expect_report_field(
+            missing_oracle_report, "reason_code", "oracle_unavailable"
+        ):
+            return 1
+
+        run_report = report_dir / "run-missing-oracle.json"
+        result = run_command(
+            [
+                skity_font,
+                "run",
+                "--manifest",
+                manifest_path,
+                "--backend",
+                BACKEND,
+                "--skia-dir",
+                tmp_dir / "missing-skia",
+                "--skity-dir",
+                tmp_dir / "skity",
+                "--repo-root",
+                repo_root,
+                "--report",
+                run_report,
+            ]
+        )
+        if expect_exit("run missing oracle", result, 6):
+            return 1
+        if expect_report_field(run_report, "input_failure_count", 1):
+            return 1
+        if expect_report_field(run_report, "cases.0.reason_code", "missing_oracle"):
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/font/tests/unit/font_harness_self_test.cc
+++ b/harness/font/tests/unit/font_harness_self_test.cc
@@ -1,0 +1,354 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <skity/graphic/path.hpp>
+#include <string>
+#include <string_view>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/case/case_document.hpp"
+#include "harness/font/case/manifest_document.hpp"
+#include "harness/font/case/repo_uri.hpp"
+#include "harness/font/compare/compare_engine.hpp"
+#include "harness/font/compare/path/path_normalizer.hpp"
+
+namespace skity {
+namespace font_harness {
+namespace {
+
+constexpr const char* kCaseId = "font.synthetic.typeface";
+constexpr const char* kMetricsCaseId = "font.synthetic.metrics";
+constexpr const char* kBackend = "coretext";
+
+class TempDir {
+ public:
+  explicit TempDir(const std::string& name) {
+    static std::atomic<int> counter{0};
+    const auto stamp =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = std::filesystem::temp_directory_path() /
+            ("skity_font_harness_" + name + "_" + std::to_string(stamp) + "_" +
+             std::to_string(counter.fetch_add(1)));
+    std::filesystem::remove_all(root_);
+    std::filesystem::create_directories(root_);
+  }
+
+  ~TempDir() {
+    std::error_code error;
+    std::filesystem::remove_all(root_, error);
+  }
+
+  const std::filesystem::path& root() const { return root_; }
+
+ private:
+  std::filesystem::path root_;
+};
+
+void WriteTextFile(const std::filesystem::path& path,
+                   std::string_view content) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream output(path, std::ios::binary);
+  ASSERT_TRUE(output.is_open()) << path;
+  output << content;
+  ASSERT_TRUE(output.good()) << path;
+}
+
+void WriteJson(const std::filesystem::path& path, const Json::Value& root) {
+  std::string error;
+  ASSERT_TRUE(WriteJsonFile(path, root, &error)) << error;
+}
+
+Json::Value MakeTypefaceCase() {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["id"] = kCaseId;
+  root["category"] = "typeface_probe";
+  root["status"] = "active";
+  root["backend"] = kBackend;
+  root["platforms"] = Json::Value(Json::arrayValue);
+  root["platforms"].append("darwin-ct");
+
+  Json::Value font_file(Json::objectValue);
+  font_file["id"] = "synthetic";
+  font_file["uri"] = "repo://fonts/synthetic.ttf";
+  font_file["collection_index"] = 0;
+  root["font_files"] = Json::Value(Json::arrayValue);
+  root["font_files"].append(std::move(font_file));
+
+  root["typeface_request"] = Json::Value(Json::objectValue);
+  root["typeface_request"]["entry"] = "MakeFromFile";
+  root["typeface_request"]["font_file"] = "synthetic";
+
+  root["glyphs"] = Json::Value(Json::objectValue);
+  root["glyphs"]["chars"] = Json::Value(Json::arrayValue);
+  root["glyphs"]["chars"].append("U+0041");
+
+  root["compare"] = Json::Value(Json::objectValue);
+  root["compare"]["typeface_identity"] = "normalized_descriptor";
+  root["compare"]["font_style"] = "exact";
+  return root;
+}
+
+Json::Value MakeManifest() {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["id"] = "font.synthetic.smoke";
+  root["backend"] = kBackend;
+  root["platforms"] = Json::Value(Json::arrayValue);
+  root["platforms"].append("darwin-ct");
+  root["case_root"] = "cases";
+  root["cases"] = Json::Value(Json::arrayValue);
+  root["cases"].append("typeface.json");
+  root["artifacts"] = Json::Value(Json::objectValue);
+  root["artifacts"]["skia_dir"] = "artifacts/skia";
+  root["artifacts"]["skity_dir"] = "artifacts/skity";
+  root["artifacts"]["compare_dir"] = "artifacts/compare";
+  return root;
+}
+
+Json::Value MakeMetricsCase() {
+  Json::Value root = MakeTypefaceCase();
+  root["id"] = kMetricsCaseId;
+  root["category"] = "font_metrics";
+  root["font_request"] = Json::Value(Json::objectValue);
+  root["font_request"]["size"] = 16.0;
+  root["compare"] = Json::Value(Json::objectValue);
+  root["compare"]["typeface_identity"] = "none";
+  root["compare"]["font_metrics"] = Json::Value(Json::objectValue);
+  root["compare"]["font_metrics"]["mode"] = "epsilon";
+  root["compare"]["font_metrics"]["epsilon"] = 0.01;
+  root["compare"]["glyph_metrics"] = Json::Value(Json::objectValue);
+  root["compare"]["glyph_metrics"]["mode"] = "ignore";
+  return root;
+}
+
+Json::Value MakeProbeArtifact(int glyph_id) {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["artifact_type"] = "font_probe_result";
+  root["case_id"] = kCaseId;
+  root["backend"] = kBackend;
+  root["ok"] = true;
+
+  Json::Value typeface(Json::objectValue);
+  typeface["family_name"] = "Synthetic";
+  typeface["post_script_name"] = "Synthetic-Regular";
+  typeface["collection_index"] = 0;
+  typeface["style"] = Json::Value(Json::objectValue);
+  typeface["style"]["weight"] = 400;
+  typeface["style"]["width"] = 5;
+  typeface["style"]["slant"] = "upright";
+  root["typeface_result"] = Json::Value(Json::objectValue);
+  root["typeface_result"]["typeface"] = std::move(typeface);
+
+  Json::Value glyph(Json::objectValue);
+  glyph["label"] = "U+0041";
+  glyph["code_point"] = 65;
+  glyph["glyph_id"] = glyph_id;
+  root["typeface_probe"] = Json::Value(Json::objectValue);
+  root["typeface_probe"]["units_per_em"] = 1000;
+  root["typeface_probe"]["table_count"] = 1;
+  root["typeface_probe"]["glyphs"] = Json::Value(Json::arrayValue);
+  root["typeface_probe"]["glyphs"].append(std::move(glyph));
+
+  Json::Value table(Json::objectValue);
+  table["tag"] = "head";
+  table["tag_value"] = 1751474532;
+  table["size"] = 54;
+  root["typeface_probe"]["tables"] = Json::Value(Json::arrayValue);
+  root["typeface_probe"]["tables"].append(std::move(table));
+  return root;
+}
+
+Json::Value MakeMetricsArtifact(double ascent) {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["artifact_type"] = "font_probe_result";
+  root["case_id"] = kMetricsCaseId;
+  root["backend"] = kBackend;
+  root["ok"] = true;
+
+  Json::Value font_metrics(Json::objectValue);
+  font_metrics["ascent"] = ascent;
+  font_metrics["descent"] = 3.0;
+  font_metrics["leading"] = 1.0;
+
+  root["metrics_probe"] = Json::Value(Json::objectValue);
+  root["metrics_probe"]["font_result"] = Json::Value(Json::objectValue);
+  root["metrics_probe"]["font_result"]["font_metrics"] = font_metrics;
+  root["metrics_probe"]["scaler_context_result"] =
+      Json::Value(Json::objectValue);
+  root["metrics_probe"]["scaler_context_result"]["font_metrics"] =
+      std::move(font_metrics);
+  return root;
+}
+
+TEST(FontHarnessCaseDocumentTest, ValidatesSyntheticTypefaceCase) {
+  TempDir temp("case_valid");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  RepoUriResolver resolver(temp.root());
+  CaseValidationResult result =
+      ValidateCaseDocument(MakeTypefaceCase(), resolver);
+
+  EXPECT_TRUE(result.valid) << WriteJsonString(result.errors.ToJson());
+  EXPECT_EQ(kCaseId, result.case_id);
+  EXPECT_EQ(kBackend, result.backend);
+  ASSERT_EQ(1u, result.resolved_font_files.size());
+  EXPECT_EQ("synthetic", result.resolved_font_files[0].id);
+  EXPECT_EQ(
+      std::filesystem::weakly_canonical(temp.root() / "fonts/synthetic.ttf"),
+      result.resolved_font_files[0].absolute_path);
+}
+
+TEST(FontHarnessCaseDocumentTest, RejectsRepoUriTraversal) {
+  TempDir temp("case_traversal");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  Json::Value root = MakeTypefaceCase();
+  root["font_files"][0]["uri"] = "repo://../outside.ttf";
+
+  RepoUriResolver resolver(temp.root());
+  CaseValidationResult result = ValidateCaseDocument(root, resolver);
+
+  EXPECT_FALSE(result.valid);
+  EXPECT_FALSE(result.errors.ToJson().empty());
+}
+
+TEST(FontHarnessManifestDocumentTest, ValidatesSyntheticManifest) {
+  TempDir temp("manifest_valid");
+
+  RepoUriResolver resolver(temp.root());
+  ManifestValidationResult result =
+      ValidateManifestDocument(MakeManifest(), resolver);
+
+  EXPECT_TRUE(result.valid) << WriteJsonString(result.errors.ToJson());
+  EXPECT_EQ("font.synthetic.smoke", result.manifest_id);
+  EXPECT_EQ(kBackend, result.backend);
+}
+
+TEST(FontHarnessManifestDocumentTest, RejectsUnsafeCasePath) {
+  TempDir temp("manifest_unsafe_case");
+  Json::Value root = MakeManifest();
+  root["cases"][0] = "../typeface.json";
+
+  RepoUriResolver resolver(temp.root());
+  ManifestValidationResult result = ValidateManifestDocument(root, resolver);
+
+  EXPECT_FALSE(result.valid);
+  EXPECT_FALSE(result.errors.ToJson().empty());
+}
+
+TEST(FontHarnessCompareEngineTest, ReportsPassMismatchAndInputFailure) {
+  TempDir temp("compare");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  const std::filesystem::path case_path = temp.root() / "cases/typeface.json";
+  const std::filesystem::path expected_path =
+      temp.root() / "artifacts/expected.json";
+  const std::filesystem::path actual_path =
+      temp.root() / "artifacts/actual.json";
+  WriteJson(case_path, MakeTypefaceCase());
+  WriteJson(expected_path, MakeProbeArtifact(1));
+  WriteJson(actual_path, MakeProbeArtifact(1));
+
+  CompareRequest request;
+  request.repo_root = temp.root();
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = kBackend;
+
+  CompareResult pass = RunCompare(request);
+  EXPECT_EQ(CompareStatus::kPass, pass.status);
+  EXPECT_TRUE(pass.report["passed"].asBool());
+  EXPECT_EQ("pass", pass.report["reason_code"].asString());
+
+  WriteJson(actual_path, MakeProbeArtifact(2));
+  CompareResult mismatch = RunCompare(request);
+  EXPECT_EQ(CompareStatus::kMismatch, mismatch.status);
+  EXPECT_FALSE(mismatch.report["passed"].asBool());
+  EXPECT_EQ("glyph_id_mismatch", mismatch.report["reason_code"].asString());
+  EXPECT_EQ("typeface_probe.glyphs[0].glyph_id",
+            mismatch.report["diff_path"].asString());
+
+  CompareRequest missing = request;
+  missing.expected_path = temp.root() / "artifacts/missing.skia.json";
+  CompareResult input_failure = RunCompare(missing);
+  EXPECT_EQ(CompareStatus::kInputFailed, input_failure.status);
+  EXPECT_EQ("expected_load", input_failure.report["stage"].asString());
+  EXPECT_EQ("oracle_unavailable",
+            input_failure.report["reason_code"].asString());
+}
+
+TEST(FontHarnessCompareEngineTest, ComparesMetricsWithEpsilon) {
+  TempDir temp("metrics_compare");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  const std::filesystem::path case_path = temp.root() / "cases/metrics.json";
+  const std::filesystem::path expected_path =
+      temp.root() / "artifacts/expected.json";
+  const std::filesystem::path actual_path =
+      temp.root() / "artifacts/actual.json";
+  WriteJson(case_path, MakeMetricsCase());
+  WriteJson(expected_path, MakeMetricsArtifact(10.0));
+  WriteJson(actual_path, MakeMetricsArtifact(10.005));
+
+  CompareRequest request;
+  request.repo_root = temp.root();
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = kBackend;
+
+  CompareResult pass = RunCompare(request);
+  EXPECT_EQ(CompareStatus::kPass, pass.status);
+  EXPECT_TRUE(pass.report["passed"].asBool());
+
+  WriteJson(actual_path, MakeMetricsArtifact(10.5));
+  CompareResult mismatch = RunCompare(request);
+  EXPECT_EQ(CompareStatus::kMismatch, mismatch.status);
+  EXPECT_FALSE(mismatch.report["passed"].asBool());
+  EXPECT_EQ("metrics_mismatch", mismatch.report["reason_code"].asString());
+  EXPECT_EQ("metrics_probe.font_result.font_metrics.ascent",
+            mismatch.report["diff_path"].asString());
+}
+
+TEST(FontHarnessPathNormalizerTest, DropsZeroLengthSegmentsAndRoundsPoints) {
+  skity::Path path;
+  path.MoveTo(0.00004f, -0.00004f);
+  path.LineTo(0.00004f, -0.00004f);
+  path.LineTo(1.00004f, 0.00004f);
+  path.LineTo(1.00004f, 1.00004f);
+  path.Close();
+
+  PathNormalizeOptions options;
+  options.epsilon = 0.001;
+  Json::Value normalized = BuildNormalizedPathJson(path, options);
+
+  EXPECT_EQ("path_normalized", normalized["mode"].asString());
+  EXPECT_EQ(
+      1, normalized["normalization"]["dropped_zero_length_segments"].asInt());
+  EXPECT_EQ(4, normalized["verb_count"].asInt());
+  ASSERT_EQ(4u, normalized["verb_sequence"].size());
+  EXPECT_EQ("move", normalized["verb_sequence"][0].asString());
+  EXPECT_EQ("line", normalized["verb_sequence"][1].asString());
+  EXPECT_EQ("line", normalized["verb_sequence"][2].asString());
+  EXPECT_EQ("close", normalized["verb_sequence"][3].asString());
+
+  ASSERT_EQ(1, normalized["contour_count"].asInt());
+  EXPECT_TRUE(normalized["contours"][0]["closed"].asBool());
+  EXPECT_DOUBLE_EQ(0.0, normalized["verbs"][0]["points"][0]["x"].asDouble());
+  EXPECT_DOUBLE_EQ(0.0, normalized["verbs"][0]["points"][0]["y"].asDouble());
+}
+
+}  // namespace
+}  // namespace font_harness
+}  // namespace skity

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -123,6 +123,13 @@ endif()
 target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
 target_link_libraries(skity_unit_test PRIVATE wgsl-cross)
 
+if(SKITY_ENABLE_FONT_HARNESS AND TARGET skity_font_harness)
+    target_sources(skity_unit_test PRIVATE
+        ${CMAKE_SOURCE_DIR}/harness/font/tests/unit/font_harness_self_test.cc
+    )
+    target_link_libraries(skity_unit_test PRIVATE skity_font_harness)
+endif()
+
 if (${SKITY_VK_BACKEND})
     set(SKITY_VK_TEST_LOADER_LIBRARIES)
     set(SKITY_VK_TEST_RPATH)


### PR DESCRIPTION
Add an optionally enabled font harness for validating Skity font behavior against Skia on macOS/CoreText. The harness provides an independent CLI, JSON protocol, case/manifest validation, platform environment probing, Skity probing, Skia oracle consumption, compare reports, and manifest run summaries.

At a high level, the harness now covers the main CoreText-backed Typeface, Font, ScalerContext, and FontManager paths. It validates explicit font file/data sources for descriptors, glyph mapping, font tables, font metrics, glyph metrics, and glyph paths, and also includes a minimal system font matching smoke set. Outputs are written as stable JSON artifacts with reproducible command arguments so Skity/Skia differences can be inspected and rerun case by case.

The change also adds harness self-checks: C++ harness tests are compiled into skity_unit_test when the harness is enabled, while a standalone CLI smoke CTest runs the real skity-font binary to verify command-line behavior, exit codes, and report writing. The harness is not part of the default build and is not wired into tools/test-runner.py; the macOS/CoreText smoke gate is run independently through skity-font run.