### PR TITLE
feat(vk): add GPUSemaphore abstraction and Vulkan implementation

### DIFF
--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -11,6 +11,7 @@
 #include <skity/gpu/gpu_backend_type.hpp>
 #include <skity/gpu/gpu_presenter.hpp>
 #include <skity/gpu/gpu_render_target.hpp>
+#include <skity/gpu/gpu_semaphore.hpp>
 #include <skity/gpu/gpu_surface.hpp>
 #include <skity/gpu/texture.hpp>
 #include <skity/macros.hpp>
@@ -190,6 +191,28 @@ class SKITY_API GPUContext {
    */
   SKITY_EXPERIMENTAL
   virtual void SetResourceCacheLimit(size_t size_in_bytes) = 0;
+
+  /**
+   * Create a reusable GPU semaphore for cross-GPU synchronization.
+   *
+   * @return A shared_ptr to the created semaphore, or nullptr on failure.
+   */
+  virtual std::shared_ptr<GPUSemaphore> CreateSemaphore() = 0;
+
+  /**
+   * Import a native sync handle into an existing semaphore.
+   *
+   * Pass a backend-specific GPUSemaphoreImportInfo derived struct:
+   * - Vulkan: GPUSemaphoreImportInfoVK with sync_fd
+   *
+   * The sync handle ownership is transferred to the GPU driver (consumed even
+   * on import failure, per Vulkan spec for SYNC_FD).
+   *
+   * @param semaphore  A semaphore previously created by CreateSemaphore().
+   * @param info       Backend-specific import descriptor.
+   */
+  virtual void ImportSemaphore(GPUSemaphore* semaphore,
+                               const GPUSemaphoreImportInfo& info) = 0;
 
   /**
    * Create a precompile context bound to this GPUContext. The returned context

--- a/include/skity/gpu/gpu_context_vk.hpp
+++ b/include/skity/gpu/gpu_context_vk.hpp
@@ -8,6 +8,7 @@
 #include <vulkan/vulkan.h>
 
 #include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/gpu_semaphore.hpp>
 #include <skity/gpu/gpu_surface.hpp>
 #include <skity/gpu/texture.hpp>
 #include <skity/macros.hpp>
@@ -341,6 +342,24 @@ struct GPUBackendTextureInfoVK : public GPUBackendTextureInfo {
    * Whether the engine owns `image_view` and should destroy it on release.
    */
   bool owns_image_view = false;
+};
+
+/**
+ * Vulkan-specific import descriptor for GPUSemaphore.
+ *
+ * Supports importing a POSIX sync file descriptor (from EGLSync fence etc.)
+ * into a Vulkan semaphore via vkImportSemaphoreFdKHR.
+ *
+ * The fd ownership is transferred to the Vulkan driver.
+ */
+struct GPUSemaphoreImportInfoVK : public GPUSemaphoreImportInfo {
+  GPUSemaphoreImportInfoVK() { backend = GPUBackendType::kVulkan; }
+
+  /**
+   * POSIX sync file descriptor (e.g. from eglDupNativeFenceFDANDROID).
+   * Ownership is transferred to the GPU driver on ImportSemaphore() call.
+   */
+  int sync_fd = -1;
 };
 
 struct GPUPresenterDescriptorVK : public GPUPresenterDescriptor {

--- a/include/skity/gpu/gpu_semaphore.hpp
+++ b/include/skity/gpu/gpu_semaphore.hpp
@@ -1,0 +1,49 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef INCLUDE_SKITY_GPU_GPU_SEMAPHORE_HPP
+#define INCLUDE_SKITY_GPU_GPU_SEMAPHORE_HPP
+
+#include <skity/gpu/gpu_backend_type.hpp>
+#include <skity/macros.hpp>
+
+namespace skity {
+
+/**
+ * Abstract GPU synchronization semaphore.
+ *
+ * Used for GPU-GPU synchronization between different GPU contexts or APIs.
+ * Create via GPUContext::CreateSemaphore(), import a native sync handle via
+ * GPUContext::ImportSemaphore(), then pass to
+ * GPUSurface::AddExternalWaitSemaphore() before flushing.
+ *
+ * The semaphore can be reused across frames: each call to ImportSemaphore()
+ * re-imports a new handle into the same underlying GPU semaphore object.
+ */
+class SKITY_API GPUSemaphore {
+ public:
+  virtual ~GPUSemaphore() = default;
+
+  GPUBackendType GetBackendType() const { return backend_; }
+
+ protected:
+  explicit GPUSemaphore(GPUBackendType backend) : backend_(backend) {}
+
+  GPUBackendType backend_ = GPUBackendType::kNone;
+};
+
+/**
+ * Base descriptor for importing a native sync handle into a GPUSemaphore.
+ *
+ * Follows the same polymorphic struct pattern as GPUBackendTextureInfo.
+ * Use the backend-specific derived struct (e.g. GPUSemaphoreImportInfoVK)
+ * matching the GPUContext backend type.
+ */
+struct GPUSemaphoreImportInfo {
+  GPUBackendType backend = GPUBackendType::kNone;
+};
+
+}  // namespace skity
+
+#endif  // INCLUDE_SKITY_GPU_GPU_SEMAPHORE_HPP

--- a/include/skity/gpu/gpu_surface.hpp
+++ b/include/skity/gpu/gpu_surface.hpp
@@ -6,6 +6,7 @@
 #define INCLUDE_SKITY_GPU_GPU_SURFACE_HPP
 
 #include <skity/gpu/gpu_backend_type.hpp>
+#include <skity/gpu/gpu_semaphore.hpp>
 #include <skity/macros.hpp>
 #include <skity/render/canvas.hpp>
 
@@ -78,6 +79,22 @@ class SKITY_API GPUSurface {
    */
   SKITY_EXPERIMENTAL
   virtual std::shared_ptr<Pixmap> ReadPixels(const Rect& rect) = 0;
+
+  /**
+   * Add an external wait semaphore for the next frame's flush.
+   *
+   * The semaphore will be waited on before GPU rendering begins.
+   * Typically used to synchronize with an external GPU context (e.g. GL)
+   * that produces textures consumed by this surface.
+   *
+   * Must be called between LockCanvas() and Flush(). The semaphore
+   * reference is released after Flush().
+   *
+   * @param semaphore  A semaphore created by GPUContext::CreateSemaphore()
+   *                    and imported via GPUContext::ImportSemaphore().
+   */
+  virtual void AddExternalWaitSemaphore(
+      std::shared_ptr<GPUSemaphore> semaphore) {}
 };
 
 }  // namespace skity

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -501,6 +501,8 @@ if(${SKITY_HW_RENDERER})
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_context_impl_vk.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_context_impl_vk.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_native_window_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_semaphore_vk.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_semaphore_vk.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pass_vk.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pass_vk.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_render_pipeline_vk.cc

