### PR TITLE
feat(vk): support wrapping AHardwareBuffer as Vulkan texture on Android

### DIFF
--- a/include/skity/gpu/gpu_context_vk.hpp
+++ b/include/skity/gpu/gpu_context_vk.hpp
@@ -13,6 +13,10 @@
 #include <skity/gpu/texture.hpp>
 #include <skity/macros.hpp>
 
+#if defined(SKITY_ANDROID)
+extern "C" struct AHardwareBuffer;
+#endif
+
 namespace skity {
 
 /**
@@ -299,6 +303,36 @@ struct GPUSurfaceDescriptorVK : public GPUSurfaceDescriptor {
   const GPUSurfaceSyncInfoVK* sync_info = nullptr;
 };
 
+/**
+ * Extension type tag for the texture info extension chain.
+ * Similar to Vulkan's VkStructureType.
+ */
+enum class GPUBackendTextureExtType {
+  kAndroidHardwareBuffer,
+};
+
+/**
+ * Base extension info struct for the texture info extension chain.
+ * Similar to Vulkan's (sType, pNext) pattern.
+ * Walk the chain via `next` and check `type` to find specific extensions.
+ */
+struct GPUBackendTextureExtInfo {
+  GPUBackendTextureExtType type;
+  GPUBackendTextureExtInfo* next = nullptr;
+};
+
+#if defined(SKITY_ANDROID)
+/**
+ * Android AHardwareBuffer extension for GPUBackendTextureInfoVK.
+ * When present in the ext chain, OnWrapTexture will import the AHardwareBuffer
+ * as a Vulkan texture instead of wrapping the provided image/image_view fields.
+ * The caller retains ownership of the AHardwareBuffer.
+ */
+struct GPUBackendTextureExtInfoAHB : public GPUBackendTextureExtInfo {
+  ::AHardwareBuffer* hardware_buffer = nullptr;
+};
+#endif
+
 struct GPUBackendTextureInfoVK : public GPUBackendTextureInfo {
   /**
    * User provided Vulkan image to wrap.
@@ -342,6 +376,12 @@ struct GPUBackendTextureInfoVK : public GPUBackendTextureInfo {
    * Whether the engine owns `image_view` and should destroy it on release.
    */
   bool owns_image_view = false;
+
+  /**
+   * Pointer to an extension info chain (similar to Vulkan's pNext).
+   * Walk the chain to find platform-specific extension data.
+   */
+  GPUBackendTextureExtInfo* ext = nullptr;
 };
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -520,6 +520,8 @@ if(${SKITY_HW_RENDERER})
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_surface_vk.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_texture_vk.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_texture_vk.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_external_texture_ahb.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/gpu_external_texture_ahb.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_debug_runtime_state.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_render_pass_cache.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/vk/vulkan_render_pass_cache.hpp

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -19,6 +19,12 @@
 #include "src/gpu/vk/vulkan_proc_table.hpp"
 #include "src/logging.hpp"
 
+#if defined(SKITY_ANDROID)
+#include <android/hardware_buffer.h>
+
+#include "src/gpu/vk/gpu_external_texture_ahb.hpp"
+#endif
+
 // put VMA_IMPLEMENTATION here
 #ifndef VMA_IMPLEMENTATION
 #define VMA_IMPLEMENTATION
@@ -607,6 +613,10 @@ bool LoadVulkanDeviceFns(PFN_vkGetDeviceProcAddr get_device_proc_addr,
 #if defined(SKITY_ANDROID)
   fns->vkImportSemaphoreFdKHR = reinterpret_cast<PFN_vkImportSemaphoreFdKHR>(
       get_device_proc_addr(device, "vkImportSemaphoreFdKHR"));
+  fns->vkGetAndroidHardwareBufferPropertiesANDROID =
+      reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+          get_device_proc_addr(device,
+                               "vkGetAndroidHardwareBufferPropertiesANDROID"));
 #endif
 #if defined(SKITY_VK_DEBUG_RUNTIME)
   fns->vkCmdBeginDebugUtilsLabelEXT =
@@ -951,6 +961,21 @@ std::shared_ptr<GPUTexture> GPUContextVK::OnWrapTexture(
 
   auto* vk_info = static_cast<GPUBackendTextureInfoVK*>(info);
 
+#if defined(SKITY_ANDROID)
+  // Walk the ext chain to find AHB extension
+  GPUBackendTextureExtInfoAHB* ahb_ext = nullptr;
+  for (auto* e = vk_info->ext; e != nullptr; e = e->next) {
+    if (e->type == GPUBackendTextureExtType::kAndroidHardwareBuffer) {
+      ahb_ext = static_cast<GPUBackendTextureExtInfoAHB*>(e);
+      break;
+    }
+  }
+  if (ahb_ext && ahb_ext->hardware_buffer) {
+    return OnWrapAHardwareBuffer(ahb_ext->hardware_buffer, vk_info->width,
+                                 vk_info->height, callback, user_data);
+  }
+#endif
+
   if (vk_info->image == VK_NULL_HANDLE ||
       vk_info->image_view == VK_NULL_HANDLE ||
       vk_info->vk_format == VK_FORMAT_UNDEFINED || vk_info->width == 0 ||
@@ -1157,5 +1182,244 @@ std::unique_ptr<GPUContext> CreateGPUContextVK(
        reinterpret_cast<void*>(get_instance_proc_addr));
   return CreateGPUContextVK(&info);
 }
+
+#if defined(SKITY_ANDROID)
+std::shared_ptr<GPUTexture> GPUContextVK::OnWrapAHardwareBuffer(
+    ::AHardwareBuffer* ahb, uint32_t width, uint32_t height,
+    ReleaseCallback callback, ReleaseUserData user_data) {
+  if (ahb == nullptr) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: null AHardwareBuffer");
+    return {};
+  }
+
+  // Check AHB extension is available
+  if (!state_->HasEnabledDeviceExtension(
+          VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: "
+        "VK_ANDROID_external_memory_android_hardware_buffer not enabled");
+    return {};
+  }
+
+  const auto& fns = state_->DeviceFns();
+  if (fns.vkGetAndroidHardwareBufferPropertiesANDROID == nullptr) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: "
+        "vkGetAndroidHardwareBufferPropertiesANDROID not loaded");
+    return {};
+  }
+
+  VkDevice device = state_->GetLogicalDevice();
+
+  // Step 1: Describe AHardwareBuffer
+  if (!state_->IsAHardwareBufferAvailable()) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: AHardwareBuffer API not "
+        "available (requires API 26+)");
+    return {};
+  }
+
+  AHardwareBuffer_Desc ahb_desc = {};
+  state_->GetAHardwareBufferDescribeFn()(ahb, &ahb_desc);
+
+  if (width == 0) {
+    width = ahb_desc.width;
+  }
+  if (height == 0) {
+    height = ahb_desc.height;
+  }
+
+  // Step 2: Map AHB format to VkFormat
+  VkFormat vk_format = VK_FORMAT_UNDEFINED;
+  switch (ahb_desc.format) {
+    case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
+      vk_format = VK_FORMAT_R8G8B8A8_UNORM;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM:
+      vk_format = VK_FORMAT_R8G8B8A8_UNORM;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM:
+      vk_format = VK_FORMAT_R8G8B8_UNORM;
+      break;
+    case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
+      vk_format = VK_FORMAT_R5G6B5_UNORM_PACK16;
+      break;
+    default:
+      LOGE("GPUContextVK::OnWrapAHardwareBuffer: unsupported AHB format {}",
+           static_cast<int32_t>(ahb_desc.format));
+      return {};
+  }
+
+  GPUTextureFormat gpu_format = ToGPUTextureFormat(vk_format);
+  if (gpu_format == GPUTextureFormat::kInvalid) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: unsupported VkFormat {}",
+         static_cast<int32_t>(vk_format));
+    return {};
+  }
+
+  // Step 3: Query Vulkan memory properties from AHB
+  VkAndroidHardwareBufferPropertiesANDROID ahb_props = {};
+  ahb_props.sType =
+      VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
+  VkResult result =
+      fns.vkGetAndroidHardwareBufferPropertiesANDROID(device, ahb, &ahb_props);
+  if (result != VK_SUCCESS) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: "
+        "vkGetAndroidHardwareBufferPropertiesANDROID failed: {}",
+        static_cast<int32_t>(result));
+    return {};
+  }
+
+  // Per VK_ANDROID_external_memory_android_hardware_buffer, the requested
+  // VkImage usage must be derivable from the AHardwareBuffer's usage flags.
+  // Blindly requesting an unsupported bit (e.g. always asking for
+  // TRANSFER_DST) makes vkCreateImage fail on some devices. skity only samples
+  // the imported buffer (its contents are produced by the external producer),
+  // so SAMPLED is all we need.
+  if ((ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) == 0) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: AHardwareBuffer is missing "
+        "AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE and cannot be sampled");
+    return {};
+  }
+  const VkImageUsageFlags image_usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+
+  // Step 4: Create VkImage with external memory
+  VkExternalMemoryImageCreateInfo external_mem_info = {};
+  external_mem_info.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  external_mem_info.handleTypes =
+      VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+  VkImageCreateInfo image_info = {};
+  image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  image_info.pNext = &external_mem_info;
+  image_info.imageType = VK_IMAGE_TYPE_2D;
+  image_info.format = vk_format;
+  image_info.extent = {width, height, 1};
+  image_info.mipLevels = 1;
+  image_info.arrayLayers = 1;
+  image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+  image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+  image_info.usage = image_usage;
+  image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  VkImage image = VK_NULL_HANDLE;
+  result = fns.vkCreateImage(device, &image_info, nullptr, &image);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: vkCreateImage failed: {}",
+         static_cast<int32_t>(result));
+    return {};
+  }
+
+  // Step 5: Select memory type (prefer DEVICE_LOCAL)
+  VkPhysicalDeviceMemoryProperties mem_props = {};
+  state_->InstanceFns().vkGetPhysicalDeviceMemoryProperties(
+      state_->GetPhysicalDevice(), &mem_props);
+  uint32_t memory_type_index = UINT32_MAX;
+  for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+    if ((ahb_props.memoryTypeBits & (1u << i)) != 0) {
+      memory_type_index = i;
+      if ((mem_props.memoryTypes[i].propertyFlags &
+           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
+        break;
+      }
+    }
+  }
+  if (memory_type_index == UINT32_MAX) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: "
+        "no suitable memory type found");
+    fns.vkDestroyImage(device, image, nullptr);
+    return {};
+  }
+
+  // Step 6: Import AHB memory
+  VkImportAndroidHardwareBufferInfoANDROID import_ahb_info = {};
+  import_ahb_info.sType =
+      VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
+  import_ahb_info.buffer = ahb;
+
+  VkMemoryDedicatedAllocateInfo dedicated_info = {};
+  dedicated_info.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated_info.pNext = &import_ahb_info;
+  dedicated_info.image = image;
+
+  VkMemoryAllocateInfo alloc_info = {};
+  alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  alloc_info.pNext = &dedicated_info;
+  alloc_info.allocationSize = ahb_props.allocationSize;
+  alloc_info.memoryTypeIndex = memory_type_index;
+
+  VkDeviceMemory memory = VK_NULL_HANDLE;
+  result = fns.vkAllocateMemory(device, &alloc_info, nullptr, &memory);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: vkAllocateMemory failed: {}",
+         static_cast<int32_t>(result));
+    fns.vkDestroyImage(device, image, nullptr);
+    return {};
+  }
+
+  // Step 7: Bind image memory
+  result = fns.vkBindImageMemory(device, image, memory, 0);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: vkBindImageMemory failed: {}",
+         static_cast<int32_t>(result));
+    fns.vkFreeMemory(device, memory, nullptr);
+    fns.vkDestroyImage(device, image, nullptr);
+    return {};
+  }
+
+  // Step 8: Create ImageView
+  VkImageViewCreateInfo view_info = {};
+  view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  view_info.image = image;
+  view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  view_info.format = vk_format;
+  view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  view_info.subresourceRange.baseMipLevel = 0;
+  view_info.subresourceRange.levelCount = 1;
+  view_info.subresourceRange.baseArrayLayer = 0;
+  view_info.subresourceRange.layerCount = 1;
+
+  VkImageView image_view = VK_NULL_HANDLE;
+  result = fns.vkCreateImageView(device, &view_info, nullptr, &image_view);
+  if (result != VK_SUCCESS) {
+    LOGE("GPUContextVK::OnWrapAHardwareBuffer: vkCreateImageView failed: {}",
+         static_cast<int32_t>(result));
+    fns.vkFreeMemory(device, memory, nullptr);
+    fns.vkDestroyImage(device, image, nullptr);
+    return {};
+  }
+
+  // Step 9: Wrap into GPUExternalTextureAHB
+  GPUTextureDescriptor desc = {};
+  desc.width = width;
+  desc.height = height;
+  desc.mip_level_count = 1;
+  desc.sample_count = 1;
+  desc.format = gpu_format;
+  desc.usage =
+      static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
+  desc.storage_mode = GPUTextureStorageMode::kPrivate;
+
+  auto texture = GPUExternalTextureAHB::Make(
+      state_, desc, image, memory, image_view, VK_IMAGE_LAYOUT_UNDEFINED,
+      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, vk_format);
+  if (texture == nullptr) {
+    LOGE(
+        "GPUContextVK::OnWrapAHardwareBuffer: GPUExternalTextureAHB::Make "
+        "failed");
+    fns.vkDestroyImageView(device, image_view, nullptr);
+    fns.vkFreeMemory(device, memory, nullptr);
+    fns.vkDestroyImage(device, image, nullptr);
+    return {};
+  }
+
+  texture->SetRelease(callback, user_data);
+  return texture;
+}
+#endif  // defined(SKITY_ANDROID)
 
 }  // namespace skity

