### PR TITLE
[Lynxtron] Add public GN entrypoint for Skity

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,101 @@
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+# Generate Skity source/config lists from the upstream CMake targets during
+# gn gen. Skity keeps CMake as the source of truth for these files.
+exec_script(
+    "//lynxtron_tools/gn/skity_build_gni.py",
+    [
+      "--build-dir",
+      rebase_path("$root_out_dir/skity_build", root_build_dir),
+      "--skity-root",
+      rebase_path("//third_party/skity/skity", root_build_dir),
+      "--build-type",
+      "Release",
+      "--generate-gni",
+    ],
+    "string")
+
+import("//third_party/skity/skity/skity.gni")
+import("//third_party/skity/skity/skity-codec.gni")
+import("//third_party/skity/skity/wgsl-cross.gni")
+import("//third_party/skity/skity/pugixml-static.gni")
+
+config("skity_config") {
+  include_dirs = [
+    "//third_party/libpng",
+    "//third_party/libjpeg-turbo",
+  ]
+  include_dirs += skity_include_dirs
+  include_dirs += skity_codec_include_dirs
+  include_dirs += wgsl_cross_include_dirs
+  include_dirs += pugixml_static_include_dirs
+
+  libs = []
+  libs += wgsl_cross_link_libs
+  libs += pugixml_static_link_libs
+
+  defines = [
+    "PUGIXML_NO_EXCEPTIONS",
+    "FREETYPE_STATIC_LIB",
+  ]
+  defines += skity_compile_definitions
+  defines += skity_codec_compile_definitions
+  defines += wgsl_cross_compile_definitions
+  defines += pugixml_static_compile_definitions
+
+  cflags = [
+    "-Wno-error=mismatched-tags",
+    "-Wno-mismatched-tags",
+    "-Wno-pessimizing-move",
+    "-Wno-unused-private-field",
+    "-Wno-newline-eof",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unguarded-availability-new",
+    "-Wno-unused-variable",
+  ]
+
+  cflags += skity_compile_options
+  cflags += skity_codec_compile_options
+  cflags += wgsl_cross_compile_options
+  cflags += pugixml_static_compile_options
+
+  cflags_objcc = [
+    "-Wno-error=mismatched-tags",
+    "-Wno-mismatched-tags",
+    "-Wno-pessimizing-move",
+    "-Wno-unused-private-field",
+    "-Wno-newline-eof",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unguarded-availability-new",
+  ]
+
+  if (is_mac) {
+    cflags -= [ "-fno-exceptions" ]
+    defines += [ "SKITY_PLATFORM_MACOS" ]
+  }
+  if (is_win) {
+    cflags -= [ "/EHs-c-" ]
+    defines += [ "SKITY_PLATFORM_WIN" ]
+  }
+}
+
+source_set("skity") {
+  sources = []
+  sources += skity_sources
+  sources += wgsl_cross_sources
+  sources += pugixml_static_sources
+  sources += skity_codec_sources
+
+  deps = [
+    "//third_party/libjpeg-turbo:turbojpeg",
+    "//third_party/libpng:libpng",
+    "//third_party/libwebp",
+    "//third_party/zlib",
+  ]
+
+  public_configs = [ ":skity_config" ]
+}

--- a/hab/DEPS
+++ b/hab/DEPS
@@ -5,7 +5,7 @@ deps = {
         "type": "git",
         "url": "https://github.com/freetype/freetype.git",
         "commit": "42608f77f20749dd6ddc9e0536788eaad70ea4b5",
-        "patches": os.path.join(root_dir, 'patches', 'freetype', '0001-Adapt-freetype-to-the-Skity-project.patch'),
+        "patches": os.path.join(root_dir, 'patches', 'freetype', '*.patch'),
         "ignore_in_git": True,
     },
     "third_party/nanopng": {

--- a/module/codec/src/codec/wuffs/wuffs_module.cc
+++ b/module/codec/src/codec/wuffs/wuffs_module.cc
@@ -2,8 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-#define WUFFS_IMPLEMENTATION  // implementation in this source file
-
 // after wuffs macros
 #include "src/codec/wuffs/wuffs_module.hpp"
 

--- a/patches/freetype/0002-Remove-stray-token-from-public-macros.patch
+++ b/patches/freetype/0002-Remove-stray-token-from-public-macros.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lynxtron Scripts <scripts@lynxtron>
+Date: Tue, 9 Jun 2026 17:08:00 +0800
+Subject: [PATCH] Remove stray token from public macros
+
+---
+ include/freetype/config/public-macros.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/freetype/config/public-macros.h b/include/freetype/config/public-macros.h
+index 66ad5e0..4912e52 100644
+--- a/include/freetype/config/public-macros.h
++++ b/include/freetype/config/public-macros.h
+@@ -63,7 +63,6 @@ FT_BEGIN_HEADER
+    */
+
+ #if !FREETYPE_STATIC_LIB
+-aaa
+ /* Visual C, mingw */
+ #if defined( _WIN32 )
+
+--
+2.50.1 (Apple Git-155)

--- a/src/base/unique_fd.hpp
+++ b/src/base/unique_fd.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <string>
 #else  // SKITY_WIN
 #include <dirent.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary

This PR adds the Skity-side build support needed by Lynxtron public Skity builds:

- add a root `BUILD.gn` entrypoint that imports generated GNI source/config lists
- keep Skity CMake as the source of truth by calling Lynxtron's CMake-to-GNI generator from GN
- add the required GN target/config wiring for Skity, codec, WGSL Cross, and pugixml sources
- fix public build issues found during Lynxtron integration: duplicate Wuffs implementation, missing Windows string include, and the stray token in the freetype patch flow

## Impact

This is mostly additive for existing Skity users because the main new surface is `BUILD.gn`. Existing CMake flows should not be affected. The non-additive pieces are small compile fixes in codec/base files and the Skity-owned freetype patch list behavior; those should be reviewed by Skity maintainers. The GN entrypoint currently assumes it is consumed from Lynxtron and calls `//lynxtron_tools/gn/skity_build_gni.py`, so it is intentionally tied to Lynxtron's build integration rather than a generic standalone GN flow.

## Validation

Validated from the Lynxtron integration branch:

- public standalone `lynxtron/lynxtron` dependency sync pulls this Skity commit
- `third_party/skity/BUILD.gn` references `//lynxtron_tools/gn/skity_build_gni.py`
- public GN has `enable_skity = true`
- `ninja -C out/Debug lynxtron_app`
- `out/Debug/lynxtron.app/Contents/MacOS/lynxtron --version` -> `v1.0.0`
