### PR TITLE
fix(build): add missing standard includes

### DIFF
--- a/include/skity/recorder/display_list.hpp
+++ b/include/skity/recorder/display_list.hpp
@@ -5,6 +5,7 @@
 #ifndef INCLUDE_SKITY_RECORDER_DISPLAY_LIST_HPP
 #define INCLUDE_SKITY_RECORDER_DISPLAY_LIST_HPP
 
+#include <cstdlib>
 #include <memory>
 #include <skity/macros.hpp>
 #include <skity/render/canvas.hpp>

--- a/module/codec/src/codec/wuffs/wuffs_codec.cc
+++ b/module/codec/src/codec/wuffs/wuffs_codec.cc
@@ -4,6 +4,7 @@
 
 #include "src/codec/wuffs/wuffs_codec.hpp"
 
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <skity/io/pixmap.hpp>

--- a/src/gpu/gl/gl_interface.hpp
+++ b/src/gpu/gl/gl_interface.hpp
@@ -13,6 +13,7 @@
 #define SRC_GPU_GL_GL_INTERFACE_HPP
 
 #include <skity/macros.hpp>
+#include <type_traits>
 
 #ifdef __GNUC__
 #pragma clang diagnostic push

--- a/src/graphic/pathop/clipper2/core.h
+++ b/src/graphic/pathop/clipper2/core.h
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iterator>
+#include <type_traits>
 #include <vector>
 
 namespace skity::Clipper2Lib {

--- a/src/graphic/pathop/clipper2/engine.cc
+++ b/src/graphic/pathop/clipper2/engine.cc
@@ -18,6 +18,7 @@
 #include "src/graphic/pathop/clipper2/engine.h"
 
 #include <algorithm>
+#include <cstdlib>
 
 namespace skity::Clipper2Lib {
 

--- a/src/io/data.cc
+++ b/src/io/data.cc
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <functional>

--- a/src/io/pixmap.cc
+++ b/src/io/pixmap.cc
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <skity/io/data.hpp>
 #include <skity/io/pixmap.hpp>

--- a/src/render/hw/hw_stage_buffer.hpp
+++ b/src/render/hw/hw_stage_buffer.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 #include "src/gpu/gpu_buffer.hpp"

--- a/src/render/sw/sw_canvas.cc
+++ b/src/render/sw/sw_canvas.cc
@@ -5,6 +5,7 @@
 #include "src/render/sw/sw_canvas.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <skity/effect/mask_filter.hpp>
 #include <skity/effect/path_effect.hpp>

--- a/src/render/text/atlas/atlas_bitmap.cc
+++ b/src/render/text/atlas/atlas_bitmap.cc
@@ -4,6 +4,7 @@
 
 #include "src/render/text/atlas/atlas_bitmap.hpp"
 
+#include <cstdlib>
 #include <cstring>
 #include <skity/text/font.hpp>
 

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -4,6 +4,7 @@
 
 #include "src/render/text/atlas/atlas_manager.hpp"
 
+#include <cstdlib>
 #include <skity/text/font.hpp>
 
 #include "src/geometry/math.hpp"

--- a/src/text/ports/darwin/font_manager_darwin.cc
+++ b/src/text/ports/darwin/font_manager_darwin.cc
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <skity/macros.hpp>
 

--- a/src/text/ports/darwin/scaler_context_darwin.cc
+++ b/src/text/ports/darwin/scaler_context_darwin.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <skity/geometry/stroke.hpp>
 
 #include "src/text/ports/darwin/typeface_darwin.hpp"

--- a/src/text/ports/darwin/types_darwin.cc
+++ b/src/text/ports/darwin/types_darwin.cc
@@ -14,6 +14,7 @@
 #include <array>
 #include <mutex>
 #include <skity/macros.hpp>
+#include <string>
 
 namespace skity {
 

--- a/src/text/ports/scaler_context_freetype.cc
+++ b/src/text/ports/scaler_context_freetype.cc
@@ -18,6 +18,7 @@
 #include <freetype/ftstroke.h>
 #include <freetype/tttables.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <skity/geometry/stroke.hpp>
 

--- a/src/utils/arena_allocator.cc
+++ b/src/utils/arena_allocator.cc
@@ -4,6 +4,8 @@
 
 #include "src/utils/arena_allocator.hpp"
 
+#include <cstdlib>
+
 #include "src/logging.hpp"
 
 namespace skity {

--- a/tools/cpplint_check.py
+++ b/tools/cpplint_check.py
@@ -10,15 +10,21 @@ ignore_lists = ["shaders", "example", "test", "benchmarking", "src/graphic/patho
 
 def cpplintCheck(target_sha):
     mr = MergeRequest(target_sha)
+    root_dir = mr.GetRootDirectory()
     files = mr.GetChangedFiles()
 
     failed_file = []
 
     for file_name in files:
-        if file_name.endswith('.cc') or file_name.endswith('.hpp'):
+        rel_file_name = file_name
+        if root_dir and os.path.isabs(file_name):
+            rel_file_name = os.path.relpath(file_name, root_dir)
+        rel_file_name = os.path.normpath(rel_file_name).replace(os.sep, "/")
+
+        if rel_file_name.endswith('.cc') or rel_file_name.endswith('.hpp'):
             ignored = False
             for prefix in ignore_lists:
-                if file_name.startswith(prefix):
+                if rel_file_name.startswith(prefix):
                     ignored = True
                     break
             if ignored:


### PR DESCRIPTION
## Summary
- Add explicit standard library includes for allocation, conversion, type-traits, and string APIs used by Skity sources.
- Normalize paths in `tools/cpplint_check.py` before applying ignore prefixes so the existing `src/graphic/pathop/clipper2` exclusion works with absolute changed-file paths.

## Root Cause
Some files relied on transitive standard library includes. Stricter build integrations can fail when symbols like `std::malloc`, `std::free`, `std::realloc`, `std::llabs`, `std::is_same_v`, or `std::string` are used without their declaring headers. While validating the touched files, `cpplint_check.py` also linted the vendored clipper2 implementation because changed files are converted to absolute paths before matching relative ignore prefixes.

## Validation
- `./tools/hab sync . --target dev,module,ci`
- `python3 tools/code_format_check.py origin/main --json --clang-format-path ./buildtools/llvm/bin/clang-format`
- `python3 tools/cpplint_check.py origin/main`
- `PATH=$PWD/buildtools/cmake/CMake.app/Contents/bin:$PWD/buildtools/ninja:$PWD/buildtools/llvm/bin:$PATH python3 tools/test-runner.py --suite=unit --build-dir /private/tmp/skity-oss-pr-20260610/build-oss-pr --parallel 8 --clean --no-color`
  - 466 passed, 0 failed