--- a/src/gpu/vk/gpu_context_impl_vk.hpp
+++ b/src/gpu/vk/gpu_context_impl_vk.hpp
@@ -53,6 +53,14 @@ class GPUContextVK : public GPUContextImpl {
 
  private:
   std::shared_ptr<VulkanContextState> state_;
+
+#if defined(SKITY_ANDROID)
+  std::shared_ptr<GPUTexture> OnWrapAHardwareBuffer(::AHardwareBuffer* ahb,
+                                                    uint32_t width,
+                                                    uint32_t height,
+                                                    ReleaseCallback callback,
+                                                    ReleaseUserData user_data);
+#endif
 };
 
 }  // namespace skity

--- a/src/gpu/vk/gpu_external_texture_ahb.cc
+++ b/src/gpu/vk/gpu_external_texture_ahb.cc
@@ -1,0 +1,67 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity/macros.hpp>
+
+#if defined(SKITY_ANDROID)
+
+#include "src/gpu/vk/gpu_external_texture_ahb.hpp"
+#include "src/gpu/vk/vulkan_context_state.hpp"
+#include "src/logging.hpp"
+
+namespace skity {
+
+GPUExternalTextureAHB::GPUExternalTextureAHB(
+    std::shared_ptr<const VulkanContextState> state,
+    const GPUTextureDescriptor& descriptor, VkImage image,
+    VkDeviceMemory memory, VkImageView image_view, VkImageLayout initial_layout,
+    VkImageLayout preferred_layout, VkFormat format)
+    : GPUTextureVK(state, descriptor, image,
+                   /*allocation=*/nullptr, image_view, preferred_layout, format,
+                   /*owns_image=*/false, /*owns_image_view=*/false),
+      state_(std::move(state)),
+      memory_(memory) {
+  SetCurrentLayout(initial_layout);
+}
+
+GPUExternalTextureAHB::~GPUExternalTextureAHB() {
+  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+    return;
+  }
+
+  VkDevice device = state_->GetLogicalDevice();
+  const auto& fns = state_->DeviceFns();
+
+  if (GetImageView() != VK_NULL_HANDLE && fns.vkDestroyImageView != nullptr) {
+    fns.vkDestroyImageView(device, GetImageView(), nullptr);
+  }
+
+  if (GetImage() != VK_NULL_HANDLE && fns.vkDestroyImage != nullptr) {
+    fns.vkDestroyImage(device, GetImage(), nullptr);
+  }
+
+  if (memory_ != VK_NULL_HANDLE && fns.vkFreeMemory != nullptr) {
+    fns.vkFreeMemory(device, memory_, nullptr);
+  }
+}
+
+std::shared_ptr<GPUTexture> GPUExternalTextureAHB::Make(
+    std::shared_ptr<const VulkanContextState> state,
+    const GPUTextureDescriptor& descriptor, VkImage image,
+    VkDeviceMemory memory, VkImageView image_view, VkImageLayout initial_layout,
+    VkImageLayout preferred_layout, VkFormat format) {
+  if (state == nullptr || image == VK_NULL_HANDLE ||
+      image_view == VK_NULL_HANDLE || format == VK_FORMAT_UNDEFINED) {
+    LOGE("GPUExternalTextureAHB::Make: invalid parameters");
+    return {};
+  }
+
+  return std::shared_ptr<GPUTexture>(new GPUExternalTextureAHB(
+      std::move(state), descriptor, image, memory, image_view, initial_layout,
+      preferred_layout, format));
+}
+
+}  // namespace skity
+
+#endif  // defined(SKITY_ANDROID)

