### PR TITLE
perf(vk): reuse HWStaticBuffer across surfaces via GPUPresenterVK

### DIFF
--- a/src/gpu/gpu_surface_impl.cc
+++ b/src/gpu/gpu_surface_impl.cc
@@ -20,6 +20,18 @@ GPUSurfaceImpl::GPUSurfaceImpl(const GPUSurfaceDescriptor& desc,
       stage_buffer_(),
       canvas_() {}
 
+GPUSurfaceImpl::GPUSurfaceImpl(const GPUSurfaceDescriptor& desc,
+                               GPUContextImpl* ctx,
+                               std::shared_ptr<HWStaticBuffer> static_buffer)
+    : width_(desc.width),
+      height_(desc.height),
+      sample_count_(desc.sample_count),
+      content_scale_(desc.content_scale),
+      ctx_(ctx),
+      stage_buffer_(),
+      static_buffer_(std::move(static_buffer)),
+      canvas_() {}
+
 GPUSurfaceImpl::~GPUSurfaceImpl() {}
 
 Canvas* GPUSurfaceImpl::LockCanvas(bool clear) {

--- a/src/gpu/gpu_surface_impl.hpp
+++ b/src/gpu/gpu_surface_impl.hpp
@@ -21,6 +21,8 @@ class GPUCommandBuffer;
 class GPUSurfaceImpl : public GPUSurface {
  public:
   GPUSurfaceImpl(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx);
+  GPUSurfaceImpl(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx,
+                 std::shared_ptr<HWStaticBuffer> static_buffer);
 
   ~GPUSurfaceImpl() override;
 
@@ -65,7 +67,7 @@ class GPUSurfaceImpl : public GPUSurface {
 
   GPUContextImpl* ctx_;
   std::unique_ptr<HWStageBuffer> stage_buffer_;
-  std::unique_ptr<HWStaticBuffer> static_buffer_;
+  std::shared_ptr<HWStaticBuffer> static_buffer_;
   std::unique_ptr<HWCanvas> canvas_;
   std::shared_ptr<BlockCacheAllocator> block_cache_allocator_;
   std::unique_ptr<ArenaAllocator> arena_allocator_;

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -879,8 +879,9 @@ std::unique_ptr<GPUSurface> GPUContextVK::CreateSurface(
     return nullptr;
   }
 
-  return std::make_unique<GPUSurfaceVK>(
-      *desc, this, std::move(texture), texture_desc.format, vk_desc->sync_info);
+  return std::make_unique<GPUSurfaceVK>(*desc, this, nullptr,
+                                        std::move(texture), texture_desc.format,
+                                        vk_desc->sync_info);
 }
 
 std::unique_ptr<GPUPresenter> GPUContextVK::CreatePresenter(
@@ -1063,7 +1064,7 @@ std::unique_ptr<GPURenderTarget> GPUContextVK::OnCreateRenderTarget(
   surface_desc.sample_count = desc.sample_count;
   surface_desc.surface_type = VKSurfaceType::kTexture;
 
-  auto surface = std::make_unique<GPUSurfaceVK>(surface_desc, this,
+  auto surface = std::make_unique<GPUSurfaceVK>(surface_desc, this, nullptr,
                                                 std::move(wrapped_texture),
                                                 texture_desc.format, nullptr);
 

--- a/src/gpu/vk/gpu_presenter_vk.cc
+++ b/src/gpu/vk/gpu_presenter_vk.cc
@@ -130,7 +130,9 @@ void LogPresentModes(const std::vector<VkPresentModeKHR>& present_modes) {
 GPUPresenterVK::GPUPresenterVK(GPUContextImpl* context,
                                std::shared_ptr<const VulkanContextState> state,
                                const GPUPresenterDescriptorVK& desc)
-    : context_(context), state_(std::move(state)), desc_(desc) {}
+    : context_(context), state_(std::move(state)), desc_(desc) {
+  static_buffer_ = std::make_shared<HWStaticBuffer>(context_->GetGPUDevice());
+}
 
 GPUPresenterVK::~GPUPresenterVK() { Reset(); }
 
@@ -305,8 +307,8 @@ GPUSurfaceAcquireResult GPUPresenterVK::AcquireNextSurface(
   }
 
   auto surface = std::make_unique<GPUSurfaceVK>(
-      surface_desc, context_, std::move(texture), texture_desc.format,
-      surface_desc.sync_info);
+      surface_desc, context_, static_buffer_, std::move(texture),
+      texture_desc.format, surface_desc.sync_info);
   GPUSurfaceVK::PresentInfo present_info = {};
   present_info.owner = this;
   present_info.image_index = image_index;

--- a/src/gpu/vk/gpu_presenter_vk.hpp
+++ b/src/gpu/vk/gpu_presenter_vk.hpp
@@ -78,6 +78,7 @@ class GPUPresenterVK : public GPUPresenter {
   void Reset();
 
   GPUContextImpl* context_ = nullptr;
+  std::shared_ptr<HWStaticBuffer> static_buffer_ = {};
   std::shared_ptr<const VulkanContextState> state_ = {};
   GPUPresenterDescriptorVK desc_ = {};
   PresenterFns fns_ = {};

--- a/src/gpu/vk/gpu_surface_vk.hpp
+++ b/src/gpu/vk/gpu_surface_vk.hpp
@@ -25,9 +25,10 @@ class GPUSurfaceVK : public GPUSurfaceImpl {
   };
 
   GPUSurfaceVK(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx,
+               std::shared_ptr<HWStaticBuffer> static_buffer,
                std::shared_ptr<GPUTexture> texture, GPUTextureFormat format,
                const GPUSurfaceSyncInfoVK* sync_info)
-      : GPUSurfaceImpl(desc, ctx),
+      : GPUSurfaceImpl(desc, ctx, std::move(static_buffer)),
         target_width_(static_cast<uint32_t>(
             std::floor(static_cast<float>(desc.width) * desc.content_scale))),
         target_height_(static_cast<uint32_t>(


### PR DESCRIPTION
GPUSurfaceVK is created on every AcquireNextSurface, so each surface previously allocated and re-uploaded its own HWStaticBuffer (static vertex/index data for tessellated paths, rrects and text). Move the HWStaticBuffer to GPUPresenterVK as a shared_ptr and inject it into each surface created from it, so the static data is built once and reused across repeatedly acquired surfaces.

GPUSurfaceImpl now stores static_buffer_ as a shared_ptr with a ctor overload accepting an external buffer; surfaces created outside a Presenter (e.g. GPUContextVK::CreateSurface / OnCreateRenderTarget) still fall back to allocating their own.