### PR TITLE
fix(vk): use VkFormat for image barrier aspect mask

### DIFF
--- a/src/gpu/vk/gpu_blit_pass_vk.cc
+++ b/src/gpu/vk/gpu_blit_pass_vk.cc
@@ -86,7 +86,7 @@ void TransitionImageLayout(const VulkanContextState& state,
   barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   barrier.image = texture.GetImage();
   barrier.subresourceRange.aspectMask =
-      GetImageAspectMask(texture.GetDescriptor().format);
+      VkFormatAspectMaskForBarrier(texture.GetVkFormat());
   barrier.subresourceRange.baseMipLevel = 0;
   barrier.subresourceRange.levelCount = texture.GetDescriptor().mip_level_count;
   barrier.subresourceRange.baseArrayLayer = 0;
@@ -118,7 +118,7 @@ void TransitionMipRangeLayout(const VulkanContextState& state,
   barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   barrier.image = texture.GetImage();
   barrier.subresourceRange.aspectMask =
-      GetImageAspectMask(texture.GetDescriptor().format);
+      VkFormatAspectMaskForBarrier(texture.GetVkFormat());
   barrier.subresourceRange.baseMipLevel = base_mip_level;
   barrier.subresourceRange.levelCount = level_count;
   barrier.subresourceRange.baseArrayLayer = 0;

--- a/src/gpu/vk/gpu_render_pass_vk.cc
+++ b/src/gpu/vk/gpu_render_pass_vk.cc
@@ -24,19 +24,6 @@ bool IsDepthStencilFormat(GPUTextureFormat format) {
          format == GPUTextureFormat::kDepth24Stencil8;
 }
 
-VkImageAspectFlags GetImageAspectMask(GPUTextureFormat format) {
-  switch (format) {
-    case GPUTextureFormat::kStencil8:
-      return VK_IMAGE_ASPECT_STENCIL_BIT;
-    case GPUTextureFormat::kDepth24Stencil8:
-      return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-    case GPUTextureFormat::kInvalid:
-      return 0;
-    default:
-      return VK_IMAGE_ASPECT_COLOR_BIT;
-  }
-}
-
 VkAccessFlags AccessMaskForLayout(VkImageLayout layout) {
   switch (layout) {
     case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
@@ -131,7 +118,7 @@ bool TransitionImageLayout(const VulkanContextState& state,
   barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   barrier.image = texture.GetImage();
   barrier.subresourceRange.aspectMask =
-      GetImageAspectMask(texture.GetDescriptor().format);
+      VkFormatAspectMaskForBarrier(texture.GetVkFormat());
   barrier.subresourceRange.baseMipLevel = 0;
   barrier.subresourceRange.levelCount = texture.GetDescriptor().mip_level_count;
   barrier.subresourceRange.baseArrayLayer = 0;

--- a/src/gpu/vk/gpu_texture_vk.hpp
+++ b/src/gpu/vk/gpu_texture_vk.hpp
@@ -16,6 +16,29 @@ namespace skity {
 
 class VulkanContextState;
 
+/**
+ * Returns the VkImageAspectFlags for an image memory barrier based on the
+ * actual VkFormat. For combined depth/stencil formats (e.g. D24_UNORM_S8_UINT),
+ * always returns both DEPTH | STENCIL aspects, as required by the Vulkan spec
+ * when the separateDepthStencilLayouts feature is not enabled.
+ */
+inline VkImageAspectFlags VkFormatAspectMaskForBarrier(VkFormat format) {
+  switch (format) {
+    case VK_FORMAT_D16_UNORM_S8_UINT:
+    case VK_FORMAT_D24_UNORM_S8_UINT:
+    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+      return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    case VK_FORMAT_D16_UNORM:
+    case VK_FORMAT_X8_D24_UNORM_PACK32:
+    case VK_FORMAT_D32_SFLOAT:
+      return VK_IMAGE_ASPECT_DEPTH_BIT;
+    case VK_FORMAT_S8_UINT:
+      return VK_IMAGE_ASPECT_STENCIL_BIT;
+    default:
+      return VK_IMAGE_ASPECT_COLOR_BIT;
+  }
+}
+
 class GPUTextureVK : public GPUTexture,
                      public std::enable_shared_from_this<GPUTextureVK> {
  public:


### PR DESCRIPTION
Use VkFormat instead of GPUTextureFormat when determining image aspect flags for VkImageMemoryBarrier. The new VkFormatAspectMaskForBarrier() handles combined depth/stencil formats (D24_UNORM_S8_UINT etc.) correctly by always returning both DEPTH | STENCIL aspects, as required by the Vulkan spec when separateDepthStencilLayouts is not enabled.