--- a/src/gpu/vk/gpu_external_texture_ahb.hpp
+++ b/src/gpu/vk/gpu_external_texture_ahb.hpp
@@ -1,0 +1,51 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_EXTERNAL_TEXTURE_AHB_HPP
+#define SRC_GPU_VK_GPU_EXTERNAL_TEXTURE_AHB_HPP
+
+#if defined(SKITY_ANDROID)
+
+#include <vulkan/vulkan.h>
+
+#include <memory>
+
+#include "src/gpu/vk/gpu_texture_vk.hpp"
+
+namespace skity {
+
+/**
+ * GPUExternalTextureAHB wraps an AHardwareBuffer imported as a Vulkan texture.
+ *
+ * Unlike regular GPUTextureVK which uses VMA for memory management, this class
+ * uses vkDestroyImage + vkFreeMemory for cleanup because the image/memory were
+ * created via external memory import (not through VMA).
+ */
+class GPUExternalTextureAHB : public GPUTextureVK {
+ public:
+  static std::shared_ptr<GPUTexture> Make(
+      std::shared_ptr<const VulkanContextState> state,
+      const GPUTextureDescriptor& descriptor, VkImage image,
+      VkDeviceMemory memory, VkImageView image_view,
+      VkImageLayout initial_layout, VkImageLayout preferred_layout,
+      VkFormat format);
+
+  ~GPUExternalTextureAHB() override;
+
+ private:
+  GPUExternalTextureAHB(std::shared_ptr<const VulkanContextState> state,
+                        const GPUTextureDescriptor& descriptor, VkImage image,
+                        VkDeviceMemory memory, VkImageView image_view,
+                        VkImageLayout initial_layout,
+                        VkImageLayout preferred_layout, VkFormat format);
+
+  std::shared_ptr<const VulkanContextState> state_;
+  VkDeviceMemory memory_ = VK_NULL_HANDLE;
+};
+
+}  // namespace skity
+
+#endif  // defined(SKITY_ANDROID)
+
+#endif  // SRC_GPU_VK_GPU_EXTERNAL_TEXTURE_AHB_HPP

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -14,6 +14,11 @@
 #include "src/gpu/vk/vulkan_platform_extensions.hpp"
 #include "src/logging.hpp"
 
