### PR TITLE
fix: Check validation before change ColorInfo in `Pixmap`

### DIFF
--- a/src/io/pixmap.cc
+++ b/src/io/pixmap.cc
@@ -96,6 +96,10 @@ bool Pixmap::SetColorInfo(AlphaType alpha_type, ColorType color_type) {
     return false;
   }
 
+  if (!pixels_ || !data_ || width_ <= 0 || height_ <= 0) {
+    return false;
+  }
+
   if ((alpha_type_ == kPremul_AlphaType && alpha_type == kUnpremul_AlphaType) ||
       (alpha_type_ == kUnpremul_AlphaType && alpha_type == kPremul_AlphaType)) {
     auto f = alpha_type == kPremul_AlphaType ? ColorToPMColor : PMColorToColor;

--- a/test/ut/io/pixmap_test.cc
+++ b/test/ut/io/pixmap_test.cc
@@ -58,14 +58,8 @@ TEST(PixmapTest, SetColorInfoAlphaType) {
   ASSERT_EQ(*pixel, ColorSetARGB(128, 128, 0, 0));
 }
 
-TEST(PixmapTest, SetColorInfoColorType) {
-  Pixmap pixmap;
-  pixmap.SetColorInfo(AlphaType::kUnpremul_AlphaType, ColorType::kA8);
-  ASSERT_EQ(pixmap.GetColorType(), skity::ColorType::kA8);
-}
-
 TEST(PixmapTest, SetColorInfo) {
-  Pixmap pixmap;
+  Pixmap pixmap{50, 50, AlphaType::kUnpremul_AlphaType, ColorType::kRGBA};
   pixmap.SetColorInfo(AlphaType::kPremul_AlphaType, ColorType::kBGRA);
   ASSERT_EQ(pixmap.GetAlphaType(), skity::AlphaType::kPremul_AlphaType);
   ASSERT_EQ(pixmap.GetColorType(), skity::ColorType::kBGRA);


### PR DESCRIPTION
Check buffer data and other status before apply ColorInfo change to prevent null pointer exception.