### PR TITLE
fix(wgx): apply std140 struct alignment rule for uniform buffers

### DIFF
--- a/module/wgx/include/wgsl_cross.h
+++ b/module/wgx/include/wgsl_cross.h
@@ -154,7 +154,8 @@ struct WGX_API Field {
 struct WGX_API StructDefinition : public TypeDefinition {
   std::vector<Field*> members = {};
 
-  StructDefinition(const std::string_view& name, std::vector<Field*> members);
+  StructDefinition(const std::string_view& name, std::vector<Field*> members,
+                   size_t min_alignment = 1);
 
   ~StructDefinition() override {
     for (auto* member : members) {

--- a/module/wgx/ir/ir_type.cpp
+++ b/module/wgx/ir/ir_type.cpp
@@ -349,6 +349,12 @@ TypeTable::LayoutInfo TypeTable::GetLayoutInfo(TypeId id,
         offset = member_offset + member_info.size;
       }
 
+      // std140 rule 9: struct alignment is rounded up to the base alignment of
+      // a vec4 (16 bytes)
+      if (rule == LayoutRule::kStd140) {
+        max_align = AlignOffset(max_align, 16);
+      }
+
       // Round up struct size to its alignment
       uint32_t struct_size = AlignOffset(offset, max_align);
       return LayoutInfo{struct_size, max_align};

--- a/module/wgx/wgsl/type_definition.cpp
+++ b/module/wgx/wgsl/type_definition.cpp
@@ -165,14 +165,18 @@ std::unique_ptr<TypeDefinition> CreateTypeDefinition(const ast::Type& type,
       return {};
     }
 
-    return std::make_unique<StructDefinition>(type_name, members);
+    // std140 and WGSL uniform require struct alignment >= 16
+    size_t min_align =
+        (layout == MemoryLayout::kStd140 || layout == MemoryLayout::kWGSL) ? 16
+                                                                           : 1;
+    return std::make_unique<StructDefinition>(type_name, members, min_align);
   }
 
   return {};
 }
 
 /**
- * calculate the struct alignment based on std140 layout rules
+ * calculate the struct alignment based on layout rules
  * @ref https://www.w3.org/TR/WGSL/#alignment-and-size
  *
  * AlignOf(S) = max(AlignOf(S.m0), ..., AlignOf(S.mN))
@@ -193,9 +197,18 @@ static size_t calculate_alignment(const std::vector<Field*>& members) {
 size_t round_up(size_t k, size_t n) { return (n + k - 1) / k * k; }
 
 StructDefinition::StructDefinition(const std::string_view& name,
-                                   std::vector<Field*> members)
-    : TypeDefinition(name, 0, calculate_alignment(members)),
-      members(std::move(members)) {
+                                   std::vector<Field*> members,
+                                   size_t min_alignment)
+    : TypeDefinition(name, 0, 0), members(std::move(members)) {
+  size_t align = calculate_alignment(this->members);
+
+  // For std140 / WGSL uniform: struct alignment must be at least 16 bytes
+  // per std140 rule 9 and WGSL uniform address space requirements.
+  if (min_alignment > align) {
+    align = min_alignment;
+  }
+  this->alignment = align;
+
   size_t offset = 0;
   for (auto* member : this->members) {
     offset = round_up(member->type->alignment, offset);
@@ -205,9 +218,8 @@ StructDefinition::StructDefinition(const std::string_view& name,
     offset += member->type->size;
   }
 
-  // round up size to 16 bytes to make sure buffer is big enough for all GPU
-  // validations
-  this->size = round_up(16, offset);
+  // Round up struct size to its alignment
+  this->size = round_up(align, offset);
 }
 
 bool StructDefinition::SetData(const void* data, size_t size) {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(skity_unit_test
     render/hw/draw/hw_wgsl_shader_writer_test.cc
     wgx/wgx_backend_name_resolution_test.cc
     wgx/wgx_resolver_test.cc
+    wgx/wgx_uniform_layout_test.cc
     render/resource_cache_test.cc
     render/shape_test.cc
     recorder/display_list_test.cc

--- a/test/ut/wgx/wgx_uniform_layout_test.cc
+++ b/test/ut/wgx/wgx_uniform_layout_test.cc
@@ -1,0 +1,235 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <wgsl_cross.h>
+
+namespace {
+
+// Helper: find uniform binding entry by group and binding index.
+const wgx::BindGroupEntry* FindUniformEntry(
+    const std::vector<wgx::BindGroup>& bind_groups, uint32_t group,
+    uint32_t binding) {
+  for (const auto& bg : bind_groups) {
+    if (bg.group != group) continue;
+    for (const auto& entry : bg.entries) {
+      if (entry.binding == binding &&
+          entry.type == wgx::BindingType::kUniformBuffer) {
+        return &entry;
+      }
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Test: Struct with only small-alignment members (vec2 + scalars).
+// std140 rule 9 requires struct alignment >= 16.
+// This is the "ConicalInfo"-style pattern that exposed the bug.
+// ---------------------------------------------------------------------------
+TEST(WgxUniformLayoutTest,
+     StructWithSmallAlignmentMembersHasCorrectSizeInGlsl) {
+  const char* source = R"(
+struct SmallAlign {
+  center1 : vec2<f32>,
+  center2 : vec2<f32>,
+  radius1 : f32,
+  radius2 : f32,
+};
+
+@group(0) @binding(0)
+var<uniform> info : SmallAlign;
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+  return vec4<f32>(info.center1.x, info.radius1, 0.0, 1.0);
+}
+)";
+
+  auto program = wgx::Program::Parse(source);
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  // GLSL uses kStd140 — struct alignment must be >= 16
+  wgx::GlslOptions glsl_opts;
+  glsl_opts.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_opts.major_version = 4;
+  glsl_opts.minor_version = 1;
+  auto result = program->WriteToGlsl("fs_main", glsl_opts);
+  ASSERT_TRUE(result.success);
+
+  const auto* entry = FindUniformEntry(result.bind_groups, 0, 0);
+  ASSERT_NE(entry, nullptr);
+  ASSERT_NE(entry->type_definition, nullptr);
+
+  // Members: vec2(8) + vec2(8) + f32(4) + f32(4) = 24 bytes
+  // std140 struct alignment = max(8,8,4,4)=8, rounded up to 16
+  // struct size = round_up(16, 24) = 32
+  EXPECT_EQ(entry->type_definition->size, 32u)
+      << "std140 struct size should be 32 (24 bytes of members + 8 padding)";
+  EXPECT_EQ(entry->type_definition->alignment, 16u)
+      << "std140 struct alignment should be 16 (rule 9: rounded to vec4)";
+
+  // GLSL output must contain std140 and inner wrapper
+  EXPECT_NE(result.content.find("std140"), std::string::npos);
+  EXPECT_NE(result.content.find("inner"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Test: MSL uses kStd430MSL — struct alignment is NOT rounded to 16.
+// The same struct should have natural alignment (8) and smaller size.
+// ---------------------------------------------------------------------------
+TEST(WgxUniformLayoutTest,
+     StructWithSmallAlignmentMembersHasNaturalAlignmentInMsl) {
+  const char* source = R"(
+struct SmallAlign {
+  center1 : vec2<f32>,
+  center2 : vec2<f32>,
+  radius1 : f32,
+  radius2 : f32,
+};
+
+@group(0) @binding(0)
+var<uniform> info : SmallAlign;
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+  return vec4<f32>(info.center1.x, info.radius1, 0.0, 1.0);
+}
+)";
+
+  auto program = wgx::Program::Parse(source);
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  // MSL uses kStd430MSL — no 16-byte alignment rounding
+  wgx::MslOptions msl_opts;
+  auto result = program->WriteToMsl("fs_main", msl_opts);
+  ASSERT_TRUE(result.success);
+
+  const auto* entry = FindUniformEntry(result.bind_groups, 0, 0);
+  ASSERT_NE(entry, nullptr);
+  ASSERT_NE(entry->type_definition, nullptr);
+
+  // Members: vec2(8) + vec2(8) + f32(4) + f32(4) = 24 bytes
+  // std430 struct alignment = max(8,8,4,4) = 8 (no rounding)
+  // struct size = round_up(8, 24) = 24
+  EXPECT_EQ(entry->type_definition->alignment, 8u)
+      << "MSL struct alignment should be 8 (natural max, no std140 rounding)";
+  EXPECT_EQ(entry->type_definition->size, 24u)
+      << "MSL struct size should be 24 (exact member total)";
+}
+
+// ---------------------------------------------------------------------------
+// Test: Struct with already-large alignment (mat4x4, vec4).
+// Alignment is already 16, fix should not change anything.
+// ---------------------------------------------------------------------------
+TEST(WgxUniformLayoutTest, StructWithLargeAlignmentMembersIsUnchanged) {
+  const char* source = R"(
+struct LargeAlign {
+  mvp           : mat4x4<f32>,
+  userTransform : mat4x4<f32>,
+  extraInfo     : vec4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> common : LargeAlign;
+
+@vertex
+fn vs_main() -> @builtin(position) vec4<f32> {
+  return common.mvp * vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+)";
+
+  auto program = wgx::Program::Parse(source);
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_opts;
+  glsl_opts.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_opts.major_version = 4;
+  glsl_opts.minor_version = 1;
+  auto result = program->WriteToGlsl("vs_main", glsl_opts);
+  ASSERT_TRUE(result.success);
+
+  const auto* entry = FindUniformEntry(result.bind_groups, 0, 0);
+  ASSERT_NE(entry, nullptr);
+  ASSERT_NE(entry->type_definition, nullptr);
+
+  // mat4x4(64) + mat4x4(64) + vec4(16) = 144, alignment already 16
+  EXPECT_EQ(entry->type_definition->size, 144u);
+  EXPECT_EQ(entry->type_definition->alignment, 16u);
+}
+
+// ---------------------------------------------------------------------------
+// Test: Nested struct where inner struct has small alignment.
+// In std140, the inner struct's alignment must be 16, affecting the outer
+// struct's member offsets.
+// ---------------------------------------------------------------------------
+TEST(WgxUniformLayoutTest,
+     NestedStructWithSmallAlignmentInnerHasCorrectLayout) {
+  const char* source = R"(
+struct Inner {
+  a : vec2<f32>,
+  b : vec2<f32>,
+};
+
+struct Outer {
+  inner : Inner,
+  extra : f32,
+};
+
+@group(0) @binding(0)
+var<uniform> data : Outer;
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+  return vec4<f32>(data.inner.a.x, data.extra, 0.0, 1.0);
+}
+)";
+
+  auto program = wgx::Program::Parse(source);
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_opts;
+  glsl_opts.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_opts.major_version = 4;
+  glsl_opts.minor_version = 1;
+  auto result = program->WriteToGlsl("fs_main", glsl_opts);
+  ASSERT_TRUE(result.success);
+
+  const auto* entry = FindUniformEntry(result.bind_groups, 0, 0);
+  ASSERT_NE(entry, nullptr);
+  ASSERT_NE(entry->type_definition, nullptr);
+  ASSERT_TRUE(entry->type_definition->IsStruct());
+
+  auto* outer =
+      static_cast<wgx::StructDefinition*>(entry->type_definition.get());
+
+  // Outer struct layout (std140):
+  //   Inner: alignment = round_up(max(8,8), 16) = 16, size = round_up(16, 16) =
+  //   16 inner at offset 0, size 16 extra (f32, align 4) at offset 16, size 4
+  //   total = 20, Outer alignment = max(16, 4) = 16
+  //   Outer size = round_up(16, 20) = 32
+  EXPECT_EQ(outer->alignment, 16u);
+  EXPECT_EQ(outer->size, 32u);
+
+  // Verify inner struct has alignment 16 in std140
+  auto* inner_field = outer->GetMember("inner");
+  ASSERT_NE(inner_field, nullptr);
+  EXPECT_EQ(inner_field->offset, 0u);
+  ASSERT_NE(inner_field->type, nullptr);
+  EXPECT_EQ(inner_field->type->alignment, 16u)
+      << "Inner struct should have alignment 16 (std140 rule 9)";
+  EXPECT_EQ(inner_field->type->size, 16u);
+
+  // "extra" should start at offset 16 (after the 16-byte inner struct)
+  auto* extra_field = outer->GetMember("extra");
+  ASSERT_NE(extra_field, nullptr);
+  EXPECT_EQ(extra_field->offset, 16u)
+      << "extra should follow inner at offset 16";
+}


### PR DESCRIPTION
std140 rule 9 requires struct alignment to be rounded up to vec4 alignment (16 bytes) when used inside uniform blocks. The 'inner' wrapper in GLSL output causes the GPU to apply this rule, but both GetLayoutInfo (IR layer) and StructDefinition (runtime reflection) did not implement it correctly.

Changes:
- ir/ir_type.cpp: round struct alignment up to 16 in GetLayoutInfo for std140 layout rule
- wgsl_cross.h: add min_alignment parameter to StructDefinition constructor
- wgsl/type_definition.cpp: compute struct alignment respecting min_alignment, and use alignment-based size rounding instead of hardcoded round_up(16, offset)

This ensures the CPU-side buffer size (from StructDefinition::size) matches the GPU-side std140 uniform block size, and nested struct member offsets are correct.