### PR TITLE
feat(harness): expand CoreText font matching harness

### DIFF
--- a/harness/font/artifact/artifact_writer.cc
+++ b/harness/font/artifact/artifact_writer.cc
@@ -100,6 +100,9 @@ std::filesystem::path DefaultArtifactPath(
               ".fonts.json");
     case ArtifactKind::kSkityResult:
       return local_root / "artifacts" / "skity" / (name + backend + ".json");
+    case ArtifactKind::kMatchResult:
+      return local_root / "artifacts" / "skity" /
+             (name + backend + ".match.json");
     case ArtifactKind::kCompareReport:
       return local_root / "artifacts" / "compare" /
              (name + backend + ".compare.json");

--- a/harness/font/artifact/artifact_writer.hpp
+++ b/harness/font/artifact/artifact_writer.hpp
@@ -22,6 +22,7 @@ enum class ArtifactKind {
   kCompareReport,
   kRunSummary,
   kPathDump,
+  kMatchResult,
 };
 
 struct ArtifactDescriptor {

--- a/harness/font/cases/family_style_set/arial_italic_coretext.json
+++ b/harness/font/cases/family_style_set/arial_italic_coretext.json
@@ -1,24 +1,19 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
-  "category": "font_manager",
+  "id": "font.family_style_set.coretext.arial_italic",
+  "category": "family_style_set",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "CreateStyleSet",
+    "family_name": "Arial",
     "style": {
       "weight": 400,
       "width": 5,
-      "slant": "upright"
+      "slant": "italic"
     },
     "sample_limit": 8
   },
@@ -40,8 +35,7 @@
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/family_style_set/baskerville_weight_500_coretext.json
+++ b/harness/font/cases/family_style_set/baskerville_weight_500_coretext.json
@@ -1,22 +1,17 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
-  "category": "font_manager",
+  "id": "font.family_style_set.coretext.baskerville_weight_500",
+  "category": "family_style_set",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "CreateStyleSet",
+    "family_name": "Baskerville",
     "style": {
-      "weight": 400,
+      "weight": 500,
       "width": 5,
       "slant": "upright"
     },
@@ -40,8 +35,7 @@
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/family_style_set/helvetica_weight_500_coretext.json
+++ b/harness/font/cases/family_style_set/helvetica_weight_500_coretext.json
@@ -1,22 +1,17 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
-  "category": "font_manager",
+  "id": "font.family_style_set.coretext.helvetica_weight_500",
+  "category": "family_style_set",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "CreateStyleSet",
+    "family_name": "Helvetica",
     "style": {
-      "weight": 400,
+      "weight": 500,
       "width": 5,
       "slant": "upright"
     },
