### PR TITLE
feat(harness): support iOS font harness runners

### DIFF
--- a/harness/font/CMakeLists.txt
+++ b/harness/font/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(skity_font_harness STATIC
   ${CMAKE_CURRENT_LIST_DIR}/artifact/json_io.cc
   ${CMAKE_CURRENT_LIST_DIR}/case/case_document.cc
   ${CMAKE_CURRENT_LIST_DIR}/case/manifest_document.cc
+  ${CMAKE_CURRENT_LIST_DIR}/case/platform_target.cc
   ${CMAKE_CURRENT_LIST_DIR}/case/repo_uri.cc
   ${CMAKE_CURRENT_LIST_DIR}/case/validation.cc
   ${CMAKE_CURRENT_LIST_DIR}/compare/compare_engine.cc
@@ -41,8 +42,29 @@ add_library(skity_font_harness STATIC
 )
 
 set(SKITY_FONT_HARNESS_HAS_CORETEXT 0)
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND SKITY_CT_FONT)
-  set(SKITY_FONT_HARNESS_HAS_CORETEXT 1)
+set(SKITY_FONT_HARNESS_TARGET_PLATFORM "unknown")
+set(SKITY_FONT_HARNESS_IS_IOS_PLATFORM OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_OSX_SYSROOT MATCHES "iphone")
+  set(SKITY_FONT_HARNESS_IS_IOS_PLATFORM ON)
+endif()
+
+set(SKITY_FONT_HARNESS_IS_MACOS_PLATFORM OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT SKITY_FONT_HARNESS_IS_IOS_PLATFORM)
+  set(SKITY_FONT_HARNESS_IS_MACOS_PLATFORM ON)
+endif()
+
+if(SKITY_CT_FONT)
+  if(SKITY_FONT_HARNESS_IS_MACOS_PLATFORM)
+    set(SKITY_FONT_HARNESS_HAS_CORETEXT 1)
+    set(SKITY_FONT_HARNESS_TARGET_PLATFORM "macos-coretext")
+  elseif(SKITY_FONT_HARNESS_IS_IOS_PLATFORM)
+    set(SKITY_FONT_HARNESS_HAS_CORETEXT 1)
+    if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator")
+      set(SKITY_FONT_HARNESS_TARGET_PLATFORM "ios-sim-coretext")
+    else()
+      set(SKITY_FONT_HARNESS_TARGET_PLATFORM "ios-device-coretext")
+    endif()
+  endif()
 endif()
 
 target_include_directories(
@@ -61,6 +83,7 @@ target_compile_definitions(
   SKITY_FONT_HARNESS_SKITY_CT_FONT=$<BOOL:${SKITY_CT_FONT}>
   SKITY_FONT_HARNESS_ENABLE_FONT_HARNESS=$<BOOL:${SKITY_ENABLE_FONT_HARNESS}>
   SKITY_FONT_HARNESS_HAS_CORETEXT=${SKITY_FONT_HARNESS_HAS_CORETEXT}
+  SKITY_FONT_HARNESS_TARGET_PLATFORM="${SKITY_FONT_HARNESS_TARGET_PLATFORM}"
 )
 target_link_libraries(
   skity_font_harness
@@ -80,14 +103,16 @@ if(SKITY_FONT_HARNESS_HAS_CORETEXT)
   )
 endif()
 
-add_executable(skity-font
-  ${CMAKE_CURRENT_LIST_DIR}/cli/skity-font/main.cc
-)
+if(NOT SKITY_FONT_HARNESS_IS_IOS_PLATFORM)
+  add_executable(skity-font
+    ${CMAKE_CURRENT_LIST_DIR}/cli/skity-font/main.cc
+  )
 
-target_link_libraries(skity-font PRIVATE skity_font_harness)
-target_compile_features(skity-font PRIVATE cxx_std_17)
+  target_link_libraries(skity-font PRIVATE skity_font_harness)
+  target_compile_features(skity-font PRIVATE cxx_std_17)
+endif()
 
-if(${SKITY_TEST})
+if(${SKITY_TEST} AND TARGET skity-font)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   enable_testing()
   add_test(
@@ -98,4 +123,8 @@ if(${SKITY_TEST})
       $<TARGET_FILE:skity-font>
   )
   set_tests_properties(font_harness_cli_smoke PROPERTIES LABELS font_harness)
+endif()
+
+if(SKITY_FONT_HARNESS_IS_IOS_PLATFORM)
+  add_subdirectory(platform/ios)
 endif()

--- a/harness/font/case/case_document.cc
+++ b/harness/font/case/case_document.cc
@@ -9,6 +9,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "harness/font/case/platform_target.hpp"
+
 namespace skity {
 namespace font_harness {
 
@@ -31,12 +33,6 @@ const std::vector<std::string>& AllowedStatuses() {
   return values;
 }
 
-const std::vector<std::string>& AllowedBackends() {
-  static const std::vector<std::string> values = {"coretext", "directwrite",
-                                                  "host-ft"};
-  return values;
-}
-
 const std::vector<std::string>& AllowedTypefaceEntries() {
   static const std::vector<std::string> values = {
       "MakeFromFile", "MakeFromData", "MakeVariation",
@@ -48,26 +44,6 @@ const std::vector<std::string>& AllowedHinting() {
   static const std::vector<std::string> values = {"none", "slight", "normal",
                                                   "full"};
   return values;
-}
-
-bool BackendMatchesPlatforms(const std::string& backend,
-                             const Json::Value& platforms) {
-  for (const auto& platform : platforms) {
-    if (!platform.isString()) {
-      continue;
-    }
-    const std::string value = platform.asString();
-    if (backend == "coretext" && value == "darwin-ct") {
-      return true;
-    }
-    if (backend == "directwrite" && value == "windows-dwrite") {
-      return true;
-    }
-    if (backend == "host-ft" && value == "host-ft") {
-      return true;
-    }
-  }
-  return false;
 }
 
 bool ValidateGlyphChar(const std::string& value) {
@@ -109,7 +85,7 @@ void ValidatePlatforms(const Json::Value& root, const std::string& backend,
     }
     ValidateNonEmptyString(platform.asString(), path, context);
   }
-  if (!backend.empty() && !BackendMatchesPlatforms(backend, *platforms)) {
+  if (!backend.empty() && !PlatformArrayMatchesBackend(backend, *platforms)) {
     context->AddError("$.platforms",
                       "platforms do not match backend: " + backend);
   }
@@ -391,7 +367,7 @@ CaseValidationResult ValidateCaseDocument(const Json::Value& root,
     ValidateStringEnum(status, "$.status", AllowedStatuses(), &result.errors);
   }
   if (!result.backend.empty()) {
-    ValidateStringEnum(result.backend, "$.backend", AllowedBackends(),
+    ValidateStringEnum(result.backend, "$.backend", AllowedBackendIds(),
                        &result.errors);
   }
   ValidatePlatforms(root, result.backend, &result.errors);

--- a/harness/font/case/manifest_document.cc
+++ b/harness/font/case/manifest_document.cc
@@ -6,6 +6,8 @@
 
 #include <filesystem>
 
+#include "harness/font/case/platform_target.hpp"
+
 namespace skity {
 namespace font_harness {
 
@@ -25,6 +27,15 @@ bool IsSafeRelativePath(const std::string& value) {
     }
   }
   return true;
+}
+
+void ValidateArtifactPath(const Json::Value& artifacts,
+                          const std::string& field, ValidationContext* errors) {
+  std::string value;
+  if (!OptionalStringField(artifacts, field, "$.artifacts", errors, &value)) {
+    return;
+  }
+  ValidateNonEmptyString(value, ChildPath("$.artifacts", field), errors);
 }
 
 }  // namespace
@@ -49,13 +60,51 @@ ManifestValidationResult ValidateManifestDocument(const Json::Value& root,
   RequireStringField(root, "id", "$", &result.errors, &result.manifest_id);
   RequireStringField(root, "backend", "$", &result.errors, &result.backend);
   ValidateNonEmptyString(result.manifest_id, "$.id", &result.errors);
-  ValidateStringEnum(result.backend, "$.backend",
-                     {"coretext", "directwrite", "host-ft"}, &result.errors);
+  ValidateStringEnum(result.backend, "$.backend", AllowedBackendIds(),
+                     &result.errors);
 
   const Json::Value* platforms = nullptr;
   if (RequireArrayField(root, "platforms", "$", &result.errors, &platforms) &&
       platforms->empty()) {
     result.errors.AddError("$.platforms", "platforms must not be empty");
+  }
+  if (platforms != nullptr) {
+    bool backend_matches_platforms = false;
+    for (Json::ArrayIndex i = 0; i < platforms->size(); ++i) {
+      const std::string path = IndexPath("$.platforms", i);
+      const Json::Value& platform = (*platforms)[i];
+      if (!platform.isString()) {
+        result.errors.AddError(path, "expected string");
+        continue;
+      }
+      const std::string value = platform.asString();
+      ValidateNonEmptyString(value, path, &result.errors);
+      if (PlatformTargetMatchesBackend(result.backend, value)) {
+        backend_matches_platforms = true;
+      }
+    }
+    if (!result.backend.empty() && !backend_matches_platforms) {
+      result.errors.AddError(
+          "$.platforms", "platforms do not match backend: " + result.backend);
+    }
+  }
+
+  if (OptionalStringField(root, "target_platform", "$", &result.errors,
+                          &result.target_platform)) {
+    ValidateNonEmptyString(result.target_platform, "$.target_platform",
+                           &result.errors);
+    result.target_platform = CanonicalPlatformTarget(result.target_platform);
+    if (platforms != nullptr &&
+        !PlatformArrayContainsTarget(*platforms, result.target_platform)) {
+      result.errors.AddError("$.target_platform",
+                             "target_platform must be listed in platforms");
+    }
+    if (!result.backend.empty() &&
+        !PlatformTargetMatchesBackend(result.backend, result.target_platform)) {
+      result.errors.AddError(
+          "$.target_platform",
+          "target_platform does not match backend: " + result.backend);
+    }
   }
 
   std::string case_root;
@@ -83,7 +132,13 @@ ManifestValidationResult ValidateManifestDocument(const Json::Value& root,
   }
 
   const Json::Value* artifacts = nullptr;
-  RequireObjectField(root, "artifacts", "$", &result.errors, &artifacts);
+  if (RequireObjectField(root, "artifacts", "$", &result.errors, &artifacts)) {
+    ValidateArtifactPath(*artifacts, "root", &result.errors);
+    ValidateArtifactPath(*artifacts, "report_root", &result.errors);
+    ValidateArtifactPath(*artifacts, "skia_dir", &result.errors);
+    ValidateArtifactPath(*artifacts, "skity_dir", &result.errors);
+    ValidateArtifactPath(*artifacts, "compare_dir", &result.errors);
+  }
 
   result.valid = result.errors.IsValid();
   return result;

--- a/harness/font/case/manifest_document.hpp
+++ b/harness/font/case/manifest_document.hpp
@@ -15,6 +15,7 @@ struct ManifestValidationResult {
   bool valid = false;
   std::string manifest_id;
   std::string backend;
+  std::string target_platform;
   Json::Value normalized_manifest;
   ValidationContext errors;
 };

--- a/harness/font/case/platform_target.cc
+++ b/harness/font/case/platform_target.cc
@@ -1,0 +1,120 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/case/platform_target.hpp"
+
+namespace skity {
+namespace font_harness {
+
+namespace {
+
+struct PlatformAliasEntry {
+  const char* alias;
+  const char* canonical_id;
+};
+
+const std::vector<PlatformTargetInfo>& PlatformTargetRegistry() {
+  static const std::vector<PlatformTargetInfo> entries = {
+      {"macos-coretext", "coretext", "host-cli"},
+      {"ios-sim-coretext", "coretext", "ios-xctest"},
+      {"ios-device-coretext", "coretext", "ios-xctest"},
+      {"android-freetype", "freetype", "android-adb"},
+      {"windows-directwrite", "directwrite", "windows-host"},
+      {"host-ft", "host-ft", "host-cli"},
+  };
+  return entries;
+}
+
+const std::vector<PlatformAliasEntry>& PlatformTargetAliases() {
+  static const std::vector<PlatformAliasEntry> aliases = {
+      {"darwin-ct", "macos-coretext"},
+      {"windows-dwrite", "windows-directwrite"},
+  };
+  return aliases;
+}
+
+}  // namespace
+
+const std::vector<std::string>& AllowedBackendIds() {
+  static const std::vector<std::string> values = {"coretext", "freetype",
+                                                  "directwrite", "host-ft"};
+  return values;
+}
+
+std::string CanonicalPlatformTarget(const std::string& platform) {
+  for (const auto& alias : PlatformTargetAliases()) {
+    if (platform == alias.alias) {
+      return alias.canonical_id;
+    }
+  }
+  return platform;
+}
+
+const PlatformTargetInfo* FindPlatformTargetInfo(const std::string& platform) {
+  const std::string canonical = CanonicalPlatformTarget(platform);
+  for (const auto& entry : PlatformTargetRegistry()) {
+    if (canonical == entry.id) {
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+bool PlatformTargetMatchesBackend(const std::string& backend,
+                                  const std::string& platform) {
+  const PlatformTargetInfo* info = FindPlatformTargetInfo(platform);
+  return info != nullptr && info->backend == backend;
+}
+
+bool PlatformArrayMatchesBackend(const std::string& backend,
+                                 const Json::Value& platforms) {
+  if (!platforms.isArray()) {
+    return false;
+  }
+  for (const auto& platform : platforms) {
+    if (!platform.isString()) {
+      continue;
+    }
+    if (PlatformTargetMatchesBackend(backend, platform.asString())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PlatformArrayContainsTarget(const Json::Value& platforms,
+                                 const std::string& target_platform) {
+  if (!platforms.isArray()) {
+    return false;
+  }
+  const std::string canonical_target = CanonicalPlatformTarget(target_platform);
+  for (const auto& platform : platforms) {
+    if (!platform.isString()) {
+      continue;
+    }
+    if (CanonicalPlatformTarget(platform.asString()) == canonical_target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string InferTargetPlatformFromArray(const Json::Value& platforms,
+                                         const std::string& backend) {
+  if (!platforms.isArray()) {
+    return "";
+  }
+  for (const auto& platform : platforms) {
+    if (!platform.isString()) {
+      continue;
+    }
+    if (PlatformTargetMatchesBackend(backend, platform.asString())) {
+      return CanonicalPlatformTarget(platform.asString());
+    }
+  }
+  return "";
+}
+
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/case/platform_target.hpp
+++ b/harness/font/case/platform_target.hpp
@@ -1,0 +1,43 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_CASE_PLATFORM_TARGET_HPP
+#define HARNESS_FONT_CASE_PLATFORM_TARGET_HPP
+
+#include <string>
+#include <vector>
+
+#include "third_party/jsoncpp/include/json/json.h"
+
+namespace skity {
+namespace font_harness {
+
+struct PlatformTargetInfo {
+  std::string id;
+  std::string backend;
+  std::string runner;
+};
+
+const std::vector<std::string>& AllowedBackendIds();
+
+std::string CanonicalPlatformTarget(const std::string& platform);
+
+const PlatformTargetInfo* FindPlatformTargetInfo(const std::string& platform);
+
+bool PlatformTargetMatchesBackend(const std::string& backend,
+                                  const std::string& platform);
+
+bool PlatformArrayMatchesBackend(const std::string& backend,
+                                 const Json::Value& platforms);
+
+bool PlatformArrayContainsTarget(const Json::Value& platforms,
+                                 const std::string& target_platform);
+
+std::string InferTargetPlatformFromArray(const Json::Value& platforms,
+                                         const std::string& backend);
+
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_CASE_PLATFORM_TARGET_HPP

--- a/harness/font/cases/family_style_set/arial_italic_coretext.json
+++ b/harness/font/cases/family_style_set/arial_italic_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "CreateStyleSet",

--- a/harness/font/cases/family_style_set/baskerville_weight_500_coretext.json
+++ b/harness/font/cases/family_style_set/baskerville_weight_500_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "CreateStyleSet",

--- a/harness/font/cases/family_style_set/helvetica_coretext.json
+++ b/harness/font/cases/family_style_set/helvetica_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "CreateStyleSet",

--- a/harness/font/cases/family_style_set/helvetica_weight_500_coretext.json
+++ b/harness/font/cases/family_style_set/helvetica_weight_500_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "CreateStyleSet",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_arabic_alef_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_arabic_alef_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_devanagari_ka_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_emoji_grinning_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_ko_hangul_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_ko_hangul_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_symbol_music_gclef_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_thai_ko_kai_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hans_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hans_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hant_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_character_zh_hant_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/apple_system_ui_font_regular_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_regular_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyle",

--- a/harness/font/cases/font_manager/apple_system_ui_font_weight_500_coretext.json
+++ b/harness/font/cases/font_manager/apple_system_ui_font_weight_500_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyle",

--- a/harness/font/cases/font_manager/css_generic_sans_serif_coretext.json
+++ b/harness/font/cases/font_manager/css_generic_sans_serif_coretext.json
@@ -10,7 +10,9 @@
   },
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyle",

--- a/harness/font/cases/font_manager/default_typeface_coretext.json
+++ b/harness/font/cases/font_manager/default_typeface_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "GetDefaultTypeface",

--- a/harness/font/cases/font_manager/match_family_style_character_cjk_coretext.json
+++ b/harness/font/cases/font_manager/match_family_style_character_cjk_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyleCharacter",

--- a/harness/font/cases/font_manager/match_family_style_helvetica_regular_coretext.json
+++ b/harness/font/cases/font_manager/match_family_style_helvetica_regular_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_manager_request": {
     "entry": "MatchFamilyStyle",

--- a/harness/font/cases/font_manager/match_family_style_helvetica_weight_500_coretext.json
+++ b/harness/font/cases/font_manager/match_family_style_helvetica_weight_500_coretext.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "id": "font.font_manager.coretext.apple_system_ui_font_character_emoji",
+  "id": "font.font_manager.coretext.match_family_style_helvetica_weight_500",
   "category": "font_manager",
   "status": "active",
   "backend": "coretext",
@@ -10,17 +10,13 @@
     "ios-device-coretext"
   ],
   "font_manager_request": {
-    "entry": "MatchFamilyStyleCharacter",
-    "family_name": ".AppleSystemUIFont",
+    "entry": "MatchFamilyStyle",
+    "family_name": "Helvetica",
     "style": {
-      "weight": 400,
+      "weight": 500,
       "width": 5,
       "slant": "upright"
     },
-    "character": "U+1F60A",
-    "bcp47": [
-      "und-Zsye"
-    ],
     "sample_limit": 8
   },
   "font_request": {
@@ -34,16 +30,14 @@
   },
   "glyphs": {
     "chars": [
-      "U+0041",
-      "U+1F60A"
+      "U+0041"
     ]
   },
   "compare": {
     "typeface_identity": "normalized_descriptor",
     "font_style": "exact",
     "font_metrics": {
-      "mode": "epsilon",
-      "epsilon": 0.001
+      "mode": "ignore"
     }
   }
 }

--- a/harness/font/cases/font_metrics/roboto_regular_64_coretext.json
+++ b/harness/font/cases/font_metrics/roboto_regular_64_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/glyph_metrics/roboto_regular_latin_coretext.json
+++ b/harness/font/cases/glyph_metrics/roboto_regular_latin_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/glyph_path/roboto_regular_latin_A_coretext.json
+++ b/harness/font/cases/glyph_path/roboto_regular_latin_A_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/glyph_path/roboto_regular_missing_glyph_coretext.json
+++ b/harness/font/cases/glyph_path/roboto_regular_missing_glyph_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/scaler_context/roboto_regular_64_coretext.json
+++ b/harness/font/cases/scaler_context/roboto_regular_64_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/typeface_probe/roboto_regular_data_coretext.json
+++ b/harness/font/cases/typeface_probe/roboto_regular_data_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cases/typeface_probe/roboto_regular_file_coretext.json
+++ b/harness/font/cases/typeface_probe/roboto_regular_file_coretext.json
@@ -5,7 +5,9 @@
   "status": "active",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext",
+    "ios-sim-coretext",
+    "ios-device-coretext"
   ],
   "font_files": [
     {

--- a/harness/font/cli/skity-font/main.cc
+++ b/harness/font/cli/skity-font/main.cc
@@ -14,6 +14,7 @@
 #include "harness/font/artifact/json_io.hpp"
 #include "harness/font/case/case_document.hpp"
 #include "harness/font/case/manifest_document.hpp"
+#include "harness/font/case/platform_target.hpp"
 #include "harness/font/compare/compare_engine.hpp"
 #include "harness/font/platform/coretext/env_info.hpp"
 #include "harness/font/probe/font_manager_probe.hpp"
@@ -67,6 +68,7 @@ struct ManifestRunPaths {
   std::filesystem::path resolved_skity_dir;
   std::filesystem::path resolved_compare_dir;
   std::string backend;
+  std::string target_platform;
 };
 
 struct ManifestRunCounts {
@@ -467,6 +469,88 @@ std::filesystem::path ReadManifestArtifactDir(const Json::Value& manifest,
   return fallback;
 }
 
+std::filesystem::path ReadManifestArtifactRoot(const Json::Value& manifest) {
+  return ReadManifestArtifactDir(manifest, "root", "");
+}
+
+std::filesystem::path ReadManifestReportRoot(const Json::Value& manifest) {
+  return ReadManifestArtifactDir(manifest, "report_root", "");
+}
+
+std::filesystem::path ReadManifestArtifactRoleDir(
+    const Json::Value& manifest, const std::filesystem::path& artifact_root,
+    const std::string& role, const std::string& legacy_field,
+    const std::string& legacy_fallback) {
+  if (!artifact_root.empty()) {
+    return artifact_root / role;
+  }
+  return ReadManifestArtifactDir(manifest, legacy_field, legacy_fallback);
+}
+
+std::string ReadManifestTargetPlatform(const Json::Value& manifest,
+                                       const std::string& backend) {
+  std::string target_platform;
+  if (ReadStringField(manifest, "target_platform", &target_platform) &&
+      !target_platform.empty()) {
+    return skity::font_harness::CanonicalPlatformTarget(target_platform);
+  }
+  if (manifest.isObject() && manifest.isMember("platforms")) {
+    return skity::font_harness::InferTargetPlatformFromArray(
+        manifest["platforms"], backend);
+  }
+  return "";
+}
+
+bool StripPrefix(std::string* value, const std::string& prefix) {
+  if (value->rfind(prefix, 0) != 0) {
+    return false;
+  }
+  value->erase(0, prefix.size());
+  return true;
+}
+
+std::string UnderscorePlatformPrefix(const std::string& target_platform) {
+  std::string prefix = target_platform;
+  for (char& c : prefix) {
+    if (c == '-') {
+      c = '_';
+    }
+  }
+  return prefix + "_";
+}
+
+std::string ReportNameForManifestId(std::string manifest_id,
+                                    const std::string& target_platform) {
+  if (target_platform == "macos-coretext") {
+    StripPrefix(&manifest_id, "pc_macos_coretext_");
+  } else if (target_platform == "ios-sim-coretext") {
+    StripPrefix(&manifest_id, "ios_sim_coretext_");
+  } else if (target_platform == "ios-device-coretext") {
+    StripPrefix(&manifest_id, "ios_device_coretext_");
+  } else if (!target_platform.empty()) {
+    StripPrefix(&manifest_id, UnderscorePlatformPrefix(target_platform));
+  }
+
+  for (char& c : manifest_id) {
+    if (c == '_') {
+      c = '-';
+    } else if (!IsSafeFileChar(c)) {
+      c = '-';
+    }
+  }
+  return SanitizeFileComponent(manifest_id, "manifest") + ".latest.json";
+}
+
+std::filesystem::path ReadManifestReportPath(
+    const Json::Value& manifest, const std::string& manifest_id,
+    const std::string& target_platform) {
+  std::filesystem::path report_root = ReadManifestReportRoot(manifest);
+  if (report_root.empty()) {
+    return {};
+  }
+  return report_root / ReportNameForManifestId(manifest_id, target_platform);
+}
+
 bool WriteArtifactSilently(
     const std::filesystem::path& repo_root,
     const skity::font_harness::ArtifactDescriptor& descriptor,
@@ -495,6 +579,9 @@ Json::Value RunManifestCase(Json::ArrayIndex index,
   item["case"] = case_relative_path;
   item["case_path"] = StablePathForRun(case_path, paths.repo_root);
   item["backend"] = paths.backend;
+  if (!paths.target_platform.empty()) {
+    item["target_platform"] = paths.target_platform;
+  }
   item["status"] = "running";
   item["artifacts"] = Json::Value(Json::objectValue);
 
@@ -533,6 +620,15 @@ Json::Value RunManifestCase(Json::ArrayIndex index,
     item["status"] = "schema_validation_failed";
     item["reason_code"] = "backend_mismatch";
     item["message"] = "case backend does not match manifest run backend";
+    counts->schema_failure_count += 1;
+    return item;
+  }
+  if (!paths.target_platform.empty() &&
+      !skity::font_harness::PlatformArrayContainsTarget(
+          case_root_json["platforms"], paths.target_platform)) {
+    item["status"] = "schema_validation_failed";
+    item["reason_code"] = "platform_mismatch";
+    item["message"] = "case platforms do not include manifest target_platform";
     counts->schema_failure_count += 1;
     return item;
   }
@@ -1226,6 +1322,8 @@ int RunManifestCommand(int argc, char** argv) {
   std::filesystem::path report_path;
   std::filesystem::path repo_root(SKITY_FONT_HARNESS_REPO_ROOT);
   std::string backend;
+  bool skia_dir_overridden = false;
+  bool skity_dir_overridden = false;
 
   for (int i = 2; i < argc; ++i) {
     const std::string arg = argv[i];
@@ -1247,12 +1345,14 @@ int RunManifestCommand(int argc, char** argv) {
         return kExitUsageError;
       }
       skia_dir = argv[++i];
+      skia_dir_overridden = true;
     } else if (arg == "--skity-dir") {
       if (i + 1 >= argc) {
         std::cerr << "--skity-dir requires a path\n";
         return kExitUsageError;
       }
       skity_dir = argv[++i];
+      skity_dir_overridden = true;
     } else if (arg == "--report") {
       if (i + 1 >= argc) {
         std::cerr << "--report requires a path\n";
@@ -1308,11 +1408,25 @@ int RunManifestCommand(int argc, char** argv) {
                               kExitSchemaValidationFailed);
   }
 
+  std::string target_platform =
+      ReadManifestTargetPlatform(manifest_root, backend);
+  if (report_path.empty()) {
+    report_path =
+        ReadManifestReportPath(manifest_root, manifest_id, target_platform);
+  }
+
   skity::font_harness::RepoUriResolver resolver(repo_root);
   skity::font_harness::ManifestValidationResult manifest_validation =
       skity::font_harness::ValidateManifestDocument(manifest_root, resolver);
   if (!manifest_validation.manifest_id.empty()) {
     manifest_id = manifest_validation.manifest_id;
+  }
+  if (!manifest_validation.target_platform.empty()) {
+    target_platform = manifest_validation.target_platform;
+  }
+  if (report_path.empty()) {
+    report_path =
+        ReadManifestReportPath(manifest_root, manifest_id, target_platform);
   }
 
   if (!manifest_validation.valid || manifest_validation.backend != backend) {
@@ -1320,6 +1434,11 @@ int RunManifestCommand(int argc, char** argv) {
         manifest_id, backend, "schema_validation_failed");
     report["status"] = "invalid";
     report["passed"] = false;
+    if (!target_platform.empty()) {
+      report["target_platform"] = target_platform;
+    }
+    report["manifest_path"] =
+        StablePathForRun(ResolveRunPath(repo_root, manifest_path), repo_root);
     report["normalized_manifest"] = manifest_validation.normalized_manifest;
     report["validation_errors"] = manifest_validation.errors.ToJson();
     if (manifest_validation.valid && manifest_validation.backend != backend) {
@@ -1341,16 +1460,24 @@ int RunManifestCommand(int argc, char** argv) {
                               kExitSchemaValidationFailed);
   }
 
+  const std::filesystem::path artifact_root =
+      ReadManifestArtifactRoot(manifest_root);
+  const std::filesystem::path report_root =
+      ReadManifestReportRoot(manifest_root);
+
   if (skia_dir.empty()) {
-    skia_dir = ReadManifestArtifactDir(manifest_root, "skia_dir",
-                                       "local/font-harness/artifacts/skia");
+    skia_dir = ReadManifestArtifactRoleDir(manifest_root, artifact_root, "skia",
+                                           "skia_dir",
+                                           "local/font-harness/artifacts/skia");
   }
   if (skity_dir.empty()) {
-    skity_dir = ReadManifestArtifactDir(manifest_root, "skity_dir",
-                                        "local/font-harness/artifacts/skity");
+    skity_dir = ReadManifestArtifactRoleDir(
+        manifest_root, artifact_root, "skity", "skity_dir",
+        "local/font-harness/artifacts/skity");
   }
-  std::filesystem::path compare_dir = ReadManifestArtifactDir(
-      manifest_root, "compare_dir", "local/font-harness/artifacts/compare");
+  std::filesystem::path compare_dir = ReadManifestArtifactRoleDir(
+      manifest_root, artifact_root, "compare", "compare_dir",
+      "local/font-harness/artifacts/compare");
 
   const std::filesystem::path resolved_skia_dir =
       ResolveRunPath(repo_root, skia_dir);
@@ -1358,14 +1485,36 @@ int RunManifestCommand(int argc, char** argv) {
       ResolveRunPath(repo_root, skity_dir);
   const std::filesystem::path resolved_compare_dir =
       ResolveRunPath(repo_root, compare_dir);
+  const std::filesystem::path resolved_artifact_root =
+      artifact_root.empty() ? std::filesystem::path()
+                            : ResolveRunPath(repo_root, artifact_root);
+  const std::filesystem::path resolved_report_root =
+      report_root.empty() ? std::filesystem::path()
+                          : ResolveRunPath(repo_root, report_root);
 
   Json::Value report =
       skity::font_harness::BuildRunSummaryReport(manifest_id, backend, "pass");
   report["status"] = "running";
   report["passed"] = false;
+  report["runner"] = "host-cli";
+  report["expected_runner"] = "host-cli";
+  report["actual_runner"] = "host-cli";
+  report["manifest_path"] =
+      StablePathForRun(ResolveRunPath(repo_root, manifest_path), repo_root);
+  if (!target_platform.empty()) {
+    report["target_platform"] = target_platform;
+  }
   report["artifacts"] = Json::Value(Json::objectValue);
   report["artifacts"]["manifest"] =
       StablePathForRun(ResolveRunPath(repo_root, manifest_path), repo_root);
+  if (!resolved_artifact_root.empty()) {
+    report["artifacts"]["root"] =
+        StablePathForRun(resolved_artifact_root, repo_root);
+  }
+  if (!resolved_report_root.empty()) {
+    report["artifacts"]["report_root"] =
+        StablePathForRun(resolved_report_root, repo_root);
+  }
   report["artifacts"]["skia_dir"] =
       StablePathForRun(resolved_skia_dir, repo_root);
   report["artifacts"]["skity_dir"] =
@@ -1375,6 +1524,7 @@ int RunManifestCommand(int argc, char** argv) {
 
   const std::string case_root_value = manifest_root["case_root"].asString();
   const Json::Value& cases = manifest_root["cases"];
+  report["case_root"] = case_root_value;
 
   ManifestRunPaths paths;
   paths.case_root = ResolveRunPath(repo_root, case_root_value);
@@ -1383,6 +1533,7 @@ int RunManifestCommand(int argc, char** argv) {
   paths.resolved_skity_dir = resolved_skity_dir;
   paths.resolved_compare_dir = resolved_compare_dir;
   paths.backend = backend;
+  paths.target_platform = target_platform;
 
   ManifestRunCounts counts;
   Json::Value case_reports(Json::arrayValue);
@@ -1406,11 +1557,11 @@ int RunManifestCommand(int argc, char** argv) {
   descriptor.explicit_output_path = report_path;
   descriptor.repro_args = {"--manifest", PathArg(manifest_path), "--backend",
                            backend};
-  if (!skia_dir.empty()) {
+  if (skia_dir_overridden && !skia_dir.empty()) {
     descriptor.repro_args.push_back("--skia-dir");
     descriptor.repro_args.push_back(PathArg(skia_dir));
   }
-  if (!skity_dir.empty()) {
+  if (skity_dir_overridden && !skity_dir.empty()) {
     descriptor.repro_args.push_back("--skity-dir");
     descriptor.repro_args.push_back(PathArg(skity_dir));
   }

--- a/harness/font/manifests/ios_device_coretext_explicit_source_smoke.json
+++ b/harness/font/manifests/ios_device_coretext_explicit_source_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "ios_device_coretext_explicit_source_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "ios-device-coretext"
+  ],
+  "target_platform": "ios-device-coretext",
+  "case_root": "harness/font/cases",
+  "cases": [
+    "typeface_probe/roboto_regular_file_coretext.json",
+    "typeface_probe/roboto_regular_data_coretext.json"
+  ],
+  "artifacts": {
+    "root": "local/font-harness/artifacts/ios-device-coretext",
+    "report_root": "local/font-harness/reports/ios-device-coretext"
+  }
+}

--- a/harness/font/manifests/ios_device_coretext_full.json
+++ b/harness/font/manifests/ios_device_coretext_full.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "id": "pc_macos_coretext_full",
+  "id": "ios_device_coretext_full",
   "backend": "coretext",
   "platforms": [
-    "macos-coretext"
+    "ios-device-coretext"
   ],
-  "target_platform": "macos-coretext",
+  "target_platform": "ios-device-coretext",
   "case_root": "harness/font/cases",
   "cases": [
     "typeface_probe/roboto_regular_file_coretext.json",
@@ -38,7 +38,7 @@
     "font_manager/css_generic_sans_serif_coretext.json"
   ],
   "artifacts": {
-    "root": "local/font-harness/artifacts/macos-coretext",
-    "report_root": "local/font-harness/reports/macos-coretext"
+    "root": "local/font-harness/artifacts/ios-device-coretext",
+    "report_root": "local/font-harness/reports/ios-device-coretext"
   }
 }

--- a/harness/font/manifests/ios_device_coretext_system_match_smoke.json
+++ b/harness/font/manifests/ios_device_coretext_system_match_smoke.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "ios_device_coretext_system_match_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "ios-device-coretext"
+  ],
+  "target_platform": "ios-device-coretext",
+  "case_root": "harness/font/cases",
+  "cases": [
+    "family_style_set/helvetica_coretext.json",
+    "font_manager/default_typeface_coretext.json",
+    "font_manager/apple_system_ui_font_regular_coretext.json",
+    "font_manager/apple_system_ui_font_weight_500_coretext.json",
+    "font_manager/match_family_style_helvetica_regular_coretext.json",
+    "font_manager/match_family_style_helvetica_weight_500_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hans_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hant_coretext.json",
+    "font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json",
+    "font_manager/apple_system_ui_font_character_ko_hangul_coretext.json"
+  ],
+  "artifacts": {
+    "root": "local/font-harness/artifacts/ios-device-coretext",
+    "report_root": "local/font-harness/reports/ios-device-coretext"
+  }
+}

--- a/harness/font/manifests/ios_sim_coretext_explicit_source_smoke.json
+++ b/harness/font/manifests/ios_sim_coretext_explicit_source_smoke.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "ios_sim_coretext_explicit_source_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "ios-sim-coretext"
+  ],
+  "target_platform": "ios-sim-coretext",
+  "case_root": "harness/font/cases",
+  "cases": [
+    "typeface_probe/roboto_regular_file_coretext.json",
+    "typeface_probe/roboto_regular_data_coretext.json",
+    "font_metrics/roboto_regular_64_coretext.json",
+    "glyph_metrics/roboto_regular_latin_coretext.json",
+    "scaler_context/roboto_regular_64_coretext.json",
+    "glyph_path/roboto_regular_latin_A_coretext.json",
+    "glyph_path/roboto_regular_missing_glyph_coretext.json"
+  ],
+  "artifacts": {
+    "root": "local/font-harness/artifacts/ios-sim-coretext",
+    "report_root": "local/font-harness/reports/ios-sim-coretext"
+  }
+}

--- a/harness/font/manifests/ios_sim_coretext_full.json
+++ b/harness/font/manifests/ios_sim_coretext_full.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "id": "pc_macos_coretext_full",
+  "id": "ios_sim_coretext_full",
   "backend": "coretext",
   "platforms": [
-    "macos-coretext"
+    "ios-sim-coretext"
   ],
-  "target_platform": "macos-coretext",
+  "target_platform": "ios-sim-coretext",
   "case_root": "harness/font/cases",
   "cases": [
     "typeface_probe/roboto_regular_file_coretext.json",
@@ -38,7 +38,7 @@
     "font_manager/css_generic_sans_serif_coretext.json"
   ],
   "artifacts": {
-    "root": "local/font-harness/artifacts/macos-coretext",
-    "report_root": "local/font-harness/reports/macos-coretext"
+    "root": "local/font-harness/artifacts/ios-sim-coretext",
+    "report_root": "local/font-harness/reports/ios-sim-coretext"
   }
 }

--- a/harness/font/manifests/ios_sim_coretext_system_match_smoke.json
+++ b/harness/font/manifests/ios_sim_coretext_system_match_smoke.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "ios_sim_coretext_system_match_smoke",
+  "backend": "coretext",
+  "platforms": [
+    "ios-sim-coretext"
+  ],
+  "target_platform": "ios-sim-coretext",
+  "case_root": "harness/font/cases",
+  "cases": [
+    "family_style_set/helvetica_coretext.json",
+    "font_manager/default_typeface_coretext.json",
+    "font_manager/apple_system_ui_font_regular_coretext.json",
+    "font_manager/apple_system_ui_font_weight_500_coretext.json",
+    "font_manager/match_family_style_helvetica_regular_coretext.json",
+    "font_manager/match_family_style_helvetica_weight_500_coretext.json",
+    "font_manager/apple_system_ui_font_character_emoji_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hans_coretext.json",
+    "font_manager/apple_system_ui_font_character_zh_hant_coretext.json",
+    "font_manager/apple_system_ui_font_character_ja_hiragana_coretext.json",
+    "font_manager/apple_system_ui_font_character_ko_hangul_coretext.json"
+  ],
+  "artifacts": {
+    "root": "local/font-harness/artifacts/ios-sim-coretext",
+    "report_root": "local/font-harness/reports/ios-sim-coretext"
+  }
+}

--- a/harness/font/manifests/pc_macos_coretext_match_smoke.json
+++ b/harness/font/manifests/pc_macos_coretext_match_smoke.json
@@ -3,8 +3,9 @@
   "id": "pc_macos_coretext_match_smoke",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext"
   ],
+  "target_platform": "macos-coretext",
   "case_root": "harness/font/cases",
   "cases": [
     "family_style_set/helvetica_coretext.json",
@@ -15,6 +16,7 @@
     "font_manager/apple_system_ui_font_regular_coretext.json",
     "font_manager/apple_system_ui_font_weight_500_coretext.json",
     "font_manager/match_family_style_helvetica_regular_coretext.json",
+    "font_manager/match_family_style_helvetica_weight_500_coretext.json",
     "font_manager/match_family_style_character_cjk_coretext.json",
     "font_manager/apple_system_ui_font_character_zh_hans_coretext.json",
     "font_manager/apple_system_ui_font_character_zh_hant_coretext.json",
@@ -29,8 +31,7 @@
     "font_manager/css_generic_sans_serif_coretext.json"
   ],
   "artifacts": {
-    "skia_dir": "local/font-harness/artifacts/skia",
-    "skity_dir": "local/font-harness/artifacts/skity",
-    "compare_dir": "local/font-harness/artifacts/compare"
+    "root": "local/font-harness/artifacts/macos-coretext",
+    "report_root": "local/font-harness/reports/macos-coretext"
   }
 }

--- a/harness/font/manifests/pc_macos_coretext_smoke.json
+++ b/harness/font/manifests/pc_macos_coretext_smoke.json
@@ -3,8 +3,9 @@
   "id": "pc_macos_coretext_smoke",
   "backend": "coretext",
   "platforms": [
-    "darwin-ct"
+    "macos-coretext"
   ],
+  "target_platform": "macos-coretext",
   "case_root": "harness/font/cases",
   "cases": [
     "typeface_probe/roboto_regular_file_coretext.json",
@@ -18,8 +19,7 @@
     "font_manager/match_family_style_helvetica_regular_coretext.json"
   ],
   "artifacts": {
-    "skia_dir": "local/font-harness/artifacts/skia",
-    "skity_dir": "local/font-harness/artifacts/skity",
-    "compare_dir": "local/font-harness/artifacts/compare"
+    "root": "local/font-harness/artifacts/macos-coretext",
+    "report_root": "local/font-harness/reports/macos-coretext"
   }
 }

--- a/harness/font/platform/coretext/env_info.cc
+++ b/harness/font/platform/coretext/env_info.cc
@@ -43,13 +43,17 @@
 #define SKITY_FONT_HARNESS_HAS_CORETEXT 0
 #endif
 
+#ifndef SKITY_FONT_HARNESS_TARGET_PLATFORM
+#define SKITY_FONT_HARNESS_TARGET_PLATFORM "unknown"
+#endif
+
 namespace skity {
 namespace font_harness {
 
 namespace {
 
 constexpr const char* kBackend = "coretext";
-constexpr const char* kPlatformId = "darwin-ct";
+constexpr const char* kTargetPlatform = SKITY_FONT_HARNESS_TARGET_PLATFORM;
 
 std::string Trim(std::string value) {
   while (!value.empty() && (value.back() == '\n' || value.back() == '\r' ||
@@ -136,6 +140,14 @@ std::string ResolveSkityCommit(const std::filesystem::path& repo_root) {
 }
 
 std::string DetectPlatformName() {
+  const std::string target_platform = kTargetPlatform;
+  if (target_platform.rfind("ios-", 0) == 0) {
+    return "iOS";
+  }
+  if (target_platform.rfind("macos-", 0) == 0) {
+    return "macOS";
+  }
+
   const std::string system_name = SKITY_FONT_HARNESS_CMAKE_SYSTEM_NAME;
   if (system_name == "Darwin") {
     return "macOS";
@@ -181,7 +193,10 @@ Json::Value BuildBaseReport(const CoreTextEnvRequest& request,
   report["schema_version"] = 1;
   report["artifact_type"] = artifact_type;
   report["platform"] = DetectPlatformName();
-  report["platform_id"] = kPlatformId;
+  report["platform_id"] = std::string(kTargetPlatform) == "macos-coretext"
+                              ? "darwin-ct"
+                              : kTargetPlatform;
+  report["target_platform"] = kTargetPlatform;
   report["backend"] = kBackend;
   report["os_version"] = DetectOSVersion();
   const std::string commit = ResolveSkityCommit(request.repo_root);

--- a/harness/font/platform/ios/CMakeLists.txt
+++ b/harness/font/platform/ios/CMakeLists.txt
@@ -1,0 +1,176 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+set(SKITY_FONT_HARNESS_IOS_PLATFORM OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR CMAKE_OSX_SYSROOT MATCHES "iphone")
+  set(SKITY_FONT_HARNESS_IOS_PLATFORM ON)
+endif()
+
+if(NOT SKITY_FONT_HARNESS_IOS_PLATFORM)
+  return()
+endif()
+
+if(NOT CMAKE_GENERATOR MATCHES "Xcode")
+  message(WARNING "skity_font_harness_ios_xctest requires the Xcode generator")
+  return()
+endif()
+
+set(
+  SKITY_FONT_HARNESS_IOS_DEVELOPMENT_TEAM
+  ""
+  CACHE STRING
+  "Apple development team id used to sign the iOS font harness runner"
+)
+set(
+  SKITY_FONT_HARNESS_IOS_BUNDLE_ID_PREFIX
+  ""
+  CACHE STRING
+  "Optional bundle id prefix used to sign the iOS font harness runner"
+)
+
+set(SKITY_FONT_HARNESS_IOS_CODE_SIGNING_ALLOWED NO)
+set(SKITY_FONT_HARNESS_IOS_CODE_SIGNING_REQUIRED NO)
+set(SKITY_FONT_HARNESS_IOS_HOST_BUNDLE_ID
+    "org.skity.font-harness.ios-host")
+set(SKITY_FONT_HARNESS_IOS_TESTS_BUNDLE_ID
+    "org.skity.font-harness.ios-tests")
+if(CMAKE_OSX_SYSROOT MATCHES "iphoneos" AND
+   NOT SKITY_FONT_HARNESS_IOS_DEVELOPMENT_TEAM STREQUAL "")
+  set(SKITY_FONT_HARNESS_IOS_CODE_SIGNING_ALLOWED YES)
+  set(SKITY_FONT_HARNESS_IOS_CODE_SIGNING_REQUIRED YES)
+  if(NOT SKITY_FONT_HARNESS_IOS_BUNDLE_ID_PREFIX STREQUAL "")
+    set(SKITY_FONT_HARNESS_IOS_HOST_BUNDLE_ID
+        "${SKITY_FONT_HARNESS_IOS_BUNDLE_ID_PREFIX}.skity.host")
+    set(SKITY_FONT_HARNESS_IOS_TESTS_BUNDLE_ID
+        "${SKITY_FONT_HARNESS_IOS_BUNDLE_ID_PREFIX}.skity.tests")
+  endif()
+endif()
+
+find_library(SKITY_FONT_HARNESS_UIKIT_FRAMEWORK UIKit REQUIRED)
+
+get_target_property(
+  SKITY_FONT_HARNESS_SKITY_LINK_LIBRARIES
+  skity
+  LINK_LIBRARIES
+)
+if(NOT "${SKITY_FONT_HARNESS_SKITY_LINK_LIBRARIES}" STREQUAL
+   "SKITY_FONT_HARNESS_SKITY_LINK_LIBRARIES-NOTFOUND")
+  list(REMOVE_ITEM SKITY_FONT_HARNESS_SKITY_LINK_LIBRARIES "-framework AppKit")
+  set_property(
+    TARGET skity
+    PROPERTY LINK_LIBRARIES ${SKITY_FONT_HARNESS_SKITY_LINK_LIBRARIES}
+  )
+endif()
+target_link_libraries(skity PRIVATE ${SKITY_FONT_HARNESS_UIKIT_FRAMEWORK})
+# The XCTest bundle links shared probe code from skity_font_harness and needs
+# those Skity C++ symbols exported by the harness build dylib.
+target_compile_options(skity PRIVATE -fvisibility=default)
+
+set(SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK iphoneos)
+if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator")
+  set(SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK iphonesimulator)
+endif()
+
+execute_process(
+  COMMAND xcrun --sdk ${SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK}
+          --show-sdk-platform-path
+  OUTPUT_VARIABLE SKITY_FONT_HARNESS_XCODE_PLATFORM_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+find_library(
+  SKITY_FONT_HARNESS_XCTEST_FRAMEWORK
+  XCTest
+  PATHS
+    "${SKITY_FONT_HARNESS_XCODE_PLATFORM_PATH}/Developer/Library/Frameworks"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
+if(NOT SKITY_FONT_HARNESS_XCTEST_FRAMEWORK)
+  find_library(SKITY_FONT_HARNESS_XCTEST_FRAMEWORK XCTest REQUIRED)
+endif()
+
+add_executable(skity_font_harness_ios_host_app
+  MACOSX_BUNDLE
+  ${CMAKE_CURRENT_LIST_DIR}/app/FontHarnessIOSHostApp.mm
+)
+
+target_compile_features(skity_font_harness_ios_host_app PRIVATE cxx_std_17)
+target_link_libraries(
+  skity_font_harness_ios_host_app
+  PRIVATE
+  skity::skity
+  ${SKITY_FONT_HARNESS_UIKIT_FRAMEWORK}
+)
+
+set_target_properties(
+  skity_font_harness_ios_host_app
+  PROPERTIES
+  MACOSX_BUNDLE TRUE
+  MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/app/Info.plist.in
+  XCODE_EXPLICIT_FILE_TYPE "wrapper.application"
+  XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED
+    "${SKITY_FONT_HARNESS_IOS_CODE_SIGNING_ALLOWED}"
+  XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED
+    "${SKITY_FONT_HARNESS_IOS_CODE_SIGNING_REQUIRED}"
+  XCODE_ATTRIBUTE_DEVELOPMENT_TEAM
+    "${SKITY_FONT_HARNESS_IOS_DEVELOPMENT_TEAM}"
+  XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER
+    "${SKITY_FONT_HARNESS_IOS_HOST_BUNDLE_ID}"
+  XCODE_ATTRIBUTE_SDKROOT "${SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK}"
+  XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "${SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK}"
+  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+  XCODE_GENERATE_SCHEME TRUE
+)
+
+add_library(skity_font_harness_ios_xctest
+  MODULE
+  ${CMAKE_CURRENT_LIST_DIR}/runner/ios_runner.mm
+  ${CMAKE_CURRENT_LIST_DIR}/tests/FontHarnessIOSRunnerTests.mm
+)
+
+target_compile_features(skity_font_harness_ios_xctest PRIVATE cxx_std_17)
+target_include_directories(
+  skity_font_harness_ios_xctest
+  PRIVATE
+  ${CMAKE_SOURCE_DIR}
+)
+target_link_libraries(
+  skity_font_harness_ios_xctest
+  PRIVATE
+  skity_font_harness
+  ${SKITY_FONT_HARNESS_UIKIT_FRAMEWORK}
+  ${SKITY_FONT_HARNESS_XCTEST_FRAMEWORK}
+)
+
+add_dependencies(
+  skity_font_harness_ios_xctest
+  skity_font_harness_ios_host_app
+)
+
+set_target_properties(
+  skity_font_harness_ios_xctest
+  PROPERTIES
+  BUNDLE TRUE
+  BUNDLE_EXTENSION xctest
+  MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/tests/Info.plist.in
+  XCODE_PRODUCT_TYPE "com.apple.product-type.bundle.unit-test"
+  XCODE_ATTRIBUTE_BUNDLE_LOADER "$<TARGET_FILE:skity_font_harness_ios_host_app>"
+  XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED
+    "${SKITY_FONT_HARNESS_IOS_CODE_SIGNING_ALLOWED}"
+  XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED
+    "${SKITY_FONT_HARNESS_IOS_CODE_SIGNING_REQUIRED}"
+  XCODE_ATTRIBUTE_DEVELOPMENT_TEAM
+    "${SKITY_FONT_HARNESS_IOS_DEVELOPMENT_TEAM}"
+  XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER
+    "${SKITY_FONT_HARNESS_IOS_TESTS_BUNDLE_ID}"
+  XCODE_ATTRIBUTE_SDKROOT "${SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK}"
+  XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "${SKITY_FONT_HARNESS_XCODE_PLATFORM_SDK}"
+  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+  XCODE_ATTRIBUTE_TEST_HOST "$<TARGET_FILE:skity_font_harness_ios_host_app>"
+  XCODE_GENERATE_SCHEME TRUE
+  XCODE_SCHEME_TEST_CONFIGURATION Debug
+)

--- a/harness/font/platform/ios/app/FontHarnessIOSHostApp.mm
+++ b/harness/font/platform/ios/app/FontHarnessIOSHostApp.mm
@@ -1,0 +1,32 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <UIKit/UIKit.h>
+
+@interface FontHarnessIOSAppDelegate : UIResponder <UIApplicationDelegate>
+@property(nonatomic, strong) UIWindow* window;
+@end
+
+@implementation FontHarnessIOSAppDelegate
+
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launch_options {
+  (void)application;
+  (void)launch_options;
+
+  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  UIViewController* controller = [[UIViewController alloc] init];
+  controller.view.backgroundColor = [UIColor whiteColor];
+  self.window.rootViewController = controller;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+@end
+
+int main(int argc, char* argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([FontHarnessIOSAppDelegate class]));
+  }
+}

--- a/harness/font/platform/ios/app/Info.plist.in
+++ b/harness/font/platform/ios/app/Info.plist.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2021 The Lynx Authors. All rights reserved.
+Licensed under the Apache License Version 2.0 that can be found in the
+LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+</dict>
+</plist>

--- a/harness/font/platform/ios/runner/ios_runner.hpp
+++ b/harness/font/platform/ios/runner/ios_runner.hpp
@@ -1,0 +1,60 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef HARNESS_FONT_PLATFORM_IOS_RUNNER_IOS_RUNNER_HPP
+#define HARNESS_FONT_PLATFORM_IOS_RUNNER_IOS_RUNNER_HPP
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace skity {
+namespace font_harness {
+namespace ios {
+
+struct RunConfig {
+  std::string target_platform;
+  std::filesystem::path artifact_output_dir;
+  std::string runner_mode;
+  std::filesystem::path case_root;
+  std::vector<std::string> cases;
+};
+
+struct RunResult {
+  bool ok = false;
+  std::string message;
+  std::filesystem::path artifact_path;
+};
+
+struct CaseRunResult {
+  bool ok = false;
+  std::string case_id;
+  std::string message;
+  std::filesystem::path artifact_path;
+};
+
+struct SmokeRunResult {
+  bool ok = false;
+  std::string message;
+  std::vector<CaseRunResult> cases;
+};
+
+RunConfig DefaultRunConfig();
+
+bool LoadRunConfig(const std::filesystem::path& config_path, RunConfig* config,
+                   std::string* error);
+
+RunResult WriteEnvironmentArtifact(const RunConfig& config);
+
+RunResult WriteEnvironmentArtifactFromConfigFile(
+    const std::filesystem::path& config_path);
+
+SmokeRunResult WriteConfiguredArtifacts(const RunConfig& config,
+                                        const std::filesystem::path& repo_root);
+
+}  // namespace ios
+}  // namespace font_harness
+}  // namespace skity
+
+#endif  // HARNESS_FONT_PLATFORM_IOS_RUNNER_IOS_RUNNER_HPP

--- a/harness/font/platform/ios/runner/ios_runner.mm
+++ b/harness/font/platform/ios/runner/ios_runner.mm
@@ -1,0 +1,408 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "harness/font/platform/ios/runner/ios_runner.hpp"
+
+#import <Foundation/Foundation.h>
+
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "harness/font/artifact/json_io.hpp"
+#include "harness/font/platform/coretext/env_info.hpp"
+#include "harness/font/probe/font_manager_probe.hpp"
+#include "harness/font/probe/glyph_path_probe.hpp"
+#include "harness/font/probe/metrics_probe.hpp"
+#include "harness/font/probe/typeface_probe.hpp"
+
+#ifndef SKITY_FONT_HARNESS_TARGET_PLATFORM
+#define SKITY_FONT_HARNESS_TARGET_PLATFORM "ios-sim-coretext"
+#endif
+
+namespace skity {
+namespace font_harness {
+namespace ios {
+namespace {
+
+RunResult Failure(std::string message) {
+  RunResult result;
+  result.ok = false;
+  result.message = std::move(message);
+  return result;
+}
+
+CaseRunResult CaseFailure(std::string case_id, std::string message) {
+  CaseRunResult result;
+  result.ok = false;
+  result.case_id = std::move(case_id);
+  result.message = std::move(message);
+  return result;
+}
+
+bool ReadStringField(const Json::Value& root, const char* field, std::string* value) {
+  if (!root.isObject() || !root.isMember(field) || !root[field].isString()) {
+    return false;
+  }
+  *value = root[field].asString();
+  return true;
+}
+
+bool ReadStringArrayField(const Json::Value& root, const char* field,
+                          std::vector<std::string>* values, std::string* error) {
+  if (!root.isObject() || !root.isMember(field)) {
+    return true;
+  }
+  const Json::Value& array = root[field];
+  if (!array.isArray()) {
+    if (error != nullptr) {
+      *error = std::string(field) + " must be an array";
+    }
+    return false;
+  }
+  values->clear();
+  for (Json::ArrayIndex i = 0; i < array.size(); ++i) {
+    const Json::Value& item = array[i];
+    if (item.isString()) {
+      values->push_back(item.asString());
+      continue;
+    }
+    if (item.isObject() && item.isMember("path") && item["path"].isString()) {
+      values->push_back(item["path"].asString());
+      continue;
+    }
+    if (error != nullptr) {
+      *error = std::string(field) + " entries must be strings or objects with string path";
+    }
+    return false;
+  }
+  return true;
+}
+
+std::string StemOrFallback(const std::filesystem::path& path, const std::string& fallback) {
+  const std::string stem = path.stem().string();
+  return stem.empty() ? fallback : stem;
+}
+
+bool IsSafeFileChar(char value) {
+  return std::isalnum(static_cast<unsigned char>(value)) || value == '-' || value == '_' ||
+         value == '.';
+}
+
+std::string SanitizeFileComponent(std::string value, const std::string& fallback) {
+  if (value.empty()) {
+    return fallback;
+  }
+  for (char& c : value) {
+    if (!IsSafeFileChar(c)) {
+      c = '_';
+    }
+  }
+  while (!value.empty() && value.front() == '.') {
+    value.erase(value.begin());
+  }
+  return value.empty() ? fallback : value;
+}
+
+std::filesystem::path TemporaryArtifactRoot() {
+  @autoreleasepool {
+    NSString* temporary_dir = NSTemporaryDirectory();
+    if (temporary_dir.length > 0) {
+      return std::filesystem::path(temporary_dir.fileSystemRepresentation) / "font-harness" /
+             "artifacts";
+    }
+  }
+
+  const char* tmpdir = std::getenv("TMPDIR");
+  if (tmpdir != nullptr && tmpdir[0] != '\0') {
+    return std::filesystem::path(tmpdir) / "font-harness" / "artifacts";
+  }
+  return std::filesystem::temp_directory_path() / "font-harness" / "artifacts";
+}
+
+std::filesystem::path AppSupportArtifactRoot() {
+  @autoreleasepool {
+    NSArray<NSURL*>* urls =
+        [[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory
+                                               inDomains:NSUserDomainMask];
+    NSURL* support_url = [urls firstObject];
+    NSString* support_path = support_url.path;
+    if (support_path.length > 0) {
+      return std::filesystem::path(support_path.fileSystemRepresentation) / "font-harness" /
+             "artifacts";
+    }
+  }
+  return TemporaryArtifactRoot();
+}
+
+Json::Value BuildUnsupportedCategoryReport(const std::string& case_id, const std::string& backend,
+                                           const std::string& category) {
+  Json::Value report(Json::objectValue);
+  report["schema_version"] = 1;
+  report["artifact_type"] = "font_probe_result";
+  report["case_id"] = case_id;
+  report["backend"] = backend;
+  report["ok"] = false;
+  report["reason_code"] = "unsupported_case_category";
+  report["message"] = std::string("iOS smoke runner does not support category ") + category;
+  return report;
+}
+
+Json::Value RunProbeForCase(const std::filesystem::path& repo_root,
+                            const std::filesystem::path& case_path, const std::string& category,
+                            bool* probe_ok) {
+  *probe_ok = false;
+  if (category == "typeface_probe") {
+    TypefaceProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = "coretext";
+    TypefaceProbeResult result = RunTypefaceProbe(request);
+    *probe_ok = result.status == TypefaceProbeStatus::kSuccess;
+    return std::move(result.report);
+  }
+
+  if (category == "font_metrics" || category == "glyph_metrics" || category == "scaler_context") {
+    MetricsProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = "coretext";
+    MetricsProbeResult result = RunMetricsProbe(request);
+    *probe_ok = result.status == MetricsProbeStatus::kSuccess;
+    return std::move(result.report);
+  }
+
+  if (category == "glyph_path") {
+    GlyphPathProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = "coretext";
+    GlyphPathProbeResult result = RunGlyphPathProbe(request);
+    *probe_ok = result.status == GlyphPathProbeStatus::kSuccess;
+    return std::move(result.report);
+  }
+
+  if (category == "font_manager" || category == "family_style_set") {
+    FontManagerProbeRequest request;
+    request.repo_root = repo_root;
+    request.case_path = case_path;
+    request.backend = "coretext";
+    FontManagerProbeResult result = RunFontManagerProbe(request);
+    *probe_ok = result.status == FontManagerProbeStatus::kSuccess;
+    return std::move(result.report);
+  }
+
+  return BuildUnsupportedCategoryReport(StemOrFallback(case_path, "case"), "coretext", category);
+}
+
+void FillIOSActualProvenance(const RunConfig& config, const std::filesystem::path& artifact_path,
+                             Json::Value* report) {
+  (*report)["target_platform"] = config.target_platform;
+  (*report)["platform_id"] = config.target_platform;
+  (*report)["artifact_role"] = "actual";
+  (*report)["producer"] = "skity";
+  (*report)["runner"] = "ios-xctest";
+  (*report)["runner_mode"] = config.runner_mode;
+  (*report)["artifact_path"] = artifact_path.generic_string();
+}
+
+CaseRunResult WriteCaseArtifact(const RunConfig& config, const std::filesystem::path& repo_root,
+                                const std::string& case_relative_path) {
+  const std::filesystem::path case_path = repo_root / config.case_root / case_relative_path;
+  Json::Value case_root;
+  std::string error;
+  std::string case_id = StemOrFallback(case_path, "case");
+  if (!LoadJsonFile(case_path, &case_root, &error)) {
+    return CaseFailure(case_id, error);
+  }
+
+  ReadStringField(case_root, "id", &case_id);
+  std::string category;
+  if (!ReadStringField(case_root, "category", &category)) {
+    return CaseFailure(case_id, "case category is required");
+  }
+
+  const std::string safe_case_id = SanitizeFileComponent(case_id, "case");
+  const std::filesystem::path artifact_path = config.artifact_output_dir / config.target_platform /
+                                              "skity" / (safe_case_id + ".skity.json");
+
+  bool probe_ok = false;
+  Json::Value report = RunProbeForCase(repo_root, case_path, category, &probe_ok);
+  FillIOSActualProvenance(config, artifact_path, &report);
+
+  if (!WriteJsonFile(artifact_path, report, &error)) {
+    return CaseFailure(case_id, error);
+  }
+
+  CaseRunResult result;
+  result.ok = probe_ok;
+  result.case_id = case_id;
+  result.artifact_path = artifact_path;
+  if (!probe_ok) {
+    if (report.isMember("reason_code") && report["reason_code"].isString()) {
+      result.message = report["reason_code"].asString();
+    } else {
+      result.message = "probe failed";
+    }
+  }
+  return result;
+}
+
+RunResult WriteEnv(const RunConfig& config) {
+  if (config.target_platform.empty()) {
+    return Failure("target_platform is required");
+  }
+  if (config.artifact_output_dir.empty()) {
+    return Failure("artifact_output_dir is required");
+  }
+  if (config.runner_mode != "actual" && config.runner_mode != "expected") {
+    return Failure("runner_mode must be actual or expected");
+  }
+
+  CoreTextEnvRequest request;
+  Json::Value report = BuildCoreTextEnvInfo(request);
+  report["artifact_role"] = "env";
+  report["target_platform"] = config.target_platform;
+  report["runner"] = "ios-xctest";
+  report["runner_mode"] = config.runner_mode;
+  report["producer"] = config.runner_mode == "expected" ? "skia" : "skity";
+
+  const std::filesystem::path artifact_path =
+      config.artifact_output_dir / config.target_platform / "env" / "latest.json";
+  report["artifact_path"] = artifact_path.generic_string();
+
+  std::string error;
+  if (!WriteJsonFile(artifact_path, report, &error)) {
+    return Failure(error);
+  }
+
+  RunResult result;
+  result.ok = true;
+  result.artifact_path = artifact_path;
+  return result;
+}
+
+}  // namespace
+
+RunConfig DefaultRunConfig() {
+  RunConfig config;
+  config.target_platform = SKITY_FONT_HARNESS_TARGET_PLATFORM;
+  config.artifact_output_dir = AppSupportArtifactRoot();
+  config.runner_mode = "actual";
+  config.case_root = "harness/font/cases";
+  return config;
+}
+
+bool LoadRunConfig(const std::filesystem::path& config_path, RunConfig* config,
+                   std::string* error) {
+  if (config == nullptr) {
+    if (error != nullptr) {
+      *error = "config must not be null";
+    }
+    return false;
+  }
+
+  Json::Value root;
+  if (!LoadJsonFile(config_path, &root, error)) {
+    return false;
+  }
+  if (!root.isObject()) {
+    if (error != nullptr) {
+      *error = "run config must be a JSON object";
+    }
+    return false;
+  }
+
+  std::string value;
+  if (ReadStringField(root, "target_platform", &value)) {
+    config->target_platform = value;
+  }
+  if (ReadStringField(root, "artifact_output_dir", &value)) {
+    config->artifact_output_dir = value;
+  }
+  if (ReadStringField(root, "runner_mode", &value)) {
+    config->runner_mode = value;
+  }
+  if (ReadStringField(root, "case_root", &value)) {
+    config->case_root = value;
+  }
+  if (!ReadStringArrayField(root, "cases", &config->cases, error)) {
+    return false;
+  }
+  return true;
+}
+
+RunResult WriteEnvironmentArtifact(const RunConfig& config) { return WriteEnv(config); }
+
+SmokeRunResult WriteArtifactsForConfiguredCases(const RunConfig& config,
+                                                const std::filesystem::path& repo_root,
+                                                const std::string& run_name) {
+  SmokeRunResult result;
+  if (config.target_platform.empty()) {
+    result.message = "target_platform is required";
+    return result;
+  }
+  if (config.artifact_output_dir.empty()) {
+    result.message = "artifact_output_dir is required";
+    return result;
+  }
+  if (config.runner_mode != "actual") {
+    result.message = "Skity iOS runner requires runner_mode=actual";
+    return result;
+  }
+  if (config.case_root.empty()) {
+    result.message = "case_root is required";
+    return result;
+  }
+  if (config.cases.empty()) {
+    result.message = "runner-config cases are required";
+    return result;
+  }
+  if (repo_root.empty()) {
+    result.message = "repo_root is required";
+    return result;
+  }
+
+  result.ok = true;
+  for (const std::string& case_relative_path : config.cases) {
+    CaseRunResult case_result = WriteCaseArtifact(config, repo_root, case_relative_path);
+    if (!case_result.ok) {
+      result.ok = false;
+    }
+    result.cases.push_back(std::move(case_result));
+  }
+
+  if (!result.ok) {
+    std::ostringstream message;
+    message << run_name << " failed";
+    for (const CaseRunResult& case_result : result.cases) {
+      if (!case_result.ok) {
+        message << "; " << case_result.case_id << ": " << case_result.message;
+      }
+    }
+    result.message = message.str();
+  }
+  return result;
+}
+
+SmokeRunResult WriteConfiguredArtifacts(const RunConfig& config,
+                                        const std::filesystem::path& repo_root) {
+  return WriteArtifactsForConfiguredCases(config, repo_root, "configured run");
+}
+
+RunResult WriteEnvironmentArtifactFromConfigFile(const std::filesystem::path& config_path) {
+  std::string error;
+  RunConfig config = DefaultRunConfig();
+  if (!LoadRunConfig(config_path, &config, &error)) {
+    return Failure(error);
+  }
+  return WriteEnv(config);
+}
+
+}  // namespace ios
+}  // namespace font_harness
+}  // namespace skity

--- a/harness/font/platform/ios/tests/FontHarnessIOSRunnerTests.mm
+++ b/harness/font/platform/ios/tests/FontHarnessIOSRunnerTests.mm
@@ -1,0 +1,64 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <XCTest/XCTest.h>
+
+#include <filesystem>
+
+#include "harness/font/platform/ios/runner/ios_runner.hpp"
+
+@interface FontHarnessIOSRunnerTests : XCTestCase
+@end
+
+@implementation FontHarnessIOSRunnerTests
+
+- (void)testWritesEnvironmentArtifact {
+  skity::font_harness::ios::RunConfig config = [self runConfigFromBundleOrDefault];
+  skity::font_harness::ios::RunResult result =
+      skity::font_harness::ios::WriteEnvironmentArtifact(config);
+
+  XCTAssertTrue(result.ok, @"%s", result.message.c_str());
+  XCTAssertFalse(result.artifact_path.empty());
+}
+
+- (std::filesystem::path)stagedRepoRoot {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  return std::filesystem::path(bundle.resourcePath.fileSystemRepresentation) / "repo";
+}
+
+- (std::filesystem::path)runConfigPath {
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  return std::filesystem::path(bundle.resourcePath.fileSystemRepresentation) / "runner-config.json";
+}
+
+- (skity::font_harness::ios::RunConfig)runConfigFromBundleOrDefault {
+  skity::font_harness::ios::RunConfig config = skity::font_harness::ios::DefaultRunConfig();
+  const std::filesystem::path config_path = [self runConfigPath];
+  if (std::filesystem::exists(config_path)) {
+    std::string error;
+    XCTAssertTrue(skity::font_harness::ios::LoadRunConfig(config_path, &config, &error), @"%s",
+                  error.c_str());
+  }
+  return config;
+}
+
+- (void)testWritesConfiguredArtifacts {
+  skity::font_harness::ios::RunConfig config = [self runConfigFromBundleOrDefault];
+  if (config.cases.empty()) {
+    XCTSkip(@"runner-config cases are required for configured artifact run");
+    return;
+  }
+  skity::font_harness::ios::SmokeRunResult result =
+      skity::font_harness::ios::WriteConfiguredArtifacts(config, [self stagedRepoRoot]);
+
+  XCTAssertTrue(result.ok, @"%s", result.message.c_str());
+  XCTAssertEqual(result.cases.size(), config.cases.size());
+  for (const skity::font_harness::ios::CaseRunResult& case_result : result.cases) {
+    XCTAssertTrue(case_result.ok, @"%s: %s", case_result.case_id.c_str(),
+                  case_result.message.c_str());
+    XCTAssertFalse(case_result.artifact_path.empty());
+  }
+}
+
+@end

--- a/harness/font/platform/ios/tests/Info.plist.in
+++ b/harness/font/platform/ios/tests/Info.plist.in
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2021 The Lynx Authors. All rights reserved.
+Licensed under the Apache License Version 2.0 that can be found in the
+LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+</dict>
+</plist>

--- a/harness/font/tests/smoke/skity_font_cli_smoke.py
+++ b/harness/font/tests/smoke/skity_font_cli_smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 CASE_ID = "font.synthetic.typeface"
 FONT_MANAGER_CASE_ID = "font.synthetic.font_manager.default_typeface"
 BACKEND = "coretext"
+TARGET_PLATFORM = "macos-coretext"
 
 
 def write_json(path, value):
@@ -30,7 +31,7 @@ def make_case():
         "category": "typeface_probe",
         "status": "active",
         "backend": BACKEND,
-        "platforms": ["darwin-ct"],
+        "platforms": [TARGET_PLATFORM],
         "font_files": [
             {
                 "id": "synthetic",
@@ -50,18 +51,18 @@ def make_case():
     }
 
 
-def make_manifest(cases=None):
+def make_manifest(cases=None, manifest_id="font.synthetic.smoke"):
     return {
         "schema_version": 1,
-        "id": "font.synthetic.smoke",
+        "id": manifest_id,
         "backend": BACKEND,
-        "platforms": ["darwin-ct"],
+        "platforms": [TARGET_PLATFORM],
+        "target_platform": TARGET_PLATFORM,
         "case_root": "cases",
         "cases": cases or ["typeface.json"],
         "artifacts": {
-            "skia_dir": "artifacts/skia",
-            "skity_dir": "artifacts/skity",
-            "compare_dir": "artifacts/compare",
+            "root": f"artifacts/{TARGET_PLATFORM}",
+            "report_root": f"reports/{TARGET_PLATFORM}",
         },
     }
 
@@ -73,7 +74,7 @@ def make_font_manager_case():
         "category": "font_manager",
         "status": "active",
         "backend": BACKEND,
-        "platforms": ["darwin-ct"],
+        "platforms": [TARGET_PLATFORM],
         "font_manager_request": {
             "entry": "GetDefaultTypeface",
             "style": {
@@ -284,7 +285,10 @@ def main():
         write_json(manifest_path, make_manifest())
         write_json(
             full_manifest_path,
-            make_manifest(["typeface.json", "font_manager_default.json"]),
+            make_manifest(
+                ["typeface.json", "font_manager_default.json"],
+                manifest_id="font.synthetic.full",
+            ),
         )
         write_json(expected_path, make_probe_artifact(1))
         write_json(actual_path, make_probe_artifact(1))
@@ -485,7 +489,9 @@ def main():
         ):
             return 1
 
-        run_report = report_dir / "run-missing-oracle.json"
+        run_report = (
+            repo_root / f"reports/{TARGET_PLATFORM}/font.synthetic.smoke.latest.json"
+        )
         result = run_command(
             [
                 skity_font,
@@ -494,24 +500,30 @@ def main():
                 manifest_path,
                 "--backend",
                 BACKEND,
-                "--skia-dir",
-                tmp_dir / "missing-skia",
-                "--skity-dir",
-                tmp_dir / "skity",
                 "--repo-root",
                 repo_root,
-                "--report",
-                run_report,
             ]
         )
         if expect_exit("run missing oracle", result, 6):
+            return 1
+        if expect_report_field(run_report, "target_platform", TARGET_PLATFORM):
+            return 1
+        if expect_report_field(
+            run_report, "artifacts.root", f"artifacts/{TARGET_PLATFORM}"
+        ):
+            return 1
+        if expect_report_field(
+            run_report, "artifacts.skia_dir", f"artifacts/{TARGET_PLATFORM}/skia"
+        ):
             return 1
         if expect_report_field(run_report, "input_failure_count", 1):
             return 1
         if expect_report_field(run_report, "cases.0.reason_code", "missing_oracle"):
             return 1
 
-        full_run_report = report_dir / "run-full-missing-oracle.json"
+        full_run_report = (
+            repo_root / f"reports/{TARGET_PLATFORM}/font.synthetic.full.latest.json"
+        )
         result = run_command(
             [
                 skity_font,
@@ -520,14 +532,8 @@ def main():
                 full_manifest_path,
                 "--backend",
                 BACKEND,
-                "--skia-dir",
-                tmp_dir / "missing-full-skia",
-                "--skity-dir",
-                tmp_dir / "full-skity",
                 "--repo-root",
                 repo_root,
-                "--report",
-                full_run_report,
             ]
         )
         if expect_exit("run synthetic full missing oracle", result, 6):

--- a/harness/font/tests/unit/font_harness_self_test.cc
+++ b/harness/font/tests/unit/font_harness_self_test.cc
@@ -15,6 +15,7 @@
 #include "harness/font/artifact/json_io.hpp"
 #include "harness/font/case/case_document.hpp"
 #include "harness/font/case/manifest_document.hpp"
+#include "harness/font/case/platform_target.hpp"
 #include "harness/font/case/repo_uri.hpp"
 #include "harness/font/compare/compare_engine.hpp"
 #include "harness/font/compare/path/path_normalizer.hpp"
@@ -28,6 +29,7 @@ constexpr const char* kMetricsCaseId = "font.synthetic.metrics";
 constexpr const char* kGlyphPathCaseId = "font.synthetic.glyph_path";
 constexpr const char* kFontManagerCaseId = "font.synthetic.font_manager";
 constexpr const char* kBackend = "coretext";
+constexpr const char* kTargetPlatform = "macos-coretext";
 
 class TempDir {
  public:
@@ -104,14 +106,14 @@ Json::Value MakeManifest() {
   root["id"] = "font.synthetic.smoke";
   root["backend"] = kBackend;
   root["platforms"] = Json::Value(Json::arrayValue);
-  root["platforms"].append("darwin-ct");
+  root["platforms"].append(kTargetPlatform);
+  root["target_platform"] = kTargetPlatform;
   root["case_root"] = "cases";
   root["cases"] = Json::Value(Json::arrayValue);
   root["cases"].append("typeface.json");
   root["artifacts"] = Json::Value(Json::objectValue);
-  root["artifacts"]["skia_dir"] = "artifacts/skia";
-  root["artifacts"]["skity_dir"] = "artifacts/skity";
-  root["artifacts"]["compare_dir"] = "artifacts/compare";
+  root["artifacts"]["root"] = "artifacts/macos-coretext";
+  root["artifacts"]["report_root"] = "reports/macos-coretext";
   return root;
 }
 
@@ -519,6 +521,51 @@ TEST(FontHarnessCaseDocumentTest, ValidatesSyntheticTypefaceCase) {
       result.resolved_font_files[0].absolute_path);
 }
 
+TEST(FontHarnessCaseDocumentTest, AcceptsIosSimulatorCoreTextPlatform) {
+  TempDir temp("case_ios_sim_coretext");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  Json::Value root = MakeTypefaceCase();
+  root["platforms"] = Json::Value(Json::arrayValue);
+  root["platforms"].append("ios-sim-coretext");
+
+  RepoUriResolver resolver(temp.root());
+  CaseValidationResult result = ValidateCaseDocument(root, resolver);
+
+  EXPECT_TRUE(result.valid) << WriteJsonString(result.errors.ToJson());
+}
+
+TEST(FontHarnessCaseDocumentTest, AcceptsReservedFuturePlatformTargets) {
+  TempDir temp("case_future_platforms");
+  WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
+
+  RepoUriResolver resolver(temp.root());
+
+  Json::Value ios_device = MakeTypefaceCase();
+  ios_device["platforms"] = Json::Value(Json::arrayValue);
+  ios_device["platforms"].append("ios-device-coretext");
+  CaseValidationResult ios_device_result =
+      ValidateCaseDocument(ios_device, resolver);
+  EXPECT_TRUE(ios_device_result.valid)
+      << WriteJsonString(ios_device_result.errors.ToJson());
+
+  Json::Value android = MakeTypefaceCase();
+  android["backend"] = "freetype";
+  android["platforms"] = Json::Value(Json::arrayValue);
+  android["platforms"].append("android-freetype");
+  CaseValidationResult android_result = ValidateCaseDocument(android, resolver);
+  EXPECT_TRUE(android_result.valid)
+      << WriteJsonString(android_result.errors.ToJson());
+
+  Json::Value windows = MakeTypefaceCase();
+  windows["backend"] = "directwrite";
+  windows["platforms"] = Json::Value(Json::arrayValue);
+  windows["platforms"].append("windows-directwrite");
+  CaseValidationResult windows_result = ValidateCaseDocument(windows, resolver);
+  EXPECT_TRUE(windows_result.valid)
+      << WriteJsonString(windows_result.errors.ToJson());
+}
+
 TEST(FontHarnessCaseDocumentTest, RejectsRepoUriTraversal) {
   TempDir temp("case_traversal");
   WriteTextFile(temp.root() / "fonts/synthetic.ttf", "synthetic font bytes");
@@ -543,6 +590,7 @@ TEST(FontHarnessManifestDocumentTest, ValidatesSyntheticManifest) {
   EXPECT_TRUE(result.valid) << WriteJsonString(result.errors.ToJson());
   EXPECT_EQ("font.synthetic.smoke", result.manifest_id);
   EXPECT_EQ(kBackend, result.backend);
+  EXPECT_EQ(kTargetPlatform, result.target_platform);
 }
 
 TEST(FontHarnessManifestDocumentTest, RejectsUnsafeCasePath) {
@@ -555,6 +603,54 @@ TEST(FontHarnessManifestDocumentTest, RejectsUnsafeCasePath) {
 
   EXPECT_FALSE(result.valid);
   EXPECT_FALSE(result.errors.ToJson().empty());
+}
+
+TEST(FontHarnessManifestDocumentTest, RejectsTargetPlatformOutsidePlatforms) {
+  TempDir temp("manifest_target_platform");
+  Json::Value root = MakeManifest();
+  root["target_platform"] = "ios-sim-coretext";
+
+  RepoUriResolver resolver(temp.root());
+  ManifestValidationResult result = ValidateManifestDocument(root, resolver);
+
+  EXPECT_FALSE(result.valid);
+  EXPECT_FALSE(result.errors.ToJson().empty());
+}
+
+TEST(FontHarnessManifestDocumentTest, AcceptsReservedFuturePlatformTargets) {
+  TempDir temp("manifest_future_platforms");
+  RepoUriResolver resolver(temp.root());
+
+  Json::Value android = MakeManifest();
+  android["backend"] = "freetype";
+  android["platforms"] = Json::Value(Json::arrayValue);
+  android["platforms"].append("android-freetype");
+  android["target_platform"] = "android-freetype";
+  ManifestValidationResult android_result =
+      ValidateManifestDocument(android, resolver);
+  EXPECT_TRUE(android_result.valid)
+      << WriteJsonString(android_result.errors.ToJson());
+  EXPECT_EQ("android-freetype", android_result.target_platform);
+
+  Json::Value windows = MakeManifest();
+  windows["backend"] = "directwrite";
+  windows["platforms"] = Json::Value(Json::arrayValue);
+  windows["platforms"].append("windows-directwrite");
+  windows["target_platform"] = "windows-directwrite";
+  ManifestValidationResult windows_result =
+      ValidateManifestDocument(windows, resolver);
+  EXPECT_TRUE(windows_result.valid)
+      << WriteJsonString(windows_result.errors.ToJson());
+  EXPECT_EQ("windows-directwrite", windows_result.target_platform);
+}
+
+TEST(FontHarnessPlatformTargetTest, CanonicalizesLegacyAliases) {
+  EXPECT_EQ("macos-coretext", CanonicalPlatformTarget("darwin-ct"));
+  EXPECT_EQ("windows-directwrite", CanonicalPlatformTarget("windows-dwrite"));
+
+  Json::Value platforms(Json::arrayValue);
+  platforms.append("darwin-ct");
+  EXPECT_TRUE(PlatformArrayContainsTarget(platforms, "macos-coretext"));
 }
 
 TEST(FontHarnessCompareEngineTest, ReportsPassMismatchAndInputFailure) {


### PR DESCRIPTION
Add platform-aware CoreText harness support for iOS simulator and iOS device runs.

The harness now uses XCTest host apps to run Skia expected probes and Skity actual probes on the target iOS environment, stages manifest-driven cases and resources into the test bundles, pulls artifacts back into platform-scoped local directories, and reuses the shared host compare logic for reports.

This also extends manifest and case platform semantics so macOS, iOS simulator, and iOS device artifacts live in separate namespaces while sharing the same comparison rules.

Current iOS simulator and device full corpus runs complete with the same two known mismatch categories: CoreText variable-axis metadata exposed by Skity but not Skia, and CSS generic sans-serif mapping where Skity resolves Helvetica while Skia reports unavailable.