--- a/src/gpu/gpu_context_impl.hpp
+++ b/src/gpu/gpu_context_impl.hpp
@@ -64,6 +64,11 @@ class GPUContextImpl : public GPUContext {
 
   std::shared_ptr<Data> ReadPixels(const std::shared_ptr<GPUTexture>& texture);
 
+  std::shared_ptr<GPUSemaphore> CreateSemaphore() override { return nullptr; }
+
+  void ImportSemaphore(GPUSemaphore* semaphore,
+                       const GPUSemaphoreImportInfo& info) override {}
+
   // Use depth-stencil capable pipeline state for stable pipeline variants.
   // Draw steps still decide whether they actually use depth or stencil
   // tests/writes.

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -12,6 +12,7 @@
 #include "src/gpu/vk/gpu_buffer_vk.hpp"
 #include "src/gpu/vk/gpu_device_vk.hpp"
 #include "src/gpu/vk/gpu_presenter_vk.hpp"
+#include "src/gpu/vk/gpu_semaphore_vk.hpp"
 #include "src/gpu/vk/gpu_surface_vk.hpp"
 #include "src/gpu/vk/gpu_texture_vk.hpp"
 #include "src/gpu/vk/vulkan_context_state.hpp"
@@ -466,6 +467,10 @@ bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
       get_device_proc_addr(device, "vkBindBufferMemory"));
   fns->vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(
       get_device_proc_addr(device, "vkBindImageMemory"));
+  fns->vkCreateSemaphore = reinterpret_cast<PFN_vkCreateSemaphore>(
+      get_device_proc_addr(device, "vkCreateSemaphore"));
+  fns->vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(
+      get_device_proc_addr(device, "vkDestroySemaphore"));
   fns->vkGetBufferMemoryRequirements =
       reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(
           get_device_proc_addr(device, "vkGetBufferMemoryRequirements"));
@@ -599,6 +604,10 @@ bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
   fns->vkSetDebugUtilsObjectNameEXT =
       reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
           get_device_proc_addr(device, "vkSetDebugUtilsObjectNameEXT"));