@@ -40,8 +35,7 @@
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_arabic_alef_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_arabic_alef_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_arabic_alef",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+0627",
+    "bcp47": [
+      "ar"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+0627"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_devanagari_ka",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+0915",
+    "bcp47": [
+      "hi"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+0915"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_emoji",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+1F60A",
+    "bcp47": [
+      "und-Zsye"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,7 +32,8 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+1F60A"
     ]
   },
   "compare": {

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_emoji_grinning",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+1F600",
+    "bcp47": [
+      "und-Zsye"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+1F600"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json
@@ -1,25 +1,29 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_ja_hiragana",
   "category": "font_manager",
   "status": "active",
   "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
+    "id": "coretext-fallback-ja-locale",
     "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
+    "summary": "Skia CoreText honors the ja locale and selects .Hiragino Kaku Gothic Interface for U+3042, while Skity Darwin MatchFamilyStyleCharacter currently falls back to .CJK Symbols Fallback SC. Keep this active as a fixable Skity runtime matching gap."
   },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+3042",
+    "bcp47": [
+      "ja"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +37,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+3042"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_ko_hangul_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_ko_hangul_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_ko_hangul",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+AC00",
+    "bcp47": [
+      "ko"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+AC00"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_symbol_music_gclef",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+1D11E",
+    "bcp47": [
+      "und"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+1D11E"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_thai_ko_kai",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+0E01",
+    "bcp47": [
+      "th"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,15 +32,15 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+0E01"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hans_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hans_coretext.json
@@ -1,25 +1,24 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_zh_hans",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+6C49",
+    "bcp47": [
+      "zh-Hans"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,7 +32,8 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+6C49"
     ]
   },
   "compare": {

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hant_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hant_coretext.json
@@ -1,25 +1,29 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_character_zh_hant",
   "category": "font_manager",
   "status": "active",
   "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
+    "id": "coretext-fallback-zh-hant-locale",
     "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
+    "summary": "Skia CoreText honors the zh-Hant locale and selects .PingFang UI TC for U+6F22, while Skity Darwin MatchFamilyStyleCharacter currently does not consume bcp47 and selects .PingFang UI SC. Keep this active as a fixable Skity runtime matching gap."
   },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "entry": "MatchFamilyStyleCharacter",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
       "slant": "upright"
     },
+    "character": "U+6F22",
+    "bcp47": [
+      "zh-Hant"
+    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -33,7 +37,8 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041"
+      "U+0041",
+      "U+6F22"
     ]
   },
   "compare": {

--- a/harness/font/cases/font_manager/apple_system_ui_font_regular_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_regular_coretext.json
@@ -1,20 +1,15 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.css_generic_sans_serif",
+  "id": "font.font_manager.coretext.apple_system_ui_font_regular",
   "category": "font_manager",
   "status": "active",
-  "known_issue": {
-    "id": "coretext-css-generic-sans-serif",
-    "reason_code": "selection_mismatch",
-    "summary": "Skia CoreText matchFamilyStyle(\"sans-serif\", Regular) returns unavailable, while Skity currently maps the CSS generic family to Helvetica. Keep this case active until the font matching harness work is complete."
-  },
   "backend": "coretext",
   "platforms": [
     "darwin-ct"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyle",
-    "family_name": "sans-serif",
+    "family_name": ".AppleSystemUIFont",
     "style": {
       "weight": 400,
       "width": 5,
@@ -40,8 +35,7 @@
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cli/skity-font/main.cc
+++ b/harness/font/cli/skity-font/main.cc
@@ -60,6 +60,25 @@ struct CompareInvocationResult {
   std::string backend;
 };
 
+struct ManifestRunPaths {
+  std::filesystem::path case_root;
+  std::filesystem::path repo_root;
+  std::filesystem::path resolved_skia_dir;
+  std::filesystem::path resolved_skity_dir;
+  std::filesystem::path resolved_compare_dir;
+  std::string backend;
+};
+
+struct ManifestRunCounts {
+  int pass_count = 0;
+  int mismatch_count = 0;
+  int input_failure_count = 0;
+  int probe_failure_count = 0;
+  int schema_failure_count = 0;
+  int backend_unavailable_count = 0;
+  int io_failure_count = 0;
+};
+
 void PrintUsage(std::ostream& out) {
   out << "skity-font - Skity font harness CLI\n"
       << "\n"
@@ -70,6 +89,7 @@ void PrintUsage(std::ostream& out) {
       << "Commands planned for the font harness:\n"
       << "  env-info      collect platform and backend information\n"
       << "  case-info     validate and normalize a case file\n"
+      << "  match         run a Skity system font match probe\n"
       << "  probe         run a Skity font probe and write result JSON\n"
       << "  compare       compare Skia oracle and Skity result JSON\n"
       << "  run           run a manifest with existing Skia oracle data\n"
@@ -79,6 +99,12 @@ void PrintUsage(std::ostream& out) {
       << "case-info options:\n"
       << "  --case <path>       input case JSON\n"
       << "  --report <path>     optional output report JSON\n"
+      << "  --repo-root <path>  optional repository root override\n"
+      << "\n"
+      << "match options:\n"
+      << "  --case <path>       input font_manager/family_style_set case JSON\n"
+      << "  --backend <name>    backend to use\n"
+      << "  --out <path>        optional output JSON\n"
       << "  --repo-root <path>  optional repository root override\n"
       << "\n"
       << "env-info/list-fonts options:\n"
@@ -271,6 +297,20 @@ std::string ReadCaseCategory(const std::filesystem::path& case_path) {
   return category;
 }
 
+Json::Value BuildMatchSchemaErrorReport(const std::string& case_id,
+                                        const std::string& backend,
+                                        const std::string& path,
+                                        const std::string& message) {
+  Json::Value report = skity::font_harness::BuildProbeResultReport(
+      case_id, backend, "schema_validation_failed");
+  Json::Value error(Json::objectValue);
+  error["path"] = path;
+  error["message"] = message;
+  report["validation_errors"] = Json::Value(Json::arrayValue);
+  report["validation_errors"].append(std::move(error));
+  return report;
+}
+
 int ExitCodeForProbeStatus(skity::font_harness::TypefaceProbeStatus status) {
   switch (status) {
     case skity::font_harness::TypefaceProbeStatus::kSuccess:
@@ -440,6 +480,246 @@ bool WriteArtifactSilently(
     *stable_path = write_result.stable_path;
   }
   return true;
+}
+
+Json::Value RunManifestCase(Json::ArrayIndex index,
+                            const std::string& case_relative_path,
+                            const ManifestRunPaths& paths,
+                            skity::font_harness::RepoUriResolver* resolver,
+                            ManifestRunCounts* counts) {
+  const std::filesystem::path case_path =
+      (paths.case_root / case_relative_path).lexically_normal();
+
+  Json::Value item(Json::objectValue);
+  item["index"] = index;
+  item["case"] = case_relative_path;
+  item["case_path"] = StablePathForRun(case_path, paths.repo_root);
+  item["backend"] = paths.backend;
+  item["status"] = "running";
+  item["artifacts"] = Json::Value(Json::objectValue);
+
+  Json::Value case_root_json;
+  std::string case_error;
+  if (!skity::font_harness::LoadJsonFile(case_path, &case_root_json,
+                                         &case_error)) {
+    item["status"] = "schema_validation_failed";
+    item["reason_code"] = "schema_validation_failed";
+    item["message"] = case_error;
+    counts->schema_failure_count += 1;
+    return item;
+  }
+
+  skity::font_harness::CaseValidationResult case_validation =
+      skity::font_harness::ValidateCaseDocument(case_root_json, *resolver);
+  const std::string case_id = case_validation.case_id.empty()
+                                  ? StemOrFallback(case_path, "case")
+                                  : case_validation.case_id;
+  item["case_id"] = case_id;
+  std::string category;
+  std::string status;
+  ReadStringField(case_root_json, "category", &category);
+  ReadStringField(case_root_json, "status", &status);
+  item["category"] = category;
+  item["case_status"] = status;
+
+  if (!case_validation.valid) {
+    item["status"] = "schema_validation_failed";
+    item["reason_code"] = "schema_validation_failed";
+    item["validation_errors"] = case_validation.errors.ToJson();
+    counts->schema_failure_count += 1;
+    return item;
+  }
+  if (case_validation.backend != paths.backend) {
+    item["status"] = "schema_validation_failed";
+    item["reason_code"] = "backend_mismatch";
+    item["message"] = "case backend does not match manifest run backend";
+    counts->schema_failure_count += 1;
+    return item;
+  }
+  if (status != "active") {
+    item["status"] = "schema_validation_failed";
+    item["reason_code"] = "non_active_case_in_smoke";
+    item["message"] = "smoke manifest entries must be active cases";
+    counts->schema_failure_count += 1;
+    return item;
+  }
+
+  const std::string safe_case_id = SanitizeFileComponent(case_id, "case");
+  const std::string safe_backend =
+      SanitizeFileComponent(paths.backend, "backend");
+  const std::filesystem::path expected_path =
+      paths.resolved_skia_dir / (safe_case_id + ".skia.json");
+  const std::filesystem::path actual_path =
+      paths.resolved_skity_dir / (safe_case_id + "." + safe_backend + ".json");
+  const std::filesystem::path compare_path =
+      paths.resolved_compare_dir /
+      (safe_case_id + "." + safe_backend + ".compare.json");
+
+  item["artifacts"]["expected"] =
+      StablePathForRun(expected_path, paths.repo_root);
+  item["artifacts"]["actual"] = StablePathForRun(actual_path, paths.repo_root);
+  item["artifacts"]["compare"] =
+      StablePathForRun(compare_path, paths.repo_root);
+
+  std::error_code exists_error;
+  if (!std::filesystem::is_regular_file(expected_path, exists_error)) {
+    item["status"] = "input_failed";
+    item["reason_code"] = "missing_oracle";
+    item["message"] = "Skia oracle is missing for manifest case";
+    item["compare_exit_code"] = kExitCompareInputFailure;
+    counts->input_failure_count += 1;
+    return item;
+  }
+
+  ProbeInvocationResult probe_invocation =
+      RunSkityProbeForCase(paths.repo_root, case_path, paths.backend);
+  item["probe_exit_code"] = probe_invocation.exit_code;
+  skity::font_harness::ArtifactDescriptor probe_descriptor;
+  probe_descriptor.kind = skity::font_harness::ArtifactKind::kSkityResult;
+  probe_descriptor.command = "probe";
+  probe_descriptor.output_flag = "--out";
+  probe_descriptor.case_id =
+      probe_invocation.case_id.empty() ? case_id : probe_invocation.case_id;
+  probe_descriptor.backend = probe_invocation.backend.empty()
+                                 ? paths.backend
+                                 : probe_invocation.backend;
+  probe_descriptor.input_path = case_path;
+  probe_descriptor.explicit_output_path = actual_path;
+  probe_descriptor.repro_args = {"--case",
+                                 StablePathForRun(case_path, paths.repo_root),
+                                 "--backend", paths.backend};
+
+  std::string write_error;
+  std::string stable_probe_path;
+  if (!WriteArtifactSilently(paths.repo_root, probe_descriptor,
+                             &probe_invocation.report, &stable_probe_path,
+                             &write_error)) {
+    item["status"] = "io_failure";
+    item["reason_code"] = "io_failure";
+    item["message"] = write_error;
+    counts->io_failure_count += 1;
+    return item;
+  }
+  item["artifacts"]["actual"] = stable_probe_path;
+
+  if (probe_invocation.exit_code != kExitSuccess) {
+    item["status"] = probe_invocation.exit_code == kExitBackendUnavailable
+                         ? "backend_unavailable"
+                         : "probe_failed";
+    item["reason_code"] =
+        probe_invocation.report.isMember("reason_code")
+            ? probe_invocation.report["reason_code"].asString()
+            : "probe_failed";
+    if (probe_invocation.exit_code == kExitBackendUnavailable) {
+      counts->backend_unavailable_count += 1;
+    } else {
+      counts->probe_failure_count += 1;
+    }
+    return item;
+  }
+
+  CompareInvocationResult compare_invocation = RunCompareForArtifacts(
+      paths.repo_root, case_path, expected_path, actual_path, paths.backend);
+  item["compare_exit_code"] = compare_invocation.exit_code;
+
+  skity::font_harness::ArtifactDescriptor compare_descriptor;
+  compare_descriptor.kind = skity::font_harness::ArtifactKind::kCompareReport;
+  compare_descriptor.command = "compare";
+  compare_descriptor.case_id =
+      compare_invocation.case_id.empty() ? case_id : compare_invocation.case_id;
+  compare_descriptor.backend = compare_invocation.backend.empty()
+                                   ? paths.backend
+                                   : compare_invocation.backend;
+  compare_descriptor.input_path = case_path;
+  compare_descriptor.explicit_output_path = compare_path;
+  compare_descriptor.repro_args = {
+      "--case",     StablePathForRun(case_path, paths.repo_root),
+      "--expected", StablePathForRun(expected_path, paths.repo_root),
+      "--actual",   StablePathForRun(actual_path, paths.repo_root),
+      "--backend",  paths.backend};
+
+  std::string stable_compare_path;
+  if (!WriteArtifactSilently(paths.repo_root, compare_descriptor,
+                             &compare_invocation.report, &stable_compare_path,
+                             &write_error)) {
+    item["status"] = "io_failure";
+    item["reason_code"] = "io_failure";
+    item["message"] = write_error;
+    counts->io_failure_count += 1;
+    return item;
+  }
+  item["artifacts"]["compare"] = stable_compare_path;
+  item["diff_count"] = compare_invocation.report.isMember("diff_count")
+                           ? compare_invocation.report["diff_count"].asInt()
+                           : 0;
+
+  if (compare_invocation.exit_code == kExitSuccess) {
+    item["status"] = "pass";
+    item["reason_code"] = "pass";
+    item["passed"] = true;
+    counts->pass_count += 1;
+  } else if (compare_invocation.exit_code == kExitCompareMismatch) {
+    item["status"] = "mismatch";
+    item["reason_code"] =
+        compare_invocation.report.isMember("reason_code")
+            ? compare_invocation.report["reason_code"].asString()
+            : "compare_mismatch";
+    item["passed"] = false;
+    counts->mismatch_count += 1;
+  } else {
+    item["status"] = "input_failed";
+    item["reason_code"] =
+        compare_invocation.report.isMember("reason_code")
+            ? compare_invocation.report["reason_code"].asString()
+            : "compare_input_failed";
+    item["passed"] = false;
+    counts->input_failure_count += 1;
+  }
+  return item;
+}
+
+int FinalizeManifestRunReport(Json::Value* report,
+                              const ManifestRunCounts& counts) {
+  (*report)["pass_count"] = counts.pass_count;
+  (*report)["mismatch_count"] = counts.mismatch_count;
+  (*report)["input_failure_count"] = counts.input_failure_count;
+  (*report)["probe_failure_count"] = counts.probe_failure_count;
+  (*report)["schema_failure_count"] = counts.schema_failure_count;
+  (*report)["backend_unavailable_count"] = counts.backend_unavailable_count;
+  (*report)["io_failure_count"] = counts.io_failure_count;
+
+  int exit_code = kExitSuccess;
+  std::string run_status = "pass";
+  std::string reason_code = "pass";
+  if (counts.schema_failure_count > 0) {
+    exit_code = kExitSchemaValidationFailed;
+    run_status = "failed";
+    reason_code = "schema_validation_failed";
+  } else if (counts.io_failure_count > 0) {
+    exit_code = kExitIOFailure;
+    run_status = "failed";
+    reason_code = "io_failure";
+  } else if (counts.backend_unavailable_count > 0) {
+    exit_code = kExitBackendUnavailable;
+    run_status = "failed";
+    reason_code = "backend_unavailable";
+  } else if (counts.input_failure_count > 0) {
+    exit_code = kExitCompareInputFailure;
+    run_status = "failed";
+    reason_code = "compare_input_failed";
+  } else if (counts.probe_failure_count > 0) {
+    exit_code = kExitSkityProbeFailure;
+    run_status = "failed";
+    reason_code = "probe_failed";
+  } else if (counts.mismatch_count > 0) {
+    exit_code = kExitCompareMismatch;
+    run_status = "mismatch";
+    reason_code = "compare_mismatch";
+  }
+  (*report)["status"] = run_status;
+  (*report)["reason_code"] = reason_code;
+  (*report)["passed"] = exit_code == kExitSuccess;
+  return exit_code;
 }
 
 int RunCaseInfo(int argc, char** argv) {
@@ -731,6 +1011,121 @@ int RunProbeCommand(int argc, char** argv) {
                             invocation.exit_code);
 }
 
+int RunMatchCommand(int argc, char** argv) {
+  std::filesystem::path case_path;
+  std::filesystem::path output_path;
+  std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
+  std::string backend;
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--case") {
+      if (i + 1 >= argc) {
+        std::cerr << "--case requires a path\n";
+        return kExitUsageError;
+      }
+      case_path = argv[++i];
+    } else if (arg == "--backend") {
+      if (i + 1 >= argc) {
+        std::cerr << "--backend requires a value\n";
+        return kExitUsageError;
+      }
+      backend = argv[++i];
+    } else if (arg == "--out" || arg == "--report") {
+      if (i + 1 >= argc) {
+        std::cerr << arg << " requires a path\n";
+        return kExitUsageError;
+      }
+      output_path = argv[++i];
+    } else if (arg == "--repo-root") {
+      if (i + 1 >= argc) {
+        std::cerr << "--repo-root requires a path\n";
+        return kExitUsageError;
+      }
+      repo_root = argv[++i];
+    } else if (IsHelpArgument(arg)) {
+      PrintUsage(std::cout);
+      return kExitSuccess;
+    } else {
+      std::cerr << "Unknown match option: " << arg << "\n";
+      return kExitUsageError;
+    }
+  }
+
+  if (case_path.empty()) {
+    std::cerr << "match requires --case <path>\n";
+    return kExitUsageError;
+  }
+  if (backend.empty()) {
+    std::cerr << "match requires --backend <backend>\n";
+    return kExitUsageError;
+  }
+
+  Json::Value case_root;
+  std::string error;
+  std::string case_id = StemOrFallback(case_path, "case");
+  if (!skity::font_harness::LoadJsonFile(case_path, &case_root, &error)) {
+    Json::Value report =
+        BuildMatchSchemaErrorReport(case_id, backend, "--case", error);
+
+    skity::font_harness::ArtifactDescriptor descriptor;
+    descriptor.kind = skity::font_harness::ArtifactKind::kMatchResult;
+    descriptor.command = "match";
+    descriptor.output_flag = "--out";
+    descriptor.case_id = case_id;
+    descriptor.backend = backend;
+    descriptor.input_path = case_path;
+    descriptor.explicit_output_path = output_path;
+    descriptor.repro_args = {"--case", PathArg(case_path), "--backend",
+                             backend};
+    return WriteCommandReport(std::move(report), repo_root, descriptor,
+                              kExitSchemaValidationFailed);
+  }
+
+  ReadStringField(case_root, "id", &case_id);
+  std::string category;
+  ReadStringField(case_root, "category", &category);
+  if (!IsFontManagerProbeCategory(category)) {
+    Json::Value report = BuildMatchSchemaErrorReport(
+        case_id, backend, "$.category",
+        "match supports only font_manager and family_style_set cases");
+
+    skity::font_harness::ArtifactDescriptor descriptor;
+    descriptor.kind = skity::font_harness::ArtifactKind::kMatchResult;
+    descriptor.command = "match";
+    descriptor.output_flag = "--out";
+    descriptor.case_id = case_id;
+    descriptor.backend = backend;
+    descriptor.input_path = case_path;
+    descriptor.explicit_output_path = output_path;
+    descriptor.repro_args = {"--case", PathArg(case_path), "--backend",
+                             backend};
+    return WriteCommandReport(std::move(report), repo_root, descriptor,
+                              kExitSchemaValidationFailed);
+  }
+
+  skity::font_harness::FontManagerProbeRequest request;
+  request.repo_root = repo_root;
+  request.case_path = case_path;
+  request.backend = backend;
+  skity::font_harness::FontManagerProbeResult result =
+      skity::font_harness::RunFontManagerProbe(request);
+  const int exit_code = ExitCodeForProbeStatus(result.status);
+
+  skity::font_harness::ArtifactDescriptor descriptor;
+  descriptor.kind = skity::font_harness::ArtifactKind::kMatchResult;
+  descriptor.command = "match";
+  descriptor.output_flag = "--out";
+  descriptor.case_id = result.case_id.empty() ? case_id : result.case_id;
+  descriptor.backend = result.backend.empty() ? backend : result.backend;
+  descriptor.input_path = case_path;
+  descriptor.explicit_output_path = output_path;
+  descriptor.repro_args = {"--case", PathArg(case_path), "--backend", backend};
+
+  return WriteCommandReport(std::move(result.report), repo_root, descriptor,
+                            exit_code);
+}
+
 int RunCompareCommand(int argc, char** argv) {
   std::filesystem::path case_path;
   std::filesystem::path expected_path;
@@ -979,256 +1374,27 @@ int RunManifestCommand(int argc, char** argv) {
       StablePathForRun(resolved_compare_dir, repo_root);
 
   const std::string case_root_value = manifest_root["case_root"].asString();
-  const std::filesystem::path case_root =
-      ResolveRunPath(repo_root, case_root_value);
   const Json::Value& cases = manifest_root["cases"];
-  int pass_count = 0;
-  int mismatch_count = 0;
-  int input_failure_count = 0;
-  int probe_failure_count = 0;
-  int schema_failure_count = 0;
-  int backend_unavailable_count = 0;
-  int io_failure_count = 0;
 
+  ManifestRunPaths paths;
+  paths.case_root = ResolveRunPath(repo_root, case_root_value);
+  paths.repo_root = repo_root;
+  paths.resolved_skia_dir = resolved_skia_dir;
+  paths.resolved_skity_dir = resolved_skity_dir;
+  paths.resolved_compare_dir = resolved_compare_dir;
+  paths.backend = backend;
+
+  ManifestRunCounts counts;
   Json::Value case_reports(Json::arrayValue);
   for (Json::ArrayIndex i = 0; i < cases.size(); ++i) {
     const std::string case_relative_path = cases[i].asString();
-    const std::filesystem::path case_path =
-        (case_root / case_relative_path).lexically_normal();
-
-    Json::Value item(Json::objectValue);
-    item["index"] = i;
-    item["case"] = case_relative_path;
-    item["case_path"] = StablePathForRun(case_path, repo_root);
-    item["backend"] = backend;
-    item["status"] = "running";
-    item["artifacts"] = Json::Value(Json::objectValue);
-
-    Json::Value case_root_json;
-    std::string case_error;
-    if (!skity::font_harness::LoadJsonFile(case_path, &case_root_json,
-                                           &case_error)) {
-      item["status"] = "schema_validation_failed";
-      item["reason_code"] = "schema_validation_failed";
-      item["message"] = case_error;
-      schema_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-
-    skity::font_harness::CaseValidationResult case_validation =
-        skity::font_harness::ValidateCaseDocument(case_root_json, resolver);
-    const std::string case_id = case_validation.case_id.empty()
-                                    ? StemOrFallback(case_path, "case")
-                                    : case_validation.case_id;
-    item["case_id"] = case_id;
-    std::string category;
-    std::string status;
-    ReadStringField(case_root_json, "category", &category);
-    ReadStringField(case_root_json, "status", &status);
-    item["category"] = category;
-    item["case_status"] = status;
-
-    if (!case_validation.valid) {
-      item["status"] = "schema_validation_failed";
-      item["reason_code"] = "schema_validation_failed";
-      item["validation_errors"] = case_validation.errors.ToJson();
-      schema_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-    if (case_validation.backend != backend) {
-      item["status"] = "schema_validation_failed";
-      item["reason_code"] = "backend_mismatch";
-      item["message"] = "case backend does not match manifest run backend";
-      schema_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-    if (status != "active") {
-      item["status"] = "schema_validation_failed";
-      item["reason_code"] = "non_active_case_in_smoke";
-      item["message"] = "smoke manifest entries must be active cases";
-      schema_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-
-    const std::string safe_case_id = SanitizeFileComponent(case_id, "case");
-    const std::string safe_backend = SanitizeFileComponent(backend, "backend");
-    const std::filesystem::path expected_path =
-        resolved_skia_dir / (safe_case_id + ".skia.json");
-    const std::filesystem::path actual_path =
-        resolved_skity_dir / (safe_case_id + "." + safe_backend + ".json");
-    const std::filesystem::path compare_path =
-        resolved_compare_dir /
-        (safe_case_id + "." + safe_backend + ".compare.json");
-
-    item["artifacts"]["expected"] = StablePathForRun(expected_path, repo_root);
-    item["artifacts"]["actual"] = StablePathForRun(actual_path, repo_root);
-    item["artifacts"]["compare"] = StablePathForRun(compare_path, repo_root);
-
-    std::error_code exists_error;
-    if (!std::filesystem::is_regular_file(expected_path, exists_error)) {
-      item["status"] = "input_failed";
-      item["reason_code"] = "missing_oracle";
-      item["message"] = "Skia oracle is missing for manifest case";
-      item["compare_exit_code"] = kExitCompareInputFailure;
-      input_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-
-    ProbeInvocationResult probe_invocation =
-        RunSkityProbeForCase(repo_root, case_path, backend);
-    item["probe_exit_code"] = probe_invocation.exit_code;
-    skity::font_harness::ArtifactDescriptor probe_descriptor;
-    probe_descriptor.kind = skity::font_harness::ArtifactKind::kSkityResult;
-    probe_descriptor.command = "probe";
-    probe_descriptor.output_flag = "--out";
-    probe_descriptor.case_id =
-        probe_invocation.case_id.empty() ? case_id : probe_invocation.case_id;
-    probe_descriptor.backend =
-        probe_invocation.backend.empty() ? backend : probe_invocation.backend;
-    probe_descriptor.input_path = case_path;
-    probe_descriptor.explicit_output_path = actual_path;
-    probe_descriptor.repro_args = {
-        "--case", StablePathForRun(case_path, repo_root), "--backend", backend};
-
-    std::string write_error;
-    std::string stable_probe_path;
-    if (!WriteArtifactSilently(repo_root, probe_descriptor,
-                               &probe_invocation.report, &stable_probe_path,
-                               &write_error)) {
-      item["status"] = "io_failure";
-      item["reason_code"] = "io_failure";
-      item["message"] = write_error;
-      io_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-    item["artifacts"]["actual"] = stable_probe_path;
-
-    if (probe_invocation.exit_code != kExitSuccess) {
-      item["status"] = probe_invocation.exit_code == kExitBackendUnavailable
-                           ? "backend_unavailable"
-                           : "probe_failed";
-      item["reason_code"] =
-          probe_invocation.report.isMember("reason_code")
-              ? probe_invocation.report["reason_code"].asString()
-              : "probe_failed";
-      if (probe_invocation.exit_code == kExitBackendUnavailable) {
-        backend_unavailable_count += 1;
-      } else {
-        probe_failure_count += 1;
-      }
-      case_reports.append(std::move(item));
-      continue;
-    }
-
-    CompareInvocationResult compare_invocation = RunCompareForArtifacts(
-        repo_root, case_path, expected_path, actual_path, backend);
-    item["compare_exit_code"] = compare_invocation.exit_code;
-
-    skity::font_harness::ArtifactDescriptor compare_descriptor;
-    compare_descriptor.kind = skity::font_harness::ArtifactKind::kCompareReport;
-    compare_descriptor.command = "compare";
-    compare_descriptor.case_id = compare_invocation.case_id.empty()
-                                     ? case_id
-                                     : compare_invocation.case_id;
-    compare_descriptor.backend = compare_invocation.backend.empty()
-                                     ? backend
-                                     : compare_invocation.backend;
-    compare_descriptor.input_path = case_path;
-    compare_descriptor.explicit_output_path = compare_path;
-    compare_descriptor.repro_args = {
-        "--case",     StablePathForRun(case_path, repo_root),
-        "--expected", StablePathForRun(expected_path, repo_root),
-        "--actual",   StablePathForRun(actual_path, repo_root),
-        "--backend",  backend};
-
-    std::string stable_compare_path;
-    if (!WriteArtifactSilently(repo_root, compare_descriptor,
-                               &compare_invocation.report, &stable_compare_path,
-                               &write_error)) {
-      item["status"] = "io_failure";
-      item["reason_code"] = "io_failure";
-      item["message"] = write_error;
-      io_failure_count += 1;
-      case_reports.append(std::move(item));
-      continue;
-    }
-    item["artifacts"]["compare"] = stable_compare_path;
-    item["diff_count"] = compare_invocation.report.isMember("diff_count")
-                             ? compare_invocation.report["diff_count"].asInt()
-                             : 0;
-
-    if (compare_invocation.exit_code == kExitSuccess) {
-      item["status"] = "pass";
-      item["reason_code"] = "pass";
-      item["passed"] = true;
-      pass_count += 1;
-    } else if (compare_invocation.exit_code == kExitCompareMismatch) {
-      item["status"] = "mismatch";
-      item["reason_code"] =
-          compare_invocation.report.isMember("reason_code")
-              ? compare_invocation.report["reason_code"].asString()
-              : "compare_mismatch";
-      item["passed"] = false;
-      mismatch_count += 1;
-    } else {
-      item["status"] = "input_failed";
-      item["reason_code"] =
-          compare_invocation.report.isMember("reason_code")
-              ? compare_invocation.report["reason_code"].asString()
-              : "compare_input_failed";
-      item["passed"] = false;
-      input_failure_count += 1;
-    }
-    case_reports.append(std::move(item));
+    case_reports.append(
+        RunManifestCase(i, case_relative_path, paths, &resolver, &counts));
   }
 
   report["cases"] = std::move(case_reports);
   report["case_count"] = static_cast<int>(cases.size());
-  report["pass_count"] = pass_count;
-  report["mismatch_count"] = mismatch_count;
-  report["input_failure_count"] = input_failure_count;
-  report["probe_failure_count"] = probe_failure_count;
-  report["schema_failure_count"] = schema_failure_count;
-  report["backend_unavailable_count"] = backend_unavailable_count;
-  report["io_failure_count"] = io_failure_count;
-
-  int exit_code = kExitSuccess;
-  std::string run_status = "pass";
-  std::string reason_code = "pass";
-  if (schema_failure_count > 0) {
-    exit_code = kExitSchemaValidationFailed;
-    run_status = "failed";
-    reason_code = "schema_validation_failed";
-  } else if (io_failure_count > 0) {
-    exit_code = kExitIOFailure;
-    run_status = "failed";
-    reason_code = "io_failure";
-  } else if (backend_unavailable_count > 0) {
-    exit_code = kExitBackendUnavailable;
-    run_status = "failed";
-    reason_code = "backend_unavailable";
-  } else if (input_failure_count > 0) {
-    exit_code = kExitCompareInputFailure;
-    run_status = "failed";
-    reason_code = "compare_input_failed";
-  } else if (probe_failure_count > 0) {
-    exit_code = kExitSkityProbeFailure;
-    run_status = "failed";
-    reason_code = "probe_failed";
-  } else if (mismatch_count > 0) {
-    exit_code = kExitCompareMismatch;
-    run_status = "mismatch";
-    reason_code = "compare_mismatch";
-  }
-  report["status"] = run_status;
-  report["reason_code"] = reason_code;
-  report["passed"] = exit_code == kExitSuccess;
+  const int exit_code = FinalizeManifestRunReport(&report, counts);
 
   skity::font_harness::ArtifactDescriptor descriptor;
   descriptor.kind = skity::font_harness::ArtifactKind::kRunSummary;
@@ -1276,6 +1442,9 @@ int main(int argc, char** argv) {
   }
   if (command == "probe") {
     return RunProbeCommand(argc, argv);
+  }
+  if (command == "match") {
+    return RunMatchCommand(argc, argv);
   }
   if (command == "dump-path") {
     return RunDumpPathCommand(argc, argv);

--- a/harness/font/compare/compare_engine.cc
+++ b/harness/font/compare/compare_engine.cc
@@ -509,6 +509,8 @@ Json::Value NormalizePathGlyphItem(const Json::Value& item) {
   Json::Value value = NormalizeGlyphItem(item);
   if (item.isObject() && item.isMember("path")) {
     value["path"] = item["path"];
+  } else if (item.isObject() && item.isMember("normalized_path")) {
+    value["path"] = item["normalized_path"];
   }
   return value;
 }
@@ -522,6 +524,11 @@ Json::Value NormalizePathGlyphArray(const Json::Value& glyphs) {
     value.append(NormalizePathGlyphItem(glyph));
   }
   return value;
+}
+
+bool IsUnavailableResult(const Json::Value& value) {
+  return value.isObject() && value.isMember("available") &&
+         value["available"].isBool() && !value["available"].asBool();
 }
 
 Json::Value NormalizePathProbe(const Json::Value& root) {
@@ -542,8 +549,12 @@ Json::Value NormalizePathProbe(const Json::Value& root) {
   const Json::Value* scaler = ObjectMember(*probe, "scaler_context_result");
   if (scaler != nullptr) {
     Json::Value scaler_result(Json::objectValue);
-    scaler_result["glyph_paths"] =
-        NormalizePathGlyphArray(OptionalValue(*scaler, "glyph_paths"));
+    if (IsUnavailableResult(*scaler)) {
+      scaler_result["available"] = false;
+    } else {
+      scaler_result["glyph_paths"] =
+          NormalizePathGlyphArray(OptionalValue(*scaler, "glyph_paths"));
+    }
     value["scaler_context_result"] = std::move(scaler_result);
   }
   return value;
@@ -758,6 +769,19 @@ std::string FirstDiffReason(const std::vector<Diff>& diffs,
   return diffs.front().reason_code;
 }
 
+bool HasNewDiffs(size_t diff_count, const std::vector<Diff>& diffs) {
+  return diffs.size() > diff_count;
+}
+
+bool CompareSelectionSubset(const Json::Value& expected,
+                            const Json::Value& actual, const std::string& path,
+                            const std::string& rule, std::vector<Diff>* diffs) {
+  const size_t diff_count = diffs->size();
+  CompareJsonSubset(expected, actual, path, "selection_mismatch", rule, 0.0,
+                    false, diffs);
+  return HasNewDiffs(diff_count, *diffs);
+}
+
 void CompareDescriptor(const Json::Value& expected, const Json::Value& actual,
                        const std::string& path, const std::string& reason_code,
                        const CompareConfig& config, std::vector<Diff>* diffs) {
@@ -906,10 +930,12 @@ void CompareGlyphPathProbe(const Json::Value& expected_root,
                  actual["font_result"]["glyph_paths"],
                  "glyph_path_probe.font_result.glyph_paths",
                  config.glyph_path_epsilon, diffs);
-  ComparePathSet(expected["scaler_context_result"]["glyph_paths"],
-                 actual["scaler_context_result"]["glyph_paths"],
-                 "glyph_path_probe.scaler_context_result.glyph_paths",
-                 config.glyph_path_epsilon, diffs);
+  if (!IsUnavailableResult(expected["scaler_context_result"])) {
+    ComparePathSet(expected["scaler_context_result"]["glyph_paths"],
+                   actual["scaler_context_result"]["glyph_paths"],
+                   "glyph_path_probe.scaler_context_result.glyph_paths",
+                   config.glyph_path_epsilon, diffs);
+  }
 }
 
 void CompareFontManagerProbe(const Json::Value& expected_root,
@@ -918,23 +944,29 @@ void CompareFontManagerProbe(const Json::Value& expected_root,
                              std::vector<Diff>* diffs) {
   Json::Value expected = NormalizeFontManagerProbe(expected_root);
   Json::Value actual = NormalizeFontManagerProbe(actual_root);
-  CompareJsonSubset(OptionalValue(expected, "entry"),
-                    OptionalValue(actual, "entry"),
-                    "font_manager_probe.operation.entry", "selection_mismatch",
-                    "exact", 0.0, false, diffs);
-
-  CompareJsonSubset(OptionalValue(expected, "create_style_set"),
-                    OptionalValue(actual, "create_style_set"),
-                    "font_manager_probe.operation.create_style_set",
-                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
-  CompareJsonSubset(OptionalValue(expected, "style_set"),
-                    OptionalValue(actual, "style_set"),
-                    "font_manager_probe.operation.style_set",
-                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
-  CompareJsonSubset(OptionalValue(expected, "match_family"),
-                    OptionalValue(actual, "match_family"),
-                    "font_manager_probe.operation.match_family",
-                    "selection_mismatch", "style_set_exact", 0.0, false, diffs);
+  if (CompareSelectionSubset(
+          OptionalValue(expected, "entry"), OptionalValue(actual, "entry"),
+          "font_manager_probe.operation.entry", "exact", diffs)) {
+    return;
+  }
+  if (CompareSelectionSubset(OptionalValue(expected, "create_style_set"),
+                             OptionalValue(actual, "create_style_set"),
+                             "font_manager_probe.operation.create_style_set",
+                             "style_set_exact", diffs)) {
+    return;
+  }
+  if (CompareSelectionSubset(OptionalValue(expected, "style_set"),
+                             OptionalValue(actual, "style_set"),
+                             "font_manager_probe.operation.style_set",
+                             "style_set_exact", diffs)) {
+    return;
+  }
+  if (CompareSelectionSubset(OptionalValue(expected, "match_family"),
+                             OptionalValue(actual, "match_family"),
+                             "font_manager_probe.operation.match_family",
+                             "style_set_exact", diffs)) {
+    return;
+  }
 
   const Json::Value& expected_typefaces = expected["matched_typefaces"];
   const Json::Value& actual_typefaces = actual["matched_typefaces"];
@@ -949,9 +981,21 @@ void CompareFontManagerProbe(const Json::Value& expected_root,
   for (Json::ArrayIndex i = 0; i < expected_typefaces.size(); ++i) {
     const std::string path =
         IndexJsonPath("font_manager_probe.matched_typefaces", i);
+    if (CompareSelectionSubset(
+            OptionalValue(expected_typefaces[i], "available"),
+            OptionalValue(actual_typefaces[i], "available"),
+            ChildJsonPath(path, "available"), "selection_exact", diffs)) {
+      return;
+    }
+
+    const size_t descriptor_diff_count = diffs->size();
     CompareDescriptor(
         expected_typefaces[i]["descriptor"], actual_typefaces[i]["descriptor"],
         ChildJsonPath(path, "descriptor"), "selection_mismatch", config, diffs);
+    if (HasNewDiffs(descriptor_diff_count, *diffs)) {
+      return;
+    }
+
     if (expected_typefaces[i].isMember("font_style") &&
         actual_typefaces[i].isMember("font_style")) {
       CompareFontStyle(expected_typefaces[i]["font_style"],

--- a/harness/font/manifests/pc_macos_coretext_full.json
+++ b/harness/font/manifests/pc_macos_coretext_full.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "pc_macos_coretext_full",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "case_root": "harness/font/cases",
+  "cases": [
+    "typeface_probe/roboto_regular_file_coretext.json",
+    "typeface_probe/roboto_regular_data_coretext.json",
+    "font_metrics/roboto_regular_64_coretext.json",
+    "glyph_metrics/roboto_regular_latin_coretext.json",
+    "glyph_path/roboto_regular_latin_A_coretext.json",
+    "glyph_path/roboto_regular_missing_glyph_coretext.json",
+    "scaler_context/roboto_regular_64_coretext.json",
+    "family_style_set/helvetica_coretext.json",
+    "family_style_set/helvetica_weight_500_coretext.json",
+    "family_style_set/baskerville_weight_500_coretext.json",
+    "family_style_set/arial_italic_coretext.json",
+    "font_manager/default_typeface_coretext.json",
+    "font_manager/apple_system_ui_font_regular_coretext.json",
+    "font_manager/match_family_style_helvetica_regular_coretext.json",
+    "font_manager/match_family_style_character_cjk_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hans_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hant_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_coretext.json",
+    "font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json",
+    "font_manager/apple_system_ui_font_character_ko_hangul_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json",
+    "font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json",
+    "font_manager/apple_system_ui_font_character_arabic_alef_coretext.json",
+    "font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json",
+    "font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json",
+    "font_manager/css_generic_sans_serif_coretext.json"
+  ],
+  "artifacts": {
+    "skia_dir": "local/font-harness/artifacts/skia",
+    "skity_dir": "local/font-harness/artifacts/skity",
+    "compare_dir": "local/font-harness/artifacts/compare"
+  }
+}

--- a/harness/font/manifests/pc_macos_coretext_match_smoke.json
+++ b/harness/font/manifests/pc_macos_coretext_match_smoke.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "pc_macos_coretext_match_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "darwin-ct"
+  ],
+  "case_root": "harness/font/cases",
+  "cases": [
+    "family_style_set/helvetica_coretext.json",
+    "family_style_set/helvetica_weight_500_coretext.json",
+    "family_style_set/baskerville_weight_500_coretext.json",
+    "family_style_set/arial_italic_coretext.json",
+    "font_manager/default_typeface_coretext.json",
+    "font_manager/apple_system_ui_font_regular_coretext.json",
+    "font_manager/match_family_style_helvetica_regular_coretext.json",
+    "font_manager/match_family_style_character_cjk_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hans_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hant_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_coretext.json",
+    "font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json",
+    "font_manager/apple_system_ui_font_character_ko_hangul_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json",
+    "font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json",
+    "font_manager/apple_system_ui_font_character_arabic_alef_coretext.json",
+    "font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json",
+    "font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json",
+    "font_manager/css_generic_sans_serif_coretext.json"
+  ],
+  "artifacts": {
+    "skia_dir": "local/font-harness/artifacts/skia",
+    "skity_dir": "local/font-harness/artifacts/skity",
+    "compare_dir": "local/font-harness/artifacts/compare"
+  }
+}

--- a/harness/font/probe/font_manager_probe.cc
+++ b/harness/font/probe/font_manager_probe.cc
@@ -144,8 +144,8 @@ bool ParseCodePoint(const std::string& value, uint32_t* code_point) {
   }
   try {
     size_t consumed = 0;
-    unsigned long parsed = std::stoul(value.substr(2), &consumed, 16);
-    if (consumed != value.size() - 2 || parsed > 0x10FFFFul) {
+    const std::uint64_t parsed = std::stoull(value.substr(2), &consumed, 16);
+    if (consumed != value.size() - 2 || parsed > 0x10FFFFu) {
       return false;
     }
     *code_point = static_cast<uint32_t>(parsed);
@@ -477,7 +477,6 @@ Json::Value BuildTypefaceSummary(const std::string& label,
   value["label"] = label;
   value["available"] = typeface != nullptr;
   if (typeface == nullptr) {
-    errors->push_back(path + ".typeface is missing");
     return value;
   }
 

--- a/harness/font/probe/glyph_path_probe.cc
+++ b/harness/font/probe/glyph_path_probe.cc
@@ -430,7 +430,7 @@ Json::Value BuildPathItem(const GlyphRequest& glyph, const Path& path,
   item["path_empty"] = path_empty;
   item["path_finite"] = path_finite;
   item["expectation"] = PathExpectationToJson(expectation);
-  item["normalized_path"] = BuildNormalizedPathJson(path, normalize_options);
+  item["path"] = BuildNormalizedPathJson(path, normalize_options);
 
   if (!path_finite) {
     errors->push_back(path_prefix + ".path is not finite");

--- a/harness/font/tests/smoke/skity_font_cli_smoke.py
+++ b/harness/font/tests/smoke/skity_font_cli_smoke.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 
 CASE_ID = "font.synthetic.typeface"
+FONT_MANAGER_CASE_ID = "font.synthetic.font_manager.default_typeface"
 BACKEND = "coretext"
 
 
@@ -49,18 +50,53 @@ def make_case():
     }
 
 
-def make_manifest():
+def make_manifest(cases=None):
     return {
         "schema_version": 1,
         "id": "font.synthetic.smoke",
         "backend": BACKEND,
         "platforms": ["darwin-ct"],
         "case_root": "cases",
-        "cases": ["typeface.json"],
+        "cases": cases or ["typeface.json"],
         "artifacts": {
             "skia_dir": "artifacts/skia",
             "skity_dir": "artifacts/skity",
             "compare_dir": "artifacts/compare",
+        },
+    }
+
+
+def make_font_manager_case():
+    return {
+        "schema_version": 1,
+        "id": FONT_MANAGER_CASE_ID,
+        "category": "font_manager",
+        "status": "active",
+        "backend": BACKEND,
+        "platforms": ["darwin-ct"],
+        "font_manager_request": {
+            "entry": "GetDefaultTypeface",
+            "style": {
+                "weight": 400,
+                "width": 5,
+                "slant": "upright",
+            },
+            "sample_limit": 1,
+        },
+        "font_request": {
+            "size": 16,
+            "scale_x": 1,
+            "skew_x": 0,
+            "linear_metrics": False,
+            "subpixel": True,
+            "embolden": False,
+            "hinting": "normal",
+        },
+        "glyphs": {"chars": ["U+0041"]},
+        "compare": {
+            "typeface_identity": "normalized_descriptor",
+            "font_style": "exact",
+            "font_metrics": {"mode": "ignore"},
         },
     }
 
@@ -105,6 +141,64 @@ def make_probe_artifact(glyph_id):
     }
 
 
+def make_font_manager_probe_artifact(post_script_name, glyph_id):
+    return {
+        "schema_version": 1,
+        "artifact_type": "font_probe_result",
+        "case_id": FONT_MANAGER_CASE_ID,
+        "backend": BACKEND,
+        "ok": True,
+        "font_manager_probe": {
+            "category": "font_manager",
+            "operation": {"entry": "GetDefaultTypeface"},
+            "matched_typefaces": [
+                {
+                    "available": True,
+                    "descriptor": {
+                        "family_name": "Synthetic",
+                        "post_script_name": post_script_name,
+                        "collection_index": 0,
+                        "style": {
+                            "weight": 400,
+                            "width": 5,
+                            "slant": "upright",
+                        },
+                    },
+                    "font_style": {
+                        "weight": 400,
+                        "width": 5,
+                        "slant": "upright",
+                    },
+                    "units_per_em": 1000,
+                    "probe_summary": {
+                        "glyphs": [
+                            {
+                                "label": "U+0041",
+                                "code_point": 65,
+                                "glyph_id": glyph_id,
+                            }
+                        ],
+                        "font_result": {
+                            "font_metrics": {
+                                "ascent": -10.0,
+                                "descent": 3.0,
+                                "leading": 1.0,
+                            }
+                        },
+                        "scaler_context_result": {
+                            "font_metrics": {
+                                "ascent": -10.0,
+                                "descent": 3.0,
+                                "leading": 1.0,
+                            }
+                        },
+                    },
+                }
+            ],
+        },
+    }
+
+
 def run_command(args):
     return subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -141,6 +235,24 @@ def expect_report_field(path, field, expected):
     return 0
 
 
+def expect_report_has(path, field):
+    report = read_json(path)
+    value = report
+    for part in field.split("."):
+        if isinstance(value, list):
+            index = int(part)
+            if index >= len(value):
+                print(f"{path}: missing {field}", file=sys.stderr)
+                return 1
+            value = value[index]
+        elif part in value:
+            value = value[part]
+        else:
+            print(f"{path}: missing {field}", file=sys.stderr)
+            return 1
+    return 0
+
+
 def main():
     if len(sys.argv) != 2:
         print("usage: skity_font_cli_smoke.py <skity-font>", file=sys.stderr)
@@ -155,19 +267,36 @@ def main():
         tmp_dir = Path(tmp)
         repo_root = tmp_dir / "repo"
         case_path = repo_root / "cases/typeface.json"
+        font_manager_case_path = repo_root / "cases/font_manager_default.json"
         manifest_path = repo_root / "manifests/smoke.json"
+        full_manifest_path = repo_root / "manifests/full.json"
         expected_path = tmp_dir / "expected.skia.json"
         actual_path = tmp_dir / "actual.skity.json"
         mismatch_path = tmp_dir / "actual-mismatch.skity.json"
+        font_manager_expected_path = tmp_dir / "font-manager-expected.skia.json"
+        font_manager_mismatch_path = tmp_dir / "font-manager-mismatch.skity.json"
         report_dir = tmp_dir / "reports"
 
         (repo_root / "fonts").mkdir(parents=True)
         (repo_root / "fonts/synthetic.ttf").write_bytes(b"synthetic font bytes")
         write_json(case_path, make_case())
+        write_json(font_manager_case_path, make_font_manager_case())
         write_json(manifest_path, make_manifest())
+        write_json(
+            full_manifest_path,
+            make_manifest(["typeface.json", "font_manager_default.json"]),
+        )
         write_json(expected_path, make_probe_artifact(1))
         write_json(actual_path, make_probe_artifact(1))
         write_json(mismatch_path, make_probe_artifact(2))
+        write_json(
+            font_manager_expected_path,
+            make_font_manager_probe_artifact("Synthetic-Regular", 1),
+        )
+        write_json(
+            font_manager_mismatch_path,
+            make_font_manager_probe_artifact("Synthetic-Bold", 2),
+        )
 
         case_info_report = report_dir / "case-info.json"
         result = run_command(
@@ -186,6 +315,67 @@ def main():
             return 1
         if expect_report_field(case_info_report, "valid", True):
             return 1
+
+        result = run_command([skity_font, "match", "--help"])
+        if expect_exit("match help", result, 0):
+            return 1
+
+        match_reject_report = report_dir / "match-reject-typeface.json"
+        result = run_command(
+            [
+                skity_font,
+                "match",
+                "--case",
+                case_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--out",
+                match_reject_report,
+            ]
+        )
+        if expect_exit("match rejects non-font-manager case", result, 3):
+            return 1
+        if expect_report_field(
+            match_reject_report, "reason_code", "schema_validation_failed"
+        ):
+            return 1
+        if expect_report_field(match_reject_report, "ok", False):
+            return 1
+
+        match_report = report_dir / "match-font-manager.json"
+        result = run_command(
+            [
+                skity_font,
+                "match",
+                "--case",
+                font_manager_case_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--out",
+                match_report,
+            ]
+        )
+        if result.returncode == 0:
+            if expect_report_field(match_report, "ok", True):
+                return 1
+            if expect_report_has(match_report, "font_manager_probe.matched_typefaces.0"):
+                return 1
+            if expect_report_has(
+                match_report,
+                "font_manager_probe.matched_typefaces.0.probe_summary",
+            ):
+                return 1
+        else:
+            if expect_exit("match font_manager", result, 5):
+                return 1
+            if expect_report_field(match_report, "reason_code", "backend_unavailable"):
+                return 1
+            if expect_report_field(match_report, "ok", False):
+                return 1
 
         compare_report = report_dir / "compare-pass.json"
         result = run_command(
@@ -233,6 +423,40 @@ def main():
         if expect_exit("compare mismatch", result, 1):
             return 1
         if expect_report_field(mismatch_report, "reason_code", "glyph_id_mismatch"):
+            return 1
+
+        selection_mismatch_report = report_dir / "compare-selection-mismatch.json"
+        result = run_command(
+            [
+                skity_font,
+                "compare",
+                "--case",
+                font_manager_case_path,
+                "--expected",
+                font_manager_expected_path,
+                "--actual",
+                font_manager_mismatch_path,
+                "--backend",
+                BACKEND,
+                "--repo-root",
+                repo_root,
+                "--report",
+                selection_mismatch_report,
+            ]
+        )
+        if expect_exit("compare selection mismatch", result, 1):
+            return 1
+        if expect_report_field(
+            selection_mismatch_report, "reason_code", "selection_mismatch"
+        ):
+            return 1
+        if expect_report_field(selection_mismatch_report, "diff_count", 1):
+            return 1
+        if expect_report_field(
+            selection_mismatch_report,
+            "diff_path",
+            "font_manager_probe.matched_typefaces[0].descriptor.post_script_name",
+        ):
             return 1
 
         missing_oracle_report = report_dir / "compare-missing-oracle.json"
@@ -285,6 +509,44 @@ def main():
         if expect_report_field(run_report, "input_failure_count", 1):
             return 1
         if expect_report_field(run_report, "cases.0.reason_code", "missing_oracle"):
+            return 1
+
+        full_run_report = report_dir / "run-full-missing-oracle.json"
+        result = run_command(
+            [
+                skity_font,
+                "run",
+                "--manifest",
+                full_manifest_path,
+                "--backend",
+                BACKEND,
+                "--skia-dir",
+                tmp_dir / "missing-full-skia",
+                "--skity-dir",
+                tmp_dir / "full-skity",
+                "--repo-root",
+                repo_root,
+                "--report",
+                full_run_report,
+            ]
+        )
+        if expect_exit("run synthetic full missing oracle", result, 6):
+            return 1
+        if expect_report_field(full_run_report, "case_count", 2):
+            return 1
+        if expect_report_field(full_run_report, "input_failure_count", 2):
+            return 1
+        if expect_report_field(full_run_report, "schema_failure_count", 0):
+            return 1
+        if expect_report_field(full_run_report, "probe_failure_count", 0):
+            return 1
+        if expect_report_field(full_run_report, "io_failure_count", 0):
+            return 1
+        if expect_report_field(full_run_report, "backend_unavailable_count", 0):
+            return 1
+        if expect_report_field(full_run_report, "cases.0.reason_code", "missing_oracle"):
+            return 1
+        if expect_report_field(full_run_report, "cases.1.reason_code", "missing_oracle"):
             return 1
 
     return 0

--- a/harness/font/tests/unit/font_harness_self_test.cc
+++ b/harness/font/tests/unit/font_harness_self_test.cc
@@ -25,6 +25,8 @@ namespace {
 
 constexpr const char* kCaseId = "font.synthetic.typeface";
 constexpr const char* kMetricsCaseId = "font.synthetic.metrics";
+constexpr const char* kGlyphPathCaseId = "font.synthetic.glyph_path";
+constexpr const char* kFontManagerCaseId = "font.synthetic.font_manager";
 constexpr const char* kBackend = "coretext";
 
 class TempDir {
@@ -129,6 +131,59 @@ Json::Value MakeMetricsCase() {
   return root;
 }
 
+Json::Value MakeFontManagerCase() {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["id"] = kFontManagerCaseId;
+  root["category"] = "font_manager";
+  root["status"] = "active";
+  root["backend"] = kBackend;
+  root["platforms"] = Json::Value(Json::arrayValue);
+  root["platforms"].append("darwin-ct");
+
+  root["font_manager_request"] = Json::Value(Json::objectValue);
+  root["font_manager_request"]["entry"] = "MatchFamilyStyle";
+  root["font_manager_request"]["family_name"] = "Synthetic";
+  root["font_manager_request"]["style"] = Json::Value(Json::objectValue);
+  root["font_manager_request"]["style"]["weight"] = 400;
+  root["font_manager_request"]["style"]["width"] = 5;
+  root["font_manager_request"]["style"]["slant"] = "upright";
+
+  root["glyphs"] = Json::Value(Json::objectValue);
+  root["glyphs"]["chars"] = Json::Value(Json::arrayValue);
+  root["glyphs"]["chars"].append("U+0041");
+
+  root["compare"] = Json::Value(Json::objectValue);
+  root["compare"]["typeface_identity"] = "normalized_descriptor";
+  root["compare"]["font_style"] = "exact";
+  root["compare"]["font_metrics"] = Json::Value(Json::objectValue);
+  root["compare"]["font_metrics"]["mode"] = "epsilon";
+  root["compare"]["font_metrics"]["epsilon"] = 0.001;
+  return root;
+}
+
+Json::Value MakeGlyphPathCase() {
+  Json::Value root = MakeTypefaceCase();
+  root["id"] = kGlyphPathCaseId;
+  root["category"] = "glyph_path";
+  root["font_request"] = Json::Value(Json::objectValue);
+  root["font_request"]["size"] = 16.0;
+  root["compare"] = Json::Value(Json::objectValue);
+  root["compare"]["typeface_identity"] = "none";
+  root["compare"]["glyph_path"] = Json::Value(Json::objectValue);
+  root["compare"]["glyph_path"]["mode"] = "path_normalized";
+  root["compare"]["glyph_path"]["epsilon"] = 0.001;
+  return root;
+}
+
+Json::Value MakeMetricSummary(double ascent) {
+  Json::Value metrics(Json::objectValue);
+  metrics["ascent"] = ascent;
+  metrics["descent"] = 3.0;
+  metrics["leading"] = 1.0;
+  return metrics;
+}
+
 Json::Value MakeProbeArtifact(int glyph_id) {
   Json::Value root(Json::objectValue);
   root["schema_version"] = 1;
@@ -167,6 +222,177 @@ Json::Value MakeProbeArtifact(int glyph_id) {
   return root;
 }
 
+Json::Value MakeFontManagerArtifact(bool available,
+                                    const std::string& post_script_name,
+                                    int glyph_id, double font_ascent,
+                                    double scaler_ascent) {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["artifact_type"] = "font_probe_result";
+  root["case_id"] = kFontManagerCaseId;
+  root["backend"] = kBackend;
+  root["ok"] = true;
+
+  root["font_manager_probe"] = Json::Value(Json::objectValue);
+  root["font_manager_probe"]["operation"] = Json::Value(Json::objectValue);
+  root["font_manager_probe"]["operation"]["entry"] = "MatchFamilyStyle";
+  root["font_manager_probe"]["matched_typefaces"] =
+      Json::Value(Json::arrayValue);
+
+  Json::Value typeface(Json::objectValue);
+  typeface["available"] = available;
+  if (available) {
+    typeface["descriptor"] = Json::Value(Json::objectValue);
+    typeface["descriptor"]["family_name"] = "Synthetic";
+    typeface["descriptor"]["post_script_name"] = post_script_name;
+    typeface["descriptor"]["collection_index"] = 0;
+    typeface["descriptor"]["style"] = Json::Value(Json::objectValue);
+    typeface["descriptor"]["style"]["weight"] = 400;
+    typeface["descriptor"]["style"]["width"] = 5;
+    typeface["descriptor"]["style"]["slant"] = "upright";
+
+    typeface["font_style"] = Json::Value(Json::objectValue);
+    typeface["font_style"]["weight"] = 400;
+    typeface["font_style"]["width"] = 5;
+    typeface["font_style"]["slant"] = "upright";
+    typeface["units_per_em"] = 1000;
+  }
+
+  typeface["probe_summary"] = Json::Value(Json::objectValue);
+  typeface["probe_summary"]["font_result"] = Json::Value(Json::objectValue);
+  typeface["probe_summary"]["font_result"]["font_metrics"] =
+      MakeMetricSummary(font_ascent);
+  typeface["probe_summary"]["scaler_context_result"] =
+      Json::Value(Json::objectValue);
+  typeface["probe_summary"]["scaler_context_result"]["font_metrics"] =
+      MakeMetricSummary(scaler_ascent);
+  typeface["probe_summary"]["glyphs"] = Json::Value(Json::arrayValue);
+
+  Json::Value glyph(Json::objectValue);
+  glyph["label"] = "U+0041";
+  glyph["code_point"] = 65;
+  glyph["glyph_id"] = glyph_id;
+  typeface["probe_summary"]["glyphs"].append(std::move(glyph));
+
+  root["font_manager_probe"]["matched_typefaces"].append(std::move(typeface));
+  return root;
+}
+
+void RunFontManagerCompare(TempDir* temp, const Json::Value& expected,
+                           const Json::Value& actual, CompareResult* result) {
+  const std::filesystem::path case_path =
+      temp->root() / "cases/font_manager.json";
+  const std::filesystem::path expected_path =
+      temp->root() / "artifacts/expected.json";
+  const std::filesystem::path actual_path =
+      temp->root() / "artifacts/actual.json";
+  WriteJson(case_path, MakeFontManagerCase());
+  WriteJson(expected_path, expected);
+  WriteJson(actual_path, actual);
+
+  CompareRequest request;
+  request.repo_root = temp->root();
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = kBackend;
+  *result = RunCompare(request);
+}
+
+void ExpectSingleDiff(const CompareResult& result,
+                      const std::string& reason_code,
+                      const std::string& diff_path) {
+  EXPECT_EQ(CompareStatus::kMismatch, result.status)
+      << WriteJsonString(result.report);
+  EXPECT_FALSE(result.report["passed"].asBool());
+  EXPECT_EQ(reason_code, result.report["reason_code"].asString());
+  EXPECT_EQ(1, result.report["diff_count"].asInt());
+  EXPECT_EQ(diff_path, result.report["diff_path"].asString());
+  ASSERT_TRUE(result.report["diffs"].isArray());
+  ASSERT_EQ(1u, result.report["diffs"].size());
+  EXPECT_EQ(reason_code, result.report["diffs"][0]["reason_code"].asString());
+  EXPECT_EQ(diff_path, result.report["diffs"][0]["path"].asString());
+}
+
+Json::Value MakeSyntheticPath() {
+  Json::Value path(Json::objectValue);
+  path["mode"] = "path_normalized";
+  path["epsilon"] = 0.001;
+  path["empty"] = false;
+  path["finite"] = true;
+  path["verb_count"] = 2;
+  path["point_count"] = 2;
+  path["verb_sequence"] = Json::Value(Json::arrayValue);
+  path["verb_sequence"].append("move");
+  path["verb_sequence"].append("line");
+
+  Json::Value move(Json::objectValue);
+  move["index"] = 0;
+  move["verb"] = "move";
+  move["point_count"] = 1;
+  move["points"] = Json::Value(Json::arrayValue);
+  Json::Value move_point(Json::objectValue);
+  move_point["x"] = 0.0;
+  move_point["y"] = 0.0;
+  move["points"].append(std::move(move_point));
+
+  Json::Value line(Json::objectValue);
+  line["index"] = 1;
+  line["verb"] = "line";
+  line["point_count"] = 2;
+  line["points"] = Json::Value(Json::arrayValue);
+  Json::Value line_start(Json::objectValue);
+  line_start["x"] = 0.0;
+  line_start["y"] = 0.0;
+  line["points"].append(std::move(line_start));
+  Json::Value line_end(Json::objectValue);
+  line_end["x"] = 1.0;
+  line_end["y"] = 1.0;
+  line["points"].append(std::move(line_end));
+
+  path["verbs"] = Json::Value(Json::arrayValue);
+  path["verbs"].append(std::move(move));
+  path["verbs"].append(std::move(line));
+  return path;
+}
+
+Json::Value MakePathArtifact(bool use_normalized_path_field,
+                             bool scaler_unavailable) {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["artifact_type"] = "font_probe_result";
+  root["case_id"] = kGlyphPathCaseId;
+  root["backend"] = kBackend;
+  root["ok"] = true;
+
+  Json::Value glyph(Json::objectValue);
+  glyph["label"] = "U+0041";
+  glyph["code_point"] = 65;
+  glyph["glyph_id"] = 1;
+  glyph[use_normalized_path_field ? "normalized_path" : "path"] =
+      MakeSyntheticPath();
+
+  root["glyph_path_probe"] = Json::Value(Json::objectValue);
+  root["glyph_path_probe"]["font_result"] = Json::Value(Json::objectValue);
+  root["glyph_path_probe"]["font_result"]["glyph_paths"] =
+      Json::Value(Json::arrayValue);
+  root["glyph_path_probe"]["font_result"]["glyph_paths"].append(glyph);
+
+  root["glyph_path_probe"]["scaler_context_result"] =
+      Json::Value(Json::objectValue);
+  if (scaler_unavailable) {
+    root["glyph_path_probe"]["scaler_context_result"]["available"] = false;
+    root["glyph_path_probe"]["scaler_context_result"]["reason"] =
+        "synthetic unavailable";
+  } else {
+    root["glyph_path_probe"]["scaler_context_result"]["glyph_paths"] =
+        Json::Value(Json::arrayValue);
+    root["glyph_path_probe"]["scaler_context_result"]["glyph_paths"].append(
+        std::move(glyph));
+  }
+  return root;
+}
+
 Json::Value MakeMetricsArtifact(double ascent) {
   Json::Value root(Json::objectValue);
   root["schema_version"] = 1;
@@ -188,6 +414,91 @@ Json::Value MakeMetricsArtifact(double ascent) {
   root["metrics_probe"]["scaler_context_result"]["font_metrics"] =
       std::move(font_metrics);
   return root;
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ComparesPathArtifactsWithLegacyPathFieldAndUnavailableScalerOracle) {
+  TempDir temp("glyph_path_compare");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  const std::filesystem::path case_path = temp.root() / "cases/glyph_path.json";
+  const std::filesystem::path expected_path =
+      temp.root() / "artifacts/expected.json";
+  const std::filesystem::path actual_path =
+      temp.root() / "artifacts/actual.json";
+  WriteJson(case_path, MakeGlyphPathCase());
+  WriteJson(expected_path, MakePathArtifact(/*use_normalized_path_field=*/false,
+                                            /*scaler_unavailable=*/true));
+  WriteJson(actual_path, MakePathArtifact(/*use_normalized_path_field=*/true,
+                                          /*scaler_unavailable=*/false));
+
+  CompareRequest request;
+  request.repo_root = temp.root();
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = kBackend;
+
+  CompareResult pass = RunCompare(request);
+  EXPECT_EQ(CompareStatus::kPass, pass.status) << WriteJsonString(pass.report);
+  EXPECT_TRUE(pass.report["passed"].asBool());
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ShortCircuitsFontManagerCompareWhenAvailabilityDiffers) {
+  TempDir temp("font_manager_availability");
+  CompareResult result;
+  RunFontManagerCompare(
+      &temp,
+      MakeFontManagerArtifact(/*available=*/false, "Synthetic-Regular",
+                              /*glyph_id=*/1, /*font_ascent=*/10.0,
+                              /*scaler_ascent=*/10.0),
+      MakeFontManagerArtifact(/*available=*/true, "Synthetic-Regular",
+                              /*glyph_id=*/2, /*font_ascent=*/12.0,
+                              /*scaler_ascent=*/12.0),
+      &result);
+
+  ExpectSingleDiff(result, "selection_mismatch",
+                   "font_manager_probe.matched_typefaces[0].available");
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ShortCircuitsFontManagerCompareWhenDescriptorDiffers) {
+  TempDir temp("font_manager_descriptor");
+  CompareResult result;
+  RunFontManagerCompare(
+      &temp,
+      MakeFontManagerArtifact(/*available=*/true, "Synthetic-Regular",
+                              /*glyph_id=*/1, /*font_ascent=*/10.0,
+                              /*scaler_ascent=*/10.0),
+      MakeFontManagerArtifact(/*available=*/true, "Synthetic-Bold",
+                              /*glyph_id=*/2, /*font_ascent=*/12.0,
+                              /*scaler_ascent=*/12.0),
+      &result);
+
+  ExpectSingleDiff(
+      result, "selection_mismatch",
+      "font_manager_probe.matched_typefaces[0].descriptor.post_script_name");
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ComparesFontManagerMetricsAfterSelectionMatches) {
+  TempDir temp("font_manager_metrics");
+  CompareResult result;
+  RunFontManagerCompare(
+      &temp,
+      MakeFontManagerArtifact(/*available=*/true, "Synthetic-Regular",
+                              /*glyph_id=*/1, /*font_ascent=*/10.0,
+                              /*scaler_ascent=*/10.0),
+      MakeFontManagerArtifact(/*available=*/true, "Synthetic-Regular",
+                              /*glyph_id=*/1, /*font_ascent=*/12.0,
+                              /*scaler_ascent=*/10.0),
+      &result);
+
+  ExpectSingleDiff(
+      result, "metrics_mismatch",
+      "font_manager_probe.matched_typefaces[0].probe_summary.font_metrics."
+      "ascent");
 }
 
 TEST(FontHarnessCaseDocumentTest, ValidatesSyntheticTypefaceCase) {


### PR DESCRIPTION
Build out the mergeable macOS/CoreText font matching harness coverage around FontManager and FontStyleSet typeface selection. This adds active corpus coverage, match/full manifests, and a CLI debug entry for inspecting matched typefaces across system UI family matching, generic family behavior, same-family style selection, and single-code-point fallback cases covering CJK, emoji, symbols, and multiple script/locale paths.

The compare flow now keeps attribution at the selection layer when matched typefaces differ, avoiding noisy follow-up glyph or metrics diffs after a selection_mismatch has already been identified. Known selection gaps remain active and are marked with stable known_issue identifiers, so the gates continue to expose real parity gaps without carrying planning-stage identifiers into mergeable harness cases.

The harness self-checks are expanded to cover the new match, compare, and run behavior, keeping the corpus, selection short-circuiting, and CLI smoke behavior validated through local unit, ctest, and CoreText manifest gates.