### PR TITLE
feat(hw): add shader precompile context

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SKITY_PUBLIC_HEADERS
   ${CMAKE_CURRENT_LIST_DIR}/skity/graphic/tile_mode.hpp
   ${CMAKE_CURRENT_LIST_DIR}/skity/macros.hpp
   ${CMAKE_CURRENT_LIST_DIR}/skity/render/canvas.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/skity/render/precompile_context.hpp
   ${CMAKE_CURRENT_LIST_DIR}/skity/skity.hpp
   ${CMAKE_CURRENT_LIST_DIR}/skity/text/font.hpp
   ${CMAKE_CURRENT_LIST_DIR}/skity/text/font_arguments.hpp

--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -14,8 +14,11 @@
 #include <skity/gpu/gpu_surface.hpp>
 #include <skity/gpu/texture.hpp>
 #include <skity/macros.hpp>
+#include <skity/render/precompile_context.hpp>
 
 namespace skity {
+
+class Paint;
 
 /**
  * Query whether a specific GPU backend type is supported by this build.
@@ -187,6 +190,18 @@ class SKITY_API GPUContext {
    */
   SKITY_EXPERIMENTAL
   virtual void SetResourceCacheLimit(size_t size_in_bytes) = 0;
+
+  /**
+   * Create a precompile context bound to this GPUContext. The returned context
+   * can warm up common graphics, image, and text pipelines before drawing, and
+   * should be used on the same thread that owns this GPUContext.
+   *
+   * @param color_type  target surface color type used by the pipelines.
+   * @param enable_msaa whether the target surface uses MSAA. When enabled,
+   *                    precompile uses sample count 4.
+   */
+  std::unique_ptr<PrecompileContext> CreatePrecompileContext(
+      PrecompileColorType color_type, bool enable_msaa);
 
   /**
    * Register a error callback for outside user.

--- a/include/skity/render/precompile_context.hpp
+++ b/include/skity/render/precompile_context.hpp
@@ -1,0 +1,66 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef INCLUDE_SKITY_RENDER_PRECOMPILE_CONTEXT_HPP
+#define INCLUDE_SKITY_RENDER_PRECOMPILE_CONTEXT_HPP
+
+#include <cstdint>
+#include <memory>
+#include <skity/macros.hpp>
+
+namespace skity {
+
+class GPUContext;
+class Paint;
+class PrecompileContextImpl;
+
+enum class PrecompileColorType : uint8_t {
+  kRGBA,
+  kBGRA,
+};
+
+enum class PrecompileDrawType : uint16_t {
+  kDrawRect,
+  kDrawRRect,
+  kDrawPath,
+  kDrawText,
+  kDrawSDFText,
+  kDrawEmojiText,
+  kDrawImage,
+  kDrawImageRRect,
+  kClipPath,
+};
+
+/**
+ * Context used to warm up GPU pipeline variants before drawing. The context
+ * should be created with values matching the surface that will later render
+ * with the precompiled shaders.
+ */
+class SKITY_API PrecompileContext {
+ public:
+  ~PrecompileContext();
+
+  /**
+   * Precompile a set of common graphics, image, and text pipelines. The exact
+   * pipeline set is an implementation detail and may evolve over time.
+   */
+  void PrecompileDefaultShaders() const;
+
+  /**
+   * Precompile pipelines for a specific draw type and paint combination.
+   */
+  void PrecompileDraw(PrecompileDrawType draw_type, const Paint& paint) const;
+
+ private:
+  friend class GPUContext;
+
+  PrecompileContext(GPUContext* gpu_context, PrecompileColorType color_type,
+                    bool enable_msaa);
+
+  std::unique_ptr<PrecompileContextImpl> impl_;
+};
+
+}  // namespace skity
+
+#endif  // INCLUDE_SKITY_RENDER_PRECOMPILE_CONTEXT_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,6 +277,7 @@ if(${SKITY_HW_RENDERER})
     ${CMAKE_CURRENT_LIST_DIR}/gpu/gpu_shader_function.hpp
     ${CMAKE_CURRENT_LIST_DIR}/gpu/gpu_surface_impl.cc
     ${CMAKE_CURRENT_LIST_DIR}/gpu/gpu_surface_impl.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/render/hw/precompile_context.cc
     ${CMAKE_CURRENT_LIST_DIR}/gpu/gpu_texture.cc
     ${CMAKE_CURRENT_LIST_DIR}/gpu/gpu_texture.hpp
     ${CMAKE_CURRENT_LIST_DIR}/gpu/texture_impl.cc

--- a/src/gpu/gpu_context_impl.cc
+++ b/src/gpu/gpu_context_impl.cc
@@ -4,6 +4,9 @@
 
 #include "src/gpu/gpu_context_impl.hpp"
 