+#if defined(SKITY_ANDROID)
+  fns->vkImportSemaphoreFdKHR = reinterpret_cast<PFN_vkImportSemaphoreFdKHR>(
+      get_device_proc_addr(device, "vkImportSemaphoreFdKHR"));
+#endif
 #if defined(SKITY_VK_DEBUG_RUNTIME)
   fns->vkCmdBeginDebugUtilsLabelEXT =
       reinterpret_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
@@ -625,6 +634,7 @@ bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
       fns->vkFlushMappedMemoryRanges == nullptr ||
       fns->vkInvalidateMappedMemoryRanges == nullptr ||
       fns->vkBindBufferMemory == nullptr || fns->vkBindImageMemory == nullptr ||
+      fns->vkCreateSemaphore == nullptr || fns->vkDestroySemaphore == nullptr ||
       fns->vkGetBufferMemoryRequirements == nullptr ||
       fns->vkGetImageMemoryRequirements == nullptr ||
       fns->vkCreateBuffer == nullptr || fns->vkDestroyBuffer == nullptr ||
@@ -875,6 +885,57 @@ std::unique_ptr<GPUPresenter> GPUContextVK::CreatePresenter(
     return nullptr;
   }
   return presenter;
+}
+
+std::shared_ptr<GPUSemaphore> GPUContextVK::CreateSemaphore() {
+  VkSemaphoreCreateInfo create_info = {};
+  create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+  VkSemaphore sem = VK_NULL_HANDLE;
+  auto result = state_->DeviceFns().vkCreateSemaphore(
+      state_->GetLogicalDevice(), &create_info, nullptr, &sem);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::CreateSemaphore: vkCreateSemaphore failed: {}",
+         static_cast<int32_t>(result));
+    return nullptr;
+  }
+
+  return std::shared_ptr<GPUSemaphoreVK>(new GPUSemaphoreVK(state_, sem));
+}
+
+void GPUContextVK::ImportSemaphore(GPUSemaphore* semaphore,
+                                   const GPUSemaphoreImportInfo& info) {
+  if (semaphore == nullptr || info.backend != GPUBackendType::kVulkan) {
+    return;
+  }
+
+  auto* vk_sem = static_cast<GPUSemaphoreVK*>(semaphore);
+  const auto& vk_info = static_cast<const GPUSemaphoreImportInfoVK&>(info);
+
+#if defined(SKITY_ANDROID)
+  if (state_->DeviceFns().vkImportSemaphoreFdKHR == nullptr) {
+    LOGE("GPUContextVK::ImportSemaphore: vkImportSemaphoreFdKHR not available");
+    return;
+  }
+
+  VkImportSemaphoreFdInfoKHR import_info = {};
+  import_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+  import_info.semaphore = vk_sem->GetVkSemaphore();
+  import_info.flags = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT;
+  import_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+  import_info.fd = vk_info.sync_fd;  // ownership transferred
+
+  VkResult result = state_->DeviceFns().vkImportSemaphoreFdKHR(
+      state_->GetLogicalDevice(), &import_info);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::ImportSemaphore: vkImportSemaphoreFdKHR failed: {}",
+         static_cast<int32_t>(result));
+  }
+#else
+  (void)vk_sem;
+  (void)vk_info;
+  LOGE("GPUContextVK::ImportSemaphore: not supported on this platform");
+#endif
 }
 
 std::unique_ptr<GPUDevice> GPUContextVK::CreateGPUDevice() {

--- a/src/gpu/vk/gpu_context_impl_vk.hpp
+++ b/src/gpu/vk/gpu_context_impl_vk.hpp
@@ -6,6 +6,7 @@
 #define SRC_GPU_VK_GPU_CONTEXT_IMPL_VK_HPP
 
 #include <memory>
+#include <skity/gpu/gpu_context_vk.hpp>
 
 #include "src/gpu/gpu_context_impl.hpp"
 
@@ -28,6 +29,11 @@ class GPUContextVK : public GPUContextImpl {
 
   std::unique_ptr<GPUPresenter> CreatePresenter(
       GPUPresenterDescriptor* desc) override;
+
+  std::shared_ptr<GPUSemaphore> CreateSemaphore() override;
+
+  void ImportSemaphore(GPUSemaphore* semaphore,
+                       const GPUSemaphoreImportInfo& info) override;
 
   const VulkanContextState* GetState() const { return state_.get(); }
 

--- a/src/gpu/vk/gpu_semaphore_vk.cc
+++ b/src/gpu/vk/gpu_semaphore_vk.cc
@@ -1,0 +1,24 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/vk/gpu_semaphore_vk.hpp"
+
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
+namespace skity {
+
+GPUSemaphoreVK::GPUSemaphoreVK(std::shared_ptr<const VulkanContextState> state,
+                               VkSemaphore semaphore)
+    : GPUSemaphore(GPUBackendType::kVulkan),
+      state_(std::move(state)),
+      semaphore_(semaphore) {}
+
+GPUSemaphoreVK::~GPUSemaphoreVK() {
+  if (semaphore_ != VK_NULL_HANDLE && state_) {
+    state_->DeviceFns().vkDestroySemaphore(state_->GetLogicalDevice(),
+                                           semaphore_, nullptr);
+  }
+}
+
+}  // namespace skity

--- a/src/gpu/vk/gpu_semaphore_vk.hpp
+++ b/src/gpu/vk/gpu_semaphore_vk.hpp
@@ -1,0 +1,49 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_SEMAPHORE_VK_HPP
+#define SRC_GPU_VK_GPU_SEMAPHORE_VK_HPP
+
+#include <vulkan/vulkan.h>
+
+#include <memory>
+#include <skity/gpu/gpu_semaphore.hpp>
+
+namespace skity {
+
+class VulkanContextState;
+
+/**
+ * Vulkan implementation of GPUSemaphore.
+ *
+ * Owns a VkSemaphore created via vkCreateSemaphore. Destroyed via
+ * vkDestroySemaphore when the last shared_ptr reference is released.
+ *
+ * Lifecycle:
+ * - Created by GPUContextVK::CreateSemaphore()
+ * - Each frame: re-imported with a new fd via GPUContextVK::ImportSemaphore()
+ * - Passed to GPUSurfaceVK::AddExternalWaitSemaphore() before flush
+ * - Destroyed when the app releases its shared_ptr
+ */
+class GPUSemaphoreVK : public GPUSemaphore {
+ public:
+  ~GPUSemaphoreVK() override;
+
+  VkSemaphore GetVkSemaphore() const { return semaphore_; }
+  VkPipelineStageFlags GetStageMask() const { return stage_mask_; }
+  void SetStageMask(VkPipelineStageFlags mask) { stage_mask_ = mask; }
+
+ private:
+  friend class GPUContextVK;
+  GPUSemaphoreVK(std::shared_ptr<const VulkanContextState> state,
+                 VkSemaphore semaphore);
+
+  std::shared_ptr<const VulkanContextState> state_;
+  VkSemaphore semaphore_ = VK_NULL_HANDLE;
+  VkPipelineStageFlags stage_mask_ = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_SEMAPHORE_VK_HPP

--- a/src/gpu/vk/gpu_surface_vk.cc
+++ b/src/gpu/vk/gpu_surface_vk.cc
@@ -27,4 +27,26 @@ HWRootLayer* GPUSurfaceVK::OnBeginNextFrame(bool clear) {
   return root_layer;
 }
 
+void GPUSurfaceVK::AddExternalWaitSemaphore(
+    std::shared_ptr<GPUSemaphore> semaphore) {
+  auto* vk_sem = static_cast<GPUSemaphoreVK*>(semaphore.get());
+  submit_info_.AddWaitSemaphore(vk_sem->GetVkSemaphore(),
+                                vk_sem->GetStageMask());
+  external_semaphores_.push_back(std::move(semaphore));
+}
+
+void GPUSurfaceVK::OnFlush() {
+  // canvas->Flush() has completed the submit. The VkSemaphore handles have
+  // been consumed by the GPU. Remove the external semaphore entries from
+  // submit_info_ and release the shared_ptr references.
+  if (!external_semaphores_.empty()) {
+    size_t count = external_semaphores_.size();
+    submit_info_.wait_semaphores.resize(submit_info_.wait_semaphores.size() -
+                                        count);
+    submit_info_.wait_stage_masks.resize(submit_info_.wait_stage_masks.size() -
+                                         count);
+    external_semaphores_.clear();
+  }
+}
+
 }  // namespace skity

--- a/src/gpu/vk/gpu_surface_vk.hpp
+++ b/src/gpu/vk/gpu_surface_vk.hpp
@@ -11,6 +11,7 @@
 
 #include "src/gpu/gpu_surface_impl.hpp"
 #include "src/gpu/vk/gpu_command_buffer_vk.hpp"
+#include "src/gpu/vk/gpu_semaphore_vk.hpp"
 
 namespace skity {
 
@@ -52,6 +53,9 @@ class GPUSurfaceVK : public GPUSurfaceImpl {
 
   const GPUSubmitInfo* GetSubmitInfo() const override;
 
+  void AddExternalWaitSemaphore(
+      std::shared_ptr<GPUSemaphore> semaphore) override;
+
   void SetPresentInfo(const PresentInfo& present_info) {
     has_present_info_ = true;
     present_info_ = present_info;
@@ -64,7 +68,7 @@ class GPUSurfaceVK : public GPUSurfaceImpl {
  protected:
   HWRootLayer* OnBeginNextFrame(bool clear) override;
 
-  void OnFlush() override {}
+  void OnFlush() override;
 
  private:
   uint32_t target_width_ = 0;
@@ -75,6 +79,7 @@ class GPUSurfaceVK : public GPUSurfaceImpl {
   GPUSubmitInfoVK submit_info_ = {};
   bool has_present_info_ = false;
   PresentInfo present_info_ = {};
+  std::vector<std::shared_ptr<GPUSemaphore>> external_semaphores_;
 };
 
 }  // namespace skity

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -813,6 +813,11 @@ bool VulkanContextState::InitializeInstance(const GPUContextInfoVK& info) {
     TryEnableInstanceExtension(
         &enabled_instance_extensions_, available_instance_extensions_,
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+#if defined(SKITY_ANDROID)
+    TryEnableInstanceExtension(
+        &enabled_instance_extensions_, available_instance_extensions_,
+        VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
+#endif
     VkInstanceCreateFlags instance_flags = 0;
     EnablePortabilityEnumerationIfAvailable(available_instance_extensions_,
                                             &enabled_instance_extensions_,
@@ -1177,6 +1182,17 @@ bool VulkanContextState::InitializeOwnedDevice() {
     enabled_device_extensions_.emplace_back(
         VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
   }
+#if defined(SKITY_ANDROID)
+  if (HasAvailableDeviceExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
+  }
+  if (HasAvailableDeviceExtension(
+          VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
+  }
+#endif
   if (HasAvailableDeviceExtension(kPortabilitySubsetExtensionName)) {
     enabled_device_extensions_.emplace_back(kPortabilitySubsetExtensionName);
   }

--- a/src/gpu/vk/vulkan_proc_table.hpp
+++ b/src/gpu/vk/vulkan_proc_table.hpp
@@ -7,6 +7,11 @@
 
 #include <vulkan/vulkan.h>
 
+#if defined(SKITY_ANDROID)
+#include <vulkan/vulkan_android.h>
+#endif
+
+#include <skity/macros.hpp>
 #include <string>
 #include <vector>
 
@@ -69,6 +74,8 @@ struct VulkanDeviceFns {
   PFN_vkInvalidateMappedMemoryRanges vkInvalidateMappedMemoryRanges = nullptr;
   PFN_vkBindBufferMemory vkBindBufferMemory = nullptr;
   PFN_vkBindImageMemory vkBindImageMemory = nullptr;
+  PFN_vkCreateSemaphore vkCreateSemaphore = nullptr;
+  PFN_vkDestroySemaphore vkDestroySemaphore = nullptr;
   PFN_vkGetBufferMemoryRequirements vkGetBufferMemoryRequirements = nullptr;
   PFN_vkGetImageMemoryRequirements vkGetImageMemoryRequirements = nullptr;
   PFN_vkCreateBuffer vkCreateBuffer = nullptr;
@@ -128,6 +135,9 @@ struct VulkanDeviceFns {
   PFN_vkCmdSetStencilWriteMask vkCmdSetStencilWriteMask = nullptr;
   PFN_vkCmdSetStencilReference vkCmdSetStencilReference = nullptr;
   PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = nullptr;
+#if defined(SKITY_ANDROID)
+  PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR = nullptr;
+#endif
 #if defined(SKITY_VK_DEBUG_RUNTIME)
   PFN_vkCmdBeginDebugUtilsLabelEXT vkCmdBeginDebugUtilsLabelEXT = nullptr;
   PFN_vkCmdEndDebugUtilsLabelEXT vkCmdEndDebugUtilsLabelEXT = nullptr;


### PR DESCRIPTION
Add a cross-GPU synchronization primitive (GPUSemaphore) for coordinating between different GPU contexts or APIs (e.g. GL and Vulkan sharing textures on Android).

- New GPUSemaphore abstract class and GPUSemaphoreImportInfo base struct
- GPUSemaphoreVK: Vulkan implementation using VkSemaphore
- GPUContext::CreateSemaphore() / ImportSemaphore() virtual methods
- GPUSurface::AddExternalWaitSemaphore() for per-frame sync
- GPUSurfaceVK::OnFlush() cleans up external semaphores after submit
- Load vkCreateSemaphore/vkDestroySemaphore in VulkanDeviceFns