+#if defined(SKITY_ANDROID)
+#include <android/hardware_buffer.h>
+#include <dlfcn.h>
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
@@ -610,6 +615,10 @@ bool VulkanContextState::Initialize(const GPUContextInfoVK& info) {
   Reset();
   LOGD("Initializing VulkanContextState");
 
+#if defined(SKITY_ANDROID)
+  LoadAndroidFns();
+#endif
+
   if (!InitializeInstance(info) || !InitializePhysicalDevice(info) ||
       !InitializeQueues(info) || !InitializeDevice(info)) {
     LOGE("Failed to initialize VulkanContextState");
@@ -1183,6 +1192,18 @@ bool VulkanContextState::InitializeOwnedDevice() {
         VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
   }
 #if defined(SKITY_ANDROID)
+  if (HasAvailableDeviceExtension(
+          VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    // VK_ANDROID_external_memory_android_hardware_buffer requires
+    // VK_EXT_queue_family_foreign as a prerequisite.
+    if (HasAvailableDeviceExtension(
+            VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME)) {
+      enabled_device_extensions_.emplace_back(
+          VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME);
+    }
+  }
   if (HasAvailableDeviceExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME)) {
     enabled_device_extensions_.emplace_back(
         VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
@@ -1523,6 +1544,25 @@ void VulkanContextState::Reset() {
   own_instance_ = false;
   own_device_ = false;
 }
+
+#if defined(SKITY_ANDROID)
+void VulkanContextState::LoadAndroidFns() {
+  void* lib = dlopen("libandroid.so", RTLD_NOW);
+  if (!lib) {
+    LOGW("VulkanContextState: failed to open libandroid.so");
+    return;
+  }
+  fn_ahb_describe_ = reinterpret_cast<Fn_AHardwareBuffer_describe>(
+      dlsym(lib, "AHardwareBuffer_describe"));
+  if (fn_ahb_describe_) {
+    LOGD("VulkanContextState: AHardwareBuffer_describe loaded");
+  } else {
+    LOGW(
+        "VulkanContextState: AHardwareBuffer_describe not available (requires "
+        "API 26+)");
+  }
+}
+#endif
 
 }  // namespace skity
 

--- a/src/gpu/vk/vulkan_context_state.hpp
+++ b/src/gpu/vk/vulkan_context_state.hpp
@@ -10,6 +10,10 @@
 #include <skity/gpu/gpu_context_vk.hpp>
 #include <vector>
 
+#if defined(SKITY_ANDROID)
+#include <android/hardware_buffer.h>
+#endif
+
 #include "src/gpu/vk/vulkan_debug_runtime_state.hpp"
 #include "src/gpu/vk/vulkan_pending_submission.hpp"
 #include "src/gpu/vk/vulkan_proc_table.hpp"
@@ -81,6 +85,19 @@ class VulkanContextState {
 
   bool IsDynamicRenderingEnabled() const { return dynamic_rendering_enabled_; }
 
+#if defined(SKITY_ANDROID)
+  using Fn_AHardwareBuffer_describe = void (*)(const ::AHardwareBuffer*,
+                                               AHardwareBuffer_Desc*);
+
+  bool IsAHardwareBufferAvailable() const {
+    return fn_ahb_describe_ != nullptr;
+  }
+
+  Fn_AHardwareBuffer_describe GetAHardwareBufferDescribeFn() const {
+    return fn_ahb_describe_;
+  }
+#endif
+
   const std::vector<VkExtensionProperties>& GetAvailableInstanceExtensions()
       const {
     return available_instance_extensions_;
@@ -124,6 +141,9 @@ class VulkanContextState {
   bool LoadAvailableDeviceExtensions();
   bool LoadDeviceFns();
   void Reset();
+#if defined(SKITY_ANDROID)
+  void LoadAndroidFns();
+#endif
 
   VulkanFunctionPointers functions_ = {};
   VkInstance instance_ = VK_NULL_HANDLE;
@@ -150,6 +170,9 @@ class VulkanContextState {
   bool synchronization2_enabled_ = false;
   bool dynamic_rendering_enabled_ = false;
   VulkanDebugRuntimeState debug_runtime_ = {};
+#if defined(SKITY_ANDROID)
+  Fn_AHardwareBuffer_describe fn_ahb_describe_ = nullptr;
+#endif
   mutable std::vector<VulkanPendingSubmission> pending_submissions_ = {};
   mutable VulkanRenderPassCache render_pass_cache_ = {};
 };

--- a/src/gpu/vk/vulkan_proc_table.hpp
+++ b/src/gpu/vk/vulkan_proc_table.hpp
@@ -136,6 +136,8 @@ struct VulkanDeviceFns {
   PFN_vkCmdSetStencilReference vkCmdSetStencilReference = nullptr;
   PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = nullptr;
 #if defined(SKITY_ANDROID)
+  PFN_vkGetAndroidHardwareBufferPropertiesANDROID
+      vkGetAndroidHardwareBufferPropertiesANDROID = nullptr;
   PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR = nullptr;
 #endif
 #if defined(SKITY_VK_DEBUG_RUNTIME)


### PR DESCRIPTION
Enable importing Android AHardwareBuffer as a Vulkan texture for cross-API texture sharing between GL and Vulkan.

- Add GPUBackendTextureExtInfo extension chain (sType/pNext pattern) with GPUBackendTextureExtInfoAHB for AHardwareBuffer
- GPUExternalTextureAHB: manages lifetime of externally-imported VkImage/VkDeviceMemory/VkImageView (no VMA)
- GPUContextVK::OnWrapAHardwareBuffer: full import pipeline (describe AHB → create image → query memory → import → bind → view)
- VulkanContextState: load AHardwareBuffer_describe via dlopen, enable VK_ANDROID_external_memory_android_hardware_buffer and VK_KHR_external_semaphore extensions on Android
- Load vkGetAndroidHardwareBufferPropertiesANDROID and vkImportSemaphoreFdKHR in VulkanDeviceFns