+#include <skity/render/precompile_context.hpp>
+#include <utility>
+
 namespace skity {
 
 bool GPUContextImpl::Init() {
@@ -60,6 +63,12 @@ std::shared_ptr<Texture> GPUContextImpl::WrapTexture(
 
 void GPUContextImpl::SetResourceCacheLimit(size_t size_in_bytes) {
   render_target_cache_->SetMaxBytes(size_in_bytes);
+}
+
+std::unique_ptr<PrecompileContext> GPUContext::CreatePrecompileContext(
+    PrecompileColorType color_type, bool enable_msaa) {
+  return std::unique_ptr<PrecompileContext>(
+      new PrecompileContext(this, color_type, enable_msaa));
 }
 
 std::unique_ptr<GPURenderTarget> GPUContextImpl::CreateRenderTarget(

--- a/src/gpu/gpu_context_impl.hpp
+++ b/src/gpu/gpu_context_impl.hpp
@@ -64,6 +64,17 @@ class GPUContextImpl : public GPUContext {
 
   std::shared_ptr<Data> ReadPixels(const std::shared_ptr<GPUTexture>& texture);
 
+  // Use depth-stencil capable pipeline state for stable pipeline variants.
+  // Draw steps still decide whether they actually use depth or stencil
+  // tests/writes.
+  void SetForceDepthStencilPipelineState(bool force) {
+    force_depth_stencil_pipeline_state_ = force;
+  }
+
+  bool IsForceDepthStencilPipelineState() const {
+    return force_depth_stencil_pipeline_state_;
+  }
+
  protected:
   void ResetOwnedResources();
 
@@ -87,6 +98,7 @@ class GPUContextImpl : public GPUContext {
   std::unique_ptr<HWRenderTargetCache> render_target_cache_ = {};
   std::unique_ptr<HWPipelineLib> pipeline_lib_ = {};
   std::unique_ptr<AtlasManager> atlas_manager_ = {};
+  bool force_depth_stencil_pipeline_state_ = false;
 };
 
 }  // namespace skity

--- a/src/render/hw/draw/hw_draw_step.cc
+++ b/src/render/hw/draw/hw_draw_step.cc
@@ -47,6 +47,14 @@ void HWDrawStep::GenerateCommand(const HWDrawStepContext& ctx, Command* cmd,
   }
 }
 
+bool HWDrawStep::PrecompilePipeline(HWDrawContext* context, HWDrawState state,
+                                    GPUTextureFormat target_format,
+                                    uint32_t sample_count,
+                                    BlendMode blend_mode) {
+  return GetPipeline(context, state, target_format, sample_count, blend_mode) !=
+         nullptr;
+}
+
 GPURenderPipeline* HWDrawStep::GetPipeline(HWDrawContext* context,
                                            HWDrawState state,
                                            GPUTextureFormat target_format,

--- a/src/render/hw/draw/hw_draw_step.hpp
+++ b/src/render/hw/draw/hw_draw_step.hpp
@@ -48,6 +48,10 @@ class HWDrawStep : public HWShaderGenerator {
   void GenerateCommand(const HWDrawStepContext& ctx, Command* cmd,
                        Command* stencil_cmd);
 
+  bool PrecompilePipeline(HWDrawContext* context, HWDrawState state,
+                          GPUTextureFormat target_format, uint32_t sample_count,
+                          BlendMode blend_mode);
+
   std::string GetVertexName() const override {
     if (geometry_->IsSnippet()) {
       return shader_writer_.GetVSShaderName();

--- a/src/render/hw/hw_layer.cc
+++ b/src/render/hw/hw_layer.cc
@@ -278,6 +278,10 @@ HWDrawState HWLayer::OnPrepare(HWDrawContext* context) {
     }
   }
 
+  if (context->gpuContext->IsForceDepthStencilPipelineState()) {
+    layer_state_ |= kDrawStateDepth | kDrawStateStencil;
+  }
+
   // abstract layer no need stencil test and depth for itself
   return HWDrawState::kDrawStateNone;
 }

--- a/src/render/hw/precompile_context.cc
+++ b/src/render/hw/precompile_context.cc
@@ -1,0 +1,519 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <memory>
+#include <skity/effect/color_filter.hpp>
+#include <skity/effect/shader.hpp>
+#include <skity/geometry/rrect.hpp>
+#include <skity/graphic/color.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/graphic/path.hpp>
+#include <skity/io/pixmap.hpp>
+#include <skity/render/canvas.hpp>
+#include <skity/render/precompile_context.hpp>
+#include <utility>
+#include <vector>
+
+#include "src/effect/pixmap_shader.hpp"
+#include "src/gpu/gpu_context_impl.hpp"
+#include "src/gpu/gpu_sampler.hpp"
+#include "src/graphic/blend_mode_priv.hpp"
+#include "src/logging.hpp"
+#include "src/render/hw/draw/fragment/wgsl_gradient_fragment.hpp"
+#include "src/render/hw/draw/fragment/wgsl_solid_color.hpp"
+#include "src/render/hw/draw/fragment/wgsl_solid_vertex_color.hpp"
+#include "src/render/hw/draw/fragment/wgsl_stencil_fragment.hpp"
+#include "src/render/hw/draw/fragment/wgsl_text_fragment.hpp"
+#include "src/render/hw/draw/fragment/wgsl_texture_fragment.hpp"
+#include "src/render/hw/draw/geometry/wgsl_clip_geometry.hpp"
+#include "src/render/hw/draw/geometry/wgsl_path_geometry.hpp"
+#include "src/render/hw/draw/geometry/wgsl_rrect_geometry.hpp"
+#include "src/render/hw/draw/geometry/wgsl_tess_path_fill_geometry.hpp"
+#include "src/render/hw/draw/geometry/wgsl_tess_path_stroke_geometry.hpp"
+#include "src/render/hw/draw/geometry/wgsl_text_geometry.hpp"
+#include "src/render/hw/draw/hw_draw_step.hpp"
+#include "src/render/hw/draw/step/clip_step.hpp"
+#include "src/render/hw/draw/step/color_step.hpp"
+#include "src/render/hw/draw/step/stencil_step.hpp"
+#include "src/render/hw/draw/wgx_filter.hpp"
+#include "src/render/hw/draw/wgx_programmable_blending.hpp"
+#include "src/render/hw/dst_read_strategy.hpp"
+#include "src/render/hw/hw_draw.hpp"
+#include "src/tracing.hpp"
+#include "src/utils/arena_allocator.hpp"
+#include "src/utils/batch_group.hpp"
+#include "src/utils/vector_cache.hpp"
+
+namespace skity {
+namespace {
+
+constexpr Rect kPrecompileBounds = {0.f, 0.f, 32.f, 32.f};
+
+Path MakePrecompilePath() {
+  Path path;
+  path.MoveTo(0.f, 0.f);
+  path.LineTo(16.f, 0.f);
+  path.LineTo(0.f, 16.f);
+  path.LineTo(16.f, 16.f);
+  path.Close();
+  return path;
+}
+
+RRect MakePrecompileRRect() {
+  return RRect::MakeRectXY(kPrecompileBounds, 8.f, 8.f);
+}
+
+Paint MakeTwoColorLinearGradientPaint(const float* pos) {
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+
+  Point pts[2] = {{0.f, 0.f, 0.f, 1.f}, {32.f, 32.f, 0.f, 1.f}};
+  Vec4 colors[2] = {Colors::kRed, Colors::kBlue};
+  paint.SetShader(Shader::MakeLinear(pts, colors, pos, 2));
+  return paint;
+}
+
+GPUTextureFormat ResolvePrecompileColorFormat(PrecompileColorType color_type) {
+  switch (color_type) {
+    case PrecompileColorType::kRGBA:
+      return GPUTextureFormat::kRGBA8Unorm;
+    case PrecompileColorType::kBGRA:
+      return GPUTextureFormat::kBGRA8Unorm;
+  }
+  return GPUTextureFormat::kInvalid;
+}
+
+bool PrecompileStep(HWDrawStep* step, HWDrawStepContext* ctx,
+                    BlendMode blend_mode) {
+  DEBUG_CHECK(step != nullptr);
+  DEBUG_CHECK(ctx != nullptr);
+
+  auto success =
+      step->PrecompilePipeline(ctx->context, ctx->state, ctx->color_format,
+                               ctx->sample_count, blend_mode);
+  if (!success) {
+    LOGE("Precompile shader failed: failed to create render pipeline");
+  }
+
+  ctx->context->pipelineLib->ResetCompileFailedPipelines();
+  return success;
+}
+
+HWWGSLFragment* ApplyPaintEffects(HWWGSLFragment* fragment, const Paint& paint,
+                                  GPUContextImpl* gpu_context) {
+  if (paint.GetColorFilter() != nullptr) {
+    fragment->SetFilter(WGXFilterFragment::Make(paint.GetColorFilter().get()));
+  }
+
+  if (IsAdvancedBlendMode(paint.GetBlendMode())) {
+    auto strategy = ResolveDstReadStrategy(
+        paint.GetBlendMode(), gpu_context->GetGPUDevice()->GetCaps());
+    fragment->SetProgrammableBlending(
+        WGXProgrammableBlending::Make(paint.GetBlendMode(), strategy));
+  }
+
+  return fragment;
+}
+
+HWWGSLFragment* MakeColorFragment(HWDrawStepContext* ctx, const Paint& paint,
+                                  bool has_color = true) {
+  auto* arena = ctx->context->arena_allocator;
+  HWWGSLFragment* fragment = nullptr;
+  if (paint.GetShader() != nullptr) {
+    Shader::GradientInfo info = {};
+    auto type = paint.GetShader()->AsGradient(&info);
+    if (type != Shader::GradientType::kNone) {
+      fragment = arena->Make<WGSLGradientFragment>(
+          info, type, paint.GetAlphaF(), paint.GetShader()->GetLocalMatrix());
+      return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+    }
+  }
+
+  if (!has_color) {
+    fragment = arena->Make<WGSLSolidVertexColor>();
+  } else {
+    fragment = arena->Make<WGSLSolidColor>(paint.GetFillColor());
+  }
+
+  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+}
+
+HWWGSLFragment* MakeTextureFragment(HWDrawStepContext* ctx, const Paint& paint,
+                                    std::shared_ptr<PixmapShader> shader,
+                                    const Matrix& matrix) {
+  auto* fragment = ctx->context->arena_allocator->Make<WGSLTextureFragment>(
+      std::move(shader), nullptr, nullptr, 1.f, matrix, 1.f, 1.f);
+  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+}
+
+void PrecompilePathStep(HWDrawStepContext* ctx, const Paint& paint,
+                        bool is_stroke) {
+  auto* arena = ctx->context->arena_allocator;
+  auto path = MakePrecompilePath();
+  auto coverage = is_stroke ? CoverageType::kNoZero : CoverageType::kWinding;
+
+  if (paint.IsAntiAlias()) {
+    auto* geometry = arena->Make<WGSLPathAAGeometry>(path, paint);
+    auto* fragment = MakeColorFragment(ctx, paint);
+    auto* aa_step = arena->Make<ColorAAStep>(geometry, fragment, coverage);
+    PrecompileStep(aa_step, ctx, paint.GetBlendMode());
+  } else if (!is_stroke) {
+    auto* geometry = arena->Make<WGSLPathGeometry>(path, paint, false);
+    auto* fragment = MakeColorFragment(ctx, paint);
+    auto* color_step =
+        arena->Make<ColorStep>(geometry, fragment, CoverageType::kNone);
+    // Single pass fill geometry is precompiled as fill geometry.
+    PrecompileStep(color_step, ctx, paint.GetBlendMode());
+  }
+
+  auto* stencil_step = arena->Make<StencilStep>(
+      arena->Make<WGSLPathGeometry>(path, paint, is_stroke),
+      arena->Make<WGSLStencilFragment>(), is_stroke);
+  PrecompileStep(stencil_step, ctx, BlendMode::kDefault);
+  auto* geometry = arena->Make<WGSLPathGeometry>(path, paint, is_stroke);
+  auto* fragment = MakeColorFragment(ctx, paint);
+  auto* color_step = arena->Make<ColorStep>(geometry, fragment, coverage);
+  PrecompileStep(color_step, ctx, paint.GetBlendMode());
+}
+
+void PrecompileTessPathStep(HWDrawStepContext* ctx, const Paint& paint,
+                            bool is_stroke) {
+  auto* arena = ctx->context->arena_allocator;
+  auto path = MakePrecompilePath();
+  HWWGSLGeometry* geometry = nullptr;
+  if (is_stroke) {
+    geometry = arena->Make<WGSLTessPathStrokeGeometry>(path, paint);
+  } else {
+    geometry = arena->Make<WGSLTessPathFillGeometry>(path, paint);
+  }
+  auto* fragment = MakeColorFragment(ctx, paint);
+  auto coverage = is_stroke ? CoverageType::kNoZero : CoverageType::kWinding;
+  auto* stencil_step = arena->Make<StencilStep>(
+      geometry, arena->Make<WGSLStencilFragment>(), is_stroke);
+  auto* color_step = arena->Make<ColorStep>(geometry, fragment, coverage);
+  if (!is_stroke && !paint.IsAntiAlias()) {
+    auto* single_pass_step =
+        arena->Make<ColorStep>(geometry, fragment, CoverageType::kNone);
+    // Single pass fill geometry is precompiled as fill geometry.
+    PrecompileStep(single_pass_step, ctx, paint.GetBlendMode());
+  }
+  PrecompileStep(stencil_step, ctx, BlendMode::kDefault);
+  PrecompileStep(color_step, ctx, paint.GetBlendMode());
+}
+
+void PrecompileRRectStep(HWDrawStepContext* ctx, const Paint& paint) {
+  auto* arena = ctx->context->arena_allocator;
+  std::vector<BatchGroup<RRect>> batch_group;
+  batch_group.emplace_back(BatchGroup<RRect>{
+      MakePrecompileRRect(),
+      paint,
+      Matrix{},
+  });
+
+  auto* geometry = arena->Make<WGSLRRectGeometry>(batch_group);
+  auto* fragment = MakeColorFragment(ctx, paint, false);
+  auto* step = arena->Make<ColorStep>(geometry, fragment, CoverageType::kNone);
+  PrecompileStep(step, ctx, paint.GetBlendMode());
+}
+
+void PrecompileImageStep(HWDrawStepContext* ctx, const Paint& paint,
+                         bool use_rrect = false) {
+  auto* arena = ctx->context->arena_allocator;
+  auto path = MakePrecompilePath();
+  auto matrix = Matrix{};
+  auto work_paint = paint;
+  work_paint.SetStyle(Paint::kFill_Style);
+
+  auto pixmap = std::make_shared<Pixmap>(1, 1, AlphaType::kPremul_AlphaType,
+                                         ColorType::kRGBA);
+  auto image = Image::MakeImage(std::move(pixmap));
+  auto shader = std::make_shared<PixmapShader>(
+      std::move(image), SamplingOptions{}, TileMode::kDecal, TileMode::kDecal,
+      matrix);
+
+  HWWGSLGeometry* geometry = nullptr;
+  if (use_rrect) {
+    std::vector<BatchGroup<RRect>> batch_group;
+    batch_group.emplace_back(BatchGroup<RRect>{
+        MakePrecompileRRect(),
+        work_paint,
+        matrix,
+    });
+    geometry = arena->Make<WGSLRRectGeometry>(batch_group);
+  } else {
+    geometry = arena->Make<WGSLPathGeometry>(path, work_paint, false);
+  }
+
+  auto* fragment =
+      MakeTextureFragment(ctx, work_paint, std::move(shader), matrix);
+  auto* step = arena->Make<ColorStep>(geometry, fragment, CoverageType::kNone);
+
+  PrecompileStep(step, ctx, work_paint.GetBlendMode());
+}
+
+ArrayList<GlyphRect, 16> MakePrecompileGlyphRects(ArenaAllocator* arena) {
+  ArrayList<GlyphRect, 16> glyph_rects;
+  glyph_rects.SetArenaAllocator(arena);
+  glyph_rects.emplace_back(Vec4{0.f, 0.f, 16.f, 16.f}, Vec2{0.f, 0.f},
+                           Vec2{1.f, 1.f});
+  return glyph_rects;
+}
+
+HWWGSLFragment* MakeTextFragment(HWDrawStepContext* ctx, const Paint& paint,
+                                 WGSLTextFragment::BatchedTexture textures,
+                                 std::shared_ptr<GPUSampler> sampler, bool sdf,
+                                 bool emoji, bool swizzle_rb) {
+  auto* arena = ctx->context->arena_allocator;
+  HWWGSLFragment* fragment = nullptr;
+
+  if (emoji) {
+    fragment = arena->Make<WGSLColorEmojiFragment>(
+        std::move(textures), std::move(sampler), swizzle_rb, paint.GetAlphaF());
+  } else if (paint.GetShader() != nullptr && !sdf &&
+             paint.GetShader()->AsGradient(nullptr) !=
+                 Shader::GradientType::kNone) {
+    Shader::GradientInfo info = {};
+    auto type = paint.GetShader()->AsGradient(&info);
+    fragment = arena->Make<WGSLGradientTextFragment>(
+        std::move(textures), std::move(sampler), info, type, paint.GetAlphaF());
+  } else if (sdf) {
+    fragment = arena->Make<WGSLSdfColorTextFragment>(
+        std::move(textures), std::move(sampler), paint.GetFillColor());
+  } else {
+    fragment = arena->Make<WGSLColorTextFragment>(std::move(textures),
+                                                  std::move(sampler));
+  }
+
+  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+}
+
+void PrecompileTextStep(HWDrawStepContext* ctx, const Paint& paint, bool sdf,
+                        bool emoji, bool swizzle_rb = false) {
+  auto* arena = ctx->context->arena_allocator;
+  auto glyph_rects = MakePrecompileGlyphRects(arena);
+  WGSLTextFragment::BatchedTexture textures = {};
+  std::shared_ptr<GPUSampler> sampler;
+
+  HWWGSLGeometry* geometry = nullptr;
+  if (paint.GetShader() != nullptr && !sdf &&
+      paint.GetShader()->AsGradient(nullptr) != Shader::GradientType::kNone) {
+    geometry = arena->Make<WGSLTextGradientGeometry>(
+        Matrix{}, std::move(glyph_rects), paint.GetShader()->GetLocalMatrix(),
+        Matrix{});
+  } else {
+    geometry = arena->Make<WGSLTextSolidColorGeometry>(
+        Matrix{}, std::move(glyph_rects), paint);
+  }
+
+  auto* fragment = MakeTextFragment(ctx, paint, std::move(textures),
+                                    std::move(sampler), sdf, emoji, swizzle_rb);
+  auto* step = arena->Make<ColorStep>(geometry, fragment, CoverageType::kNone);
+  PrecompileStep(step, ctx, paint.GetBlendMode());
+}
+
+}  // namespace
+
+class PrecompileContextImpl {
+ public:
+  PrecompileContextImpl(GPUContextImpl* gpu_context,
+                        GPUTextureFormat color_format, uint32_t sample_count);
+
+  void PrecompileDefaultShaders();
+
+  void PrecompileDraw(PrecompileDrawType draw_type, const Paint& paint);
+
+ private:
+  void Init();
+
+  GPUContextImpl* gpu_context_ = nullptr;
+  bool valid_ = false;
+  GPUTextureFormat color_format_ = GPUTextureFormat::kInvalid;
+  uint32_t sample_count_ = 1;
+  std::shared_ptr<BlockCacheAllocator> block_cache_allocator_ =
+      std::make_shared<BlockCacheAllocator>();
+  ArenaAllocator arena_{block_cache_allocator_};
+  VectorCache<float> vertex_vector_cache_;
+  VectorCache<uint32_t> index_vector_cache_;
+  HWDrawContext draw_context_ = {};
+  HWDrawStepContext step_context_ = {};
+};
+
+PrecompileContextImpl::PrecompileContextImpl(GPUContextImpl* gpu_context,
+                                             GPUTextureFormat color_format,
+                                             uint32_t sample_count)
+    : gpu_context_(gpu_context),
+      color_format_(color_format),
+      sample_count_(sample_count) {
+  Init();
+}
+
+void PrecompileContextImpl::Init() {
+  if (gpu_context_ == nullptr || gpu_context_->GetPipelineLib() == nullptr) {
+    return;
+  }
+
+  if (color_format_ == GPUTextureFormat::kInvalid) {
+    return;
+  }
+
+  draw_context_.pipelineLib = gpu_context_->GetPipelineLib();
+  draw_context_.gpuContext = gpu_context_;
+  draw_context_.vertex_vector_cache = &vertex_vector_cache_;
+  draw_context_.index_vector_cache = &index_vector_cache_;
+  draw_context_.arena_allocator = &arena_;
+  draw_context_.scale = {1.f, 1.f};
+  draw_context_.ctx_scale = 1.f;
+
+  step_context_.context = &draw_context_;
+  step_context_.state = kDrawStateDepth | kDrawStateStencil;
+  step_context_.color_format = color_format_;
+  step_context_.sample_count = sample_count_;
+  valid_ = true;
+}
+
+void PrecompileContextImpl::PrecompileDefaultShaders() {
+  if (!valid_) {
+    return;
+  }
+
+  Paint solid_paint;
+  solid_paint.SetStyle(Paint::kFill_Style);
+  Paint stroke_paint;
+  stroke_paint.SetStyle(Paint::kStroke_Style);
+
+  PrecompileDraw(PrecompileDrawType::kDrawPath, solid_paint);
+  PrecompileDraw(PrecompileDrawType::kDrawPath, stroke_paint);
+  PrecompileDraw(PrecompileDrawType::kDrawRRect, solid_paint);
+  PrecompileDraw(PrecompileDrawType::kDrawText, solid_paint);
+  PrecompileDraw(PrecompileDrawType::kDrawImage, solid_paint);
+  PrecompileDraw(PrecompileDrawType::kDrawImageRRect, solid_paint);
+
+  PrecompileDraw(PrecompileDrawType::kDrawPath,
+                 MakeTwoColorLinearGradientPaint(nullptr));
+  float color_fast_pos[2] = {0.f, 1.f};
+  PrecompileDraw(PrecompileDrawType::kDrawPath,
+                 MakeTwoColorLinearGradientPaint(color_fast_pos));
+  float pos[2] = {0.25f, 0.75f};
+  PrecompileDraw(PrecompileDrawType::kDrawPath,
+                 MakeTwoColorLinearGradientPaint(pos));
+}
+
+void PrecompileContextImpl::PrecompileDraw(PrecompileDrawType draw_type,
+                                           const Paint& paint) {
+  if (!valid_) {
+    return;
+  }
+
+  auto work_paint = paint;
+  if (gpu_context_->IsEnableSimpleShapePipeline() &&
+      (draw_type == PrecompileDrawType::kDrawRRect ||
+       (draw_type == PrecompileDrawType::kDrawRect &&
+        work_paint.GetStyle() == Paint::kStroke_Style))) {
+    PrecompileRRectStep(&step_context_, work_paint);
+    return;
+  }
+
+  if (draw_type == PrecompileDrawType::kDrawText ||
+      draw_type == PrecompileDrawType::kDrawSDFText ||
+      draw_type == PrecompileDrawType::kDrawEmojiText) {
+    bool is_emoji = draw_type == PrecompileDrawType::kDrawEmojiText;
+    bool is_sdf = draw_type == PrecompileDrawType::kDrawSDFText;
+    if (is_emoji) {
+      PrecompileTextStep(&step_context_, work_paint, false, true, false);
+      PrecompileTextStep(&step_context_, work_paint, false, true, true);
+    } else {
+      PrecompileTextStep(&step_context_, work_paint, is_sdf, false, false);
+    }
+    return;
+  }
+
+  if (draw_type == PrecompileDrawType::kDrawImage ||
+      draw_type == PrecompileDrawType::kDrawImageRRect) {
+    PrecompileImageStep(&step_context_, work_paint,
+                        draw_type == PrecompileDrawType::kDrawImageRRect);
+    return;
+  }
+
+  if (draw_type == PrecompileDrawType::kClipPath) {
+    auto path = MakePrecompilePath();
+    auto* step = arena_.Make<ClipStep>(
+        arena_.Make<WGSLClipGeometry>(path, work_paint, false,
+                                      Canvas::ClipOp::kIntersect),
+        arena_.Make<WGSLStencilFragment>(), path.GetFillType(),
+        Canvas::ClipOp::kIntersect);
+    PrecompileStep(step, &step_context_, BlendMode::kDefault);
+    return;
+  }
+
+  if (gpu_context_->IsEnableGPUTessellation() &&
+      (sample_count_ > 1 || !gpu_context_->IsEnableContourAA() ||
+       !work_paint.IsAntiAlias())) {
+    if (work_paint.GetStyle() != Paint::kStroke_Style) {
+      Paint fill_paint(work_paint);
+      fill_paint.SetStyle(Paint::kFill_Style);
+      fill_paint.SetAntiAlias(false);
+      PrecompileTessPathStep(&step_context_, fill_paint, false);
+    }
+
+    if (work_paint.GetStyle() != Paint::kFill_Style) {
+      Paint stroke_paint(work_paint);
+      stroke_paint.SetStyle(Paint::kStroke_Style);
+      stroke_paint.SetAntiAlias(false);
+      PrecompileTessPathStep(&step_context_, stroke_paint, true);
+    }
+    return;
+  }
+
+  bool need_contour_aa = sample_count_ == 1 &&
+                         gpu_context_->IsEnableContourAA() &&
+                         work_paint.IsAntiAlias();
+
+  if (need_contour_aa) {
+    work_paint.SetAntiAlias(true);
+    // Contour AA stroke is precompiled as fill geometry.
+    PrecompilePathStep(&step_context_, work_paint, false);
+    return;
+  }
+
+  work_paint.SetAntiAlias(false);
+  if (work_paint.GetStyle() != Paint::kStroke_Style) {
+    PrecompilePathStep(&step_context_, work_paint, false);
+  }
+  if (work_paint.GetStyle() != Paint::kFill_Style) {
+    PrecompilePathStep(&step_context_, work_paint, true);
+  }
+}
+
+PrecompileContext::PrecompileContext(GPUContext* gpu_context,
+                                     PrecompileColorType color_type,
+                                     bool enable_msaa) {
+  auto gpu_context_impl = static_cast<GPUContextImpl*>(gpu_context);
+
+  auto color_format = ResolvePrecompileColorFormat(color_type);
+  if (color_format == GPUTextureFormat::kInvalid) {
+    LOGE("Precompile shader failed: precompile color type {} is not supported",
+         static_cast<int>(color_type));
+  }
+  if (color_format != GPUTextureFormat::kInvalid) {
+    gpu_context_impl->SetForceDepthStencilPipelineState(true);
+  }
+  impl_ = std::make_unique<PrecompileContextImpl>(
+      gpu_context_impl, color_format, enable_msaa ? 4u : 1u);
+}
+
+PrecompileContext::~PrecompileContext() = default;
+
+void PrecompileContext::PrecompileDefaultShaders() const {
+  SKITY_TRACE_EVENT(PrecompileContext_PrecompileDefaultShaders);
+  impl_->PrecompileDefaultShaders();
+}
+
+void PrecompileContext::PrecompileDraw(PrecompileDrawType draw_type,
+                                       const Paint& paint) const {
+  SKITY_TRACE_EVENT(PrecompileContext_PrecompileDraw);
+  impl_->PrecompileDraw(draw_type, paint);
+}
+
+}  // namespace skity

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(skity_unit_test
     render/canvas_state_test.cc
     render/hw/hw_buffer_layout_test.cc
     render/hw/hw_pipeline_key_test.cc
+    render/hw/precompile_test.cc
     render/hw/hw_texture_copy_info_test.cc
     render/hw/draw/hw_wgsl_shader_writer_test.cc
     wgx/wgx_backend_name_resolution_test.cc

--- a/test/ut/render/hw/precompile_test.cc
+++ b/test/ut/render/hw/precompile_test.cc
@@ -1,0 +1,1070 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <skity/effect/color_filter.hpp>
+#include <skity/effect/shader.hpp>
+#include <skity/geometry/rrect.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/graphic/path.hpp>
+#include <skity/graphic/sampling_options.hpp>
+#include <skity/io/pixmap.hpp>
+#include <skity/render/canvas.hpp>
+#include <skity/render/precompile_context.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/gpu/gpu_blit_pass.hpp"
+#include "src/gpu/gpu_buffer.hpp"
+#include "src/gpu/gpu_command_buffer.hpp"
+#include "src/gpu/gpu_context_impl.hpp"
+#include "src/gpu/gpu_device.hpp"
+#include "src/gpu/gpu_render_pipeline.hpp"
+#include "src/gpu/gpu_sampler.hpp"
+#include "src/gpu/gpu_shader_function.hpp"
+#include "src/gpu/gpu_shader_module.hpp"
+#include "src/gpu/gpu_surface_impl.hpp"
+#include "src/gpu/gpu_texture.hpp"
+#include "src/render/hw/layer/hw_root_layer.hpp"
+
+namespace skity {
+namespace {
+
+class FakeShaderFunction : public GPUShaderFunction {
+ public:
+  explicit FakeShaderFunction(GPULabel label)
+      : GPUShaderFunction(std::move(label)) {}
+
+  bool IsValid() const override { return true; }
+};
+
+class FakeRenderPipeline : public GPURenderPipeline {
+ public:
+  explicit FakeRenderPipeline(const GPURenderPipelineDescriptor& desc)
+      : GPURenderPipeline(desc) {}
+};
+
+class FakeSampler : public GPUSampler {
+ public:
+  explicit FakeSampler(const GPUSamplerDescriptor& desc) : GPUSampler(desc) {}
+
+  ~FakeSampler() override = default;
+};
+
+class FakeGPUTexture : public GPUTexture {
+ public:
+  explicit FakeGPUTexture(const GPUTextureDescriptor& desc)
+      : GPUTexture(desc) {}
+
+  ~FakeGPUTexture() override = default;
+
+  size_t GetBytes() const override {
+    return desc_.width * desc_.height *
+           GetTextureFormatBytesPerPixel(desc_.format);
+  }
+
+  void UploadData(uint32_t, uint32_t, uint32_t, uint32_t, void*) override {}
+};
+
+class FakeBlitPass : public GPUBlitPass {
+ public:
+  void UploadTextureData(std::shared_ptr<GPUTexture>, uint32_t, uint32_t,
+                         uint32_t, uint32_t, void*) override {}
+
+  void UploadBufferData(GPUBuffer*, void*, size_t) override {}
+
+  void GenerateMipmaps(const std::shared_ptr<GPUTexture>&) override {}
+
+  void End() override {}
+};
+
+class FakeRenderPass : public GPURenderPass {
+ public:
+  explicit FakeRenderPass(const GPURenderPassDescriptor& desc)
+      : GPURenderPass(desc) {}
+
+  void EncodeCommands(std::optional<GPUViewport> = std::nullopt,
+                      std::optional<GPUScissorRect> = std::nullopt) override {}
+};
+
+class FakeCommandBuffer : public GPUCommandBuffer {
+ public:
+  std::shared_ptr<GPURenderPass> BeginRenderPass(
+      const GPURenderPassDescriptor& desc) override {
+    return std::make_shared<FakeRenderPass>(desc);
+  }
+
+  std::shared_ptr<GPUBlitPass> BeginBlitPass() override {
+    return std::make_shared<FakeBlitPass>();
+  }
+
+  bool Submit(const GPUSubmitInfo* = nullptr) override { return true; }
+};
+
+class FakeGPUDevice : public GPUDevice {
+ public:
+  FakeGPUDevice() {
+    auto caps = std::make_unique<GPUCaps>();
+    InitCaps(std::move(caps));
+  }
+
+  std::unique_ptr<GPUBuffer> CreateBuffer(GPUBufferUsageMask usage) override {
+    return std::make_unique<GPUBuffer>(usage);
+  }
+
+  std::shared_ptr<GPUShaderFunction> CreateShaderFunction(
+      const GPUShaderFunctionDescriptor& desc) override {
+    shader_function_count_++;
+    if (disallow_shader_pipeline_creation_) {
+      disallowed_shader_function_count_++;
+    }
+
+    auto function = std::make_shared<FakeShaderFunction>(desc.label);
+    if (desc.source_type == GPUShaderSourceType::kWGX &&
+        desc.shader_source != nullptr) {
+      auto source = static_cast<GPUShaderSourceWGX*>(desc.shader_source);
+      function->SetWGXContext(source->context);
+    }
+    return function;
+  }
+
+  std::unique_ptr<GPURenderPipeline> CreateRenderPipeline(
+      const GPURenderPipelineDescriptor& desc) override {
+    render_pipeline_count_++;
+    if (disallow_shader_pipeline_creation_) {
+      disallowed_render_pipeline_count_++;
+    }
+    if (fail_render_pipeline_creation_) {
+      return nullptr;
+    }
+    if (desc.fragment_function != nullptr) {
+      fragment_function_labels_.push_back(desc.fragment_function->GetLabel());
+    }
+    if (desc.vertex_function != nullptr) {
+      vertex_function_labels_.push_back(desc.vertex_function->GetLabel());
+    }
+    return std::make_unique<FakeRenderPipeline>(desc);
+  }
+
+  std::unique_ptr<GPURenderPipeline> ClonePipeline(
+      GPURenderPipeline*, const GPURenderPipelineDescriptor& desc) override {
+    clone_pipeline_count_++;
+    if (disallow_shader_pipeline_creation_) {
+      disallowed_clone_pipeline_count_++;
+    }
+    return std::make_unique<FakeRenderPipeline>(desc);
+  }
+
+  std::shared_ptr<GPUCommandBuffer> CreateCommandBuffer() override {
+    return std::make_shared<FakeCommandBuffer>();
+  }
+
+  std::shared_ptr<GPUSampler> CreateSampler(
+      const GPUSamplerDescriptor& desc) override {
+    sampler_count_++;
+    return std::make_shared<FakeSampler>(desc);
+  }
+
+  std::shared_ptr<GPUTexture> CreateTexture(
+      const GPUTextureDescriptor& desc) override {
+    texture_count_++;
+    if (fail_texture_creation_) {
+      return nullptr;
+    }
+    return std::make_shared<FakeGPUTexture>(desc);
+  }
+
+  bool CanUseMSAA() override { return true; }
+
+  uint32_t GetBufferAlignment() override { return 256; }
+
+  uint32_t GetMaxTextureSize() override { return 4096; }
+
+  uint32_t shader_function_count() const { return shader_function_count_; }
+
+  uint32_t render_pipeline_count() const { return render_pipeline_count_; }
+
+  uint32_t clone_pipeline_count() const { return clone_pipeline_count_; }
+
+  uint32_t texture_count() const { return texture_count_; }
+
+  uint32_t sampler_count() const { return sampler_count_; }
+
+  uint32_t disallowed_shader_function_count() const {
+    return disallowed_shader_function_count_;
+  }
+
+  uint32_t disallowed_render_pipeline_count() const {
+    return disallowed_render_pipeline_count_;
+  }
+
+  uint32_t disallowed_clone_pipeline_count() const {
+    return disallowed_clone_pipeline_count_;
+  }
+
+  bool HasFragmentFunctionLabelContaining(const std::string& text) const {
+    for (const auto& label : fragment_function_labels_) {
+      if (label.find(text) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool HasFragmentFunctionLabel(const std::string& text) const {
+    for (const auto& label : fragment_function_labels_) {
+      if (label == text) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool HasVertexFunctionLabelContaining(const std::string& text) const {
+    for (const auto& label : vertex_function_labels_) {
+      if (label.find(text) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void set_fail_render_pipeline_creation(bool fail) {
+    fail_render_pipeline_creation_ = fail;
+  }
+
+  void set_fail_texture_creation(bool fail) { fail_texture_creation_ = fail; }
+
+  void set_disallow_shader_pipeline_creation(bool disallow) {
+    disallow_shader_pipeline_creation_ = disallow;
+    disallowed_shader_function_count_ = 0;
+    disallowed_render_pipeline_count_ = 0;
+    disallowed_clone_pipeline_count_ = 0;
+  }
+
+ private:
+  uint32_t shader_function_count_ = 0;
+  uint32_t render_pipeline_count_ = 0;
+  uint32_t clone_pipeline_count_ = 0;
+  uint32_t disallowed_shader_function_count_ = 0;
+  uint32_t disallowed_render_pipeline_count_ = 0;
+  uint32_t disallowed_clone_pipeline_count_ = 0;
+  uint32_t texture_count_ = 0;
+  uint32_t sampler_count_ = 0;
+  std::vector<std::string> fragment_function_labels_;
+  std::vector<std::string> vertex_function_labels_;
+  bool disallow_shader_pipeline_creation_ = false;
+  bool fail_render_pipeline_creation_ = false;
+  bool fail_texture_creation_ = false;
+};
+
+class FakeRootLayer : public HWRootLayer {
+ public:
+  FakeRootLayer(uint32_t width, uint32_t height, const Rect& bounds,
+                GPUTextureFormat format, HWDrawState* last_draw_state)
+      : HWRootLayer(width, height, bounds, format),
+        last_draw_state_(last_draw_state) {}
+
+ private:
+  std::shared_ptr<GPURenderPass> OnBeginRenderPass(GPUCommandBuffer* cmd,
+                                                   bool force_load) override {
+    if (last_draw_state_ != nullptr) {
+      *last_draw_state_ = GetLayerDrawState();
+    }
+
+    GPUTextureDescriptor texture_desc{};
+    texture_desc.width = GetWidth();
+    texture_desc.height = GetHeight();
+    texture_desc.format = GetColorFormat();
+
+    auto texture = std::make_shared<FakeGPUTexture>(texture_desc);
+
+    GPURenderPassDescriptor desc{};
+    desc.color_attachment.texture = texture;
+    desc.stencil_attachment.texture = texture;
+    desc.depth_attachment.texture = texture;
+    desc.color_attachment.load_op = (force_load || !NeedClearSurface())
+                                        ? GPULoadOp::kLoad
+                                        : GPULoadOp::kClear;
+    desc.stencil_attachment.load_op = GPULoadOp::kClear;
+    desc.depth_attachment.load_op = GPULoadOp::kClear;
+    desc.label = "FakeRootLayer";
+    return cmd->BeginRenderPass(desc);
+  }
+
+  void OnPostDraw(GPURenderPass*, GPUCommandBuffer*) override {}
+
+ private:
+  HWDrawState* last_draw_state_ = nullptr;
+};
+
+class FakeGPUSurface : public GPUSurfaceImpl {
+ public:
+  FakeGPUSurface(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx,
+                 GPUTextureFormat format)
+      : GPUSurfaceImpl(desc, ctx), format_(format) {}
+
+  GPUTextureFormat GetGPUFormat() const override { return format_; }
+
+  std::shared_ptr<Pixmap> ReadPixels(const Rect&) override { return nullptr; }
+
+  HWDrawState last_draw_state() const { return last_draw_state_; }
+
+ protected:
+  HWRootLayer* OnBeginNextFrame(bool clear) override {
+    auto* root_layer = GetArenaAllocator()->Make<FakeRootLayer>(
+        GetWidth(), GetHeight(), Rect::MakeWH(GetWidth(), GetHeight()),
+        GetGPUFormat(), &last_draw_state_);
+    root_layer->SetClearSurface(clear);
+    root_layer->SetSampleCount(GetSampleCount());
+    root_layer->SetArenaAllocator(GetArenaAllocator());
+    return root_layer;
+  }
+
+  void OnFlush() override {}
+
+ private:
+  GPUTextureFormat format_;
+  HWDrawState last_draw_state_ = HWDrawState::kDrawStateNone;
+};
+
+class FakeGPUContext : public GPUContextImpl {
+ public:
+  FakeGPUContext() : GPUContextImpl(GPUBackendType::kNone) {}
+
+  FakeGPUDevice* device() const {
+    return static_cast<FakeGPUDevice*>(GetGPUDevice());
+  }
+
+  std::unique_ptr<GPUSurface> CreateSurface(
+      GPUSurfaceDescriptor* desc) override {
+    return std::make_unique<FakeGPUSurface>(*desc, this,
+                                            GPUTextureFormat::kRGBA8Unorm);
+  }
+
+ protected:
+  std::unique_ptr<GPUDevice> CreateGPUDevice() override {
+    return std::make_unique<FakeGPUDevice>();
+  }
+
+  std::shared_ptr<GPUTexture> OnWrapTexture(GPUBackendTextureInfo*,
+                                            ReleaseCallback,
+                                            ReleaseUserData) override {
+    return nullptr;
+  }
+
+  std::unique_ptr<GPURenderTarget> OnCreateRenderTarget(
+      const GPURenderTargetDescriptor&, std::shared_ptr<Texture>) override {
+    return nullptr;
+  }
+
+  std::shared_ptr<Data> OnReadPixels(
+      const std::shared_ptr<GPUTexture>&) const override {
+    return nullptr;
+  }
+};
+
+std::unique_ptr<PrecompileContext> MakePrecompileContext(
+    FakeGPUContext& context, bool enable_msaa) {
+  return context.CreatePrecompileContext(PrecompileColorType::kRGBA,
+                                         enable_msaa);
+}
+
+void PrecompileDefaultShaders(FakeGPUContext& context, bool enable_msaa) {
+  MakePrecompileContext(context, enable_msaa)->PrecompileDefaultShaders();
+}
+
+void PrecompileDraw(FakeGPUContext& context, bool enable_msaa,
+                    PrecompileDrawType draw_type, const Paint& paint) {
+  MakePrecompileContext(context, enable_msaa)->PrecompileDraw(draw_type, paint);
+}
+
+Path MakeTestPath() {
+  Path path;
+  path.MoveTo(0.f, 0.f);
+  path.LineTo(16.f, 0.f);
+  path.LineTo(0.f, 16.f);
+  path.LineTo(16.f, 16.f);
+  path.Close();
+  return path;
+}
+
+Path MakeConvexTestPath() {
+  Path path;
+  path.MoveTo(2.f, 2.f);
+  path.LineTo(24.f, 4.f);
+  path.LineTo(8.f, 26.f);
+  path.Close();
+  return path;
+}
+
+std::shared_ptr<Image> MakeTestImage() {
+  auto pixmap = std::make_shared<Pixmap>(1, 1, AlphaType::kPremul_AlphaType,
+                                         ColorType::kRGBA);
+  return Image::MakeImage(std::move(pixmap));
+}
+
+Paint MakeImagePaint(const std::shared_ptr<Image>& image) {
+  Paint paint;
+  paint.SetShader(Shader::MakeShader(image, SamplingOptions{}, TileMode::kDecal,
+                                     TileMode::kDecal, Matrix{}));
+  return paint;
+}
+
+template <typename DrawProc>
+void ExpectRealDrawHitsPrecompiledPipeline(FakeGPUContext& context,
+                                           PrecompileDrawType draw_type,
+                                           const Paint& paint, bool enable_msaa,
+                                           DrawProc draw_proc) {
+  auto precompile_context = MakePrecompileContext(context, enable_msaa);
+  precompile_context->PrecompileDraw(draw_type, paint);
+
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+  device->set_disallow_shader_pipeline_creation(true);
+
+  GPUSurfaceDescriptor desc{};
+  desc.width = 32;
+  desc.height = 32;
+  desc.sample_count = enable_msaa ? 4 : 1;
+  auto surface = context.CreateSurface(&desc);
+  auto* canvas = surface->LockCanvas();
+  draw_proc(canvas);
+  canvas->Flush();
+  surface->Flush();
+
+  EXPECT_EQ(device->disallowed_shader_function_count(), 0u);
+  EXPECT_EQ(device->disallowed_render_pipeline_count(), 0u);
+  EXPECT_EQ(device->disallowed_clone_pipeline_count(), 0u);
+
+  device->set_disallow_shader_pipeline_creation(false);
+}
+
+}  // namespace
+
+TEST(PrecompileDrawTest, ReturnsBeforeContextInit) {
+  FakeGPUContext context;
+  Paint paint;
+
+  PrecompileDefaultShaders(context, false);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+}
+
+TEST(PrecompileDrawTest, InvalidPrecompileColorTypeDoesNotCreateGPUResources) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  EXPECT_FALSE(context.IsForceDepthStencilPipelineState());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  auto invalid_context = context.CreatePrecompileContext(
+      static_cast<PrecompileColorType>(255), false);
+
+  Paint paint;
+  invalid_context->PrecompileDefaultShaders();
+  invalid_context->PrecompileDraw(PrecompileDrawType::kDrawImage, paint);
+
+  EXPECT_FALSE(context.IsForceDepthStencilPipelineState());
+  EXPECT_EQ(device->shader_function_count(), 0u);
+  EXPECT_EQ(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, PrecompileContextForcesDepthStencilLayerState) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  EXPECT_FALSE(context.IsForceDepthStencilPipelineState());
+
+  auto precompile_context = MakePrecompileContext(context, false);
+  ASSERT_NE(precompile_context, nullptr);
+  EXPECT_TRUE(context.IsForceDepthStencilPipelineState());
+
+  GPUSurfaceDescriptor desc{};
+  desc.width = 32;
+  desc.height = 32;
+  auto surface = context.CreateSurface(&desc);
+  auto* fake_surface = static_cast<FakeGPUSurface*>(surface.get());
+
+  Paint paint;
+  auto* canvas = surface->LockCanvas();
+  canvas->DrawRect(Rect::MakeWH(16.f, 16.f), paint);
+  canvas->Flush();
+  surface->Flush();
+
+  EXPECT_EQ(fake_surface->last_draw_state(),
+            kDrawStateDepth | kDrawStateStencil);
+}
+
+TEST(PrecompileDrawTest, PrecompileDefaultShadersSupportsCommonDraws) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  PrecompileDefaultShaders(context, false);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDefaultShaders(context, false);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest, PrecompileDefaultShadersCoversExplicitDefaultDraws) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+
+  PrecompileDefaultShaders(context, false);
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawText, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImageRRect, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest, PrecompileDefaultShadersCoversGPUTessellationPath) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  PrecompileDefaultShaders(context, false);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathFill"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathStroke"));
+}
+
+TEST(PrecompileDrawTest,
+     PrecompileDefaultShadersCoversTwoColorLinearGradientPath) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  PrecompileDefaultShaders(context, false);
+
+  EXPECT_TRUE(device->HasFragmentFunctionLabel(
+      "FS_GradientLinear2OffsetFastColorFast"));
+  EXPECT_TRUE(device->HasFragmentFunctionLabel("FS_GradientLinear2ColorFast"));
+  EXPECT_TRUE(device->HasFragmentFunctionLabel("FS_GradientLinear2"));
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  Paint paint;
+  Point pts[] = {{0.f, 0.f, 0.f, 1.f}, {32.f, 32.f, 0.f, 1.f}};
+  Vec4 colors[] = {Colors::kRed, Colors::kBlue};
+  paint.SetShader(Shader::MakeLinear(pts, colors, nullptr, 2));
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+  float color_fast_pos[] = {0.f, 1.f};
+  paint.SetShader(Shader::MakeLinear(pts, colors, color_fast_pos, 2));
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+  float pos[] = {0.25f, 0.75f};
+  paint.SetShader(Shader::MakeLinear(pts, colors, pos, 2));
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest, PrecompilePathUsesContourAAWhenEnabled) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableContourAA(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetAntiAlias(true);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("PathAA"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("TessPath"));
+}
+
+TEST(PrecompileDrawTest, PrecompilePathUsesGPUTessellationWithMSAA) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableContourAA(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStrokeAndFill_Style);
+  paint.SetAntiAlias(true);
+  PrecompileDraw(context, true, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathFill"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathStroke"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("PathAA"));
+}
+
+TEST(PrecompileDrawTest, PrecompilePathUsesGPUTessellationWithoutContourAA) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStrokeAndFill_Style);
+  paint.SetAntiAlias(true);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathFill"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathStroke"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("PathAA"));
+}
+
+TEST(PrecompileDrawTest, PrecompilePathUsesGPUTessellationWhenPaintDisablesAA) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableContourAA(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStrokeAndFill_Style);
+  paint.SetAntiAlias(false);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathFill"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathStroke"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("PathAA"));
+}
+
+TEST(PrecompileDrawTest, PrecompilePathUsesPathWhenGPUTessellationDisabled) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableGPUTessellation(false);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("VS_Path"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("TessPath"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("PathAA"));
+}
+
+TEST(PrecompileDrawTest, PrecompileRRectUsesSolidVertexColor) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableSimpleShapePipeline(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStrokeAndFill_Style);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("RRect"));
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("SolidVertexColor"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("TessPath"));
+}
+
+TEST(PrecompileDrawTest, PrecompileStrokeRectUsesRRectPipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableSimpleShapePipeline(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStroke_Style);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRect, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("RRect"));
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("SolidVertexColor"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("TessPath"));
+}
+
+TEST(PrecompileDrawTest, PrecompileDrawIncludesColorFilterPipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableSimpleShapePipeline(true);
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetColorFilter(ColorFilters::Blend(0xFF00FF00, BlendMode::kSrcATop));
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("BlendSrcATopFilter"));
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest, PrecompileDrawIncludesAdvancedBlendingPipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  paint.SetBlendMode(BlendMode::kOverlay);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_GT(device->shader_function_count(), shader_function_count);
+  EXPECT_GT(device->render_pipeline_count(), render_pipeline_count);
+
+  shader_function_count = device->shader_function_count();
+  render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest,
+     PrecompileRRectFallsBackToPathWhenSimpleShapeDisabled) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  paint.SetStyle(Paint::kStrokeAndFill_Style);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathFill"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("TessPathStroke"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("RRect"));
+}
+
+TEST(PrecompileDrawTest, CreatesAndCachesSolidDrawPipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+  auto clone_pipeline_count = device->clone_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+  EXPECT_EQ(device->clone_pipeline_count(), clone_pipeline_count);
+
+  PrecompileDraw(context, true, PrecompileDrawType::kDrawRRect, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+  EXPECT_GT(device->clone_pipeline_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, PrecompiledPathPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawPath, paint, false,
+      [&](Canvas* canvas) { canvas->DrawPath(MakeTestPath(), paint); });
+}
+
+TEST(PrecompileDrawTest, PrecompiledConvexTessPathPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+  paint.SetAntiAlias(false);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawPath, paint, false,
+      [&](Canvas* canvas) { canvas->DrawPath(MakeConvexTestPath(), paint); });
+}
+
+TEST(PrecompileDrawTest, PrecompiledConvexPathPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableGPUTessellation(false);
+
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+  paint.SetAntiAlias(false);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawPath, paint, false,
+      [&](Canvas* canvas) { canvas->DrawPath(MakeConvexTestPath(), paint); });
+}
+
+TEST(PrecompileDrawTest, PrecompiledRRectPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableSimpleShapePipeline(true);
+
+  Paint paint;
+  paint.SetStyle(Paint::kFill_Style);
+  auto rrect = RRect::MakeRectXY(Rect::MakeWH(24.f, 24.f), 4.f, 4.f);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawRRect, paint, false,
+      [&](Canvas* canvas) { canvas->DrawRRect(rrect, paint); });
+}
+
+TEST(PrecompileDrawTest, PrecompiledImagePathPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableGPUTessellation(false);
+
+  auto image = MakeTestImage();
+  auto paint = MakeImagePaint(image);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawImage, paint, false,
+      [&](Canvas* canvas) { canvas->DrawPath(MakeConvexTestPath(), paint); });
+}
+
+TEST(PrecompileDrawTest, PrecompiledImageRRectPipelineIsHitByRealDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  context.SetEnableSimpleShapePipeline(true);
+
+  auto image = MakeTestImage();
+  auto paint = MakeImagePaint(image);
+  auto rrect = RRect::MakeRectXY(Rect::MakeWH(24.f, 24.f), 4.f, 4.f);
+  ExpectRealDrawHitsPrecompiledPipeline(
+      context, PrecompileDrawType::kDrawImageRRect, paint, false,
+      [&](Canvas* canvas) { canvas->DrawRRect(rrect, paint); });
+}
+
+TEST(PrecompileDrawTest, ClearsFailedPipelineCacheAfterPrecompileFailure) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  device->set_fail_render_pipeline_creation(true);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+
+  EXPECT_EQ(device->render_pipeline_count(), 1u);
+
+  device->set_fail_render_pipeline_creation(false);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+
+  EXPECT_EQ(device->render_pipeline_count(), 2u);
+}
+
+TEST(PrecompileDrawTest, ImagePrecompileDoesNotCreateTextureResources) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  device->set_fail_texture_creation(true);
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("Texture"));
+}
+
+TEST(PrecompileDrawTest, ImagePrecompileUsesTexturePipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("Texture"));
+  EXPECT_FALSE(device->HasFragmentFunctionLabelContaining("Solid"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("Path"));
+  EXPECT_FALSE(device->HasVertexFunctionLabelContaining("RRect"));
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, ImageRRectPrecompileUsesTextureRRectPipeline) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+  ASSERT_NE(device, nullptr);
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImageRRect, paint);
+
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_TRUE(device->HasFragmentFunctionLabelContaining("Texture"));
+  EXPECT_TRUE(device->HasVertexFunctionLabelContaining("RRect"));
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, SupportsCommonSolidDrawTypes) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawRect, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawPath, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImage, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawImageRRect, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kClipPath, paint);
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, SupportsTextDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, SupportsGradientTextDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  Point pts[] = {{0.f, 0.f, 0.f, 1.f}, {16.f, 16.f, 0.f, 1.f}};
+  Vec4 colors[] = {Colors::kRed, Colors::kBlue};
+  paint.SetShader(Shader::MakeLinear(pts, colors, nullptr, 2));
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, SupportsSDFTextDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawSDFText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+}
+
+TEST(PrecompileDrawTest, SupportsEmojiTextDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawEmojiText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+  EXPECT_TRUE(
+      device->HasFragmentFunctionLabel("FS_ColorEmojiNoSwizzleFragmentWGSL"));
+  EXPECT_TRUE(
+      device->HasFragmentFunctionLabel("FS_ColorEmojiSwizzleRBFragmentWGSL"));
+  EXPECT_FALSE(device->HasFragmentFunctionLabelContaining("TextWGSL"));
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawEmojiText, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+TEST(PrecompileDrawTest, SupportsGradientEmojiTextDraw) {
+  FakeGPUContext context;
+  ASSERT_TRUE(context.Init());
+  auto* device = context.device();
+
+  Paint paint;
+  Point pts[] = {{0.f, 0.f, 0.f, 1.f}, {16.f, 16.f, 0.f, 1.f}};
+  Vec4 colors[] = {Colors::kRed, Colors::kBlue};
+  paint.SetShader(Shader::MakeLinear(pts, colors, nullptr, 2));
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawEmojiText, paint);
+
+  EXPECT_GT(device->shader_function_count(), 0u);
+  EXPECT_GT(device->render_pipeline_count(), 0u);
+  EXPECT_EQ(device->texture_count(), 0u);
+  EXPECT_EQ(device->sampler_count(), 0u);
+  EXPECT_TRUE(
+      device->HasFragmentFunctionLabel("FS_ColorEmojiNoSwizzleFragmentWGSL"));
+  EXPECT_TRUE(
+      device->HasFragmentFunctionLabel("FS_ColorEmojiSwizzleRBFragmentWGSL"));
+  EXPECT_FALSE(device->HasFragmentFunctionLabelContaining("TextWGSL"));
+
+  auto shader_function_count = device->shader_function_count();
+  auto render_pipeline_count = device->render_pipeline_count();
+
+  PrecompileDraw(context, false, PrecompileDrawType::kDrawEmojiText, paint);
+
+  EXPECT_EQ(device->shader_function_count(), shader_function_count);
+  EXPECT_EQ(device->render_pipeline_count(), render_pipeline_count);
+}
+
+}  // namespace skity


### PR DESCRIPTION
Add a public precompile context for warming common GPU pipelines and explicit draw pipelines before first render. Cover solid, image, text, tessellation, contour AA, paint effects, and real draw cache hits with unit tests.