### PR TITLE
feat(text): migrate Windows font manager to DirectWrite backend

### DIFF
--- a/example/case/text/CMakeLists.txt
+++ b/example/case/text/CMakeLists.txt
@@ -14,4 +14,14 @@ else()
 endif()
 
 target_link_libraries(text_example PUBLIC skity::example_common)
-target_compile_definitions(text_example PRIVATE -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")
+target_compile_definitions(text_example PRIVATE
+    -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    add_executable(dwrite_text_example
+        win/dwrite_text_example.cc
+    )
+    target_link_libraries(dwrite_text_example PUBLIC skity::example_common)
+    target_compile_definitions(dwrite_text_example PRIVATE
+        -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")
+endif()

--- a/example/case/text/win/dwrite_text_example.cc
+++ b/example/case/text/win/dwrite_text_example.cc
@@ -1,0 +1,590 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+#include <memory>
+#include <skity/skity.hpp>
+#include <skity/utils/settings.hpp>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/app.hpp"
+
+namespace {
+
+constexpr float kWindowWidth = 1700.f;
+constexpr float kWindowHeight = 1120.f;
+
+skity::Color Color(uint8_t r, uint8_t g, uint8_t b) {
+  return skity::ColorSetARGB(0xFF, r, g, b);
+}
+
+skity::FontStyle MakeStyle(int weight, skity::FontStyle::Slant slant =
+                                           skity::FontStyle::kUpright_Slant) {
+  return skity::FontStyle{weight, skity::FontStyle::kNormal_Width, slant};
+}
+
+void AppendUtf8(std::string* text, uint32_t cp) {
+  if (cp <= 0x7F) {
+    text->push_back(static_cast<char>(cp));
+  } else if (cp <= 0x7FF) {
+    text->push_back(static_cast<char>(0xC0 | (cp >> 6)));
+    text->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else if (cp <= 0xFFFF) {
+    text->push_back(static_cast<char>(0xE0 | (cp >> 12)));
+    text->push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    text->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else {
+    text->push_back(static_cast<char>(0xF0 | (cp >> 18)));
+    text->push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+    text->push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    text->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  }
+}
+
+std::string Utf8(std::initializer_list<uint32_t> cps) {
+  std::string text;
+  for (auto cp : cps) {
+    AppendUtf8(&text, cp);
+  }
+  return text;
+}
+
+std::string AppendUtf8Text(std::string text,
+                           std::initializer_list<uint32_t> cps) {
+  for (auto cp : cps) {
+    AppendUtf8(&text, cp);
+  }
+  return text;
+}
+
+std::vector<skity::Unichar> Codepoints(const char* text) {
+  std::vector<skity::Unichar> cps;
+  skity::UTF::UTF8ToCodePoint(text, std::strlen(text), cps);
+  return cps;
+}
+
+std::string SlantName(skity::FontStyle::Slant slant) {
+  switch (slant) {
+    case skity::FontStyle::kUpright_Slant:
+      return "upright";
+    case skity::FontStyle::kItalic_Slant:
+      return "italic";
+    case skity::FontStyle::kOblique_Slant:
+      return "oblique";
+  }
+  return "unknown";
+}
+
+std::string StyleSummary(skity::FontStyle style) {
+  std::ostringstream stream;
+  stream << "w" << style.weight() << " width" << style.width() << " "
+         << SlantName(style.slant());
+  return stream.str();
+}
+
+std::string TypefaceSummary(const std::shared_ptr<skity::Typeface>& typeface) {
+  if (!typeface) {
+    return "null typeface";
+  }
+
+  auto desc = typeface->GetFontDescriptor();
+  std::ostringstream stream;
+  stream << (desc.family_name.empty() ? "(no family)" : desc.family_name);
+  if (!desc.full_name.empty() && desc.full_name != desc.family_name) {
+    stream << " / " << desc.full_name;
+  }
+  stream << " | " << StyleSummary(typeface->GetFontStyle());
+  stream << " | tables=" << typeface->CountTables();
+  stream << " | color=" << (typeface->ContainsColorTable() ? "yes" : "no");
+  return stream.str();
+}
+
+std::shared_ptr<skity::Typeface> MatchOrDefault(
+    const std::shared_ptr<skity::FontManager>& font_manager, const char* family,
+    skity::FontStyle style) {
+  auto typeface = font_manager->MatchFamilyStyle(family, style);
+  if (typeface) {
+    return typeface;
+  }
+  return skity::Typeface::GetDefaultTypeface(style);
+}
+
+void AddTypeface(std::vector<std::shared_ptr<skity::Typeface>>* typefaces,
+                 std::shared_ptr<skity::Typeface> typeface) {
+  if (!typeface) {
+    return;
+  }
+  auto same_typeface =
+      [&typeface](const std::shared_ptr<skity::Typeface>& item) {
+        return item && item->TypefaceId() == typeface->TypefaceId();
+      };
+  if (std::find_if(typefaces->begin(), typefaces->end(), same_typeface) ==
+      typefaces->end()) {
+    typefaces->push_back(std::move(typeface));
+  }
+}
+
+std::shared_ptr<skity::Typeface> MatchCharacter(
+    const std::shared_ptr<skity::FontManager>& font_manager,
+    skity::Unichar codepoint, const char* family = nullptr,
+    const char* bcp47 = nullptr) {
+  const char* bcp47_list[] = {bcp47};
+  const char** bcp47_ptr = bcp47 == nullptr ? nullptr : bcp47_list;
+  const int bcp47_count = bcp47 == nullptr ? 0 : 1;
+  return font_manager->MatchFamilyStyleCharacter(
+      family, skity::FontStyle::Normal(), bcp47_ptr, bcp47_count, codepoint);
+}
+
+std::unique_ptr<skity::TypefaceDelegate> BuildFallbackDelegate(
+    const std::shared_ptr<skity::FontManager>& font_manager,
+    const std::shared_ptr<skity::Typeface>& base_typeface) {
+  std::vector<std::shared_ptr<skity::Typeface>> typefaces;
+  AddTypeface(&typefaces, base_typeface);
+  AddTypeface(&typefaces, MatchOrDefault(font_manager, "Segoe UI",
+                                         skity::FontStyle::Normal()));
+  AddTypeface(&typefaces,
+              MatchCharacter(font_manager, 0x4E2D, nullptr, "zh-CN"));
+  AddTypeface(&typefaces,
+              MatchCharacter(font_manager, 0x304B, nullptr, "ja-JP"));
+  AddTypeface(&typefaces,
+              MatchCharacter(font_manager, 0xD55C, nullptr, "ko-KR"));
+  AddTypeface(&typefaces,
+              MatchCharacter(font_manager, 0x0639, nullptr, "ar-SA"));
+  AddTypeface(&typefaces,
+              MatchCharacter(font_manager, 0x0939, nullptr, "hi-IN"));
+  AddTypeface(&typefaces, MatchCharacter(font_manager, 0x1F600));
+  AddTypeface(&typefaces, skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT
+                                                        "/NotoColorEmoji.ttf"));
+  AddTypeface(&typefaces, skity::Typeface::MakeFromFile(
+                              EXAMPLE_IMAGE_ROOT "/NotoEmoji-Regular.ttf"));
+  return skity::TypefaceDelegate::CreateSimpleFallbackDelegate(typefaces);
+}
+
+skity::Paint PaintForText(
+    std::shared_ptr<skity::Typeface> typeface, float text_size,
+    skity::Color color, skity::Paint::Style style = skity::Paint::kFill_Style) {
+  skity::Paint paint;
+  paint.SetAntiAlias(true);
+  paint.SetTypeface(std::move(typeface));
+  paint.SetTextSize(text_size);
+  paint.SetColor(color);
+  paint.SetFillColor(color);
+  paint.SetStrokeColor(color);
+  paint.SetStyle(style);
+  return paint;
+}
+
+void DrawText(skity::Canvas* canvas, const std::string& text, float x, float y,
+              const skity::Paint& paint) {
+  canvas->DrawSimpleText(text.c_str(), x, y, paint);
+}
+
+void DrawBlobText(skity::Canvas* canvas, const std::string& text, float x,
+                  float y, const skity::Paint& paint,
+                  skity::TypefaceDelegate* delegate) {
+  skity::TextBlobBuilder builder;
+  auto blob = builder.BuildTextBlob(text.c_str(), paint, delegate);
+  canvas->DrawTextBlob(blob.get(), x, y, paint);
+}
+
+void DrawGlyphText(skity::Canvas* canvas, const std::string& text, float x,
+                   float y, const skity::Font& font,
+                   const skity::Paint& paint) {
+  auto cps = Codepoints(text.c_str());
+  if (cps.empty() || !font.GetTypeface()) {
+    return;
+  }
+
+  std::vector<skity::GlyphID> glyphs(cps.size());
+  font.GetTypeface()->UnicharsToGlyphs(cps.data(), static_cast<int>(cps.size()),
+                                       glyphs.data());
+
+  std::vector<const skity::GlyphData*> glyph_data(glyphs.size());
+  font.LoadGlyphMetrics(glyphs.data(), static_cast<uint32_t>(glyphs.size()),
+                        glyph_data.data(), paint);
+
+  std::vector<float> pos_x;
+  std::vector<float> pos_y;
+  pos_x.reserve(glyphs.size());
+  pos_y.reserve(glyphs.size());
+  float advance_x = x;
+  for (auto glyph : glyph_data) {
+    pos_x.push_back(advance_x);
+    pos_y.push_back(y);
+    advance_x += glyph == nullptr ? 0.f : glyph->AdvanceX();
+  }
+
+  canvas->DrawGlyphs(static_cast<int>(glyphs.size()), glyphs.data(),
+                     pos_x.data(), pos_y.data(), font, paint);
+}
+
+void DrawLabel(skity::Canvas* canvas, const std::string& text, float x, float y,
+               float width, std::shared_ptr<skity::Typeface> label_typeface) {
+  skity::Paint paint =
+      PaintForText(std::move(label_typeface), 13.f, Color(72, 82, 96));
+  const size_t max_chars = static_cast<size_t>(std::max(20.f, width / 7.2f));
+  std::string line = text;
+  if (line.size() > max_chars) {
+    line = line.substr(0, max_chars - 3) + "...";
+  }
+  DrawText(canvas, line, x, y, paint);
+}
+
+void DrawSectionTitle(skity::Canvas* canvas, const std::string& title, float x,
+                      float y,
+                      const std::shared_ptr<skity::Typeface>& typeface) {
+  auto paint = PaintForText(typeface, 22.f, Color(28, 38, 50));
+  DrawText(canvas, title, x, y, paint);
+}
+
+void DrawDivider(skity::Canvas* canvas, float x, float y, float width) {
+  skity::Paint paint;
+  paint.SetAntiAlias(true);
+  paint.SetColor(Color(205, 213, 224));
+  paint.SetStrokeColor(Color(205, 213, 224));
+  paint.SetStrokeWidth(1.f);
+  canvas->DrawLine(x, y, x + width, y, paint);
+}
+
+struct FamilyCase {
+  const char* family;
+  skity::FontStyle style;
+  std::string sample;
+};
+
+void DrawFamilyCases(skity::Canvas* canvas,
+                     const std::shared_ptr<skity::FontManager>& font_manager,
+                     const std::shared_ptr<skity::Typeface>& label_typeface,
+                     float x, float y, float column_width) {
+  DrawSectionTitle(canvas, "Family and style matching", x, y, label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 28.f;
+
+  const std::vector<FamilyCase> cases = {
+      {"Arial", skity::FontStyle::Normal(), "Arial normal"},
+      {"Arial", skity::FontStyle::Bold(), "Arial bold"},
+      {"Arial", skity::FontStyle::Italic(), "Arial italic"},
+      {"Arial", skity::FontStyle::BoldItalic(), "Arial bold italic"},
+      {"Times New Roman", skity::FontStyle::BoldItalic(), "Serif bold italic"},
+      {"Consolas", skity::FontStyle::Italic(), "Consolas italic 012345"},
+      {"Segoe UI", MakeStyle(skity::FontStyle::kSemiBold_Weight),
+       "Segoe UI semibold"},
+      {"Microsoft YaHei", skity::FontStyle::Bold(),
+       AppendUtf8Text("Microsoft YaHei ", {0x4E2D, 0x6587})},
+      {"SimSun", skity::FontStyle::Normal(),
+       AppendUtf8Text("SimSun ", {0x5B8B, 0x4F53})},
+      {"Segoe UI Emoji", skity::FontStyle::Normal(),
+       AppendUtf8Text("Segoe UI Emoji ", {0x1F600, 0x1F680})},
+      {"SkityMissingFamilyName", skity::FontStyle::Bold(),
+       "Missing family fallback"},
+  };
+
+  for (const auto& family_case : cases) {
+    auto typeface =
+        MatchOrDefault(font_manager, family_case.family, family_case.style);
+    auto paint = PaintForText(typeface, 24.f, Color(20, 25, 33));
+    DrawText(canvas, family_case.sample, x, y, paint);
+    DrawLabel(
+        canvas,
+        std::string(family_case.family) + " -> " + TypefaceSummary(typeface), x,
+        y + 18.f, column_width, label_typeface);
+    y += 55.f;
+  }
+}
+
+void DrawWeightSweep(skity::Canvas* canvas,
+                     const std::shared_ptr<skity::FontManager>& font_manager,
+                     const std::shared_ptr<skity::Typeface>& label_typeface,
+                     float x, float y, float column_width) {
+  DrawSectionTitle(canvas, "Weight selection sweep", x, y, label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 28.f;
+
+  const int weights[] = {100, 200, 300, 400, 500, 600, 700, 800, 900};
+  for (auto weight : weights) {
+    auto style = MakeStyle(weight);
+    auto typeface = MatchOrDefault(font_manager, "Segoe UI", style);
+    auto paint = PaintForText(typeface, 23.f, Color(18, 65, 95));
+    std::ostringstream sample;
+    sample << "Segoe UI weight " << weight << " AaBbCc 123";
+    DrawText(canvas, sample.str(), x, y, paint);
+    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 17.f, column_width,
+              label_typeface);
+    y += 48.f;
+  }
+
+  y += 8.f;
+  for (auto weight : {300, 400, 700, 900}) {
+    auto style = MakeStyle(weight);
+    auto typeface = MatchOrDefault(font_manager, "Microsoft YaHei", style);
+    auto paint = PaintForText(typeface, 23.f, Color(40, 83, 45));
+    auto sample = AppendUtf8Text("YaHei weight ", {0x4E2D, 0x6587, 0x95E8});
+    DrawText(canvas, sample + " " + std::to_string(weight), x, y, paint);
+    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 17.f, column_width,
+              label_typeface);
+    y += 48.f;
+  }
+}
+
+void DrawFallbackAndEmoji(
+    skity::Canvas* canvas,
+    const std::shared_ptr<skity::FontManager>& font_manager,
+    const std::shared_ptr<skity::Typeface>& label_typeface, float x, float y,
+    float column_width) {
+  DrawSectionTitle(canvas, "Fallback scripts and color glyphs", x, y,
+                   label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 32.f;
+
+  auto base_typeface =
+      MatchOrDefault(font_manager, "Arial", skity::FontStyle::Normal());
+  auto fallback_delegate = BuildFallbackDelegate(font_manager, base_typeface);
+
+  auto mixed = AppendUtf8Text(
+      "Arial fallback: ",
+      {0x4E2D, 0x6587, 0x20,   0x65E5, 0x672C, 0x8A9E, 0x20,   0xD55C,
+       0xAD6D, 0xC5B4, 0x20,   0x0639, 0x0631, 0x0628, 0x064A, 0x20,
+       0x0939, 0x093F, 0x0928, 0x094D, 0x0926, 0x0940, 0x20,   0x1F600});
+  auto paint = PaintForText(base_typeface, 26.f, Color(27, 49, 79));
+  DrawBlobText(canvas, mixed, x, y, paint, fallback_delegate.get());
+  DrawLabel(canvas,
+            "TextBlob fallback from Arial across CJK/Arabic/Hindi/emoji", x,
+            y + 20.f, column_width, label_typeface);
+  y += 68.f;
+
+  auto emoji_text = Utf8({0x1F600, 0x20, 0x1F642, 0x20, 0x1F680, 0x20, 0x1F4A9,
+                          0x20, 0x1F469, 0x200D, 0x1F4BB});
+  auto emoji_system = MatchOrDefault(font_manager, "Segoe UI Emoji",
+                                     skity::FontStyle::Normal());
+  auto emoji_file =
+      skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT "/NotoColorEmoji.ttf");
+  auto emoji_mono = skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT
+                                                  "/NotoEmoji-Regular.ttf");
+  for (const auto& item :
+       std::vector<std::pair<std::string, std::shared_ptr<skity::Typeface>>>{
+           {"system Segoe UI Emoji", emoji_system},
+           {"file NotoColorEmoji.ttf", emoji_file},
+           {"file NotoEmoji-Regular.ttf", emoji_mono},
+       }) {
+    auto emoji_paint = PaintForText(item.second, 38.f, Color(23, 68, 66));
+    DrawText(canvas, item.first + ": " + emoji_text, x, y, emoji_paint);
+    DrawLabel(canvas, TypefaceSummary(item.second), x, y + 24.f, column_width,
+              label_typeface);
+    y += 72.f;
+  }
+
+  auto locale_cjk = MatchCharacter(font_manager, 0x95E8, "Arial", "zh-CN");
+  auto locale_jp = MatchCharacter(font_manager, 0x304B, "Arial", "ja-JP");
+  auto locale_kr = MatchCharacter(font_manager, 0xD55C, "Arial", "ko-KR");
+  auto locale_ar = MatchCharacter(font_manager, 0x0639, "Arial", "ar-SA");
+  auto locale_hi = MatchCharacter(font_manager, 0x0939, "Arial", "hi-IN");
+  const std::vector<std::pair<std::string, std::shared_ptr<skity::Typeface>>>
+      locale_cases = {
+          {"zh-CN U+95E8", locale_cjk}, {"ja-JP U+304B", locale_jp},
+          {"ko-KR U+D55C", locale_kr},  {"ar-SA U+0639", locale_ar},
+          {"hi-IN U+0939", locale_hi},
+      };
+  for (const auto& item : locale_cases) {
+    DrawLabel(canvas, item.first + " -> " + TypefaceSummary(item.second), x, y,
+              column_width, label_typeface);
+    y += 22.f;
+  }
+}
+
+void DrawPaintModes(skity::Canvas* canvas,
+                    const std::shared_ptr<skity::FontManager>& font_manager,
+                    const std::shared_ptr<skity::Typeface>& label_typeface,
+                    float x, float y, float column_width) {
+  DrawSectionTitle(canvas, "Fill/stroke/fake-bold glyph masks", x, y,
+                   label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 34.f;
+
+  auto typeface =
+      MatchOrDefault(font_manager, "Segoe UI", skity::FontStyle::Normal());
+  const std::string sample = "DWrite Stroke Agj 123";
+
+  struct PaintMode {
+    const char* label;
+    skity::Paint::Style style;
+    float stroke_width;
+    skity::Color fill_color;
+    skity::Color stroke_color;
+  };
+
+  const std::vector<PaintMode> modes = {
+      {"fill", skity::Paint::kFill_Style, 1.f, Color(21, 42, 77),
+       Color(21, 42, 77)},
+      {"stroke", skity::Paint::kStroke_Style, 1.8f, Color(21, 42, 77),
+       Color(201, 48, 56)},
+      {"stroke and fill", skity::Paint::kStrokeAndFill_Style, 2.2f,
+       Color(20, 80, 52), Color(180, 70, 42)},
+      {"stroke then fill", skity::Paint::kStrokeThenFill_Style, 2.6f,
+       Color(22, 70, 118), Color(154, 65, 120)},
+  };
+
+  for (const auto& mode : modes) {
+    auto paint = PaintForText(typeface, 34.f, mode.fill_color, mode.style);
+    paint.SetStrokeWidth(mode.stroke_width);
+    paint.SetFillColor(mode.fill_color);
+    paint.SetStrokeColor(mode.stroke_color);
+    DrawText(canvas, sample, x, y, paint);
+    DrawLabel(canvas, mode.label, x, y + 24.f, column_width, label_typeface);
+    y += 68.f;
+  }
+
+  skity::Font normal_font(typeface, 38.f);
+  skity::Font fake_bold_font(typeface, 38.f);
+  fake_bold_font.SetEmbolden(true);
+
+  auto normal_paint = PaintForText(typeface, 38.f, Color(64, 64, 74),
+                                   skity::Paint::kFill_Style);
+  DrawGlyphText(canvas, "DrawGlyphs normal", x, y, normal_font, normal_paint);
+  DrawLabel(canvas, "DrawGlyphs without embolden", x, y + 24.f, column_width,
+            label_typeface);
+  y += 70.f;
+
+  auto bold_paint = PaintForText(typeface, 38.f, Color(82, 42, 86),
+                                 skity::Paint::kFill_Style);
+  DrawGlyphText(canvas, "DrawGlyphs fake bold", x, y, fake_bold_font,
+                bold_paint);
+  DrawLabel(canvas, "DrawGlyphs with Font::SetEmbolden(true)", x, y + 24.f,
+            column_width, label_typeface);
+  y += 70.f;
+
+  auto bold_stroke_paint = PaintForText(typeface, 38.f, Color(95, 62, 24),
+                                        skity::Paint::kStroke_Style);
+  bold_stroke_paint.SetStrokeWidth(1.8f);
+  bold_stroke_paint.SetStrokeColor(Color(95, 62, 24));
+  DrawGlyphText(canvas, "Fake bold stroke", x, y, fake_bold_font,
+                bold_stroke_paint);
+  DrawLabel(canvas, "embolden plus stroke mask", x, y + 24.f, column_width,
+            label_typeface);
+}
+
+void DrawTransforms(skity::Canvas* canvas,
+                    const std::shared_ptr<skity::FontManager>& font_manager,
+                    const std::shared_ptr<skity::Typeface>& label_typeface,
+                    float x, float y, float column_width) {
+  DrawSectionTitle(canvas, "Transforms and large path fallback", x, y,
+                   label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 40.f;
+
+  auto typeface =
+      MatchOrDefault(font_manager, "Consolas", skity::FontStyle::Normal());
+  auto paint = PaintForText(typeface, 34.f, Color(25, 72, 84));
+
+  canvas->Save();
+  canvas->Translate(x, y);
+  canvas->Scale(1.25f, 1.25f);
+  DrawText(canvas, "scaled text", 0.f, 0.f, paint);
+  canvas->Restore();
+  DrawLabel(canvas, "canvas scale 1.25x", x, y + 46.f, column_width,
+            label_typeface);
+  y += 90.f;
+
+  canvas->Save();
+  canvas->Translate(x, y);
+  canvas->Skew(-0.25f, 0.f);
+  DrawText(canvas, "skewed text", 0.f, 0.f, paint);
+  canvas->Restore();
+  DrawLabel(canvas, "canvas skew", x, y + 30.f, column_width, label_typeface);
+  y += 84.f;
+
+  canvas->Save();
+  canvas->Rotate(-9.f, x + 160.f, y);
+  DrawText(canvas, "rotated text", x, y, paint);
+  canvas->Restore();
+  DrawLabel(canvas, "canvas rotate around baseline", x, y + 34.f, column_width,
+            label_typeface);
+  y += 90.f;
+
+  auto large_paint = PaintForText(typeface, 92.f, Color(65, 52, 98),
+                                  skity::Paint::kFill_Style);
+  large_paint.SetFontThreshold(48.f);
+  DrawText(canvas, "PATH", x, y, large_paint);
+  DrawLabel(canvas, "large text with low font threshold", x, y + 42.f,
+            column_width, label_typeface);
+  y += 120.f;
+
+  auto emoji_typeface = MatchOrDefault(font_manager, "Segoe UI Emoji",
+                                       skity::FontStyle::Normal());
+  auto emoji_paint = PaintForText(emoji_typeface, 54.f, Color(24, 78, 74),
+                                  skity::Paint::kFill_Style);
+  auto emoji_text = Utf8({0x1F600, 0x20, 0x1F680, 0x20, 0x1F4A9});
+  canvas->Save();
+  canvas->Translate(x, y);
+  canvas->Scale(1.35f, 0.85f);
+  DrawText(canvas, emoji_text, 0.f, 0.f, emoji_paint);
+  canvas->Restore();
+  DrawLabel(canvas, "color emoji under non-uniform transform", x, y + 54.f,
+            column_width, label_typeface);
+}
+
+void DrawOverview(skity::Canvas* canvas,
+                  const std::shared_ptr<skity::FontManager>& font_manager,
+                  const std::shared_ptr<skity::Typeface>& label_typeface) {
+  auto title_typeface =
+      MatchOrDefault(font_manager, "Segoe UI", skity::FontStyle::Bold());
+  auto title_paint = PaintForText(title_typeface, 28.f, Color(18, 27, 38));
+  DrawText(canvas, "Windows text example", 36.f, 42.f, title_paint);
+
+  const char* mode = skity::Settings::GetSettings().EnableDWriteFontManager()
+                         ? "DWrite font manager"
+                         : "legacy Windows font manager";
+  std::ostringstream info;
+  info << mode << " | families=" << font_manager->CountFamilies()
+       << " | default="
+       << TypefaceSummary(skity::Typeface::GetDefaultTypeface());
+  DrawLabel(canvas, info.str(), 36.f, 66.f, kWindowWidth - 72.f,
+            label_typeface);
+}
+
+class DWriteTextExample : public skity::example::WindowClient {
+ public:
+  void OnDraw(skity::GPUContext*, skity::Canvas* canvas) override {
+    canvas->Clear(Color(248, 250, 252));
+
+    auto font_manager = skity::FontManager::RefDefault();
+    auto label_typeface =
+        MatchOrDefault(font_manager, "Segoe UI", skity::FontStyle::Normal());
+
+    DrawOverview(canvas, font_manager, label_typeface);
+
+    constexpr float column_width = 370.f;
+    DrawFamilyCases(canvas, font_manager, label_typeface, 36.f, 110.f,
+                    column_width);
+    DrawWeightSweep(canvas, font_manager, label_typeface, 446.f, 110.f,
+                    column_width);
+    DrawFallbackAndEmoji(canvas, font_manager, label_typeface, 856.f, 110.f,
+                         column_width);
+    DrawPaintModes(canvas, font_manager, label_typeface, 856.f, 610.f,
+                   column_width);
+    DrawTransforms(canvas, font_manager, label_typeface, 1266.f, 110.f,
+                   column_width);
+  }
+};
+
+}  // namespace
+
+int main(int argc, const char** argv) {
+  DWriteTextExample example;
+  std::string title = skity::Settings::GetSettings().EnableDWriteFontManager()
+                          ? "Windows Text Example - DWrite"
+                          : "Windows Text Example - Legacy";
+  return skity::example::StartExampleApp(
+      argc, argv, example, static_cast<int>(kWindowWidth),
+      static_cast<int>(kWindowHeight), title);
+}

--- a/harness/font/cli/skity-font/main.cc
+++ b/harness/font/cli/skity-font/main.cc
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <filesystem>
 #include <iostream>
+#include <skity/utils/settings.hpp>
 #include <string>
 #include <system_error>
 #include <utility>
@@ -38,6 +39,15 @@ constexpr int kExitIOFailure = 4;
 constexpr int kExitBackendUnavailable = 5;
 constexpr int kExitCompareInputFailure = 6;
 constexpr int kExitSkityProbeFailure = 7;
+
+void ConfigureFontManagerBackend(const std::string& backend) {
+#if defined(SKITY_WIN)
+  skity::Settings::GetSettings().SetEnableDWriteFontManager(backend ==
+                                                            "directwrite");
+#else
+  (void)backend;
+#endif
+}
 
 struct CaseMetadata {
   std::string case_id;
@@ -404,6 +414,8 @@ int ExitCodeForCompareStatus(skity::font_harness::CompareStatus status) {
 ProbeInvocationResult RunSkityProbeForCase(
     const std::filesystem::path& repo_root,
     const std::filesystem::path& case_path, const std::string& backend) {
+  ConfigureFontManagerBackend(backend);
+
   ProbeInvocationResult invocation;
   const std::string category = ReadCaseCategory(case_path);
   if (IsMetricsProbeCategory(category)) {
@@ -964,6 +976,7 @@ int RunPlatformInfoCommand(int argc, char** argv, const std::string& command) {
     std::cerr << command << " requires --backend <backend>\n";
     return kExitUsageError;
   }
+  ConfigureFontManagerBackend(backend);
 
   Json::Value report;
   if (backend == "coretext") {
@@ -1053,6 +1066,7 @@ int RunDumpPathCommand(int argc, char** argv) {
   request.repo_root = repo_root;
   request.case_path = case_path;
   request.backend = backend;
+  ConfigureFontManagerBackend(backend);
   skity::font_harness::GlyphPathProbeResult result =
       skity::font_harness::RunGlyphPathDump(request);
   Json::Value report = std::move(result.report);
@@ -1241,6 +1255,7 @@ int RunMatchCommand(int argc, char** argv) {
   request.repo_root = repo_root;
   request.case_path = case_path;
   request.backend = backend;
+  ConfigureFontManagerBackend(backend);
   skity::font_harness::FontManagerProbeResult result =
       skity::font_harness::RunFontManagerProbe(request);
   const int exit_code = ExitCodeForProbeStatus(result.status);

--- a/harness/font/compare/compare_engine.cc
+++ b/harness/font/compare/compare_engine.cc
@@ -693,6 +693,35 @@ Json::Value NormalizeGlyphImageProbe(const Json::Value& root,
   return value;
 }
 
+void ConvertGlyphImageActualOriginYToSkiaMaskTop(Json::Value* actual_glyphs) {
+  if (actual_glyphs == nullptr || !actual_glyphs->isArray()) {
+    return;
+  }
+
+  for (Json::ArrayIndex i = 0; i < actual_glyphs->size(); ++i) {
+    Json::Value& actual_glyph = (*actual_glyphs)[i];
+    if (!actual_glyph.isObject() || !actual_glyph.isMember("image") ||
+        !actual_glyph["image"].isObject()) {
+      continue;
+    }
+
+    Json::Value& actual_image = actual_glyph["image"];
+    Json::Value& actual_origin_y = actual_image["origin_y"];
+    if (!actual_origin_y.isNumeric()) {
+      continue;
+    }
+
+    const double value = actual_origin_y.asDouble();
+    if (!std::isfinite(value)) {
+      continue;
+    }
+
+    // Skia oracle stores SkGlyph::top() here. Skity stores the draw origin
+    // used by runtime placement, so compare actual in mask-top coordinates.
+    actual_origin_y = -value;
+  }
+}
+
 Json::Value NormalizeMatchedTypeface(const Json::Value& typeface) {
   Json::Value value(Json::objectValue);
   if (!typeface.isObject()) {
@@ -1099,6 +1128,8 @@ void CompareGlyphImageProbe(const Json::Value& expected_root,
   Json::Value expected =
       NormalizeGlyphImageProbe(expected_root, include_digest);
   Json::Value actual = NormalizeGlyphImageProbe(actual_root, include_digest);
+  ConvertGlyphImageActualOriginYToSkiaMaskTop(
+      &actual["font_result"]["glyph_images"]);
   CompareJsonSubset(expected["font_result"]["glyph_images"],
                     actual["font_result"]["glyph_images"],
                     "glyph_image_probe.font_result.glyph_images",

--- a/harness/font/probe/backend_support.hpp
+++ b/harness/font/probe/backend_support.hpp
@@ -5,6 +5,7 @@
 #ifndef HARNESS_FONT_PROBE_BACKEND_SUPPORT_HPP
 #define HARNESS_FONT_PROBE_BACKEND_SUPPORT_HPP
 
+#include <skity/utils/settings.hpp>
 #include <string>
 
 #ifndef SKITY_FONT_HARNESS_HAS_CORETEXT
@@ -27,7 +28,14 @@ inline bool IsHostFontProbeBackendAvailable(const std::string& backend) {
     return static_cast<bool>(SKITY_FONT_HARNESS_HAS_CORETEXT);
   }
   if (backend == "directwrite") {
-    return static_cast<bool>(SKITY_FONT_HARNESS_HAS_DIRECTWRITE);
+    if (!static_cast<bool>(SKITY_FONT_HARNESS_HAS_DIRECTWRITE)) {
+      return false;
+    }
+#if defined(SKITY_WIN)
+    return Settings::GetSettings().EnableDWriteFontManager();
+#else
+    return false;
+#endif
   }
   return false;
 }
@@ -39,6 +47,12 @@ inline std::string HostFontBackendUnavailableMessage(
            "SKITY_CT_FONT=ON";
   }
   if (backend == "directwrite") {
+#if defined(SKITY_WIN)
+    if (!Settings::GetSettings().EnableDWriteFontManager()) {
+      return "DirectWrite font manager is disabled; enable it before "
+             "running the DirectWrite font harness";
+    }
+#endif
     return "DirectWrite backend is unavailable; build on Windows";
   }
   return probe_name + " supports only the coretext and directwrite backends";

--- a/harness/font/tests/unit/font_harness_self_test.cc
+++ b/harness/font/tests/unit/font_harness_self_test.cc
@@ -334,6 +334,62 @@ void RunFontManagerCompare(TempDir* temp, const Json::Value& expected,
   *result = RunCompare(request);
 }
 
+Json::Value MakeGlyphImageArtifact(double origin_y) {
+  Json::Value root(Json::objectValue);
+  root["schema_version"] = 1;
+  root["artifact_type"] = "font_probe_result";
+  root["case_id"] = kGlyphImageCaseId;
+  root["backend"] = kBackend;
+  root["ok"] = true;
+
+  Json::Value image(Json::objectValue);
+  image["origin_x"] = 1.0;
+  image["origin_y"] = origin_y;
+  image["origin_x_for_raster"] = 1.0;
+  image["origin_y_for_raster"] = -46.0;
+  image["width"] = 32.0;
+  image["height"] = 48.0;
+  image["format"] = "A8";
+  image["has_buffer"] = true;
+  image["byte_size"] = 1536;
+
+  Json::Value glyph(Json::objectValue);
+  glyph["label"] = "U+0041";
+  glyph["code_point"] = 65;
+  glyph["glyph_id"] = 1;
+  glyph["image"] = std::move(image);
+
+  root["glyph_image_probe"] = Json::Value(Json::objectValue);
+  root["glyph_image_probe"]["font_result"] = Json::Value(Json::objectValue);
+  root["glyph_image_probe"]["font_result"]["glyph_images"] =
+      Json::Value(Json::arrayValue);
+  root["glyph_image_probe"]["font_result"]["glyph_images"].append(
+      std::move(glyph));
+  return root;
+}
+
+void RunGlyphImageCompare(TempDir* temp, const Json::Value& expected,
+                          const Json::Value& actual, CompareResult* result) {
+  WriteTextFile(temp->root() / "fonts/synthetic.ttf", "synthetic font bytes");
+  const std::filesystem::path case_path =
+      temp->root() / "cases/glyph_image.json";
+  const std::filesystem::path expected_path =
+      temp->root() / "artifacts/expected.json";
+  const std::filesystem::path actual_path =
+      temp->root() / "artifacts/actual.json";
+  WriteJson(case_path, MakeGlyphImageCase());
+  WriteJson(expected_path, expected);
+  WriteJson(actual_path, actual);
+
+  CompareRequest request;
+  request.repo_root = temp->root();
+  request.case_path = case_path;
+  request.expected_path = expected_path;
+  request.actual_path = actual_path;
+  request.backend = kBackend;
+  *result = RunCompare(request);
+}
+
 void ExpectSingleDiff(const CompareResult& result,
                       const std::string& reason_code,
                       const std::string& diff_path) {
@@ -568,6 +624,41 @@ TEST(FontHarnessCompareEngineTest,
 
   ExpectSingleDiff(result, "table_mismatch",
                    "font_manager_probe.matched_typefaces[0].tables[0].size");
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ComparesGlyphImageOriginYInSkiaMaskTopSpace) {
+  TempDir temp("glyph_image_origin_y_mask_top");
+  CompareResult result;
+  RunGlyphImageCompare(&temp, MakeGlyphImageArtifact(-46.0),
+                       MakeGlyphImageArtifact(46.0), &result);
+
+  EXPECT_EQ(CompareStatus::kPass, result.status)
+      << WriteJsonString(result.report);
+  EXPECT_TRUE(result.report["passed"].asBool());
+}
+
+TEST(FontHarnessCompareEngineTest, ReportsGlyphImageOriginYWhenSignMatches) {
+  TempDir temp("glyph_image_origin_y_same_sign");
+  CompareResult result;
+  RunGlyphImageCompare(&temp, MakeGlyphImageArtifact(-46.0),
+                       MakeGlyphImageArtifact(-46.0), &result);
+
+  ExpectSingleDiff(
+      result, "image_mismatch",
+      "glyph_image_probe.font_result.glyph_images[0].image.origin_y");
+}
+
+TEST(FontHarnessCompareEngineTest,
+     ReportsGlyphImageOriginYWhenMagnitudeDiffers) {
+  TempDir temp("glyph_image_origin_y_magnitude");
+  CompareResult result;
+  RunGlyphImageCompare(&temp, MakeGlyphImageArtifact(-46.0),
+                       MakeGlyphImageArtifact(47.0), &result);
+
+  ExpectSingleDiff(
+      result, "image_mismatch",
+      "glyph_image_probe.font_result.glyph_images[0].image.origin_y");
 }
 
 TEST(FontHarnessCaseDocumentTest, ValidatesSyntheticTypefaceCase) {

--- a/include/skity/text/glyph.hpp
+++ b/include/skity/text/glyph.hpp
@@ -34,11 +34,7 @@ enum class BitmapFormat {
   kRGBA8,
 };
 
-enum class GlyphColorType {
-  kNoColor,
-  kColorV0,
-  kColorV1
-};
+enum class GlyphColorType { kNoColor, kColorV0, kColorV1 };
 
 struct SKITY_API GlyphBitmapData {
   // origin point for rendering, This value used in canvas draw
@@ -135,6 +131,7 @@ class SKITY_API GlyphData {
 
   GlyphColorType color_type_ = GlyphColorType::kNoColor;
 
+  friend class GlyphDataWinAccess;
   friend class TypefaceFreeType;
   friend class ScalerContextFreetype;
   friend class ScalerContextDarwin;

--- a/include/skity/utils/settings.hpp
+++ b/include/skity/utils/settings.hpp
@@ -27,9 +27,13 @@ class SKITY_API Settings {
   bool IsAnyWeightEnabled() const;
   void SetAnyWeightEnabled(bool enable);
 
+  bool EnableDWriteFontManager() const;
+  void SetEnableDWriteFontManager(bool enable);
+
  private:
   std::atomic<bool> enable_theme_font_{false};
   std::atomic<bool> enable_any_weight_{true};
+  std::atomic<bool> enable_dwrite_font_manager_{false};
 };
 
 }  // namespace skity

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,6 +247,9 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
     skity
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/text/ports/win/font_manager_win.cc
+    ${CMAKE_CURRENT_LIST_DIR}/text/ports/win/font_manager_win2.cc
+    ${CMAKE_CURRENT_LIST_DIR}/text/ports/win/scaler_context_win.cc
+    ${CMAKE_CURRENT_LIST_DIR}/text/ports/win/typeface_win.cc
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR EMSCRIPTEN)
   target_sources(skity PRIVATE ${CMAKE_CURRENT_LIST_DIR}/text/ports/test/font_manager_test.cc)

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -100,14 +100,12 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
   }
   scaler_context_desc.context_scale = load_sdf ? 1.f : context_scale;
 
-  if (font.GetTypeface()->ContainsColorTable()) {
-    scaler_context_desc.foreground_color =
-        paint.GetStyle() == Paint::kStroke_Style
-            ? Color4fToColor(paint.GetStrokeColor())
-            : Color4fToColor(paint.GetFillColor());
-  } else {
-    scaler_context_desc.foreground_color = Color_TRANSPARENT;
+  Paint glyph_image_paint = paint;
+  if (load_sdf) {
+    glyph_image_paint.SetStyle(Paint::kFill_Style);
   }
+  scaler_context_desc.foreground_color =
+      ScalerContextDesc::GetGlyphImageForegroundColor(font, glyph_image_paint);
 
   scaler_context_desc.stroke_width =
       paint.GetStyle() == Paint::kStroke_Style ? paint.GetStrokeWidth() : 0.f;

--- a/src/text/ports/win/dwrite_utils.hpp
+++ b/src/text/ports/win/dwrite_utils.hpp
@@ -15,6 +15,9 @@
 #include "src/text/ports/win/dwrite_version.hpp"
 #include "src/base/platform/win/lean_windows.hpp"
 #include "src/base/platform/win/handle_result.hpp"
+#ifdef GetGlyphIndices
+#undef GetGlyphIndices
+#endif
 #include <dwrite.h>
 // clang-format on
 

--- a/src/text/ports/win/font_manager_win2.cc
+++ b/src/text/ports/win/font_manager_win2.cc
@@ -14,6 +14,7 @@
 #include "src/base/platform/win/str_conversion.hpp"
 #include "src/text/ports/win/scoped_com_ptr.hpp"
 #include "src/text/ports/win/dwrite_utils.hpp"
+#include "src/text/ports/win/typeface_win.hpp"
 // clang-format on
 
 #include <dwrite.h>
@@ -22,23 +23,18 @@
 #include <winsdkver.h>
 
 #include <cassert>
-#include <cstring>
+#include <cstdlib>
+#include <memory>
 #include <mutex>
 #include <skity/io/data.hpp>
-#include <skity/text/font_arguments.hpp>
 #include <skity/text/font_manager.hpp>
 #include <skity/text/utf.hpp>
-#include <skity/utils/settings.hpp>
 #include <utility>
 #include <vector>
 
 #include "src/logging.hpp"
-#include "src/text/ports/typeface_freetype.hpp"
-#include "src/utils/no_destructor.hpp"
 
 namespace skity {
-
-std::shared_ptr<FontManager> InitFontManagerDWrite();
 
 namespace {
 static IDWriteFactory* gDWriteFactory = nullptr;
@@ -79,156 +75,6 @@ IDWriteFactory* get_dwrite_factory() {
   std::call_once(flag, [] { create_dwrite_factory(&gDWriteFactory); });
 
   return gDWriteFactory;
-}
-
-/** Reverse all 4 bytes in a 32bit value.
-  e.g. 0x12345678 -> 0x78563412
-*/
-static constexpr uint32_t EndianSwap32(uint32_t value) {
-  return ((value & 0xFF) << 24) | ((value & 0xFF00) << 8) |
-         ((value & 0xFF0000) >> 8) | (value >> 24);
-}
-
-// Korean fonts Gulim, Dotum, Batang, Gungsuh have bitmap strikes that get
-// artifically emboldened by Windows without antialiasing. Korean users prefer
-// these over the synthetic boldening performed by Skia. So let's make an
-// exception for fonts with bitmap strikes and allow passing through Windows
-// simulations for those, until Skia provides more control over simulations in
-// font matching, see https://crbug.com/1258378
-bool HasBitmapStrikes(const ScopedComPtr<IDWriteFont>& font) {
-  ScopedComPtr<IDWriteFontFace> fontFace;
-  HRB(font->CreateFontFace(&fontFace));
-
-  AutoDWriteTable ebdtTable(fontFace.get(),
-                            EndianSwap32(SetFourByteTag('E', 'B', 'D', 'T')));
-  return ebdtTable.exists;
-}
-
-template <typename T, typename U>
-bool SameCOMObject(T* lhs, U* rhs) {
-  if (!lhs || !rhs) {
-    return lhs == rhs;
-  }
-
-  ScopedComPtr<IUnknown> lhsUnknown;
-  if (FAILED(lhs->QueryInterface(&lhsUnknown))) {
-    return false;
-  }
-
-  ScopedComPtr<IUnknown> rhsUnknown;
-  if (FAILED(rhs->QueryInterface(&rhsUnknown))) {
-    return false;
-  }
-
-  return lhsUnknown.get() == rhsUnknown.get();
-}
-
-bool GetDWriteFontFiles(IDWriteFontFace* font_face,
-                        std::vector<ScopedComPtr<IDWriteFontFile>>& files) {
-  files.clear();
-
-  uint32_t number_of_files = 0;
-  if (FAILED(font_face->GetFiles(&number_of_files, nullptr))) {
-    return false;
-  }
-
-  files.resize(number_of_files);
-  if (files.empty()) {
-    return true;
-  }
-
-  return SUCCEEDED(font_face->GetFiles(
-      &number_of_files, reinterpret_cast<IDWriteFontFile**>(files.data())));
-}
-
-bool DWriteFontFileEqual(IDWriteFontFile* lhs, IDWriteFontFile* rhs) {
-  if (SameCOMObject(lhs, rhs)) {
-    return true;
-  }
-
-  if (!lhs || !rhs) {
-    return false;
-  }
-
-  ScopedComPtr<IDWriteFontFileLoader> lhsLoader;
-  ScopedComPtr<IDWriteFontFileLoader> rhsLoader;
-  if (FAILED(lhs->GetLoader(&lhsLoader)) ||
-      FAILED(rhs->GetLoader(&rhsLoader))) {
-    return false;
-  }
-
-  if (!SameCOMObject(lhsLoader.get(), rhsLoader.get())) {
-    return false;
-  }
-
-  const void* lhsKey = nullptr;
-  const void* rhsKey = nullptr;
-  UINT32 lhsKeySize = 0;
-  UINT32 rhsKeySize = 0;
-  lhs->GetReferenceKey(&lhsKey, &lhsKeySize);
-  rhs->GetReferenceKey(&rhsKey, &rhsKeySize);
-
-  if (lhsKeySize != rhsKeySize) {
-    return false;
-  }
-
-  if (lhsKeySize == 0) {
-    return true;
-  }
-
-  return lhsKey && rhsKey && std::memcmp(lhsKey, rhsKey, lhsKeySize) == 0;
-}
-
-bool DWriteFontFaceEqualByFiles(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
-  if (lhs->GetIndex() != rhs->GetIndex() ||
-      lhs->GetSimulations() != rhs->GetSimulations()) {
-    return false;
-  }
-
-  std::vector<ScopedComPtr<IDWriteFontFile>> lhsFiles;
-  std::vector<ScopedComPtr<IDWriteFontFile>> rhsFiles;
-  if (!GetDWriteFontFiles(lhs, lhsFiles) ||
-      !GetDWriteFontFiles(rhs, rhsFiles)) {
-    return false;
-  }
-
-  if (lhsFiles.size() != rhsFiles.size()) {
-    return false;
-  }
-
-  for (size_t index = 0; index < lhsFiles.size(); index++) {
-    if (!DWriteFontFileEqual(lhsFiles[index].get(), rhsFiles[index].get())) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
-  if (SameCOMObject(lhs, rhs)) {
-    return true;
-  }
-
-  if (!lhs || !rhs) {
-    return false;
-  }
-
-  // IDWriteFontFace5::Equals accounts for newer face identity such as variation
-  // axis values. Older DirectWrite versions can only compare file identity.
-#if defined(__IDWriteFontFace5_INTERFACE_DEFINED__)
-  ScopedComPtr<IDWriteFontFace5> lhsFace5;
-  if (SUCCEEDED(lhs->QueryInterface(&lhsFace5))) {
-    return lhsFace5->Equals(rhs);
-  }
-
-  ScopedComPtr<IDWriteFontFace5> rhsFace5;
-  if (SUCCEEDED(rhs->QueryInterface(&rhsFace5))) {
-    return rhsFace5->Equals(lhs);
-  }
-#endif
-
-  return DWriteFontFaceEqualByFiles(lhs, rhs);
 }
 
 class DWriteTypefaceCache {
@@ -277,51 +123,18 @@ class DWriteTypefaceCache {
   std::vector<Entry> entries_;
 };
 
-// Iterate calls to GetFirstMatchingFont incrementally removing bold or italic
-// styling that can trigger the simulations. Implementing it this way gets us a
-// IDWriteFont that can be used as before and has the correct information on its
-// own style. Stripping simulations from IDWriteFontFace is possible via
-// IDWriteFontList1, IDWriteFontFaceReference and CreateFontFace, but this way
-// we won't have a matching IDWriteFont which is still used in get_style().
-HRESULT FirstMatchingFontWithoutSimulations(
-    const ScopedComPtr<IDWriteFontFamily>& family, DWriteStyle dwStyle,
-    ScopedComPtr<IDWriteFont>& font) {
-  bool noSimulations = false;
-  while (!noSimulations) {
-    ScopedComPtr<IDWriteFont> searchFont;
-    HR(family->GetFirstMatchingFont(dwStyle.weight, dwStyle.width,
-                                    dwStyle.slant, &searchFont));
-    DWRITE_FONT_SIMULATIONS simulations = searchFont->GetSimulations();
-    // If we still get simulations even though we're not asking for bold or
-    // italic, we can't help it and exit the loop.
-
-    noSimulations = simulations == DWRITE_FONT_SIMULATIONS_NONE ||
-                    (dwStyle.weight == DWRITE_FONT_WEIGHT_REGULAR &&
-                     dwStyle.slant == DWRITE_FONT_STYLE_NORMAL) ||
-                    HasBitmapStrikes(searchFont);
-
-    if (noSimulations) {
-      font = std::move(searchFont);
-      break;
-    }
-    if (simulations & DWRITE_FONT_SIMULATIONS_BOLD) {
-      dwStyle.weight = DWRITE_FONT_WEIGHT_REGULAR;
-      continue;
-    }
-    if (simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) {
-      dwStyle.slant = DWRITE_FONT_STYLE_NORMAL;
-      continue;
-    }
-  }
-  return S_OK;
+bool HasOnlyAllowedSimulations(DWRITE_FONT_SIMULATIONS actual,
+                               DWRITE_FONT_SIMULATIONS allowed) {
+  return (static_cast<UINT32>(actual) & ~static_cast<UINT32>(allowed)) == 0;
 }
 
 }  // namespace
 
-class FontFallbackSource : public IDWriteTextAnalysisSource {
+class FontFallbackSourceDWrite : public IDWriteTextAnalysisSource {
  public:
-  FontFallbackSource(const WCHAR* string, UINT32 length, const WCHAR* locale,
-                     IDWriteNumberSubstitution* numberSubstitution)
+  FontFallbackSourceDWrite(const WCHAR* string, UINT32 length,
+                           const WCHAR* locale,
+                           IDWriteNumberSubstitution* numberSubstitution)
       : fRefCount(1),
         fString(string),
         fLength(length),
@@ -387,6 +200,7 @@ class FontFallbackSource : public IDWriteTextAnalysisSource {
   SK_STDMETHODIMP GetLocaleName(UINT32 textPosition, UINT32* textLength,
                                 WCHAR const** localeName) override {
     *localeName = fLocale;
+    *textLength = this->RemainingTextLength(textPosition);
     return S_OK;
   }
 
@@ -394,11 +208,19 @@ class FontFallbackSource : public IDWriteTextAnalysisSource {
       UINT32 textPosition, UINT32* textLength,
       IDWriteNumberSubstitution** numberSubstitution) override {
     *numberSubstitution = fNumberSubstitution;
+    *textLength = this->RemainingTextLength(textPosition);
+    if (fNumberSubstitution) {
+      fNumberSubstitution->AddRef();
+    }
     return S_OK;
   }
 
  private:
-  virtual ~FontFallbackSource() {}
+  UINT32 RemainingTextLength(UINT32 textPosition) const {
+    return textPosition < fLength ? fLength - textPosition : 0;
+  }
+
+  virtual ~FontFallbackSourceDWrite() {}
 
   ULONG fRefCount;
   const WCHAR* fString;
@@ -407,11 +229,11 @@ class FontFallbackSource : public IDWriteTextAnalysisSource {
   IDWriteNumberSubstitution* fNumberSubstitution;
 };
 
-class FontManagerWin;
-class FontStyleSetWin : public FontStyleSet {
+class FontManagerDWrite;
+class FontStyleSetDWrite : public FontStyleSet {
  public:
-  explicit FontStyleSetWin(const FontManagerWin* font_manager,
-                           IDWriteFontFamily* font_family)
+  explicit FontStyleSetDWrite(const FontManagerDWrite* font_manager,
+                              IDWriteFontFamily* font_family)
       : font_manager_(font_manager), font_family_(RefComPtr(font_family)) {}
 
   int Count() override { return font_family_->GetFontCount(); }
@@ -423,17 +245,17 @@ class FontStyleSetWin : public FontStyleSet {
   std::shared_ptr<Typeface> MatchStyle(const FontStyle& pattern) override;
 
  private:
-  const FontManagerWin* font_manager_;
+  const FontManagerDWrite* font_manager_;
   ScopedComPtr<IDWriteFontFamily> font_family_;
 
-  friend class FontManagerWin;
+  friend class FontManagerDWrite;
 };
 
-class FontManagerWin : public FontManager {
+class FontManagerDWrite : public FontManager {
  public:
-  FontManagerWin(IDWriteFactory* factory,
-                 IDWriteFontCollection* font_collection,
-                 IDWriteFontFallback* fallback, std::wstring locale_name)
+  FontManagerDWrite(IDWriteFactory* factory,
+                    IDWriteFontCollection* font_collection,
+                    IDWriteFontFallback* fallback, std::wstring locale_name)
       : factory_(RefComPtr(factory)),
         font_collection_(RefComPtr(font_collection)),
         fallback_(SafeRefComPtr(fallback)),
@@ -448,16 +270,39 @@ class FontManagerWin : public FontManager {
     return font_collection_->GetFontFamilyCount();
   }
 
-  std::string OnGetFamilyName(int) const override {
-    LOGE("onGetFamilyName called with bad index");
-    return "";
+  std::string OnGetFamilyName(int index) const override {
+    if (index < 0 ||
+        index >= static_cast<int>(font_collection_->GetFontFamilyCount())) {
+      LOGE("onGetFamilyName called with bad index");
+      return "";
+    }
+
+    ScopedComPtr<IDWriteFontFamily> font_family;
+    if (FAILED(font_collection_->GetFontFamily(index, &font_family))) {
+      LOGE("Could not get requested family.");
+      return "";
+    }
+
+    ScopedComPtr<IDWriteLocalizedStrings> family_names;
+    if (FAILED(font_family->GetFamilyNames(&family_names))) {
+      LOGE("Could not get family names.");
+      return "";
+    }
+
+    return CopyLocalizedString(family_names.get(), locale_name_);
   }
 
   std::shared_ptr<FontStyleSet> OnCreateStyleSet(int index) const override {
+    if (index < 0 ||
+        index >= static_cast<int>(font_collection_->GetFontFamilyCount())) {
+      LOGE("OnCreateStyleSet called with bad index");
+      return nullptr;
+    }
+
     ScopedComPtr<IDWriteFontFamily> font_family;
     HRNM(font_collection_->GetFontFamily(index, &font_family),
          "Could not get requested family.");
-    return std::make_shared<FontStyleSetWin>(this, font_family.get());
+    return std::make_shared<FontStyleSetDWrite>(this, font_family.get());
   }
 
   std::shared_ptr<FontStyleSet> OnMatchFamily(
@@ -473,20 +318,35 @@ class FontManagerWin : public FontManager {
 
   std::shared_ptr<Typeface> OnMakeFromData(std::shared_ptr<Data> const& data,
                                            int ttcIndex) const override {
-    return TypefaceFreeType::Make(data,
-                                  FontArguments().SetCollectionIndex(ttcIndex));
+    return MakeDWriteTypefaceFromData(factory_.get(), locale_name_, data,
+                                      ttcIndex);
   }
 
   std::shared_ptr<Typeface> OnMakeFromFile(const char path[],
                                            int ttcIndex) const override {
     auto data = Data::MakeFromFileName(path);
-    return TypefaceFreeType::Make(data,
-                                  FontArguments().SetCollectionIndex(ttcIndex));
+    auto directwrite_typeface = MakeDWriteTypefaceFromData(
+        factory_.get(), locale_name_, data, ttcIndex);
+    if (!directwrite_typeface) {
+      directwrite_typeface = MakeDWriteTypefaceFromFileReference(
+          factory_.get(), locale_name_, path, ttcIndex);
+    }
+    return directwrite_typeface;
   }
 
   std::shared_ptr<Typeface> OnGetDefaultTypeface(
-      FontStyle const&) const override {
-    return nullptr;
+      FontStyle const& font_style) const override {
+    auto default_typeface = OnMatchFamilyStyle("Segoe UI", font_style);
+    if (default_typeface) {
+      return default_typeface;
+    }
+
+    if (font_collection_->GetFontFamilyCount() == 0) {
+      return nullptr;
+    }
+
+    auto first_style_set = OnCreateStyleSet(0);
+    return first_style_set ? first_style_set->MatchStyle(font_style) : nullptr;
   }
 
  private:
@@ -496,20 +356,26 @@ class FontManagerWin : public FontManager {
   std::wstring locale_name_;
   mutable DWriteTypefaceCache typeface_cache_;
 
-  std::shared_ptr<Typeface> fallback(const WCHAR* dwFamilyName, DWriteStyle,
-                                     const WCHAR* dwBcp47,
-                                     UINT32 character) const;
+  std::shared_ptr<Typeface> fallback(
+      const WCHAR* dwFamilyName, DWriteStyle, const WCHAR* dwBcp47,
+      UINT32 character, DWRITE_FONT_SIMULATIONS allowedSimulations) const;
 
   std::shared_ptr<Typeface> layoutFallback(const WCHAR* dwFamilyName,
                                            DWriteStyle, const WCHAR* dwBcp47,
                                            UINT32 character) const;
 
-  friend class FontFallbackRenderer;
+  static constexpr DWRITE_FONT_SIMULATIONS kDefaultSimulations =
+      static_cast<DWRITE_FONT_SIMULATIONS>(DWRITE_FONT_SIMULATIONS_BOLD |
+                                           DWRITE_FONT_SIMULATIONS_OBLIQUE);
+
+  friend class FontFallbackRendererDWrite;
+  friend class FontStyleSetDWrite;
 };
 
-class FontFallbackRenderer : public IDWriteTextRenderer {
+class FontFallbackRendererDWrite : public IDWriteTextRenderer {
  public:
-  FontFallbackRenderer(const FontManagerWin* font_manager, UINT32 character)
+  FontFallbackRendererDWrite(const FontManagerDWrite* font_manager,
+                             UINT32 character)
       : ref_count_(1),
         font_manager_(font_manager),
         character_(character),
@@ -623,37 +489,42 @@ class FontFallbackRenderer : public IDWriteTextRenderer {
   bool FallbackTypefaceHasSimulations() { return has_simulations_; }
 
  private:
-  virtual ~FontFallbackRenderer() {}
+  virtual ~FontFallbackRendererDWrite() {}
 
   ULONG ref_count_;
-  const FontManagerWin* font_manager_;
+  const FontManagerDWrite* font_manager_;
   UINT32 character_;
   std::shared_ptr<Typeface> fallback_typeface_;
   bool has_simulations_{false};
 };
 
-/// FontStyleSetWin Impl
+/// FontStyleSetDWrite Impl
 
-void FontStyleSetWin::GetStyle(int index, FontStyle* style, std::string* name) {
+void FontStyleSetDWrite::GetStyle(int index, FontStyle* style,
+                                  std::string* name) {
+  if (index < 0 || index >= Count()) {
+    return;
+  }
+
   ScopedComPtr<IDWriteFont> font;
   HRVM(font_family_->GetFont(index, &font), "Could not get font.");
 
-  // if (style) {
-  //   ScopedComPtr<IDWriteFontFace> face;
-  //   HRVM(font->CreateFontFace(&face), "Could not get face.");
-  //   *fs = DWriteFontTypeface::GetStyle(font.get(), face.get());
-  // }
+  if (style) {
+    *style = FontStyleFromDWriteFont(font.get());
+  }
 
-  // if (name) {
-  //   ScopedComPtr<IDWriteLocalizedStrings> faceNames;
-  //   if (SUCCEEDED(font->GetFaceNames(&faceNames))) {
-  //     sk_get_locale_string(faceNames.get(), fFontMgr->fLocaleName.get(),
-  //                          styleName);
-  //   }
-  // }
+  if (name) {
+    ScopedComPtr<IDWriteLocalizedStrings> face_names;
+    if (SUCCEEDED(font->GetFaceNames(&face_names))) {
+      *name =
+          CopyLocalizedString(face_names.get(), font_manager_->locale_name_);
+    } else {
+      name->clear();
+    }
+  }
 }
 
-std::shared_ptr<Typeface> FontStyleSetWin::CreateTypeface(int index) {
+std::shared_ptr<Typeface> FontStyleSetDWrite::CreateTypeface(int index) {
   ScopedComPtr<IDWriteFont> font;
   HRNM(font_family_->GetFont(index, &font), "Could not get font.");
 
@@ -664,7 +535,7 @@ std::shared_ptr<Typeface> FontStyleSetWin::CreateTypeface(int index) {
                                                    font_family_.get());
 }
 
-std::shared_ptr<Typeface> FontStyleSetWin::MatchStyle(
+std::shared_ptr<Typeface> FontStyleSetDWrite::MatchStyle(
     const FontStyle& pattern) {
   ScopedComPtr<IDWriteFont> font;
   DWriteStyle dwStyle(pattern);
@@ -679,9 +550,9 @@ std::shared_ptr<Typeface> FontStyleSetWin::MatchStyle(
                                                    font_family_.get());
 }
 
-/// FontManagerWin Impl
+/// FontManagerDWrite Impl
 
-std::shared_ptr<FontStyleSet> FontManagerWin::OnMatchFamily(
+std::shared_ptr<FontStyleSet> FontManagerDWrite::OnMatchFamily(
     const char family_name[]) const {
   if (!family_name) {
     return nullptr;
@@ -701,20 +572,22 @@ std::shared_ptr<FontStyleSet> FontManagerWin::OnMatchFamily(
   return this->OnCreateStyleSet(index);
 }
 
-std::shared_ptr<Typeface> FontManagerWin::OnMatchFamilyStyle(
+std::shared_ptr<Typeface> FontManagerDWrite::OnMatchFamilyStyle(
     const char family_name[], const FontStyle& style) const {
   std::shared_ptr<FontStyleSet> sset(this->MatchFamily(family_name));
-  return sset->MatchStyle(style);
+  return sset ? sset->MatchStyle(style) : nullptr;
 }
 
-std::shared_ptr<Typeface> FontManagerWin::OnMatchFamilyStyleCharacter(
+std::shared_ptr<Typeface> FontManagerDWrite::OnMatchFamilyStyleCharacter(
     const char family_name[], const FontStyle& style, const char* bcp47[],
     int bcp47_count, Unichar character) const {
   DWriteStyle dwStyle(style);
 
   std::wstring w_family_name;
+  const WCHAR* dw_family_name = nullptr;
   if (family_name) {
     HRN(StrConversion::StringToWideString(family_name, &w_family_name));
+    dw_family_name = w_family_name.c_str();
   }
 
   std::wstring dw_bcp47;
@@ -725,20 +598,18 @@ std::shared_ptr<Typeface> FontManagerWin::OnMatchFamilyStyleCharacter(
   }
 
   if (fallback_) {
-    return this->fallback(w_family_name.c_str(), dwStyle, dw_bcp47.c_str(),
-                          character);
+    return this->fallback(dw_family_name, dwStyle, dw_bcp47.c_str(), character,
+                          kDefaultSimulations);
   }
 
   // Windows 7 does not support font fallback and performs a single layout pass
   // to find a suitable font.
-  return layoutFallback(w_family_name.c_str(), dwStyle, dw_bcp47.c_str(),
-                        character);
+  return layoutFallback(dw_family_name, dwStyle, dw_bcp47.c_str(), character);
 }
 
-std::shared_ptr<Typeface> FontManagerWin::fallback(const WCHAR* dwFamilyName,
-                                                   DWriteStyle dwStyle,
-                                                   const WCHAR* dwBcp47,
-                                                   UINT32 character) const {
+std::shared_ptr<Typeface> FontManagerDWrite::fallback(
+    const WCHAR* dwFamilyName, DWriteStyle dwStyle, const WCHAR* dwBcp47,
+    UINT32 character, DWRITE_FONT_SIMULATIONS allowedSimulations) const {
   WCHAR utf16[16];
   size_t utf16_len =
       UTF::ConvertToUTF16(character, reinterpret_cast<uint16_t*>(utf16));
@@ -748,8 +619,9 @@ std::shared_ptr<Typeface> FontManagerWin::fallback(const WCHAR* dwFamilyName,
       factory_->CreateNumberSubstitution(DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE,
                                          dwBcp47, TRUE, &numberSubstitution),
       "Could not create number substitution.");
-  ScopedComPtr<FontFallbackSource> fontFallbackSource(new FontFallbackSource(
-      utf16, utf16_len, dwBcp47, numberSubstitution.get()));
+  ScopedComPtr<FontFallbackSourceDWrite> fontFallbackSource(
+      new FontFallbackSourceDWrite(utf16, utf16_len, dwBcp47,
+                                   numberSubstitution.get()));
 
   UINT32 mappedLength;
   ScopedComPtr<IDWriteFont> font;
@@ -770,16 +642,30 @@ std::shared_ptr<Typeface> FontManagerWin::fallback(const WCHAR* dwFamilyName,
 
     DWRITE_FONT_SIMULATIONS simulations = font->GetSimulations();
     noSimulations =
-        simulations == DWRITE_FONT_SIMULATIONS_NONE || HasBitmapStrikes(font);
+        HasOnlyAllowedSimulations(simulations, allowedSimulations) ||
+        HasBitmapStrikes(font) ||
+        (dwStyle.weight == DWRITE_FONT_WEIGHT_REGULAR &&
+         dwStyle.slant == DWRITE_FONT_STYLE_NORMAL);
 
-    if (simulations & DWRITE_FONT_SIMULATIONS_BOLD) {
-      dwStyle.weight = DWRITE_FONT_WEIGHT_REGULAR;
-      continue;
+    if (noSimulations) {
+      break;
     }
 
-    if (simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) {
+    bool relaxed = false;
+    if ((simulations & DWRITE_FONT_SIMULATIONS_BOLD) &&
+        dwStyle.weight != DWRITE_FONT_WEIGHT_REGULAR) {
+      dwStyle.weight = DWRITE_FONT_WEIGHT_REGULAR;
+      relaxed = true;
+    }
+
+    if ((simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) &&
+        dwStyle.slant != DWRITE_FONT_STYLE_NORMAL) {
       dwStyle.slant = DWRITE_FONT_STYLE_NORMAL;
-      continue;
+      relaxed = true;
+    }
+
+    if (!relaxed) {
+      break;
     }
   }
 
@@ -792,7 +678,7 @@ std::shared_ptr<Typeface> FontManagerWin::fallback(const WCHAR* dwFamilyName,
                                           fontFamily.get());
 }
 
-std::shared_ptr<Typeface> FontManagerWin::layoutFallback(
+std::shared_ptr<Typeface> FontManagerDWrite::layoutFallback(
     const WCHAR* dwFamilyName, DWriteStyle dwStyle, const WCHAR* dwBcp47,
     UINT32 character) const {
   WCHAR utf16[16];
@@ -817,8 +703,8 @@ std::shared_ptr<Typeface> FontManagerWin::layoutFallback(
                                     200.0f, 200.0f, &fallbackLayout),
          "Could not create text layout.");
 
-    ScopedComPtr<FontFallbackRenderer> fontFallbackRenderer(
-        new FontFallbackRenderer(this, character));
+    ScopedComPtr<FontFallbackRendererDWrite> fontFallbackRenderer(
+        new FontFallbackRendererDWrite(this, character));
     HRNM(fallbackLayout->SetFontCollection(
              font_collection_.get(), {0, static_cast<uint32_t>(utf16_len)}),
          "Could not set layout font collection.");
@@ -829,6 +715,10 @@ std::shared_ptr<Typeface> FontManagerWin::layoutFallback(
     noSimulations = !fontFallbackRenderer->FallbackTypefaceHasSimulations();
     if (noSimulations) {
       fallback_typeface = fontFallbackRenderer->ConsumeFallbackTypeface();
+    } else if (dwStyle.weight == DWRITE_FONT_WEIGHT_REGULAR &&
+               dwStyle.slant == DWRITE_FONT_STYLE_NORMAL) {
+      fallback_typeface = fontFallbackRenderer->ConsumeFallbackTypeface();
+      break;
     }
 
     if (dwStyle.weight != DWRITE_FONT_WEIGHT_REGULAR) {
@@ -844,81 +734,20 @@ std::shared_ptr<Typeface> FontManagerWin::layoutFallback(
   return fallback_typeface;
 }
 
-static std::wstring GetFontFilePath(IDWriteFontFile* fontFile) {
-  ScopedComPtr<IDWriteFontFileLoader> loader;
-  if (FAILED(fontFile->GetLoader(&loader))) {
-    return L"";
-  }
-
-  ScopedComPtr<IDWriteLocalFontFileLoader> localLoader;
-  HRESULT hr = loader->QueryInterface(IID_PPV_ARGS(&localLoader));
-  if (FAILED(hr)) {
-    LOGE("{}\n", "loader->QueryInterface failed.");
-    return L"";
-  }
-
-  const void* key = nullptr;
-  UINT32 keySize = 0;
-  fontFile->GetReferenceKey(&key, &keySize);
-
-  UINT32 pathLen = 0;
-  if (FAILED(localLoader->GetFilePathLengthFromKey(key, keySize, &pathLen))) {
-    return L"";
-  }
-
-  std::wstring path(pathLen, L'\0');
-  if (FAILED(localLoader->GetFilePathFromKey(key, keySize, &path[0],
-                                             pathLen + 1))) {
-    LOGE("{}\n", "localLoader->GetFilePathFromKey failed.");
-    return L"";
-  }
-
-  return path;
-}
-
-std::shared_ptr<Typeface> FontManagerWin::MakeTypefaceFromDWriteFont(
+std::shared_ptr<Typeface> FontManagerDWrite::MakeTypefaceFromDWriteFont(
     IDWriteFontFace* font_face, IDWriteFont* font,
     IDWriteFontFamily* font_family) const {
-  (void)font;
-  (void)font_family;
-
   auto cached_typeface = typeface_cache_.Find(font_face);
   if (cached_typeface) {
     return cached_typeface;
   }
 
-  std::vector<ScopedComPtr<IDWriteFontFile>> files;
-  if (!GetDWriteFontFiles(font_face, files)) {
-    LOGE("{}\n", "Could not get files from font face.");
-    return nullptr;
-  }
-
-  if (files.empty()) {
-    LOGE("{}\n", "Get 0 files from font face.");
-    return nullptr;
-  }
-
-  for (auto& file : files) {
-    std::wstring w_path = GetFontFilePath(file.get());
-    if (!w_path.empty()) {
-      std::string path;
-      HRNM(StrConversion::WideStringToString(w_path, &path),
-           "WideStringToString failed");
-      LOGE("Font file path: {}\n", path);
-      std::shared_ptr<Data> data = Data::MakeFromFileMapping(path.c_str());
-      UINT32 ttc_index = font_face->GetIndex();
-      auto typeface = TypefaceFreeType::Make(
-          data, FontArguments().SetCollectionIndex(ttc_index));
-      return typeface_cache_.AddOrGetExisting(font_face, std::move(typeface));
-    } else {
-      LOGE("Font file path not available (maybe custom loader)");
-    }
-  }
-
-  return nullptr;
+  auto typeface = MakeDWriteTypefaceFromDWriteFont(
+      factory_.get(), locale_name_, font_face, font, font_family);
+  return typeface_cache_.AddOrGetExisting(font_face, std::move(typeface));
 }
 
-static std::shared_ptr<FontManager> InitFontManagerWin() {
+std::shared_ptr<FontManager> InitFontManagerDWrite() {
   IDWriteFactory* factory = nullptr;
   IDWriteFontCollection* collection = nullptr;
   IDWriteFontFallback* fallback = nullptr;
@@ -971,17 +800,8 @@ static std::shared_ptr<FontManager> InitFontManagerWin() {
   }
   std::wstring locale_name{localeName, localeNameLen - 1};
 
-  return std::make_shared<FontManagerWin>(factory, collection, fallback,
-                                          std::move(locale_name));
-}
-
-std::shared_ptr<FontManager> FontManager::RefDefault() {
-  static const NoDestructor<std::shared_ptr<FontManager>> font_manager([] {
-    return Settings::GetSettings().EnableDWriteFontManager()
-               ? InitFontManagerDWrite()
-               : InitFontManagerWin();
-  }());
-  return *font_manager;
+  return std::make_shared<FontManagerDWrite>(factory, collection, fallback,
+                                             std::move(locale_name));
 }
 
 }  // namespace skity

--- a/src/text/ports/win/glyph_data_win_access.hpp
+++ b/src/text/ports/win/glyph_data_win_access.hpp
@@ -1,0 +1,46 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_TEXT_PORTS_WIN_GLYPH_DATA_WIN_ACCESS_HPP
+#define SRC_TEXT_PORTS_WIN_GLYPH_DATA_WIN_ACCESS_HPP
+
+#include <optional>
+#include <skity/geometry/rect.hpp>
+#include <skity/text/glyph.hpp>
+#include <utility>
+
+namespace skity {
+
+class GlyphDataWinAccess {
+ public:
+  static void SetMetrics(GlyphData* glyph, float advance_x, float advance_y,
+                         const Rect& bounds,
+                         std::optional<GlyphFormat> format) {
+    glyph->advance_x_ = advance_x;
+    glyph->advance_y_ = advance_y;
+    glyph->width_ = bounds.Width();
+    glyph->height_ = bounds.Height();
+    glyph->hori_bearing_x_ = bounds.Left();
+    glyph->hori_bearing_y_ = -bounds.Top();
+    glyph->y_min_ = bounds.Top();
+    glyph->y_max_ = bounds.Bottom();
+    glyph->format_ = format;
+  }
+
+  static void SetPath(GlyphData* glyph, Path path) {
+    glyph->path_ = std::move(path);
+  }
+
+  static void SetImage(GlyphData* glyph, GlyphBitmapData image) {
+    glyph->image_ = image;
+  }
+
+  static void SetFormat(GlyphData* glyph, std::optional<GlyphFormat> format) {
+    glyph->format_ = format;
+  }
+};
+
+}  // namespace skity
+
+#endif  // SRC_TEXT_PORTS_WIN_GLYPH_DATA_WIN_ACCESS_HPP

--- a/src/text/ports/win/scaler_context_win.cc
+++ b/src/text/ports/win/scaler_context_win.cc
@@ -1,0 +1,2593 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/text/ports/win/scaler_context_win.hpp"
+
+// clang-format off
+#include "src/text/ports/win/dwrite_version.hpp"
+#include "src/base/platform/win/handle_result.hpp"
+#include "src/text/ports/win/dwrite_utils.hpp"
+#include "src/text/ports/win/glyph_data_win_access.hpp"
+// clang-format on
+
+#include <d2d1.h>
+#include <dwrite.h>
+#include <dwrite_2.h>
+#include <dwrite_3.h>
+#include <png.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <skity/effect/shader.hpp>
+#include <skity/geometry/stroke.hpp>
+#include <skity/graphic/bitmap.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/graphic/sampling_options.hpp>
+#include <skity/render/canvas.hpp>
+#include <utility>
+#include <vector>
+
+#include "src/logging.hpp"
+#include "src/render/auto_canvas.hpp"
+
+namespace skity {
+namespace {
+
+static constexpr float kSkiaMaskGammaContrast = 128.f / 255.f;
+
+static float ComputeFakeBoldScale(float text_size) {
+  if (text_size <= 9.0f) {
+    return 1.0f / 24.0f;
+  }
+  if (text_size >= 36.0f) {
+    return 1.0f / 32.0f;
+  }
+
+  float ratio = (text_size - 9.0f) / 27.0f;
+  return (1.0f - ratio) / 24.0f + ratio / 32.0f;
+}
+
+/** Reverse all 4 bytes in a 32bit value.
+  e.g. 0x12345678 -> 0x78563412
+*/
+static constexpr uint32_t EndianSwap32(uint32_t value) {
+  return ((value & 0xFF) << 24) | ((value & 0xFF00) << 8) |
+         ((value & 0xFF0000) >> 8) | (value >> 24);
+}
+
+int16_t ReadBigEndianInt16(const uint8_t* data) {
+  return static_cast<int16_t>((static_cast<uint16_t>(data[0]) << 8) |
+                              static_cast<uint16_t>(data[1]));
+}
+
+float ScaleDWriteMetric(int32_t value, float text_size, float upem) {
+  return text_size * static_cast<float>(value) / upem;
+}
+
+uint8_t DWriteColorChannelToByte(float value) {
+  if (value <= 0.0f) {
+    return 0;
+  }
+  if (value >= 1.0f) {
+    return 255;
+  }
+  return static_cast<uint8_t>(std::round(value * 255.0f));
+}
+
+Color DWriteColorToColor(const DWRITE_COLOR_F& color) {
+  return ColorSetARGB(
+      DWriteColorChannelToByte(color.a), DWriteColorChannelToByte(color.r),
+      DWriteColorChannelToByte(color.g), DWriteColorChannelToByte(color.b));
+}
+
+#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+DWRITE_COLOR_F ColorToDWriteColor(Color color) {
+  DWRITE_COLOR_F dwrite_color;
+  dwrite_color.r = static_cast<float>(ColorGetR(color)) / 255.0f;
+  dwrite_color.g = static_cast<float>(ColorGetG(color)) / 255.0f;
+  dwrite_color.b = static_cast<float>(ColorGetB(color)) / 255.0f;
+  dwrite_color.a = static_cast<float>(ColorGetA(color)) / 255.0f;
+  return dwrite_color;
+}
+
+TileMode DWriteExtendModeToTileMode(D2D1_EXTEND_MODE mode) {
+  switch (mode) {
+    case D2D1_EXTEND_MODE_WRAP:
+      return TileMode::kRepeat;
+    case D2D1_EXTEND_MODE_MIRROR:
+      return TileMode::kMirror;
+    case D2D1_EXTEND_MODE_CLAMP:
+    default:
+      return TileMode::kClamp;
+  }
+}
+
+BlendMode DWriteCompositeModeToBlendMode(DWRITE_COLOR_COMPOSITE_MODE mode) {
+  switch (mode) {
+    case DWRITE_COLOR_COMPOSITE_CLEAR:
+      return BlendMode::kClear;
+    case DWRITE_COLOR_COMPOSITE_SRC:
+      return BlendMode::kSrc;
+    case DWRITE_COLOR_COMPOSITE_DEST:
+      return BlendMode::kDst;
+    case DWRITE_COLOR_COMPOSITE_SRC_OVER:
+      return BlendMode::kSrcOver;
+    case DWRITE_COLOR_COMPOSITE_DEST_OVER:
+      return BlendMode::kDstOver;
+    case DWRITE_COLOR_COMPOSITE_SRC_IN:
+      return BlendMode::kSrcIn;
+    case DWRITE_COLOR_COMPOSITE_DEST_IN:
+      return BlendMode::kDstIn;
+    case DWRITE_COLOR_COMPOSITE_SRC_OUT:
+      return BlendMode::kSrcOut;
+    case DWRITE_COLOR_COMPOSITE_DEST_OUT:
+      return BlendMode::kDstOut;
+    case DWRITE_COLOR_COMPOSITE_SRC_ATOP:
+      return BlendMode::kSrcATop;
+    case DWRITE_COLOR_COMPOSITE_DEST_ATOP:
+      return BlendMode::kDstATop;
+    case DWRITE_COLOR_COMPOSITE_XOR:
+      return BlendMode::kXor;
+    case DWRITE_COLOR_COMPOSITE_PLUS:
+      return BlendMode::kPlus;
+    case DWRITE_COLOR_COMPOSITE_SCREEN:
+      return BlendMode::kScreen;
+    case DWRITE_COLOR_COMPOSITE_OVERLAY:
+      return BlendMode::kOverlay;
+    case DWRITE_COLOR_COMPOSITE_DARKEN:
+      return BlendMode::kDarken;
+    case DWRITE_COLOR_COMPOSITE_LIGHTEN:
+      return BlendMode::kLighten;
+    case DWRITE_COLOR_COMPOSITE_COLOR_DODGE:
+      return BlendMode::kColorDodge;
+    case DWRITE_COLOR_COMPOSITE_COLOR_BURN:
+      return BlendMode::kColorBurn;
+    case DWRITE_COLOR_COMPOSITE_HARD_LIGHT:
+      return BlendMode::kHardLight;
+    case DWRITE_COLOR_COMPOSITE_SOFT_LIGHT:
+      return BlendMode::kSoftLight;
+    case DWRITE_COLOR_COMPOSITE_DIFFERENCE:
+      return BlendMode::kDifference;
+    case DWRITE_COLOR_COMPOSITE_EXCLUSION:
+      return BlendMode::kExclusion;
+    case DWRITE_COLOR_COMPOSITE_MULTIPLY:
+      return BlendMode::kMultiply;
+    case DWRITE_COLOR_COMPOSITE_HSL_HUE:
+      return BlendMode::kHue;
+    case DWRITE_COLOR_COMPOSITE_HSL_SATURATION:
+      return BlendMode::kSaturation;
+    case DWRITE_COLOR_COMPOSITE_HSL_COLOR:
+      return BlendMode::kColor;
+    case DWRITE_COLOR_COMPOSITE_HSL_LUMINOSITY:
+      return BlendMode::kLuminosity;
+    default:
+      return BlendMode::kDst;
+  }
+}
+
+float Vec2Cross(const Vec2& lhs, const Vec2& rhs) {
+  return lhs.x * rhs.y - lhs.y * rhs.x;
+}
+
+Vec2 Vec2Projection(const Vec2& lhs, const Vec2& rhs) {
+  float length = std::sqrt(rhs.x * rhs.x + rhs.y * rhs.y);
+  if (length == 0.0f) {
+    return Vec2{};
+  }
+
+  Vec2 normalized = {rhs.x / length, rhs.y / length};
+  float scale = (lhs.x * rhs.x + lhs.y * rhs.y) / length;
+  return {normalized.x * scale, normalized.y * scale};
+}
+
+bool Color4fHasAlpha(const Color4f& color) { return color.a > 0.0f; }
+#endif
+
+bool DWriteRectIsEmpty(const D2D_RECT_F& rect) {
+  return rect.left >= rect.right || rect.top >= rect.bottom;
+}
+
+Rect DWriteRectToRect(const D2D_RECT_F& rect) {
+  return Rect::MakeLTRB(rect.left, rect.top, rect.right, rect.bottom);
+}
+
+Matrix DWriteMatrixToMatrix(const DWRITE_MATRIX& matrix) {
+  return Matrix{matrix.m11, matrix.m21, matrix.dx,  //
+                matrix.m12, matrix.m22, matrix.dy,  //
+                0.0f,       0.0f,       1.0f};
+}
+
+class DWritePathSink final : public IDWriteGeometrySink {
+ public:
+  explicit DWritePathSink(Path* path) : path_(path) {}
+
+  SK_STDMETHODIMP QueryInterface(REFIID riid, void** object) override {
+    if (!object) {
+      return E_POINTER;
+    }
+
+    if (riid == __uuidof(IUnknown) || riid == __uuidof(IDWriteGeometrySink)) {
+      *object = static_cast<IDWriteGeometrySink*>(this);
+      AddRef();
+      return S_OK;
+    }
+
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  SK_STDMETHODIMP_(ULONG) AddRef() override {
+    return static_cast<ULONG>(InterlockedIncrement(&ref_count_));
+  }
+
+  SK_STDMETHODIMP_(ULONG) Release() override {
+    ULONG result = static_cast<ULONG>(InterlockedDecrement(&ref_count_));
+    if (result == 0) {
+      delete this;
+    }
+    return result;
+  }
+
+  SK_STDMETHODIMP_(void) SetFillMode(D2D1_FILL_MODE fill_mode) override {
+    switch (fill_mode) {
+      case D2D1_FILL_MODE_ALTERNATE:
+        path_->SetFillType(Path::PathFillType::kEvenOdd);
+        break;
+      case D2D1_FILL_MODE_WINDING:
+        path_->SetFillType(Path::PathFillType::kWinding);
+        break;
+      default:
+        break;
+    }
+  }
+
+  SK_STDMETHODIMP_(void)
+  SetSegmentFlags(D2D1_PATH_SEGMENT segment_flags) override {}
+
+  SK_STDMETHODIMP_(void)
+  BeginFigure(D2D1_POINT_2F start_point,
+              D2D1_FIGURE_BEGIN figure_begin) override {
+    started_ = false;
+    current_ = start_point;
+  }
+
+  SK_STDMETHODIMP_(void)
+  AddLines(const D2D1_POINT_2F* points, UINT points_count) override {
+    for (UINT i = 0; i < points_count; i++) {
+      if (!CurrentIsNot(points[i])) {
+        continue;
+      }
+      GoingTo(points[i]);
+      path_->LineTo(points[i].x, points[i].y);
+    }
+  }
+
+  SK_STDMETHODIMP_(void)
+  AddBeziers(const D2D1_BEZIER_SEGMENT* beziers, UINT beziers_count) override {
+    for (UINT i = 0; i < beziers_count; i++) {
+      const D2D1_BEZIER_SEGMENT& bezier = beziers[i];
+      if (!CurrentIsNot(bezier.point1) && !CurrentIsNot(bezier.point2) &&
+          !CurrentIsNot(bezier.point3)) {
+        continue;
+      }
+
+      D2D1_POINT_2F start_point = current_;
+      D2D1_POINT_2F quadratic_control;
+      const bool is_quadratic =
+          CheckQuadratic(start_point, bezier, &quadratic_control);
+
+      GoingTo(bezier.point3);
+      if (is_quadratic) {
+        path_->QuadTo(quadratic_control.x, quadratic_control.y, bezier.point3.x,
+                      bezier.point3.y);
+      } else {
+        path_->CubicTo(bezier.point1.x, bezier.point1.y, bezier.point2.x,
+                       bezier.point2.y, bezier.point3.x, bezier.point3.y);
+      }
+    }
+  }
+
+  SK_STDMETHODIMP_(void) EndFigure(D2D1_FIGURE_END figure_end) override {
+    if (started_) {
+      path_->Close();
+    }
+  }
+
+  SK_STDMETHODIMP Close() override { return S_OK; }
+
+ private:
+  void GoingTo(D2D1_POINT_2F point) {
+    if (!started_) {
+      started_ = true;
+      path_->MoveTo(current_.x, current_.y);
+    }
+    current_ = point;
+  }
+
+  bool CurrentIsNot(D2D1_POINT_2F point) const {
+    return current_.x != point.x || current_.y != point.y;
+  }
+
+  static bool ApproximatelyEqual(float lhs, float rhs) {
+    if (lhs == rhs) {
+      return true;
+    }
+    const float tolerance =
+        std::max(1.0f, std::max(std::fabs(lhs), std::fabs(rhs))) * 1e-5f;
+    return std::fabs(lhs - rhs) <= tolerance;
+  }
+
+  static bool CheckQuadratic(D2D1_POINT_2F start_point,
+                             const D2D1_BEZIER_SEGMENT& bezier,
+                             D2D1_POINT_2F* quadratic_control) {
+    float dx10 = bezier.point1.x - start_point.x;
+    float dx23 = bezier.point2.x - bezier.point3.x;
+    float mid_x = start_point.x + dx10 * 1.5f;
+    if (!ApproximatelyEqual(mid_x, dx23 * 1.5f + bezier.point3.x)) {
+      return false;
+    }
+
+    float dy10 = bezier.point1.y - start_point.y;
+    float dy23 = bezier.point2.y - bezier.point3.y;
+    float mid_y = start_point.y + dy10 * 1.5f;
+    if (!ApproximatelyEqual(mid_y, dy23 * 1.5f + bezier.point3.y)) {
+      return false;
+    }
+
+    quadratic_control->x = mid_x;
+    quadratic_control->y = mid_y;
+    return true;
+  }
+
+  LONG ref_count_ = 1;
+  Path* path_ = nullptr;
+  bool started_ = false;
+  D2D1_POINT_2F current_ = {0.0f, 0.0f};
+};
+
+static uint8_t Expand3BitLuminance(uint8_t value) {
+  value <<= 5;
+  return value | (value >> 3) | (value >> 6);
+}
+
+static uint8_t SkiaCanonicalColorChannel(uint8_t value) {
+  return Expand3BitLuminance(static_cast<uint8_t>(value >> 5));
+}
+
+static uint8_t SkiaA8LuminanceTableIndex(Color foreground_color) {
+  uint8_t r = SkiaCanonicalColorChannel(ColorGetR(foreground_color));
+  uint8_t g = SkiaCanonicalColorChannel(ColorGetG(foreground_color));
+  uint8_t b = SkiaCanonicalColorChannel(ColorGetB(foreground_color));
+  uint8_t luminance = static_cast<uint8_t>((r * 54 + g * 183 + b * 19) >> 8);
+  return static_cast<uint8_t>(luminance >> 5);
+}
+
+static uint8_t FloatToByte(float value) {
+  return static_cast<uint8_t>(
+      std::clamp(static_cast<int>(std::lround(value)), 0, 255));
+}
+
+static float SrgbToLinear(float luminance) {
+  if (luminance <= 0.04045f) {
+    return luminance / 12.92f;
+  }
+  return std::pow((luminance + 0.055f) / 1.055f, 2.4f);
+}
+
+static float LinearToSrgb(float luma) {
+  if (luma <= 0.0031308f) {
+    return luma * 12.92f;
+  }
+  return 1.055f * std::pow(luma, 1.f / 2.4f) - 0.055f;
+}
+
+static uint8_t PremultiplyByte(uint8_t value, uint8_t alpha) {
+  return static_cast<uint8_t>((static_cast<uint16_t>(value) * alpha + 127) /
+                              255);
+}
+
+static void PremultiplyBGRA(uint8_t* pixels, size_t pixel_count) {
+  if (!pixels) {
+    return;
+  }
+
+  for (size_t i = 0; i < pixel_count; i++) {
+    uint8_t* pixel = pixels + i * 4;
+    uint8_t alpha = pixel[3];
+    if (alpha == 255) {
+      continue;
+    }
+    if (alpha == 0) {
+      pixel[0] = 0;
+      pixel[1] = 0;
+      pixel[2] = 0;
+      continue;
+    }
+    pixel[0] = PremultiplyByte(pixel[0], alpha);
+    pixel[1] = PremultiplyByte(pixel[1], alpha);
+    pixel[2] = PremultiplyByte(pixel[2], alpha);
+  }
+}
+
+static bool CheckedImageByteSize(uint32_t width, uint32_t height,
+                                 size_t* byte_size) {
+  if (!byte_size || width == 0 || height == 0) {
+    return false;
+  }
+
+  constexpr size_t kBytesPerPixel = 4;
+  size_t w = static_cast<size_t>(width);
+  size_t h = static_cast<size_t>(height);
+  if (w > std::numeric_limits<size_t>::max() / h ||
+      w * h > std::numeric_limits<size_t>::max() / kBytesPerPixel) {
+    return false;
+  }
+
+  *byte_size = w * h * kBytesPerPixel;
+  return true;
+}
+
+static bool ScaleBGRANearest(const uint8_t* src, uint32_t src_width,
+                             uint32_t src_height, uint8_t* dst,
+                             uint32_t dst_width, uint32_t dst_height) {
+  if (!src || !dst || src_width == 0 || src_height == 0 || dst_width == 0 ||
+      dst_height == 0) {
+    return false;
+  }
+
+  for (uint32_t y = 0; y < dst_height; y++) {
+    uint32_t src_y =
+        std::min((static_cast<uint64_t>(y) * src_height) / dst_height,
+                 static_cast<uint64_t>(src_height - 1));
+    for (uint32_t x = 0; x < dst_width; x++) {
+      uint32_t src_x =
+          std::min((static_cast<uint64_t>(x) * src_width) / dst_width,
+                   static_cast<uint64_t>(src_width - 1));
+      std::memcpy(dst + (static_cast<size_t>(y) * dst_width + x) * 4,
+                  src + (static_cast<size_t>(src_y) * src_width + src_x) * 4,
+                  4);
+    }
+  }
+
+  return true;
+}
+
+static bool DecodePngGlyphImageToBGRA(const void* data, size_t size,
+                                      uint32_t target_width,
+                                      uint32_t target_height,
+                                      GlyphBitmapData* image) {
+  if (!data || size == 0 || !image) {
+    return false;
+  }
+
+  png_image png_image_info = {};
+  png_image_info.version = PNG_IMAGE_VERSION;
+  if (!png_image_begin_read_from_memory(&png_image_info, data, size)) {
+    return false;
+  }
+
+  png_image_info.format = PNG_FORMAT_BGRA;
+  const uint32_t src_width = png_image_info.width;
+  const uint32_t src_height = png_image_info.height;
+  if (src_width == 0 || src_height == 0) {
+    png_image_free(&png_image_info);
+    return false;
+  }
+  if (target_width == 0) {
+    target_width = src_width;
+  }
+  if (target_height == 0) {
+    target_height = src_height;
+  }
+
+  size_t src_byte_size = PNG_IMAGE_SIZE(png_image_info);
+  if (src_byte_size == 0) {
+    png_image_free(&png_image_info);
+    return false;
+  }
+  auto* src_pixels = static_cast<uint8_t*>(std::malloc(src_byte_size));
+  if (!src_pixels) {
+    png_image_free(&png_image_info);
+    return false;
+  }
+
+  bool ok = png_image_finish_read(&png_image_info, nullptr, src_pixels, 0,
+                                  nullptr) != 0;
+  png_image_free(&png_image_info);
+  if (!ok) {
+    std::free(src_pixels);
+    return false;
+  }
+
+  PremultiplyBGRA(src_pixels, static_cast<size_t>(src_width) *
+                                  static_cast<size_t>(src_height));
+
+  if (src_width == target_width && src_height == target_height) {
+    image->buffer = src_pixels;
+    image->width = static_cast<float>(src_width);
+    image->height = static_cast<float>(src_height);
+    image->format = BitmapFormat::kBGRA8;
+    image->need_free = true;
+    return true;
+  }
+
+  size_t dst_byte_size = 0;
+  if (!CheckedImageByteSize(target_width, target_height, &dst_byte_size)) {
+    std::free(src_pixels);
+    return false;
+  }
+
+  auto* dst_pixels = static_cast<uint8_t*>(std::malloc(dst_byte_size));
+  if (!dst_pixels) {
+    std::free(src_pixels);
+    return false;
+  }
+
+  ok = ScaleBGRANearest(src_pixels, src_width, src_height, dst_pixels,
+                        target_width, target_height);
+  std::free(src_pixels);
+  if (!ok) {
+    std::free(dst_pixels);
+    return false;
+  }
+
+  image->buffer = dst_pixels;
+  image->width = static_cast<float>(target_width);
+  image->height = static_cast<float>(target_height);
+  image->format = BitmapFormat::kBGRA8;
+  image->need_free = true;
+  return true;
+}
+
+static std::array<std::array<uint8_t, 256>, 8> BuildSkiaMaskGammaTables() {
+  std::array<std::array<uint8_t, 256>, 8> tables{};
+
+  for (size_t table_index = 0; table_index < tables.size(); table_index++) {
+    float src = Expand3BitLuminance(static_cast<uint8_t>(table_index)) / 255.f;
+    float lin_src = SrgbToLinear(src);
+    float dst = 1.f - src;
+    float lin_dst = SrgbToLinear(dst);
+    float adjusted_contrast = kSkiaMaskGammaContrast * lin_dst;
+
+    for (size_t alpha = 0; alpha < tables[table_index].size(); alpha++) {
+      float raw_src_alpha = static_cast<float>(alpha) / 255.f;
+      float src_alpha = raw_src_alpha + ((1.f - raw_src_alpha) *
+                                         adjusted_contrast * raw_src_alpha);
+      if (std::fabs(src - dst) < (1.f / 256.f)) {
+        tables[table_index][alpha] = FloatToByte(src_alpha * 255.f);
+        continue;
+      }
+
+      float dst_alpha = 1.f - src_alpha;
+      float lin_out = lin_src * src_alpha + dst_alpha * lin_dst;
+      float out = LinearToSrgb(lin_out);
+      float result = (out - dst) / (src - dst);
+      tables[table_index][alpha] = FloatToByte(result * 255.f);
+    }
+  }
+
+  return tables;
+}
+
+static uint8_t ApplySkiaMaskGammaToAlpha(uint8_t alpha,
+                                         Color foreground_color) {
+  static const auto tables = BuildSkiaMaskGammaTables();
+  uint8_t table_index = SkiaA8LuminanceTableIndex(foreground_color);
+  return tables[table_index][alpha];
+}
+
+float SkiaRelaxMatrixScalar(float value) {
+  static constexpr float kScale = 1024.f;
+  return std::round(value * kScale) / kScale;
+}
+
+Matrix22 SkiaRelaxMatrix(const Matrix22& matrix) {
+  return Matrix22{SkiaRelaxMatrixScalar(matrix.GetScaleX()),
+                  SkiaRelaxMatrixScalar(matrix.GetSkewX()),
+                  SkiaRelaxMatrixScalar(matrix.GetSkewY()),
+                  SkiaRelaxMatrixScalar(matrix.GetScaleY())};
+}
+
+class ScalerContextDWrite : public ScalerContext {
+ public:
+  ScalerContextDWrite(std::shared_ptr<Typeface> typeface,
+                      IDWriteFactory* factory, IDWriteFontFace* font_face,
+                      const ScalerContextDesc* desc)
+      : ScalerContext(std::move(typeface), desc),
+        factory_(RefComPtr(factory)),
+        font_face_(RefComPtr(font_face)) {}
+
+ protected:
+  void GenerateMetrics(GlyphData* glyph) override {
+    if (!glyph) {
+      return;
+    }
+
+    if (GenerateDWriteMetrics(glyph)) {
+      return;
+    }
+
+    glyph->ZeroMetrics();
+    GlyphDataWinAccess::SetFormat(glyph, GlyphFormat::A8);
+  }
+
+  void GenerateImage(GlyphData* glyph, const StrokeDesc& stroke_desc) override {
+    if (CanGenerateDWriteColorImage(glyph, stroke_desc) &&
+        GenerateDWriteColorImage(glyph)) {
+      return;
+    }
+
+    if (CanGenerateDWriteGrayImage(glyph, stroke_desc) &&
+        GenerateDWriteImage(glyph)) {
+      return;
+    }
+
+    (void)GenerateDWritePathImageInfo(glyph, stroke_desc, true);
+  }
+
+  void GenerateImageInfo(GlyphData* glyph,
+                         const StrokeDesc& stroke_desc) override {
+    if (CanGenerateDWriteColorImage(glyph, stroke_desc) &&
+        GenerateDWriteColorImageInfo(glyph)) {
+      return;
+    }
+
+    if (CanGenerateDWriteGrayImage(glyph, stroke_desc) &&
+        GenerateDWriteImageInfo(glyph)) {
+      return;
+    }
+
+    (void)GenerateDWritePathImageInfo(glyph, stroke_desc, false);
+  }
+
+  bool GeneratePath(GlyphData* glyph) override {
+    if (!glyph) {
+      return false;
+    }
+
+    if (font_face_->GetGlyphCount() <= glyph->Id()) {
+      GlyphDataWinAccess::SetPath(glyph, Path{});
+      return false;
+    }
+
+    if (GenerateDWritePath(glyph)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  void GenerateFontMetrics(FontMetrics* metrics) override {
+    if (!metrics) {
+      return;
+    }
+
+    std::memset(metrics, 0, sizeof(*metrics));
+
+    DWRITE_FONT_METRICS dw_metrics;
+    font_face_->GetMetrics(&dw_metrics);
+    if (dw_metrics.designUnitsPerEm == 0) {
+      return;
+    }
+
+    float scale_x = 1.0f;
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    desc_.DecomposeMatrix(PortScaleType::kVertical, &scale_x, &text_size,
+                          &transform);
+
+    float upem = static_cast<float>(dw_metrics.designUnitsPerEm);
+    metrics->ascent_ = -ScaleDWriteMetric(dw_metrics.ascent, text_size, upem);
+    metrics->descent_ = ScaleDWriteMetric(dw_metrics.descent, text_size, upem);
+    metrics->leading_ = ScaleDWriteMetric(dw_metrics.lineGap, text_size, upem);
+    metrics->x_height_ = ScaleDWriteMetric(dw_metrics.xHeight, text_size, upem);
+    metrics->cap_height_ =
+        ScaleDWriteMetric(dw_metrics.capHeight, text_size, upem);
+    metrics->underline_thickness_ =
+        ScaleDWriteMetric(dw_metrics.underlineThickness, text_size, upem);
+    metrics->underline_position_ =
+        -ScaleDWriteMetric(dw_metrics.underlinePosition, text_size, upem);
+    metrics->strikeout_thickness_ =
+        ScaleDWriteMetric(dw_metrics.strikethroughThickness, text_size, upem);
+    metrics->strikeout_position_ =
+        -ScaleDWriteMetric(dw_metrics.strikethroughPosition, text_size, upem);
+
+    ScopedComPtr<IDWriteFontFace1> font_face1;
+    if (SUCCEEDED(font_face_->QueryInterface(&font_face1))) {
+      DWRITE_FONT_METRICS1 dw_metrics1;
+      font_face1->GetMetrics(&dw_metrics1);
+      metrics->top_ =
+          -ScaleDWriteMetric(dw_metrics1.glyphBoxTop, text_size, upem);
+      metrics->bottom_ =
+          -ScaleDWriteMetric(dw_metrics1.glyphBoxBottom, text_size, upem);
+      metrics->x_min_ =
+          ScaleDWriteMetric(dw_metrics1.glyphBoxLeft, text_size, upem);
+      metrics->x_max_ =
+          ScaleDWriteMetric(dw_metrics1.glyphBoxRight, text_size, upem);
+      metrics->max_char_width_ = metrics->x_max_ - metrics->x_min_;
+      return;
+    }
+
+    static constexpr FontTableTag kHeadTag = SetFourByteTag('h', 'e', 'a', 'd');
+    static constexpr size_t kHeadXMinOffset = 36;
+    static constexpr size_t kHeadYMinOffset = 38;
+    static constexpr size_t kHeadXMaxOffset = 40;
+    static constexpr size_t kHeadYMaxOffset = 42;
+    static constexpr size_t kRequiredHeadSize = kHeadYMaxOffset + 2;
+    AutoDWriteTable head_table(font_face_.get(), EndianSwap32(kHeadTag));
+    if (head_table.exists && head_table.size >= kRequiredHeadSize) {
+      int16_t x_min = ReadBigEndianInt16(head_table.data + kHeadXMinOffset);
+      int16_t y_min = ReadBigEndianInt16(head_table.data + kHeadYMinOffset);
+      int16_t x_max = ReadBigEndianInt16(head_table.data + kHeadXMaxOffset);
+      int16_t y_max = ReadBigEndianInt16(head_table.data + kHeadYMaxOffset);
+      metrics->top_ = -ScaleDWriteMetric(y_max, text_size, upem);
+      metrics->bottom_ = -ScaleDWriteMetric(y_min, text_size, upem);
+      metrics->x_min_ = ScaleDWriteMetric(x_min, text_size, upem);
+      metrics->x_max_ = ScaleDWriteMetric(x_max, text_size, upem);
+      metrics->max_char_width_ = metrics->x_max_ - metrics->x_min_;
+      return;
+    }
+
+    metrics->top_ = metrics->ascent_;
+    metrics->bottom_ = metrics->descent_;
+  }
+
+  uint16_t OnGetFixedSize() override { return 0; }
+
+ private:
+  bool CanGenerateDWriteColorImage(const GlyphData* glyph,
+                                   const StrokeDesc& stroke_desc) {
+    if (!glyph || stroke_desc.is_stroke) {
+      return false;
+    }
+
+    auto format = glyph->GetFormat();
+    if (desc_.fake_bold) {
+      return format && *format == GlyphFormat::BGRA32;
+    }
+    return !format || *format == GlyphFormat::BGRA32;
+  }
+
+  bool CanGenerateDWriteGrayImage(const GlyphData* glyph,
+                                  const StrokeDesc& stroke_desc) {
+    if (!glyph || stroke_desc.is_stroke || desc_.fake_bold) {
+      return false;
+    }
+
+    auto format = glyph->GetFormat();
+    return !format || *format == GlyphFormat::A8;
+  }
+
+  void ApplyImageBoundsMetadata(GlyphBitmapData* image, const Rect& bounds) {
+    if (!image || bounds.IsEmpty()) {
+      return;
+    }
+
+    image->origin_x = bounds.Left();
+    image->origin_y = bounds.Top();
+    image->origin_x_for_raster = image->origin_x;
+    image->origin_y_for_raster = image->origin_y;
+    image->width = bounds.Width();
+    image->height = bounds.Height();
+  }
+
+  void ApplyDWritePathImageBoundsMetadata(GlyphBitmapData* image,
+                                          const Rect& bounds) {
+    if (!image || bounds.IsEmpty()) {
+      return;
+    }
+
+    image->origin_x = bounds.Left() / desc_.context_scale;
+    image->origin_y = -bounds.Top() / desc_.context_scale;
+    image->origin_x_for_raster = image->origin_x;
+    image->origin_y_for_raster = bounds.Top() / desc_.context_scale;
+    image->width = bounds.Width();
+    image->height = bounds.Height();
+  }
+
+  void RepackGrayImageToBounds(GlyphBitmapData* image, const Rect& bounds) {
+    if (!image || image->format != BitmapFormat::kGray8 ||
+        image->buffer == nullptr || bounds.IsEmpty()) {
+      return;
+    }
+
+    const int old_width = static_cast<int>(image->width);
+    const int old_height = static_cast<int>(image->height);
+    const int new_width = static_cast<int>(bounds.Width());
+    const int new_height = static_cast<int>(bounds.Height());
+    if (old_width <= 0 || old_height <= 0 || new_width <= 0 ||
+        new_height <= 0) {
+      return;
+    }
+
+    const size_t new_byte_size =
+        static_cast<size_t>(new_width) * static_cast<size_t>(new_height);
+    auto* buffer = static_cast<uint8_t*>(std::calloc(new_byte_size, 1));
+    if (!buffer) {
+      return;
+    }
+
+    const int old_left = static_cast<int>(std::lround(image->origin_x));
+    const int old_top = static_cast<int>(std::lround(image->origin_y));
+    const int new_left = static_cast<int>(std::lround(bounds.Left()));
+    const int new_top = static_cast<int>(std::lround(bounds.Top()));
+
+    for (int y = 0; y < old_height; y++) {
+      const int target_y = old_top + y - new_top;
+      if (target_y < 0 || target_y >= new_height) {
+        continue;
+      }
+      for (int x = 0; x < old_width; x++) {
+        const int target_x = old_left + x - new_left;
+        if (target_x < 0 || target_x >= new_width) {
+          continue;
+        }
+        buffer[target_y * new_width + target_x] =
+            image->buffer[y * old_width + x];
+      }
+    }
+
+    if (image->need_free) {
+      std::free(image->buffer);
+    }
+    image->buffer = buffer;
+    image->need_free = true;
+    ApplyImageBoundsMetadata(image, bounds);
+  }
+
+  size_t BytesPerPixel(BitmapFormat format) const {
+    switch (format) {
+      case BitmapFormat::kGray8:
+        return 1;
+      case BitmapFormat::kBGRA8:
+      case BitmapFormat::kRGBA8:
+        return 4;
+      case BitmapFormat::kUnknown:
+        return 0;
+    }
+    return 0;
+  }
+
+  bool AllocateImageBuffer(GlyphBitmapData* image) const {
+    if (!image || image->buffer != nullptr) {
+      return image && image->buffer != nullptr;
+    }
+
+    const size_t bytes_per_pixel = BytesPerPixel(image->format);
+    const size_t width =
+        image->width > 0.0f ? static_cast<size_t>(image->width) : 0;
+    const size_t height =
+        image->height > 0.0f ? static_cast<size_t>(image->height) : 0;
+    if (bytes_per_pixel == 0 || width == 0 || height == 0) {
+      return false;
+    }
+
+    if (width > std::numeric_limits<size_t>::max() / height ||
+        width * height > std::numeric_limits<size_t>::max() / bytes_per_pixel) {
+      return false;
+    }
+
+    const size_t byte_size = width * height * bytes_per_pixel;
+    auto* buffer = static_cast<uint8_t*>(std::calloc(byte_size, 1));
+    if (!buffer) {
+      return false;
+    }
+
+    image->buffer = buffer;
+    image->need_free = true;
+    return true;
+  }
+
+  bool GenerateDWriteStrokePath(const Path& path, const StrokeDesc& stroke_desc,
+                                float stroke_width, Path* stroke_path) {
+    if (!stroke_path || path.IsEmpty()) {
+      return false;
+    }
+
+    Paint paint;
+    paint.SetStyle(Paint::kStroke_Style);
+    paint.SetStrokeWidth(stroke_width);
+    paint.SetStrokeCap(stroke_desc.cap);
+    paint.SetStrokeJoin(stroke_desc.join);
+    paint.SetStrokeMiter(stroke_desc.miter_limit);
+
+    Path quad_path;
+    Stroke stroke(paint);
+    stroke.QuadPath(path, &quad_path);
+    stroke.StrokePath(quad_path, stroke_path);
+    return !stroke_path->IsEmpty();
+  }
+
+  bool RasterDWritePathImage(GlyphBitmapData* image, const Rect& bounds,
+                             const Path* fill_path, const Path* stroke_path) {
+    if (!image || bounds.IsEmpty()) {
+      return false;
+    }
+
+    const uint32_t width = static_cast<uint32_t>(image->width);
+    const uint32_t height = static_cast<uint32_t>(image->height);
+    const size_t byte_size = static_cast<size_t>(width) * height;
+    if (width == 0 || height == 0 || byte_size == 0) {
+      return false;
+    }
+
+    Bitmap bitmap(width, height, AlphaType::kPremul_AlphaType, ColorType::kA8);
+    auto canvas = Canvas::MakeSoftwareCanvas(&bitmap);
+    if (!canvas || !bitmap.GetPixelAddr()) {
+      return false;
+    }
+
+    Paint paint;
+    paint.SetAntiAlias(true);
+    paint.SetStyle(Paint::kFill_Style);
+    paint.SetFillColor(Color_WHITE);
+
+    canvas->Translate(-bounds.Left(), -bounds.Top());
+    if (fill_path && !fill_path->IsEmpty()) {
+      canvas->DrawPath(*fill_path, paint);
+    }
+    if (stroke_path && !stroke_path->IsEmpty()) {
+      canvas->DrawPath(*stroke_path, paint);
+    }
+
+    uint8_t* buffer = reinterpret_cast<uint8_t*>(std::malloc(byte_size));
+    if (!buffer) {
+      return false;
+    }
+
+    if (bitmap.RowBytes() == width) {
+      std::memcpy(buffer, bitmap.GetPixelAddr(), byte_size);
+    } else {
+      for (uint32_t y = 0; y < height; y++) {
+        std::memcpy(
+            buffer + static_cast<size_t>(y) * width,
+            bitmap.GetPixelAddr() + static_cast<size_t>(y) * bitmap.RowBytes(),
+            width);
+      }
+    }
+
+    image->buffer = buffer;
+    image->need_free = true;
+    return true;
+  }
+
+  bool GenerateDWritePathImageInfo(GlyphData* glyph,
+                                   const StrokeDesc& stroke_desc,
+                                   bool allocate_buffer) {
+    if (!glyph || (!stroke_desc.is_stroke && !desc_.fake_bold)) {
+      return false;
+    }
+
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    Rect bounds;
+    Path fill_path;
+    Path stroke_path;
+    if (desc_.fake_bold) {
+      if (!GenerateDWriteOutlinePath(glyph->Id(), text_size, transform,
+                                     &fill_path) ||
+          fill_path.IsEmpty()) {
+        return false;
+      }
+
+      StrokeDesc fake_bold_stroke = stroke_desc;
+      float stroke_width = text_size * ComputeFakeBoldScale(text_size);
+      if (stroke_desc.is_stroke) {
+        float stroke_scale =
+            desc_.text_size > 0.0f ? text_size / desc_.text_size : 1.0f;
+        stroke_width = stroke_desc.stroke_width * stroke_scale;
+      } else {
+        fake_bold_stroke.cap = Paint::Cap::kDefault_Cap;
+        fake_bold_stroke.join = Paint::Join::kDefault_Join;
+        fake_bold_stroke.miter_limit = Paint::kDefaultMiterLimit;
+      }
+      if (!GenerateDWriteStrokePath(fill_path, fake_bold_stroke, stroke_width,
+                                    &stroke_path)) {
+        return false;
+      }
+
+      bounds = stroke_path.GetBounds();
+      if (!stroke_desc.is_stroke) {
+        bounds.Join(fill_path.GetBounds());
+      }
+      bounds.SetLTRB(std::floor(bounds.Left()), std::floor(bounds.Top()),
+                     std::ceil(bounds.Right()), std::ceil(bounds.Bottom()));
+      bounds.SetBottom(bounds.Bottom() + 1.0f);
+    } else {
+      if (!GenerateDWriteOutlinePath(glyph->Id(), text_size, transform,
+                                     &fill_path) ||
+          fill_path.IsEmpty()) {
+        return false;
+      }
+
+      float stroke_scale =
+          desc_.text_size > 0.0f ? text_size / desc_.text_size : 1.0f;
+      if (!GenerateDWriteStrokePath(fill_path, stroke_desc,
+                                    stroke_desc.stroke_width * stroke_scale,
+                                    &stroke_path)) {
+        return false;
+      }
+
+      bounds = stroke_path.GetBounds();
+      bounds.SetLTRB(std::floor(bounds.Left()), std::floor(bounds.Top()),
+                     std::ceil(bounds.Right()), std::ceil(bounds.Bottom()));
+    }
+
+    GlyphBitmapData image;
+    image.format = BitmapFormat::kGray8;
+    ApplyDWritePathImageBoundsMetadata(&image, bounds);
+    const Path* raster_fill_path =
+        desc_.fake_bold && !stroke_desc.is_stroke ? &fill_path : nullptr;
+    if (allocate_buffer &&
+        !RasterDWritePathImage(&image, bounds, raster_fill_path,
+                               &stroke_path)) {
+      return false;
+    }
+    GlyphDataWinAccess::SetImage(glyph, image);
+    return true;
+  }
+
+  DWRITE_MATRIX ToDWriteMatrix(const Matrix22& transform) {
+    DWRITE_MATRIX matrix;
+    matrix.m11 = transform.GetScaleX();
+    matrix.m12 = transform.GetSkewY();
+    matrix.m21 = transform.GetSkewX();
+    matrix.m22 = transform.GetScaleY();
+    matrix.dx = 0.0f;
+    matrix.dy = 0.0f;
+    return matrix;
+  }
+
+  void DecomposeDWriteImageMatrix(float* scale_x, float* scale_y,
+                                  Matrix22* transform) {
+    Matrix22 total =
+        SkiaRelaxMatrix(desc_.GetTransformMatrix()) * desc_.GetLocalMatrix();
+
+    bool only_scale =
+        FloatNearlyZero(total.GetSkewX()) && FloatNearlyZero(total.GetSkewY());
+    if (only_scale) {
+      if (FloatNearlyZero(total.GetScaleX()) ||
+          FloatNearlyZero(total.GetScaleY())) {
+        *scale_x = 1.f;
+        *scale_y = 1.f;
+        *transform = Matrix22{0.f, 0.f, 0.f, 0.f};
+        return;
+      }
+      if (!FloatNearlyZero(total.GetScaleX() - total.GetScaleY())) {
+        *scale_y = std::fabs(total.GetScaleY());
+        *scale_x = *scale_y;
+        *transform = Matrix22{total.GetScaleX() / *scale_x, 0.f, 0.f,
+                              total.GetScaleY() < 0.f ? -1.f : 1.f};
+      } else {
+        *scale_x = std::fabs(total.GetScaleX());
+        *scale_y = std::fabs(total.GetScaleY());
+        *transform = Matrix22{total.GetScaleX() < 0.f ? -1.f : 1.f, 0.f, 0.f,
+                              total.GetScaleY() < 0.f ? -1.f : 1.f};
+      }
+      return;
+    }
+
+    Matrix22 q, r;
+    total.QRDecompose(&q, &r);
+    if (FloatNearlyZero(r.GetScaleX()) || FloatNearlyZero(r.GetScaleY())) {
+      *scale_x = 1.f;
+      *scale_y = 1.f;
+      *transform = Matrix22{0.f, 0.f, 0.f, 0.f};
+      return;
+    }
+    *scale_y = std::fabs(r.GetScaleY());
+    *scale_x = *scale_y;
+    *transform = total * Matrix22(1 / *scale_x, 0, 0, 1 / *scale_y);
+  }
+
+  bool GetDWriteImageTransform(float* text_size, Matrix22* transform) {
+    float scale_x = 1.0f;
+    DecomposeDWriteImageMatrix(&scale_x, text_size, transform);
+    *text_size *= desc_.context_scale;
+    return *text_size > 0.0f;
+  }
+
+  bool CreateDWriteGrayGlyphRunAnalysis(
+      UINT16 glyph_id, float text_size, const Matrix22& transform,
+      IDWriteGlyphRunAnalysis** glyph_run_analysis) {
+    DWRITE_MATRIX matrix = ToDWriteMatrix(transform);
+
+    FLOAT advance = 0.0f;
+    DWRITE_GLYPH_OFFSET offset;
+    offset.advanceOffset = 0.0f;
+    offset.ascenderOffset = 0.0f;
+
+    DWRITE_GLYPH_RUN run;
+    run.fontFace = font_face_.get();
+    run.fontEmSize = text_size;
+    run.glyphCount = 1;
+    run.glyphIndices = &glyph_id;
+    run.glyphAdvances = &advance;
+    run.glyphOffsets = &offset;
+    run.isSideways = FALSE;
+    run.bidiLevel = 0;
+
+    ScopedComPtr<IDWriteFactory2> factory2;
+    ScopedComPtr<IDWriteFontFace2> font_face2;
+    if (SUCCEEDED(factory_->QueryInterface(&factory2)) &&
+        SUCCEEDED(font_face_->QueryInterface(&font_face2))) {
+      return SUCCEEDED(factory2->CreateGlyphRunAnalysis(
+          &run, &matrix, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+          DWRITE_MEASURING_MODE_NATURAL, DWRITE_GRID_FIT_MODE_ENABLED,
+          DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE, 0.0f, 0.0f,
+          glyph_run_analysis));
+    }
+
+    return SUCCEEDED(factory_->CreateGlyphRunAnalysis(
+        &run, 1.0f, &matrix, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+        DWRITE_MEASURING_MODE_NATURAL, 0.0f, 0.0f, glyph_run_analysis));
+  }
+
+  bool CreateDWriteColorGlyphRunEnumerator(
+      UINT16 glyph_id, float text_size, const Matrix22& transform,
+      IDWriteColorGlyphRunEnumerator** color_layers) {
+    ScopedComPtr<IDWriteFactory2> factory2;
+    if (FAILED(factory_->QueryInterface(&factory2))) {
+      return false;
+    }
+
+    DWRITE_MATRIX matrix = ToDWriteMatrix(transform);
+
+    FLOAT advance = 0.0f;
+    DWRITE_GLYPH_OFFSET offset;
+    offset.advanceOffset = 0.0f;
+    offset.ascenderOffset = 0.0f;
+
+    DWRITE_GLYPH_RUN run;
+    run.fontFace = font_face_.get();
+    run.fontEmSize = text_size;
+    run.glyphCount = 1;
+    run.glyphIndices = &glyph_id;
+    run.glyphAdvances = &advance;
+    run.glyphOffsets = &offset;
+    run.isSideways = FALSE;
+    run.bidiLevel = 0;
+
+    HRESULT hr = factory2->TranslateColorGlyphRun(0.0f, 0.0f, &run, nullptr,
+                                                  DWRITE_MEASURING_MODE_NATURAL,
+                                                  &matrix, 0, color_layers);
+    return hr != DWRITE_E_NOCOLOR && SUCCEEDED(hr) && *color_layers;
+  }
+
+  bool GenerateDWriteColorLayerPath(const DWRITE_COLOR_GLYPH_RUN* color_run,
+                                    Path* path) {
+    if (!color_run || !path) {
+      return false;
+    }
+
+    const DWRITE_GLYPH_RUN& run = color_run->glyphRun;
+    ScopedComPtr<IDWriteGeometrySink> geometry_sink(new DWritePathSink(path));
+    HRESULT hr = run.fontFace->GetGlyphRunOutline(
+        run.fontEmSize, run.glyphIndices, run.glyphAdvances, run.glyphOffsets,
+        run.glyphCount, run.isSideways, run.bidiLevel % 2, geometry_sink.get());
+    return SUCCEEDED(hr);
+  }
+
+  bool GenerateDWriteColorLayerBounds(UINT16 glyph_id, float text_size,
+                                      const Matrix22& transform, Rect* bounds) {
+    ScopedComPtr<IDWriteColorGlyphRunEnumerator> color_layers;
+    if (!CreateDWriteColorGlyphRunEnumerator(glyph_id, text_size, transform,
+                                             &color_layers)) {
+      return false;
+    }
+
+    bounds->SetEmpty();
+    BOOL has_color_layer = FALSE;
+    while (SUCCEEDED(color_layers->MoveNext(&has_color_layer)) &&
+           has_color_layer) {
+      const DWRITE_COLOR_GLYPH_RUN* color_run = nullptr;
+      if (FAILED(color_layers->GetCurrentRun(&color_run))) {
+        return false;
+      }
+
+      Path path;
+      if (!GenerateDWriteColorLayerPath(color_run, &path)) {
+        return false;
+      }
+      bounds->Join(path.GetBounds());
+    }
+
+    if (bounds->IsEmpty()) {
+      return false;
+    }
+
+    if (!transform.IsIdentity()) {
+      *bounds = transform.ToMatrix().MapRect(*bounds);
+    }
+
+    return !bounds->IsEmpty();
+  }
+
+  bool GenerateDWritePaintGlyphBounds(UINT32 glyph_index, float text_size,
+                                      const Matrix& ctm, Rect* bounds) {
+    if (glyph_index > std::numeric_limits<UINT16>::max()) {
+      return false;
+    }
+
+    UINT16 glyph_id = static_cast<UINT16>(glyph_index);
+    Path path;
+    ScopedComPtr<IDWriteGeometrySink> geometry_sink(new DWritePathSink(&path));
+    if (FAILED(font_face_->GetGlyphRunOutline(text_size, &glyph_id, nullptr,
+                                              nullptr, 1, FALSE, FALSE,
+                                              geometry_sink.get()))) {
+      return false;
+    }
+
+    Matrix path_matrix = ctm;
+    path_matrix.PreScale(1.0f / text_size, 1.0f / text_size);
+    if (!path_matrix.IsIdentity()) {
+      path = path.CopyWithMatrix(path_matrix);
+    }
+    bounds->Join(path.GetBounds());
+    return true;
+  }
+
+  bool SetDWriteColorImageInfoFromBounds(GlyphData* glyph, const Rect& bounds) {
+    const float left = std::floor(bounds.Left());
+    const float top = std::floor(bounds.Top());
+    const float right = std::ceil(bounds.Right());
+    const float bottom = std::ceil(bounds.Bottom());
+    if (left >= right || top >= bottom) {
+      return false;
+    }
+
+    GlyphBitmapData image;
+    image.origin_x = left / desc_.context_scale;
+    image.origin_y = -top / desc_.context_scale;
+    image.origin_x_for_raster = image.origin_x;
+    image.origin_y_for_raster = top / desc_.context_scale;
+    image.width = right - left;
+    image.height = bottom - top;
+    image.format = BitmapFormat::kBGRA8;
+    GlyphDataWinAccess::SetImage(glyph, image);
+    return true;
+  }
+
+#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+  bool GenerateDWriteColorV1PaintBounds(IDWritePaintReader* paint_reader,
+                                        const DWRITE_PAINT_ELEMENT& element,
+                                        float text_size, Matrix* ctm,
+                                        Rect* bounds) {
+    auto bound_children = [&](UINT32 child_count) {
+      if (child_count == 0) {
+        return true;
+      }
+
+      DWRITE_PAINT_ELEMENT child;
+      if (FAILED(paint_reader->MoveToFirstChild(&child))) {
+        return false;
+      }
+
+      bool ok = GenerateDWriteColorV1PaintBounds(paint_reader, child, text_size,
+                                                 ctm, bounds);
+      for (UINT32 i = 1; ok && i < child_count; ++i) {
+        if (FAILED(paint_reader->MoveToNextSibling(&child))) {
+          ok = false;
+          break;
+        }
+        ok = GenerateDWriteColorV1PaintBounds(paint_reader, child, text_size,
+                                              ctm, bounds);
+      }
+
+      return SUCCEEDED(paint_reader->MoveToParent()) && ok;
+    };
+
+    Matrix restore_matrix = *ctm;
+    switch (element.paintType) {
+      case DWRITE_PAINT_TYPE_NONE:
+        return false;
+      case DWRITE_PAINT_TYPE_LAYERS:
+        return bound_children(element.paint.layers.childCount);
+      case DWRITE_PAINT_TYPE_SOLID_GLYPH:
+        return GenerateDWritePaintGlyphBounds(
+            element.paint.solidGlyph.glyphIndex, text_size, *ctm, bounds);
+      case DWRITE_PAINT_TYPE_SOLID:
+      case DWRITE_PAINT_TYPE_LINEAR_GRADIENT:
+      case DWRITE_PAINT_TYPE_RADIAL_GRADIENT:
+      case DWRITE_PAINT_TYPE_SWEEP_GRADIENT:
+        return true;
+      case DWRITE_PAINT_TYPE_GLYPH:
+        return GenerateDWritePaintGlyphBounds(element.paint.glyph.glyphIndex,
+                                              text_size, *ctm, bounds);
+      case DWRITE_PAINT_TYPE_COLOR_GLYPH:
+        if (!DWriteRectIsEmpty(element.paint.colorGlyph.clipBox)) {
+          Rect clip_bounds =
+              ctm->MapRect(DWriteRectToRect(element.paint.colorGlyph.clipBox));
+          bounds->Join(clip_bounds);
+          return true;
+        }
+        return bound_children(1);
+      case DWRITE_PAINT_TYPE_TRANSFORM:
+        ctm->PreConcat(DWriteMatrixToMatrix(element.paint.transform));
+        {
+          bool ok = bound_children(1);
+          *ctm = restore_matrix;
+          return ok;
+        }
+      case DWRITE_PAINT_TYPE_COMPOSITE:
+        return bound_children(2);
+      default:
+        return false;
+    }
+  }
+#endif
+
+  bool GenerateDWriteColorV1Bounds(UINT16 glyph_id, float text_size,
+                                   const Matrix22& transform, Rect* bounds) {
+#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+    ScopedComPtr<IDWriteFontFace7> font_face7;
+    if (FAILED(font_face_->QueryInterface(&font_face7))) {
+      return false;
+    }
+
+    ScopedComPtr<IDWritePaintReader> paint_reader;
+    if (FAILED(font_face7->CreatePaintReader(
+            DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE,
+            DWRITE_PAINT_FEATURE_LEVEL_COLR_V1, &paint_reader))) {
+      return false;
+    }
+
+    DWRITE_PAINT_ELEMENT paint_element;
+    D2D_RECT_F clip_box;
+    DWRITE_PAINT_ATTRIBUTES attributes;
+    if (FAILED(paint_reader->SetCurrentGlyph(glyph_id, &paint_element,
+                                             &clip_box, &attributes)) ||
+        paint_element.paintType == DWRITE_PAINT_TYPE_NONE) {
+      return false;
+    }
+
+    Matrix matrix = transform.ToMatrix();
+    matrix.PreScale(text_size, text_size);
+
+    if (!DWriteRectIsEmpty(clip_box)) {
+      *bounds = matrix.MapRect(DWriteRectToRect(clip_box));
+    } else if (!GenerateDWriteColorV1PaintBounds(paint_reader.get(),
+                                                 paint_element, text_size,
+                                                 &matrix, bounds)) {
+      return false;
+    }
+
+    return !bounds->IsEmpty();
+#else
+    return false;
+#endif
+  }
+
+  bool GenerateDWritePaintGlyphPath(UINT32 glyph_index, float text_size,
+                                    Path* path) {
+    if (!path || glyph_index > std::numeric_limits<UINT16>::max()) {
+      return false;
+    }
+
+    UINT16 glyph_id = static_cast<UINT16>(glyph_index);
+    ScopedComPtr<IDWriteGeometrySink> geometry_sink(new DWritePathSink(path));
+    if (FAILED(font_face_->GetGlyphRunOutline(text_size, &glyph_id, nullptr,
+                                              nullptr, 1, FALSE, FALSE,
+                                              geometry_sink.get()))) {
+      return false;
+    }
+
+    Matrix path_matrix;
+    path_matrix.PreScale(1.0f / text_size, 1.0f / text_size);
+    *path = path->CopyWithMatrix(path_matrix);
+    return true;
+  }
+
+#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+  bool FetchDWriteGradientStops(IDWritePaintReader* paint_reader,
+                                UINT32 stop_count, std::vector<Color4f>* colors,
+                                std::vector<float>* positions) {
+    if (!paint_reader || !colors || !positions || stop_count == 0) {
+      return false;
+    }
+
+    std::vector<D2D1_GRADIENT_STOP> stops(stop_count);
+    if (FAILED(paint_reader->GetGradientStops(0, stop_count, stops.data()))) {
+      return false;
+    }
+
+    colors->clear();
+    positions->clear();
+    colors->reserve(stop_count);
+    positions->reserve(stop_count);
+    for (const auto& stop : stops) {
+      colors->push_back(
+          {stop.color.r, stop.color.g, stop.color.b, stop.color.a});
+      positions->push_back(stop.position);
+    }
+    return true;
+  }
+
+  bool ConfigureDWriteLinearGradientPaint(IDWritePaintReader* paint_reader,
+                                          const DWRITE_PAINT_ELEMENT& element,
+                                          Paint* paint, bool* draws_content) {
+    *draws_content = false;
+    const auto& gradient = element.paint.linearGradient;
+    std::vector<Color4f> colors;
+    std::vector<float> positions;
+    if (!FetchDWriteGradientStops(paint_reader, gradient.gradientStopCount,
+                                  &colors, &positions)) {
+      return false;
+    }
+
+    if (colors.size() == 1) {
+      paint->SetColor(Color4fToColor(colors.front()));
+      *draws_content = Color4fHasAlpha(colors.front());
+      return true;
+    }
+
+    Vec2 p0{gradient.x0, gradient.y0};
+    Vec2 p1{gradient.x1, gradient.y1};
+    Vec2 p2{gradient.x2, gradient.y2};
+    if (p1 == p0 || p2 == p0 || Vec2Cross(p1 - p0, p2 - p0) == 0.0f) {
+      paint->SetColor(Color4fToColor(colors.front()));
+      *draws_content = Color4fHasAlpha(colors.front());
+      return true;
+    }
+
+    Vec2 p0p2 = p2 - p0;
+    Vec2 perpendicular{p0p2.y, -p0p2.x};
+    Vec2 p3 = p0 + Vec2Projection(p1 - p0, perpendicular);
+
+    float stop_range = positions.back() - positions.front();
+    if (stop_range == 0.0f) {
+      if (gradient.extendMode != D2D1_EXTEND_MODE_CLAMP) {
+        paint->SetColor(Color_TRANSPARENT);
+        return true;
+      }
+      positions.push_back(positions.back() + 1.0f);
+      colors.push_back(colors.back());
+      stop_range = 1.0f;
+    }
+
+    if (stop_range != 1.0f || positions.front() != 0.0f) {
+      Vec2 start_to_end = p3 - p0;
+      Vec2 start_offset = start_to_end;
+      start_offset.x *= positions.front();
+      start_offset.y *= positions.front();
+      Vec2 end_offset = start_to_end;
+      end_offset.x *= positions.back();
+      end_offset.y *= positions.back();
+      Vec2 start = p0 + start_offset;
+      Vec2 end = p0 + end_offset;
+      float stop_start = positions.front();
+      float scale = 1.0f / stop_range;
+      p0 = start;
+      p3 = end;
+      for (auto& position : positions) {
+        position = (position - stop_start) * scale;
+      }
+    }
+
+    Point line_points[2] = {Point(p0.x, p0.y, 0, 1), Point(p3.x, p3.y, 0, 1)};
+    auto shader = Shader::MakeLinear(
+        line_points, colors.data(), positions.data(),
+        static_cast<int>(positions.size()),
+        DWriteExtendModeToTileMode(
+            static_cast<D2D1_EXTEND_MODE>(gradient.extendMode)));
+    if (!shader) {
+      return false;
+    }
+    paint->SetColor(Color_BLACK);
+    paint->SetShader(std::move(shader));
+    *draws_content = true;
+    return true;
+  }
+
+  bool ConfigureDWriteRadialGradientPaint(IDWritePaintReader* paint_reader,
+                                          const DWRITE_PAINT_ELEMENT& element,
+                                          Paint* paint, bool* draws_content) {
+    *draws_content = false;
+    const auto& gradient = element.paint.radialGradient;
+    std::vector<Color4f> colors;
+    std::vector<float> positions;
+    if (!FetchDWriteGradientStops(paint_reader, gradient.gradientStopCount,
+                                  &colors, &positions)) {
+      return false;
+    }
+
+    if (colors.size() == 1) {
+      paint->SetColor(Color4fToColor(colors.front()));
+      *draws_content = Color4fHasAlpha(colors.front());
+      return true;
+    }
+
+    Point start{gradient.x0, gradient.y0, 0, 1};
+    Point end{gradient.x1, gradient.y1, 0, 1};
+    float start_radius = gradient.radius0;
+    float end_radius = gradient.radius1;
+    float stop_range = positions.back() - positions.front();
+    if (stop_range == 0.0f) {
+      if (gradient.extendMode != D2D1_EXTEND_MODE_CLAMP) {
+        paint->SetColor(Color_TRANSPARENT);
+        return true;
+      }
+      positions.push_back(positions.back() + 1.0f);
+      colors.push_back(colors.back());
+      stop_range = 1.0f;
+    }
+
+    if (stop_range != 1.0f || positions.front() != 0.0f) {
+      Vec2 start_to_end = Vec2{end - start};
+      float radius_diff = end_radius - start_radius;
+      Vec2 start_offset = start_to_end;
+      start_offset.x *= positions.front();
+      start_offset.y *= positions.front();
+      Vec2 end_offset = start_to_end;
+      end_offset.x *= positions.back();
+      end_offset.y *= positions.back();
+
+      end = Point(start.x + end_offset.x, start.y + end_offset.y, 0, 1);
+      start = Point(start.x + start_offset.x, start.y + start_offset.y, 0, 1);
+      end_radius = start_radius + radius_diff * positions.back();
+      start_radius = start_radius + radius_diff * positions.front();
+
+      float stop_start = positions.front();
+      float scale = 1.0f / stop_range;
+      for (auto& position : positions) {
+        position = (position - stop_start) * scale;
+      }
+    }
+
+    if (start_radius < 0.0f || end_radius < 0.0f) {
+      paint->SetColor(Color_TRANSPARENT);
+      return true;
+    }
+
+    auto shader = Shader::MakeTwoPointConical(
+        start, start_radius, end, end_radius, colors.data(), positions.data(),
+        static_cast<int>(positions.size()),
+        DWriteExtendModeToTileMode(
+            static_cast<D2D1_EXTEND_MODE>(gradient.extendMode)));
+    if (!shader) {
+      return false;
+    }
+    paint->SetColor(Color_BLACK);
+    paint->SetShader(std::move(shader));
+    *draws_content = true;
+    return true;
+  }
+
+  bool ConfigureDWriteSweepGradientPaint(IDWritePaintReader* paint_reader,
+                                         const DWRITE_PAINT_ELEMENT& element,
+                                         Paint* paint, bool* draws_content) {
+    *draws_content = false;
+    const auto& gradient = element.paint.sweepGradient;
+    std::vector<Color4f> colors;
+    std::vector<float> positions;
+    if (!FetchDWriteGradientStops(paint_reader, gradient.gradientStopCount,
+                                  &colors, &positions)) {
+      return false;
+    }
+
+    if (colors.size() == 1) {
+      paint->SetColor(Color4fToColor(colors.front()));
+      *draws_content = Color4fHasAlpha(colors.front());
+      return true;
+    }
+
+    float start_angle = gradient.startAngle;
+    float end_angle = gradient.endAngle;
+    float sector_angle = end_angle - start_angle;
+    if (sector_angle == 0.0f && gradient.extendMode != D2D1_EXTEND_MODE_CLAMP) {
+      paint->SetColor(Color_TRANSPARENT);
+      return true;
+    }
+
+    float scaled_start = start_angle + sector_angle * positions.front();
+    float scaled_end = start_angle + sector_angle * positions.back();
+    float stop_range = positions.back() - positions.front();
+    if (stop_range == 0.0f) {
+      if (gradient.extendMode != D2D1_EXTEND_MODE_CLAMP) {
+        paint->SetColor(Color_TRANSPARENT);
+        return true;
+      }
+      positions.push_back(positions.back() + 1.0f);
+      colors.push_back(colors.back());
+      stop_range = 1.0f;
+    }
+
+    float stop_start = positions.front();
+    float scale = 1.0f / stop_range;
+    for (auto& position : positions) {
+      position = (position - stop_start) * scale;
+    }
+
+    scaled_start = 360.0f - scaled_start;
+    scaled_end = 360.0f - scaled_end;
+    if (scaled_start >= scaled_end) {
+      std::swap(scaled_start, scaled_end);
+      std::reverse(colors.begin(), colors.end());
+      std::reverse(positions.begin(), positions.end());
+      for (auto& position : positions) {
+        position = 1.0f - position;
+      }
+    }
+
+    auto shader = Shader::MakeSweep(
+        gradient.centerX, gradient.centerY, scaled_start, scaled_end,
+        colors.data(), positions.data(), static_cast<int>(positions.size()),
+        DWriteExtendModeToTileMode(
+            static_cast<D2D1_EXTEND_MODE>(gradient.extendMode)));
+    if (!shader) {
+      return false;
+    }
+    paint->SetColor(Color_BLACK);
+    paint->SetShader(std::move(shader));
+    *draws_content = true;
+    return true;
+  }
+
+  bool DrawDWriteColorV1Children(IDWritePaintReader* paint_reader,
+                                 UINT32 child_count, float text_size,
+                                 Canvas* canvas, bool* did_draw) {
+    if (child_count == 0) {
+      return true;
+    }
+
+    DWRITE_PAINT_ELEMENT child;
+    if (FAILED(paint_reader->MoveToFirstChild(&child))) {
+      return false;
+    }
+
+    bool ok = DrawDWriteColorV1Paint(paint_reader, child, text_size, canvas,
+                                     did_draw);
+    for (UINT32 i = 1; ok && i < child_count; ++i) {
+      if (FAILED(paint_reader->MoveToNextSibling(&child))) {
+        ok = false;
+        break;
+      }
+      ok = DrawDWriteColorV1Paint(paint_reader, child, text_size, canvas,
+                                  did_draw);
+    }
+
+    return SUCCEEDED(paint_reader->MoveToParent()) && ok;
+  }
+
+  bool DrawDWriteColorV1Paint(IDWritePaintReader* paint_reader,
+                              const DWRITE_PAINT_ELEMENT& element,
+                              float text_size, Canvas* canvas, bool* did_draw) {
+    AutoCanvasRestore restore(canvas, true);
+    switch (element.paintType) {
+      case DWRITE_PAINT_TYPE_NONE:
+        return true;
+      case DWRITE_PAINT_TYPE_LAYERS:
+        return DrawDWriteColorV1Children(paint_reader,
+                                         element.paint.layers.childCount,
+                                         text_size, canvas, did_draw);
+      case DWRITE_PAINT_TYPE_SOLID_GLYPH: {
+        Path path;
+        if (!GenerateDWritePaintGlyphPath(element.paint.solidGlyph.glyphIndex,
+                                          text_size, &path)) {
+          return false;
+        }
+        Paint paint;
+        paint.SetAntiAlias(true);
+        paint.SetColor(
+            DWriteColorToColor(element.paint.solidGlyph.color.value));
+        canvas->DrawPath(path, paint);
+        *did_draw = true;
+        return true;
+      }
+      case DWRITE_PAINT_TYPE_SOLID: {
+        Paint paint;
+        paint.SetColor(DWriteColorToColor(element.paint.solid.value));
+        canvas->DrawPaint(paint);
+        *did_draw = true;
+        return true;
+      }
+      case DWRITE_PAINT_TYPE_LINEAR_GRADIENT: {
+        Paint paint;
+        bool draws_content = false;
+        if (!ConfigureDWriteLinearGradientPaint(paint_reader, element, &paint,
+                                                &draws_content)) {
+          return false;
+        }
+        if (draws_content) {
+          canvas->DrawPaint(paint);
+          *did_draw = true;
+        }
+        return true;
+      }
+      case DWRITE_PAINT_TYPE_RADIAL_GRADIENT: {
+        Paint paint;
+        bool draws_content = false;
+        if (!ConfigureDWriteRadialGradientPaint(paint_reader, element, &paint,
+                                                &draws_content)) {
+          return false;
+        }
+        if (draws_content) {
+          canvas->DrawPaint(paint);
+          *did_draw = true;
+        }
+        return true;
+      }
+      case DWRITE_PAINT_TYPE_SWEEP_GRADIENT: {
+        Paint paint;
+        bool draws_content = false;
+        if (!ConfigureDWriteSweepGradientPaint(paint_reader, element, &paint,
+                                               &draws_content)) {
+          return false;
+        }
+        if (draws_content) {
+          canvas->DrawPaint(paint);
+          *did_draw = true;
+        }
+        return true;
+      }
+      case DWRITE_PAINT_TYPE_GLYPH: {
+        Path path;
+        if (!GenerateDWritePaintGlyphPath(element.paint.glyph.glyphIndex,
+                                          text_size, &path)) {
+          return false;
+        }
+        canvas->ClipPath(path);
+        return DrawDWriteColorV1Children(paint_reader, 1, text_size, canvas,
+                                         did_draw);
+      }
+      case DWRITE_PAINT_TYPE_COLOR_GLYPH: {
+        const auto& color_glyph = element.paint.colorGlyph;
+        if (!DWriteRectIsEmpty(color_glyph.clipBox)) {
+          canvas->ClipRect(DWriteRectToRect(color_glyph.clipBox));
+        }
+        return DrawDWriteColorV1Children(paint_reader, 1, text_size, canvas,
+                                         did_draw);
+      }
+      case DWRITE_PAINT_TYPE_TRANSFORM:
+        canvas->Concat(DWriteMatrixToMatrix(element.paint.transform));
+        return DrawDWriteColorV1Children(paint_reader, 1, text_size, canvas,
+                                         did_draw);
+      case DWRITE_PAINT_TYPE_COMPOSITE: {
+        DWRITE_PAINT_ELEMENT source;
+        DWRITE_PAINT_ELEMENT backdrop;
+        if (FAILED(paint_reader->MoveToFirstChild(&source)) ||
+            FAILED(paint_reader->MoveToNextSibling(&backdrop))) {
+          return false;
+        }
+
+        canvas->SaveLayer(canvas->GetLocalClipBounds(), Paint{});
+        bool ok = DrawDWriteColorV1Paint(paint_reader, backdrop, text_size,
+                                         canvas, did_draw);
+        if (FAILED(paint_reader->MoveToParent()) || !ok ||
+            FAILED(paint_reader->MoveToFirstChild(&source))) {
+          return false;
+        }
+
+        Paint blend_paint;
+        blend_paint.SetBlendMode(
+            DWriteCompositeModeToBlendMode(element.paint.composite.mode));
+        canvas->SaveLayer(canvas->GetLocalClipBounds(), blend_paint);
+        ok = DrawDWriteColorV1Paint(paint_reader, source, text_size, canvas,
+                                    did_draw);
+        return SUCCEEDED(paint_reader->MoveToParent()) && ok;
+      }
+      default:
+        return false;
+    }
+  }
+#endif
+
+  bool DrawDWriteColorV1Image(UINT16 glyph_id, float text_size,
+                              const Matrix22& transform, Canvas* canvas) {
+#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+    ScopedComPtr<IDWriteFontFace7> font_face7;
+    if (!canvas || FAILED(font_face_->QueryInterface(&font_face7))) {
+      return false;
+    }
+
+    ScopedComPtr<IDWritePaintReader> paint_reader;
+    if (FAILED(font_face7->CreatePaintReader(
+            DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE,
+            DWRITE_PAINT_FEATURE_LEVEL_COLR_V1, &paint_reader))) {
+      return false;
+    }
+
+    DWRITE_PAINT_ELEMENT paint_element;
+    D2D_RECT_F clip_box;
+    DWRITE_PAINT_ATTRIBUTES attributes;
+    if (FAILED(paint_reader->SetCurrentGlyph(glyph_id, &paint_element,
+                                             &clip_box, &attributes)) ||
+        paint_element.paintType == DWRITE_PAINT_TYPE_NONE) {
+      return false;
+    }
+
+    Matrix matrix = transform.ToMatrix();
+    matrix.PreScale(text_size, text_size);
+    canvas->Concat(matrix);
+    if (!DWriteRectIsEmpty(clip_box)) {
+      canvas->ClipRect(DWriteRectToRect(clip_box));
+    }
+
+    paint_reader->SetTextColor(ColorToDWriteColor(desc_.foreground_color));
+
+    bool did_draw = false;
+    return DrawDWriteColorV1Paint(paint_reader.get(), paint_element, text_size,
+                                  canvas, &did_draw) &&
+           did_draw;
+#else
+    return false;
+#endif
+  }
+
+  bool GenerateDWritePngImageBounds(UINT16 glyph_id, float text_size,
+                                    const Matrix22& transform, Rect* bounds) {
+    ScopedComPtr<IDWriteFontFace4> font_face4;
+    if (!bounds || FAILED(font_face_->QueryInterface(&font_face4))) {
+      return false;
+    }
+
+    DWRITE_GLYPH_IMAGE_FORMATS image_formats;
+    if (FAILED(font_face4->GetGlyphImageFormats(glyph_id, 0, UINT32_MAX,
+                                                &image_formats)) ||
+        !(image_formats & DWRITE_GLYPH_IMAGE_FORMATS_PNG)) {
+      return false;
+    }
+
+    DWRITE_GLYPH_IMAGE_DATA image_data = {};
+    void* image_context = nullptr;
+    if (FAILED(font_face4->GetGlyphImageData(
+            glyph_id, DWritePixelsPerEm(text_size),
+            DWRITE_GLYPH_IMAGE_FORMATS_PNG, &image_data, &image_context))) {
+      return false;
+    }
+
+    bool ok = false;
+    if (image_data.pixelSize.width > 0 && image_data.pixelSize.height > 0 &&
+        image_data.pixelsPerEm > 0) {
+      Rect image_bounds =
+          Rect::MakeWH(static_cast<float>(image_data.pixelSize.width),
+                       static_cast<float>(image_data.pixelSize.height));
+
+      *bounds = DWritePngImageMatrix(text_size, transform, image_data)
+                    .MapRect(image_bounds);
+      bounds->SetLTRB(std::floor(bounds->Left()), std::floor(bounds->Top()),
+                      std::ceil(bounds->Right()), std::ceil(bounds->Bottom()));
+      ok = !bounds->IsEmpty();
+    }
+
+    font_face4->ReleaseGlyphImageData(image_context);
+    return ok;
+  }
+
+  UINT32 DWritePixelsPerEm(float text_size) const {
+    return static_cast<UINT32>(std::max(1.0f, std::round(text_size)));
+  }
+
+  Matrix DWritePngImageMatrix(float text_size, const Matrix22& transform,
+                              const DWRITE_GLYPH_IMAGE_DATA& image_data) const {
+    Matrix matrix = transform.ToMatrix();
+    float scale = text_size / static_cast<float>(image_data.pixelsPerEm);
+    matrix.PreScale(scale, scale);
+    matrix.PreTranslate(-static_cast<float>(image_data.horizontalLeftOrigin.x),
+                        -static_cast<float>(image_data.horizontalLeftOrigin.y));
+    return matrix;
+  }
+
+  bool RasterDWritePngImage(const GlyphBitmapData& source,
+                            uint32_t target_width, uint32_t target_height,
+                            float text_size, const Matrix22& transform,
+                            const DWRITE_GLYPH_IMAGE_DATA& image_data,
+                            GlyphBitmapData* image) {
+    if (!source.buffer || !image || source.width <= 0.0f ||
+        source.height <= 0.0f || target_width == 0 || target_height == 0 ||
+        image_data.pixelsPerEm == 0) {
+      return false;
+    }
+
+    size_t target_byte_size = 0;
+    if (!CheckedImageByteSize(target_width, target_height, &target_byte_size)) {
+      return false;
+    }
+
+    const uint32_t source_width = static_cast<uint32_t>(source.width);
+    const uint32_t source_height = static_cast<uint32_t>(source.height);
+    size_t source_byte_size = 0;
+    if (!CheckedImageByteSize(source_width, source_height, &source_byte_size)) {
+      return false;
+    }
+
+    Bitmap source_bitmap(source_width, source_height,
+                         AlphaType::kPremul_AlphaType, ColorType::kBGRA);
+    if (!source_bitmap.GetPixelAddr()) {
+      return false;
+    }
+    std::memcpy(source_bitmap.GetPixelAddr(), source.buffer, source_byte_size);
+
+    Bitmap bitmap(target_width, target_height, AlphaType::kPremul_AlphaType,
+                  ColorType::kBGRA);
+    auto canvas = Canvas::MakeSoftwareCanvas(&bitmap);
+    if (!canvas || !bitmap.GetPixelAddr()) {
+      return false;
+    }
+
+    canvas->Clear(Color_TRANSPARENT);
+    canvas->Translate(-image->origin_x_for_raster * desc_.context_scale,
+                      -image->origin_y_for_raster * desc_.context_scale);
+    canvas->Concat(DWritePngImageMatrix(text_size, transform, image_data));
+    canvas->DrawImage(Image::MakeImage(source_bitmap.GetPixmap()), 0, 0,
+                      SamplingOptions{FilterMode::kNearest, MipmapMode::kNone});
+
+    auto* buffer = static_cast<uint8_t*>(std::malloc(target_byte_size));
+    if (!buffer) {
+      return false;
+    }
+
+    const uint32_t target_row_bytes = target_width * 4;
+    if (bitmap.RowBytes() == target_row_bytes) {
+      std::memcpy(buffer, bitmap.GetPixelAddr(), target_byte_size);
+    } else {
+      for (uint32_t y = 0; y < target_height; y++) {
+        std::memcpy(
+            buffer + static_cast<size_t>(y) * target_row_bytes,
+            bitmap.GetPixelAddr() + static_cast<size_t>(y) * bitmap.RowBytes(),
+            target_row_bytes);
+      }
+    }
+
+    image->buffer = buffer;
+    image->width = static_cast<float>(target_width);
+    image->height = static_cast<float>(target_height);
+    image->format = BitmapFormat::kBGRA8;
+    image->need_free = true;
+    return true;
+  }
+
+  bool GenerateDWritePngImage(UINT16 glyph_id, float text_size,
+                              const Matrix22& transform,
+                              GlyphBitmapData* image) {
+    ScopedComPtr<IDWriteFontFace4> font_face4;
+    if (!image || FAILED(font_face_->QueryInterface(&font_face4))) {
+      return false;
+    }
+
+    DWRITE_GLYPH_IMAGE_FORMATS image_formats;
+    if (FAILED(font_face4->GetGlyphImageFormats(glyph_id, 0, UINT32_MAX,
+                                                &image_formats)) ||
+        !(image_formats & DWRITE_GLYPH_IMAGE_FORMATS_PNG)) {
+      return false;
+    }
+
+    DWRITE_GLYPH_IMAGE_DATA image_data = {};
+    void* image_context = nullptr;
+    if (FAILED(font_face4->GetGlyphImageData(
+            glyph_id, DWritePixelsPerEm(text_size),
+            DWRITE_GLYPH_IMAGE_FORMATS_PNG, &image_data, &image_context))) {
+      return false;
+    }
+
+    uint32_t target_width =
+        image->width > 0.0f ? static_cast<uint32_t>(std::lround(image->width))
+                            : 0;
+    uint32_t target_height =
+        image->height > 0.0f ? static_cast<uint32_t>(std::lround(image->height))
+                             : 0;
+    image->buffer = nullptr;
+    image->need_free = false;
+    GlyphBitmapData source;
+    bool ok =
+        image_data.imageData && image_data.imageDataSize > 0 &&
+        DecodePngGlyphImageToBGRA(image_data.imageData,
+                                  image_data.imageDataSize, 0, 0, &source) &&
+        RasterDWritePngImage(source, target_width, target_height, text_size,
+                             transform, image_data, image);
+    if (source.need_free) {
+      std::free(source.buffer);
+    }
+
+    font_face4->ReleaseGlyphImageData(image_context);
+    return ok;
+  }
+
+  bool GenerateDWriteColorV1Image(UINT16 glyph_id, float text_size,
+                                  const Matrix22& transform,
+                                  GlyphBitmapData* image) {
+    if (!image) {
+      return false;
+    }
+
+    uint32_t width = image->width > 0.0f
+                         ? static_cast<uint32_t>(std::lround(image->width))
+                         : 0;
+    uint32_t height = image->height > 0.0f
+                          ? static_cast<uint32_t>(std::lround(image->height))
+                          : 0;
+    size_t byte_size = 0;
+    if (width == 0 || height == 0 ||
+        !CheckedImageByteSize(width, height, &byte_size)) {
+      return false;
+    }
+
+    Bitmap bitmap(width, height, AlphaType::kPremul_AlphaType,
+                  ColorType::kBGRA);
+    auto canvas = Canvas::MakeSoftwareCanvas(&bitmap);
+    if (!canvas || !bitmap.GetPixelAddr()) {
+      return false;
+    }
+
+    canvas->Clear(Color_TRANSPARENT);
+    canvas->Translate(-image->origin_x_for_raster * desc_.context_scale,
+                      -image->origin_y_for_raster * desc_.context_scale);
+    if (!DrawDWriteColorV1Image(glyph_id, text_size, transform, canvas.get())) {
+      return false;
+    }
+
+    auto* buffer = static_cast<uint8_t*>(std::malloc(byte_size));
+    if (!buffer) {
+      return false;
+    }
+
+    const uint32_t row_bytes = width * 4;
+    if (bitmap.RowBytes() == row_bytes) {
+      std::memcpy(buffer, bitmap.GetPixelAddr(), byte_size);
+    } else {
+      for (uint32_t y = 0; y < height; y++) {
+        std::memcpy(
+            buffer + static_cast<size_t>(y) * row_bytes,
+            bitmap.GetPixelAddr() + static_cast<size_t>(y) * bitmap.RowBytes(),
+            row_bytes);
+      }
+    }
+
+    image->buffer = buffer;
+    image->width = static_cast<float>(width);
+    image->height = static_cast<float>(height);
+    image->format = BitmapFormat::kBGRA8;
+    image->need_free = true;
+    return true;
+  }
+
+  bool GenerateDWriteColorBounds(UINT16 glyph_id, float text_size,
+                                 const Matrix22& transform, Rect* bounds) {
+    if (!bounds) {
+      return false;
+    }
+
+    if (GenerateDWriteColorV1Bounds(glyph_id, text_size, transform, bounds)) {
+      return true;
+    }
+
+    if (GenerateDWriteColorLayerBounds(glyph_id, text_size, transform,
+                                       bounds)) {
+      return true;
+    }
+
+    return GenerateDWritePngImageBounds(glyph_id, text_size, transform, bounds);
+  }
+
+  bool GenerateDWriteColorImageInfo(GlyphData* glyph) {
+    UINT16 glyph_id = glyph->Id();
+    if (font_face_->GetGlyphCount() <= glyph_id) {
+      return false;
+    }
+
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    Rect bounds;
+    return GenerateDWriteColorBounds(glyph_id, text_size, transform, &bounds) &&
+           SetDWriteColorImageInfoFromBounds(glyph, bounds);
+  }
+
+  bool DrawDWriteColorImage(UINT16 glyph_id, float text_size,
+                            const Matrix22& transform, Canvas* canvas) {
+    ScopedComPtr<IDWriteColorGlyphRunEnumerator> color_layers;
+    if (!CreateDWriteColorGlyphRunEnumerator(glyph_id, text_size, transform,
+                                             &color_layers)) {
+      return false;
+    }
+
+    Paint paint;
+    paint.SetAntiAlias(true);
+    if (!transform.IsIdentity()) {
+      canvas->Concat(transform.ToMatrix());
+    }
+
+    BOOL has_color_layer = FALSE;
+    bool drew_color_layer = false;
+    while (true) {
+      HRESULT hr = color_layers->MoveNext(&has_color_layer);
+      if (FAILED(hr)) {
+        return false;
+      }
+      if (!has_color_layer) {
+        break;
+      }
+
+      const DWRITE_COLOR_GLYPH_RUN* color_run = nullptr;
+      if (FAILED(color_layers->GetCurrentRun(&color_run))) {
+        return false;
+      }
+
+      Path path;
+      if (!GenerateDWriteColorLayerPath(color_run, &path)) {
+        return false;
+      }
+
+      if (color_run->paletteIndex == 0xFFFF) {
+        paint.SetColor(desc_.foreground_color);
+      } else {
+        paint.SetColor(DWriteColorToColor(color_run->runColor));
+      }
+      canvas->DrawPath(path, paint);
+      drew_color_layer = true;
+    }
+
+    return drew_color_layer;
+  }
+
+  bool GenerateDWriteColorImage(GlyphData* glyph) {
+    if (glyph->Image().width <= 0.0f || glyph->Image().height <= 0.0f ||
+        glyph->Image().format != BitmapFormat::kBGRA8) {
+      if (!GenerateDWriteColorImageInfo(glyph)) {
+        return false;
+      }
+    }
+
+    GlyphBitmapData image = glyph->Image();
+    const uint32_t width = static_cast<uint32_t>(image.width);
+    const uint32_t height = static_cast<uint32_t>(image.height);
+    const size_t byte_size = static_cast<size_t>(width) * height * 4;
+    if (width == 0 || height == 0 || byte_size == 0) {
+      return false;
+    }
+
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    if (GenerateDWriteColorV1Image(glyph->Id(), text_size, transform, &image)) {
+      GlyphDataWinAccess::SetImage(glyph, image);
+      return true;
+    }
+
+    Bitmap bitmap(width, height, AlphaType::kPremul_AlphaType,
+                  ColorType::kBGRA);
+    auto canvas = Canvas::MakeSoftwareCanvas(&bitmap);
+    if (!canvas || !bitmap.GetPixelAddr()) {
+      return false;
+    }
+
+    canvas->Clear(Color_TRANSPARENT);
+    canvas->Translate(-image.origin_x_for_raster * desc_.context_scale,
+                      -image.origin_y_for_raster * desc_.context_scale);
+    if (!DrawDWriteColorImage(glyph->Id(), text_size, transform,
+                              canvas.get())) {
+      if (GenerateDWritePngImage(glyph->Id(), text_size, transform, &image)) {
+        GlyphDataWinAccess::SetImage(glyph, image);
+        return true;
+      }
+
+      // Do not cache an undrawn transparent bitmap as success.
+      GlyphDataWinAccess::SetImage(glyph, GlyphBitmapData{});
+      return false;
+    }
+
+    uint8_t* buffer = reinterpret_cast<uint8_t*>(std::malloc(byte_size));
+    if (!buffer) {
+      return false;
+    }
+    std::memcpy(buffer, bitmap.GetPixelAddr(), byte_size);
+
+    image.buffer = buffer;
+    image.need_free = true;
+    GlyphDataWinAccess::SetImage(glyph, image);
+    return true;
+  }
+
+  bool GenerateDWriteImageInfo(GlyphData* glyph) {
+    UINT16 glyph_id = glyph->Id();
+    if (font_face_->GetGlyphCount() <= glyph_id) {
+      return false;
+    }
+
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    ScopedComPtr<IDWriteGlyphRunAnalysis> glyph_run_analysis;
+    if (!CreateDWriteGrayGlyphRunAnalysis(glyph_id, text_size, transform,
+                                          &glyph_run_analysis)) {
+      return false;
+    }
+
+    RECT texture_bounds;
+    if (FAILED(glyph_run_analysis->GetAlphaTextureBounds(
+            DWRITE_TEXTURE_ALIASED_1x1, &texture_bounds)) ||
+        texture_bounds.left >= texture_bounds.right ||
+        texture_bounds.top >= texture_bounds.bottom) {
+      return false;
+    }
+
+    GlyphBitmapData image;
+    image.origin_x =
+        static_cast<float>(texture_bounds.left) / desc_.context_scale;
+    image.origin_y =
+        -static_cast<float>(texture_bounds.top) / desc_.context_scale;
+    image.origin_x_for_raster = image.origin_x;
+    image.origin_y_for_raster =
+        static_cast<float>(texture_bounds.top) / desc_.context_scale;
+    image.width =
+        static_cast<float>(texture_bounds.right - texture_bounds.left);
+    image.height =
+        static_cast<float>(texture_bounds.bottom - texture_bounds.top);
+    image.format = BitmapFormat::kGray8;
+    GlyphDataWinAccess::SetImage(glyph, image);
+    return true;
+  }
+
+  bool GenerateDWriteImage(GlyphData* glyph) {
+    if (glyph->Image().width <= 0.0f || glyph->Image().height <= 0.0f ||
+        glyph->Image().format != BitmapFormat::kGray8) {
+      if (!GenerateDWriteImageInfo(glyph)) {
+        return false;
+      }
+    }
+
+    GlyphBitmapData image = glyph->Image();
+    const size_t width = static_cast<size_t>(image.width);
+    const size_t height = static_cast<size_t>(image.height);
+    const size_t byte_size = width * height;
+    if (width == 0 || height == 0 || byte_size == 0) {
+      return false;
+    }
+
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    ScopedComPtr<IDWriteGlyphRunAnalysis> glyph_run_analysis;
+    if (!CreateDWriteGrayGlyphRunAnalysis(glyph->Id(), text_size, transform,
+                                          &glyph_run_analysis)) {
+      return false;
+    }
+
+    RECT texture_bounds;
+    texture_bounds.left = static_cast<LONG>(
+        std::lround(image.origin_x_for_raster * desc_.context_scale));
+    texture_bounds.top = static_cast<LONG>(
+        std::lround(image.origin_y_for_raster * desc_.context_scale));
+    texture_bounds.right = texture_bounds.left + static_cast<LONG>(width);
+    texture_bounds.bottom = texture_bounds.top + static_cast<LONG>(height);
+
+    uint8_t* buffer = reinterpret_cast<uint8_t*>(std::malloc(byte_size));
+    if (!buffer) {
+      return false;
+    }
+    std::memset(buffer, 0, byte_size);
+
+    if (FAILED(glyph_run_analysis->CreateAlphaTexture(
+            DWRITE_TEXTURE_ALIASED_1x1, &texture_bounds, buffer,
+            static_cast<UINT32>(byte_size)))) {
+      std::free(buffer);
+      return false;
+    }
+
+    for (size_t i = 0; i < byte_size; i++) {
+      buffer[i] = ApplySkiaMaskGammaToAlpha(buffer[i], desc_.foreground_color);
+    }
+
+    image.buffer = buffer;
+    image.need_free = true;
+    GlyphDataWinAccess::SetImage(glyph, image);
+    return true;
+  }
+
+  bool GenerateDWritePath(GlyphData* glyph) {
+    float scale_x = 1.0f;
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    desc_.DecomposeMatrix(PortScaleType::kVertical, &scale_x, &text_size,
+                          &transform);
+
+    UINT16 glyph_id = glyph->Id();
+    if (HasDWriteColorGlyph(glyph_id, text_size, transform)) {
+      GlyphDataWinAccess::SetPath(glyph, Path{});
+      return true;
+    }
+
+    Path path;
+    if (!GenerateDWriteOutlinePath(glyph_id, text_size, transform, &path)) {
+      return false;
+    }
+
+    GlyphDataWinAccess::SetPath(glyph, std::move(path));
+    return true;
+  }
+
+  bool HasDWriteColorGlyph(UINT16 glyph_id, float text_size,
+                           const Matrix22& transform) {
+    ScopedComPtr<IDWriteFactory2> factory2;
+    if (FAILED(factory_->QueryInterface(&factory2))) {
+      return false;
+    }
+
+    DWRITE_MATRIX matrix;
+    matrix.m11 = transform.GetScaleX();
+    matrix.m12 = transform.GetSkewY();
+    matrix.m21 = transform.GetSkewX();
+    matrix.m22 = transform.GetScaleY();
+    matrix.dx = 0.0f;
+    matrix.dy = 0.0f;
+
+    FLOAT advance = 0.0f;
+    DWRITE_GLYPH_OFFSET offset;
+    offset.advanceOffset = 0.0f;
+    offset.ascenderOffset = 0.0f;
+
+    DWRITE_GLYPH_RUN run;
+    run.fontFace = font_face_.get();
+    run.fontEmSize = text_size;
+    run.glyphCount = 1;
+    run.glyphIndices = &glyph_id;
+    run.glyphAdvances = &advance;
+    run.glyphOffsets = &offset;
+    run.isSideways = FALSE;
+    run.bidiLevel = 0;
+
+    ScopedComPtr<IDWriteColorGlyphRunEnumerator> color_layers;
+    HRESULT hr = factory2->TranslateColorGlyphRun(0.0f, 0.0f, &run, nullptr,
+                                                  DWRITE_MEASURING_MODE_NATURAL,
+                                                  &matrix, 0, &color_layers);
+    if (hr == DWRITE_E_NOCOLOR || FAILED(hr) || !color_layers) {
+      return false;
+    }
+
+    BOOL has_color_layer = FALSE;
+    return SUCCEEDED(color_layers->MoveNext(&has_color_layer)) &&
+           has_color_layer;
+  }
+
+  bool GenerateDWriteMetrics(GlyphData* glyph) {
+    glyph->ZeroMetrics();
+
+    UINT16 glyph_id = glyph->Id();
+    if (font_face_->GetGlyphCount() <= glyph_id) {
+      return false;
+    }
+
+    DWRITE_FONT_METRICS font_metrics;
+    font_face_->GetMetrics(&font_metrics);
+    if (font_metrics.designUnitsPerEm == 0) {
+      return false;
+    }
+
+    float scale_x = 1.0f;
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    desc_.DecomposeMatrix(PortScaleType::kVertical, &scale_x, &text_size,
+                          &transform);
+
+    DWRITE_GLYPH_METRICS glyph_metrics;
+    if (FAILED(
+            font_face_->GetDesignGlyphMetrics(&glyph_id, 1, &glyph_metrics))) {
+      return false;
+    }
+
+    float advance_x = text_size *
+                      static_cast<float>(glyph_metrics.advanceWidth) /
+                      static_cast<float>(font_metrics.designUnitsPerEm);
+    Vec2 advance = transform * Vec2{advance_x, 0.0f};
+
+    Rect bounds;
+    if (desc_.fake_bold &&
+        GenerateDWriteFakeBoldBounds(glyph_id, text_size, transform, &bounds)) {
+      GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
+                                     GlyphFormat::A8);
+      return true;
+    }
+
+    if (GenerateDWriteColorBounds(glyph_id, text_size, transform, &bounds)) {
+      GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
+                                     GlyphFormat::BGRA32);
+      return true;
+    }
+
+    if (GenerateDWriteBounds(glyph_id, text_size, transform, &bounds)) {
+      GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
+                                     GlyphFormat::A8);
+      return true;
+    }
+
+    if (GenerateFallbackBoundsWithDWriteAdvance(glyph, advance)) {
+      return true;
+    }
+    GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y,
+                                   Rect::MakeEmpty(), GlyphFormat::A8);
+    return true;
+  }
+
+  bool GenerateDWriteFakeBoldBounds(UINT16 glyph_id, float text_size,
+                                    const Matrix22& transform, Rect* bounds) {
+    Path path;
+    if (!GenerateDWriteOutlinePath(glyph_id, text_size, transform, &path) ||
+        path.IsEmpty()) {
+      return false;
+    }
+
+    Paint paint;
+    paint.SetStyle(Paint::kStroke_Style);
+    float stroke_width = text_size * ComputeFakeBoldScale(text_size);
+    if (desc_.stroke_width > 0.0f) {
+      float stroke_scale =
+          desc_.text_size > 0.0f ? text_size / desc_.text_size : 1.0f;
+      stroke_width = desc_.stroke_width * stroke_scale;
+      paint.SetStrokeCap(desc_.cap);
+      paint.SetStrokeJoin(desc_.join);
+      paint.SetStrokeMiter(desc_.miter_limit);
+    }
+    paint.SetStrokeWidth(stroke_width);
+
+    Path quad_path;
+    Path stroke_path;
+    Stroke stroke(paint);
+    stroke.QuadPath(path, &quad_path);
+    stroke.StrokePath(quad_path, &stroke_path);
+    if (stroke_path.IsEmpty()) {
+      return false;
+    }
+
+    Rect path_bounds = path.GetBounds();
+    path_bounds.Join(stroke_path.GetBounds());
+    bounds->SetLTRB(
+        std::floor(path_bounds.Left()), std::floor(path_bounds.Top()),
+        std::ceil(path_bounds.Right()), std::ceil(path_bounds.Bottom()));
+    return !bounds->IsEmpty();
+  }
+
+  bool GenerateFallbackBoundsWithDWriteAdvance(GlyphData* glyph,
+                                               const Vec2& advance) {
+    float text_size = desc_.text_size;
+    Matrix22 transform;
+    if (!GetDWriteImageTransform(&text_size, &transform)) {
+      return false;
+    }
+
+    Rect bounds;
+    if (desc_.fake_bold) {
+      if (!GenerateDWriteFakeBoldBounds(glyph->Id(), text_size, transform,
+                                        &bounds)) {
+        return false;
+      }
+    } else {
+      Path path;
+      if (!GenerateDWriteOutlinePath(glyph->Id(), text_size, transform,
+                                     &path) ||
+          path.IsEmpty()) {
+        return false;
+      }
+      bounds = path.GetBounds();
+      bounds.SetLTRB(std::floor(bounds.Left()), std::floor(bounds.Top()),
+                     std::ceil(bounds.Right()), std::ceil(bounds.Bottom()));
+    }
+
+    if (bounds.IsEmpty()) {
+      return false;
+    }
+
+    GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
+                                   GlyphFormat::A8);
+    return true;
+  }
+
+  bool GenerateDWriteOutlinePath(UINT16 glyph_id, float text_size,
+                                 const Matrix22& transform, Path* path) {
+    Path outline;
+    ScopedComPtr<IDWriteGeometrySink> geometry_sink(
+        new DWritePathSink(&outline));
+    if (FAILED(font_face_->GetGlyphRunOutline(text_size, &glyph_id, nullptr,
+                                              nullptr, 1, FALSE, FALSE,
+                                              geometry_sink.get()))) {
+      return false;
+    }
+
+    if (!transform.IsIdentity()) {
+      outline = outline.CopyWithMatrix(transform.ToMatrix());
+    }
+
+    *path = std::move(outline);
+    return true;
+  }
+
+  bool GenerateDWriteBounds(UINT16 glyph_id, float text_size,
+                            const Matrix22& transform, Rect* bounds) {
+    DWRITE_MATRIX matrix;
+    matrix.m11 = transform.GetScaleX();
+    matrix.m12 = transform.GetSkewY();
+    matrix.m21 = transform.GetSkewX();
+    matrix.m22 = transform.GetScaleY();
+    matrix.dx = 0.0f;
+    matrix.dy = 0.0f;
+
+    FLOAT advance = 0.0f;
+    DWRITE_GLYPH_OFFSET offset;
+    offset.advanceOffset = 0.0f;
+    offset.ascenderOffset = 0.0f;
+
+    DWRITE_GLYPH_RUN run;
+    run.fontFace = font_face_.get();
+    run.fontEmSize = text_size;
+    run.glyphCount = 1;
+    run.glyphIndices = &glyph_id;
+    run.glyphAdvances = &advance;
+    run.glyphOffsets = &offset;
+    run.isSideways = FALSE;
+    run.bidiLevel = 0;
+
+    ScopedComPtr<IDWriteGlyphRunAnalysis> glyph_run_analysis;
+    ScopedComPtr<IDWriteFactory2> factory2;
+    ScopedComPtr<IDWriteFontFace2> font_face2;
+    if (SUCCEEDED(factory_->QueryInterface(&factory2)) &&
+        SUCCEEDED(font_face_->QueryInterface(&font_face2))) {
+      if (FAILED(factory2->CreateGlyphRunAnalysis(
+              &run, &matrix, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+              DWRITE_MEASURING_MODE_NATURAL, DWRITE_GRID_FIT_MODE_ENABLED,
+              DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE, 0.0f, 0.0f,
+              &glyph_run_analysis))) {
+        return false;
+      }
+    } else if (FAILED(factory_->CreateGlyphRunAnalysis(
+                   &run, 1.0f, &matrix, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+                   DWRITE_MEASURING_MODE_NATURAL, 0.0f, 0.0f,
+                   &glyph_run_analysis))) {
+      return false;
+    }
+
+    RECT texture_bounds;
+    if (FAILED(glyph_run_analysis->GetAlphaTextureBounds(
+            DWRITE_TEXTURE_ALIASED_1x1, &texture_bounds)) ||
+        texture_bounds.left >= texture_bounds.right ||
+        texture_bounds.top >= texture_bounds.bottom) {
+      return false;
+    }
+
+    bounds->SetLTRB(static_cast<float>(texture_bounds.left),
+                    static_cast<float>(texture_bounds.top),
+                    static_cast<float>(texture_bounds.right),
+                    static_cast<float>(texture_bounds.bottom));
+    return true;
+  }
+
+  ScopedComPtr<IDWriteFactory> factory_;
+  ScopedComPtr<IDWriteFontFace> font_face_;
+};
+
+}  // namespace
+
+std::unique_ptr<ScalerContext> MakeScalerContextDWrite(
+    std::shared_ptr<Typeface> typeface, IDWriteFactory* factory,
+    IDWriteFontFace* font_face, const ScalerContextDesc* desc) {
+  return std::make_unique<ScalerContextDWrite>(std::move(typeface), factory,
+                                               font_face, desc);
+}
+
+}  // namespace skity

--- a/src/text/ports/win/scaler_context_win.hpp
+++ b/src/text/ports/win/scaler_context_win.hpp
@@ -1,0 +1,26 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_TEXT_PORTS_WIN_SCALER_CONTEXT_WIN_HPP
+#define SRC_TEXT_PORTS_WIN_SCALER_CONTEXT_WIN_HPP
+
+// clang-format off
+#include "src/text/ports/win/dwrite_version.hpp"
+#include <dwrite.h>
+// clang-format on
+
+#include <memory>
+
+#include "src/text/ports/win/scoped_com_ptr.hpp"
+#include "src/text/scaler_context.hpp"
+
+namespace skity {
+
+std::unique_ptr<ScalerContext> MakeScalerContextDWrite(
+    std::shared_ptr<Typeface> typeface, IDWriteFactory* factory,
+    IDWriteFontFace* font_face, const ScalerContextDesc* desc);
+
+}  // namespace skity
+
+#endif  // SRC_TEXT_PORTS_WIN_SCALER_CONTEXT_WIN_HPP

--- a/src/text/ports/win/typeface_win.cc
+++ b/src/text/ports/win/typeface_win.cc
@@ -1,0 +1,1676 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/text/ports/win/typeface_win.hpp"
+
+// clang-format off
+#include "src/text/ports/win/dwrite_version.hpp"
+#include "src/base/platform/win/handle_result.hpp"
+#include "src/base/platform/win/str_conversion.hpp"
+#include "src/text/ports/win/scaler_context_win.hpp"
+// clang-format on
+
+#ifdef GetGlyphIndices
+#undef GetGlyphIndices
+#endif
+
+#include <dwrite.h>
+#include <dwrite_2.h>
+#include <dwrite_3.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "src/logging.hpp"
+
+namespace skity {
+namespace {
+
+static constexpr FourByteTag kDWriteFactoryID =
+    SetFourByteTag('d', 'w', 'r', 't');
+
+/** Reverse all 4 bytes in a 32bit value.
+  e.g. 0x12345678 -> 0x78563412
+*/
+static constexpr uint32_t EndianSwap32(uint32_t value) {
+  return ((value & 0xFF) << 24) | ((value & 0xFF00) << 8) |
+         ((value & 0xFF0000) >> 8) | (value >> 24);
+}
+
+int16_t ReadBigEndianInt16(const uint8_t* data) {
+  return static_cast<int16_t>((static_cast<uint16_t>(data[0]) << 8) |
+                              static_cast<uint16_t>(data[1]));
+}
+
+uint16_t ReadBigEndianUInt16(const uint8_t* data) {
+  return (static_cast<uint16_t>(data[0]) << 8) | static_cast<uint16_t>(data[1]);
+}
+
+uint32_t ReadBigEndianUInt32(const uint8_t* data) {
+  return (static_cast<uint32_t>(data[0]) << 24) |
+         (static_cast<uint32_t>(data[1]) << 16) |
+         (static_cast<uint32_t>(data[2]) << 8) | static_cast<uint32_t>(data[3]);
+}
+
+bool RangeInBounds(size_t offset, size_t length, size_t total_size) {
+  return offset <= total_size && length <= total_size - offset;
+}
+
+bool IsSfntFontType(uint32_t font_type) {
+  return font_type == SetFourByteTag(0, 1, 0, 0) ||
+         font_type == SetFourByteTag('t', 'r', 'u', 'e') ||
+         font_type == SetFourByteTag('O', 'T', 'T', 'O') ||
+         font_type == SetFourByteTag('t', 'y', 'p', '1');
+}
+
+bool GetSfntOffset(const std::shared_ptr<Data>& data, UINT32 face_index,
+                   size_t* sfnt_offset) {
+  static constexpr uint32_t kTtcTag = SetFourByteTag('t', 't', 'c', 'f');
+  static constexpr size_t kSfntHeaderSize = 12;
+  static constexpr size_t kTtcFaceOffsetsStart = 12;
+
+  if (!data || !sfnt_offset ||
+      !RangeInBounds(0, kSfntHeaderSize, data->Size())) {
+    return false;
+  }
+
+  const uint8_t* bytes = data->Bytes();
+  const uint32_t font_type = ReadBigEndianUInt32(bytes);
+  if (font_type == kTtcTag) {
+    const uint32_t face_count = ReadBigEndianUInt32(bytes + 8);
+    if (face_index >= face_count) {
+      return false;
+    }
+
+    const size_t face_offset_entry =
+        kTtcFaceOffsetsStart + static_cast<size_t>(face_index) * 4;
+    if (!RangeInBounds(face_offset_entry, 4, data->Size())) {
+      return false;
+    }
+
+    const size_t face_offset =
+        static_cast<size_t>(ReadBigEndianUInt32(bytes + face_offset_entry));
+    if (!RangeInBounds(face_offset, kSfntHeaderSize, data->Size())) {
+      return false;
+    }
+
+    const uint32_t face_type = ReadBigEndianUInt32(bytes + face_offset);
+    if (!IsSfntFontType(face_type)) {
+      return false;
+    }
+
+    *sfnt_offset = face_offset;
+    return true;
+  }
+
+  if (face_index != 0 || !IsSfntFontType(font_type)) {
+    return false;
+  }
+
+  *sfnt_offset = 0;
+  return true;
+}
+
+int GetSfntTableTags(const std::shared_ptr<Data>& data, UINT32 face_index,
+                     FontTableTag tags[]) {
+  static constexpr size_t kSfntHeaderSize = 12;
+  static constexpr size_t kSfntTableDirectoryEntrySize = 16;
+  static constexpr size_t kSfntNumTablesOffset = 4;
+
+  size_t sfnt_offset = 0;
+  if (!GetSfntOffset(data, face_index, &sfnt_offset)) {
+    return 0;
+  }
+
+  const uint8_t* bytes = data->Bytes();
+  const uint16_t table_count =
+      ReadBigEndianUInt16(bytes + sfnt_offset + kSfntNumTablesOffset);
+  const size_t table_directory_offset = sfnt_offset + kSfntHeaderSize;
+  const size_t table_directory_size =
+      static_cast<size_t>(table_count) * kSfntTableDirectoryEntrySize;
+  if (!RangeInBounds(table_directory_offset, table_directory_size,
+                     data->Size())) {
+    return 0;
+  }
+
+  if (tags) {
+    for (uint16_t i = 0; i < table_count; ++i) {
+      const size_t table_offset =
+          table_directory_offset +
+          static_cast<size_t>(i) * kSfntTableDirectoryEntrySize;
+      tags[i] = ReadBigEndianUInt32(bytes + table_offset);
+    }
+  }
+  return table_count;
+}
+
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+FourByteTag DWriteAxisTagToFourByteTag(DWRITE_FONT_AXIS_TAG tag) {
+  return EndianSwap32(static_cast<uint32_t>(tag));
+}
+
+bool IsDWriteVariableAxis(IDWriteFontResource* font_resource,
+                          UINT32 axis_index) {
+  return (font_resource->GetFontAxisAttributes(axis_index) &
+          DWRITE_FONT_AXIS_ATTRIBUTES_VARIABLE) != 0;
+}
+
+VariationPosition GetDWriteVariationDesignPosition(
+    IDWriteFontFace5* font_face5) {
+  VariationPosition position;
+  if (!font_face5 || !font_face5->HasVariations()) {
+    return position;
+  }
+
+  ScopedComPtr<IDWriteFontResource> font_resource;
+  if (FAILED(font_face5->GetFontResource(&font_resource))) {
+    return {};
+  }
+
+  UINT32 axis_count = font_face5->GetFontAxisValueCount();
+  std::vector<DWRITE_FONT_AXIS_VALUE> axis_values(axis_count);
+  if (axis_count == 0 ||
+      FAILED(font_face5->GetFontAxisValues(axis_values.data(), axis_count))) {
+    return {};
+  }
+
+  for (UINT32 i = 0; i < axis_count; i++) {
+    if (!IsDWriteVariableAxis(font_resource.get(), i)) {
+      continue;
+    }
+    position.AddCoordinate(DWriteAxisTagToFourByteTag(axis_values[i].axisTag),
+                           axis_values[i].value);
+  }
+  return position;
+}
+
+std::vector<VariationAxis> GetDWriteVariationDesignParameters(
+    IDWriteFontFace5* font_face5) {
+  if (!font_face5 || !font_face5->HasVariations()) {
+    return {};
+  }
+
+  ScopedComPtr<IDWriteFontResource> font_resource;
+  if (FAILED(font_face5->GetFontResource(&font_resource))) {
+    return {};
+  }
+
+  UINT32 axis_count = font_face5->GetFontAxisValueCount();
+  if (axis_count == 0) {
+    return {};
+  }
+
+  std::vector<DWRITE_FONT_AXIS_RANGE> axis_ranges(axis_count);
+  if (FAILED(
+          font_resource->GetFontAxisRanges(axis_ranges.data(), axis_count))) {
+    return {};
+  }
+
+  std::vector<DWRITE_FONT_AXIS_VALUE> default_values(axis_count);
+  if (FAILED(font_resource->GetDefaultFontAxisValues(default_values.data(),
+                                                     axis_count))) {
+    return {};
+  }
+
+  std::vector<VariationAxis> axes;
+  axes.reserve(axis_count);
+  for (UINT32 i = 0; i < axis_count; i++) {
+    if (!IsDWriteVariableAxis(font_resource.get(), i)) {
+      continue;
+    }
+    const auto attributes = font_resource->GetFontAxisAttributes(i);
+    axes.emplace_back(DWriteAxisTagToFourByteTag(default_values[i].axisTag),
+                      axis_ranges[i].minValue, default_values[i].value,
+                      axis_ranges[i].maxValue,
+                      (attributes & DWRITE_FONT_AXIS_ATTRIBUTES_HIDDEN) != 0);
+  }
+  return axes;
+}
+
+ScopedComPtr<IDWriteFontFace> MakeDWriteVariationFontFace(
+    IDWriteFontFace5* font_face5, const FontArguments& args) {
+  if (!font_face5 || !font_face5->HasVariations()) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  UINT32 axis_count = font_face5->GetFontAxisValueCount();
+  if (axis_count == 0) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  std::vector<DWRITE_FONT_AXIS_VALUE> axis_values(axis_count);
+  if (FAILED(font_face5->GetFontAxisValues(axis_values.data(), axis_count))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  for (const auto& coordinate :
+       args.GetVariationDesignPosition().GetCoordinates()) {
+    for (auto& axis_value : axis_values) {
+      if (DWriteAxisTagToFourByteTag(axis_value.axisTag) == coordinate.axis) {
+        axis_value.value = coordinate.value;
+        break;
+      }
+    }
+  }
+
+  ScopedComPtr<IDWriteFontResource> font_resource;
+  if (FAILED(font_face5->GetFontResource(&font_resource))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontFace5> new_font_face5;
+  if (FAILED(font_resource->CreateFontFace(font_face5->GetSimulations(),
+                                           axis_values.data(), axis_count,
+                                           &new_font_face5))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontFace> new_font_face;
+  if (FAILED(new_font_face5->QueryInterface(&new_font_face))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+  return new_font_face;
+}
+
+ScopedComPtr<IDWriteFontFace> MakeDWriteDefaultVariationFontFace(
+    IDWriteFontFace* font_face) {
+  if (!font_face) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontFace5> font_face5;
+  if (FAILED(font_face->QueryInterface(&font_face5)) ||
+      !font_face5->HasVariations()) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  UINT32 axis_count = font_face5->GetFontAxisValueCount();
+  if (axis_count == 0) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontResource> font_resource;
+  if (FAILED(font_face5->GetFontResource(&font_resource))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  std::vector<DWRITE_FONT_AXIS_VALUE> axis_values(axis_count);
+  if (FAILED(font_resource->GetDefaultFontAxisValues(axis_values.data(),
+                                                     axis_count))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontFace5> default_font_face5;
+  if (FAILED(font_resource->CreateFontFace(font_face->GetSimulations(),
+                                           axis_values.data(), axis_count,
+                                           &default_font_face5))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+
+  ScopedComPtr<IDWriteFontFace> default_font_face;
+  if (FAILED(default_font_face5->QueryInterface(&default_font_face))) {
+    return ScopedComPtr<IDWriteFontFace>(nullptr);
+  }
+  return default_font_face;
+}
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+
+// Korean fonts Gulim, Dotum, Batang, Gungsuh have bitmap strikes that get
+// artifically emboldened by Windows without antialiasing. Korean users prefer
+// these over the synthetic boldening performed by Skia. So let's make an
+// exception for fonts with bitmap strikes and allow passing through Windows
+// simulations for those, until Skia provides more control over simulations in
+
+}  // namespace
+
+bool HasBitmapStrikes(const ScopedComPtr<IDWriteFont>& font) {
+  ScopedComPtr<IDWriteFontFace> fontFace;
+  HRB(font->CreateFontFace(&fontFace));
+
+  AutoDWriteTable ebdtTable(fontFace.get(),
+                            EndianSwap32(SetFourByteTag('E', 'B', 'D', 'T')));
+  return ebdtTable.exists;
+}
+
+template <typename T, typename U>
+bool SameCOMObject(T* lhs, U* rhs) {
+  if (!lhs || !rhs) {
+    return lhs == rhs;
+  }
+
+  ScopedComPtr<IUnknown> lhsUnknown;
+  if (FAILED(lhs->QueryInterface(&lhsUnknown))) {
+    return false;
+  }
+
+  ScopedComPtr<IUnknown> rhsUnknown;
+  if (FAILED(rhs->QueryInterface(&rhsUnknown))) {
+    return false;
+  }
+
+  return lhsUnknown.get() == rhsUnknown.get();
+}
+
+bool GetDWriteFontFiles(IDWriteFontFace* font_face,
+                        std::vector<ScopedComPtr<IDWriteFontFile>>& files) {
+  files.clear();
+
+  uint32_t number_of_files = 0;
+  if (FAILED(font_face->GetFiles(&number_of_files, nullptr))) {
+    return false;
+  }
+
+  files.resize(number_of_files);
+  if (files.empty()) {
+    return true;
+  }
+
+  return SUCCEEDED(font_face->GetFiles(
+      &number_of_files, reinterpret_cast<IDWriteFontFile**>(files.data())));
+}
+
+bool DWriteFontFileEqual(IDWriteFontFile* lhs, IDWriteFontFile* rhs) {
+  if (SameCOMObject(lhs, rhs)) {
+    return true;
+  }
+
+  if (!lhs || !rhs) {
+    return false;
+  }
+
+  ScopedComPtr<IDWriteFontFileLoader> lhsLoader;
+  ScopedComPtr<IDWriteFontFileLoader> rhsLoader;
+  if (FAILED(lhs->GetLoader(&lhsLoader)) ||
+      FAILED(rhs->GetLoader(&rhsLoader))) {
+    return false;
+  }
+
+  if (!SameCOMObject(lhsLoader.get(), rhsLoader.get())) {
+    return false;
+  }
+
+  const void* lhsKey = nullptr;
+  const void* rhsKey = nullptr;
+  UINT32 lhsKeySize = 0;
+  UINT32 rhsKeySize = 0;
+  lhs->GetReferenceKey(&lhsKey, &lhsKeySize);
+  rhs->GetReferenceKey(&rhsKey, &rhsKeySize);
+
+  if (lhsKeySize != rhsKeySize) {
+    return false;
+  }
+
+  if (lhsKeySize == 0) {
+    return true;
+  }
+
+  return lhsKey && rhsKey && std::memcmp(lhsKey, rhsKey, lhsKeySize) == 0;
+}
+
+bool DWriteFontFaceEqualByFiles(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
+  if (lhs->GetIndex() != rhs->GetIndex() ||
+      lhs->GetSimulations() != rhs->GetSimulations()) {
+    return false;
+  }
+
+  std::vector<ScopedComPtr<IDWriteFontFile>> lhsFiles;
+  std::vector<ScopedComPtr<IDWriteFontFile>> rhsFiles;
+  if (!GetDWriteFontFiles(lhs, lhsFiles) ||
+      !GetDWriteFontFiles(rhs, rhsFiles)) {
+    return false;
+  }
+
+  if (lhsFiles.size() != rhsFiles.size()) {
+    return false;
+  }
+
+  for (size_t index = 0; index < lhsFiles.size(); index++) {
+    if (!DWriteFontFileEqual(lhsFiles[index].get(), rhsFiles[index].get())) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
+  if (SameCOMObject(lhs, rhs)) {
+    return true;
+  }
+
+  if (!lhs || !rhs) {
+    return false;
+  }
+
+  // IDWriteFontFace5::Equals accounts for newer face identity such as variation
+  // axis values. Older DirectWrite versions can only compare file identity.
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+  ScopedComPtr<IDWriteFontFace5> lhsFace5;
+  if (SUCCEEDED(lhs->QueryInterface(&lhsFace5))) {
+    return lhsFace5->Equals(rhs);
+  }
+
+  ScopedComPtr<IDWriteFontFace5> rhsFace5;
+  if (SUCCEEDED(rhs->QueryInterface(&rhsFace5))) {
+    return rhsFace5->Equals(lhs);
+  }
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+
+  return DWriteFontFaceEqualByFiles(lhs, rhs);
+}
+
+namespace {
+
+class DataFontFileStream : public IDWriteFontFileStream {
+ public:
+  explicit DataFontFileStream(std::shared_ptr<Data> data)
+      : ref_count_(1), data_(std::move(data)) {}
+
+  // IUnknown methods
+  SK_STDMETHODIMP QueryInterface(IID const& riid, void** object) override {
+    if (!object) {
+      return E_POINTER;
+    }
+
+    if (riid == IID_IUnknown || riid == __uuidof(IDWriteFontFileStream)) {
+      *object = this;
+      AddRef();
+      return S_OK;
+    }
+
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  SK_STDMETHODIMP_(ULONG) AddRef() override {
+    return InterlockedIncrement(&ref_count_);
+  }
+
+  SK_STDMETHODIMP_(ULONG) Release() override {
+    ULONG new_count = InterlockedDecrement(&ref_count_);
+    if (new_count == 0) {
+      delete this;
+    }
+    return new_count;
+  }
+
+  // IDWriteFontFileStream methods
+  SK_STDMETHODIMP ReadFileFragment(const void** fragment_start,
+                                   UINT64 file_offset, UINT64 fragment_size,
+                                   void** fragment_context) override {
+    if (!fragment_start || !fragment_context || !data_) {
+      return E_POINTER;
+    }
+
+    *fragment_start = nullptr;
+    *fragment_context = nullptr;
+
+    UINT64 file_size = static_cast<UINT64>(data_->Size());
+    if (file_offset > file_size || fragment_size > file_size - file_offset) {
+      return E_FAIL;
+    }
+
+    *fragment_start = data_->Bytes() + static_cast<size_t>(file_offset);
+    return S_OK;
+  }
+
+  SK_STDMETHODIMP_(void) ReleaseFileFragment(void*) override {}
+
+  SK_STDMETHODIMP GetFileSize(UINT64* file_size) override {
+    if (!file_size || !data_) {
+      return E_POINTER;
+    }
+
+    *file_size = static_cast<UINT64>(data_->Size());
+    return S_OK;
+  }
+
+  SK_STDMETHODIMP GetLastWriteTime(UINT64* last_write_time) override {
+    if (!last_write_time) {
+      return E_POINTER;
+    }
+
+    *last_write_time = 0;
+    return E_NOTIMPL;
+  }
+
+ private:
+  ~DataFontFileStream() = default;
+
+  ULONG ref_count_;
+  std::shared_ptr<Data> data_;
+};
+
+class DataFontFileLoader : public IDWriteFontFileLoader {
+ public:
+  explicit DataFontFileLoader(std::shared_ptr<Data> data)
+      : ref_count_(1), data_(std::move(data)) {}
+
+  // IUnknown methods
+  SK_STDMETHODIMP QueryInterface(IID const& riid, void** object) override {
+    if (!object) {
+      return E_POINTER;
+    }
+
+    if (riid == IID_IUnknown || riid == __uuidof(IDWriteFontFileLoader)) {
+      *object = this;
+      AddRef();
+      return S_OK;
+    }
+
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  SK_STDMETHODIMP_(ULONG) AddRef() override {
+    return InterlockedIncrement(&ref_count_);
+  }
+
+  SK_STDMETHODIMP_(ULONG) Release() override {
+    ULONG new_count = InterlockedDecrement(&ref_count_);
+    if (new_count == 0) {
+      delete this;
+    }
+    return new_count;
+  }
+
+  // IDWriteFontFileLoader methods
+  SK_STDMETHODIMP CreateStreamFromKey(const void*, UINT32,
+                                      IDWriteFontFileStream** stream) override {
+    if (!stream || !data_) {
+      return E_POINTER;
+    }
+
+    *stream = new DataFontFileStream(data_);
+    return *stream ? S_OK : E_OUTOFMEMORY;
+  }
+
+ private:
+  ~DataFontFileLoader() = default;
+
+  ULONG ref_count_;
+  std::shared_ptr<Data> data_;
+};
+
+class DataFontFileEnumerator : public IDWriteFontFileEnumerator {
+ public:
+  DataFontFileEnumerator(IDWriteFactory* factory,
+                         IDWriteFontFileLoader* font_file_loader)
+      : ref_count_(1),
+        factory_(RefComPtr(factory)),
+        font_file_loader_(RefComPtr(font_file_loader)),
+        has_next_(true) {}
+
+  SK_STDMETHODIMP QueryInterface(IID const& riid, void** object) override {
+    if (!object) {
+      return E_POINTER;
+    }
+
+    if (riid == IID_IUnknown || riid == __uuidof(IDWriteFontFileEnumerator)) {
+      *object = this;
+      AddRef();
+      return S_OK;
+    }
+
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  SK_STDMETHODIMP_(ULONG) AddRef() override {
+    return InterlockedIncrement(&ref_count_);
+  }
+
+  SK_STDMETHODIMP_(ULONG) Release() override {
+    ULONG new_count = InterlockedDecrement(&ref_count_);
+    if (new_count == 0) {
+      delete this;
+    }
+    return new_count;
+  }
+
+  SK_STDMETHODIMP MoveNext(BOOL* has_current_file) override {
+    if (!has_current_file) {
+      return E_POINTER;
+    }
+
+    *has_current_file = FALSE;
+    if (!has_next_) {
+      return S_OK;
+    }
+    has_next_ = false;
+
+    UINT32 font_file_reference_key = 0;
+    HR(factory_->CreateCustomFontFileReference(
+        &font_file_reference_key, sizeof(font_file_reference_key),
+        font_file_loader_.get(), &current_file_));
+    *has_current_file = TRUE;
+    return S_OK;
+  }
+
+  SK_STDMETHODIMP GetCurrentFontFile(IDWriteFontFile** font_file) override {
+    if (!font_file) {
+      return E_POINTER;
+    }
+
+    if (!current_file_) {
+      *font_file = nullptr;
+      return E_FAIL;
+    }
+
+    *font_file = RefComPtr(current_file_.get());
+    return S_OK;
+  }
+
+ private:
+  ~DataFontFileEnumerator() = default;
+
+  ULONG ref_count_;
+  ScopedComPtr<IDWriteFactory> factory_;
+  ScopedComPtr<IDWriteFontFile> current_file_;
+  ScopedComPtr<IDWriteFontFileLoader> font_file_loader_;
+  bool has_next_;
+};
+
+class DataFontCollectionLoader : public IDWriteFontCollectionLoader {
+ public:
+  explicit DataFontCollectionLoader(IDWriteFontFileLoader* font_file_loader)
+      : ref_count_(1), font_file_loader_(RefComPtr(font_file_loader)) {}
+
+  SK_STDMETHODIMP QueryInterface(IID const& riid, void** object) override {
+    if (!object) {
+      return E_POINTER;
+    }
+
+    if (riid == IID_IUnknown || riid == __uuidof(IDWriteFontCollectionLoader)) {
+      *object = this;
+      AddRef();
+      return S_OK;
+    }
+
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  SK_STDMETHODIMP_(ULONG) AddRef() override {
+    return InterlockedIncrement(&ref_count_);
+  }
+
+  SK_STDMETHODIMP_(ULONG) Release() override {
+    ULONG new_count = InterlockedDecrement(&ref_count_);
+    if (new_count == 0) {
+      delete this;
+    }
+    return new_count;
+  }
+
+  SK_STDMETHODIMP CreateEnumeratorFromKey(
+      IDWriteFactory* factory, const void*, UINT32,
+      IDWriteFontFileEnumerator** font_file_enumerator) override {
+    if (!factory || !font_file_enumerator) {
+      return E_POINTER;
+    }
+
+    *font_file_enumerator =
+        new DataFontFileEnumerator(factory, font_file_loader_.get());
+    return *font_file_enumerator ? S_OK : E_OUTOFMEMORY;
+  }
+
+ private:
+  ~DataFontCollectionLoader() = default;
+
+  ULONG ref_count_;
+  ScopedComPtr<IDWriteFontFileLoader> font_file_loader_;
+};
+
+class RegisteredFontFileLoader {
+ public:
+  static std::shared_ptr<RegisteredFontFileLoader> Make(
+      IDWriteFactory* factory, IDWriteFontFileLoader* loader) {
+    if (!factory || !loader ||
+        FAILED(factory->RegisterFontFileLoader(loader))) {
+      return nullptr;
+    }
+
+    return std::shared_ptr<RegisteredFontFileLoader>(
+        new RegisteredFontFileLoader(factory, loader));
+  }
+
+  ~RegisteredFontFileLoader() {
+    if (factory_ && loader_) {
+      factory_->UnregisterFontFileLoader(loader_.get());
+    }
+  }
+
+ private:
+  RegisteredFontFileLoader(IDWriteFactory* factory,
+                           IDWriteFontFileLoader* loader)
+      : factory_(RefComPtr(factory)), loader_(RefComPtr(loader)) {}
+
+  ScopedComPtr<IDWriteFactory> factory_;
+  ScopedComPtr<IDWriteFontFileLoader> loader_;
+};
+
+class RegisteredFontCollectionLoader {
+ public:
+  static std::shared_ptr<RegisteredFontCollectionLoader> Make(
+      IDWriteFactory* factory, IDWriteFontCollectionLoader* loader) {
+    if (!factory || !loader ||
+        FAILED(factory->RegisterFontCollectionLoader(loader))) {
+      return nullptr;
+    }
+
+    return std::shared_ptr<RegisteredFontCollectionLoader>(
+        new RegisteredFontCollectionLoader(factory, loader));
+  }
+
+  ~RegisteredFontCollectionLoader() {
+    if (factory_ && loader_) {
+      factory_->UnregisterFontCollectionLoader(loader_.get());
+    }
+  }
+
+ private:
+  RegisteredFontCollectionLoader(IDWriteFactory* factory,
+                                 IDWriteFontCollectionLoader* loader)
+      : factory_(RefComPtr(factory)), loader_(RefComPtr(loader)) {}
+
+  ScopedComPtr<IDWriteFactory> factory_;
+  ScopedComPtr<IDWriteFontCollectionLoader> loader_;
+};
+
+}  // namespace
+
+// Iterate calls to GetFirstMatchingFont incrementally removing bold or italic
+// styling that can trigger the simulations. Implementing it this way gets us a
+// IDWriteFont that can be used as before and has the correct information on its
+// own style. Stripping simulations from IDWriteFontFace is possible via
+// IDWriteFontList1, IDWriteFontFaceReference and CreateFontFace, but this way
+// we won't have a matching IDWriteFont which is still used in get_style().
+HRESULT FirstMatchingFontWithoutSimulations(
+    const ScopedComPtr<IDWriteFontFamily>& family, DWriteStyle dwStyle,
+    ScopedComPtr<IDWriteFont>& font) {
+  bool noSimulations = false;
+  while (!noSimulations) {
+    ScopedComPtr<IDWriteFont> searchFont;
+    HR(family->GetFirstMatchingFont(dwStyle.weight, dwStyle.width,
+                                    dwStyle.slant, &searchFont));
+    DWRITE_FONT_SIMULATIONS simulations = searchFont->GetSimulations();
+    // If we still get simulations even though we're not asking for bold or
+    // italic, we can't help it and exit the loop.
+
+    noSimulations = simulations == DWRITE_FONT_SIMULATIONS_NONE ||
+                    (dwStyle.weight == DWRITE_FONT_WEIGHT_REGULAR &&
+                     dwStyle.slant == DWRITE_FONT_STYLE_NORMAL) ||
+                    HasBitmapStrikes(searchFont);
+
+    if (noSimulations) {
+      font = std::move(searchFont);
+      break;
+    }
+    if (simulations & DWRITE_FONT_SIMULATIONS_BOLD) {
+      dwStyle.weight = DWRITE_FONT_WEIGHT_REGULAR;
+      continue;
+    }
+    if (simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) {
+      dwStyle.slant = DWRITE_FONT_STYLE_NORMAL;
+      continue;
+    }
+  }
+  return S_OK;
+}
+
+FontStyle::Slant FontSlantFromDWrite(DWRITE_FONT_STYLE slant) {
+  switch (slant) {
+    case DWRITE_FONT_STYLE_ITALIC:
+      return FontStyle::kItalic_Slant;
+    case DWRITE_FONT_STYLE_OBLIQUE:
+      return FontStyle::kOblique_Slant;
+    case DWRITE_FONT_STYLE_NORMAL:
+    default:
+      return FontStyle::kUpright_Slant;
+  }
+}
+
+FontStyle FontStyleFromDWriteFont(IDWriteFont* font) {
+  return FontStyle(static_cast<int>(font->GetWeight()),
+                   static_cast<int>(font->GetStretch()),
+                   FontSlantFromDWrite(font->GetStyle()));
+}
+
+namespace {
+
+int FontWidthFromVariationWidth(float width) {
+  if (width <= 50.0f) {
+    return 1;
+  }
+  if (width <= 62.5f) {
+    return 2;
+  }
+  if (width <= 75.0f) {
+    return 3;
+  }
+  if (width <= 87.5f) {
+    return 4;
+  }
+  if (width <= 100.0f) {
+    return 5;
+  }
+  if (width <= 112.5f) {
+    return 6;
+  }
+  if (width <= 125.0f) {
+    return 7;
+  }
+  if (width <= 150.0f) {
+    return 8;
+  }
+  return 9;
+}
+
+FontStyle ApplyVariationStyle(IDWriteFontFace* font_face,
+                              const FontStyle& style) {
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+  ScopedComPtr<IDWriteFontFace5> font_face5;
+  if (!font_face || FAILED(font_face->QueryInterface(&font_face5)) ||
+      !font_face5->HasVariations()) {
+    return style;
+  }
+
+  UINT32 axis_count = font_face5->GetFontAxisValueCount();
+  if (axis_count == 0) {
+    return style;
+  }
+
+  std::vector<DWRITE_FONT_AXIS_VALUE> axis_values(axis_count);
+  if (FAILED(font_face5->GetFontAxisValues(axis_values.data(), axis_count))) {
+    return style;
+  }
+
+  int weight = style.weight();
+  int width = style.width();
+  FontStyle::Slant slant = style.slant();
+  for (const auto& axis_value : axis_values) {
+    FourByteTag axis = DWriteAxisTagToFourByteTag(axis_value.axisTag);
+    if (axis == SetFourByteTag('w', 'g', 'h', 't')) {
+      weight = static_cast<int>(std::lround(axis_value.value));
+    } else if (axis == SetFourByteTag('w', 'd', 't', 'h')) {
+      width = FontWidthFromVariationWidth(axis_value.value);
+    } else if (axis == SetFourByteTag('i', 't', 'a', 'l') &&
+               axis_value.value > 0.0f) {
+      slant = FontStyle::kItalic_Slant;
+    } else if (axis == SetFourByteTag('s', 'l', 'n', 't') &&
+               axis_value.value != 0.0f) {
+      slant = FontStyle::kOblique_Slant;
+    }
+  }
+
+  return FontStyle(weight, width, slant);
+#else
+  (void)font_face;
+  return style;
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+}
+
+std::optional<FontStyle> FontStyleFromOS2Table(IDWriteFontFace* font_face) {
+  if (!font_face) {
+    return std::nullopt;
+  }
+
+  static constexpr FontTableTag kOS2Tag = SetFourByteTag('O', 'S', '/', '2');
+  static constexpr size_t kWeightOffset = 4;
+  static constexpr size_t kWidthOffset = 6;
+  static constexpr size_t kFsSelectionOffset = 62;
+  static constexpr size_t kRequiredSize = kFsSelectionOffset + 2;
+  static constexpr uint16_t kItalicSelectionBit = 1u << 0;
+  static constexpr uint16_t kObliqueSelectionBit = 1u << 9;
+
+  AutoDWriteTable os2_table(font_face, EndianSwap32(kOS2Tag));
+  if (!os2_table.exists || os2_table.size < kRequiredSize) {
+    return std::nullopt;
+  }
+
+  uint16_t os2_weight = ReadBigEndianUInt16(os2_table.data + kWeightOffset);
+  uint16_t os2_width = ReadBigEndianUInt16(os2_table.data + kWidthOffset);
+  if (os2_weight == 0 || os2_weight > 1000 || os2_width == 0 || os2_width > 9) {
+    return std::nullopt;
+  }
+
+  uint16_t fs_selection =
+      ReadBigEndianUInt16(os2_table.data + kFsSelectionOffset);
+  FontStyle::Slant slant = FontStyle::kUpright_Slant;
+  if (fs_selection & kItalicSelectionBit) {
+    slant = FontStyle::kItalic_Slant;
+  } else if (fs_selection & kObliqueSelectionBit) {
+    slant = FontStyle::kOblique_Slant;
+  }
+
+  DWRITE_FONT_SIMULATIONS simulations = font_face->GetSimulations();
+  if (simulations & DWRITE_FONT_SIMULATIONS_BOLD) {
+    os2_weight = FontStyle::kBold_Weight;
+  }
+  if (simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) {
+    slant = FontStyle::kOblique_Slant;
+  }
+
+  return FontStyle(static_cast<int>(os2_weight), static_cast<int>(os2_width),
+                   slant);
+}
+
+std::string GetDWriteFamilyName(IDWriteFontFace3* font_face3,
+                                IDWriteFontFamily* font_family,
+                                const std::wstring& locale_name) {
+  ScopedComPtr<IDWriteLocalizedStrings> family_names;
+  if (font_face3 && SUCCEEDED(font_face3->GetFamilyNames(&family_names))) {
+    return CopyLocalizedString(family_names.get(), locale_name);
+  }
+
+  if (font_family && SUCCEEDED(font_family->GetFamilyNames(&family_names))) {
+    return CopyLocalizedString(family_names.get(), locale_name);
+  }
+
+  return "";
+}
+
+std::string GetDWritePostScriptName(IDWriteFontFace3* font_face3,
+                                    const std::wstring& locale_name) {
+  ScopedComPtr<IDWriteLocalizedStrings> post_script_names;
+  BOOL exists = FALSE;
+  if (!font_face3 ||
+      FAILED(font_face3->GetInformationalStrings(
+          DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &post_script_names,
+          &exists)) ||
+      !exists) {
+    return "";
+  }
+
+  return CopyLocalizedString(post_script_names.get(), locale_name);
+}
+
+std::string GetDWritePostScriptName(IDWriteFont* font,
+                                    const std::wstring& locale_name) {
+  ScopedComPtr<IDWriteLocalizedStrings> post_script_names;
+  BOOL exists = FALSE;
+  if (!font ||
+      FAILED(font->GetInformationalStrings(
+          DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &post_script_names,
+          &exists)) ||
+      !exists) {
+    return "";
+  }
+
+  return CopyLocalizedString(post_script_names.get(), locale_name);
+}
+
+std::string DecodeNameTableString(const uint8_t* data, size_t size,
+                                  uint16_t platform_id) {
+  std::string result;
+  if (!data || size == 0) {
+    return result;
+  }
+
+  if (platform_id == 3) {
+    if ((size % 2) != 0) {
+      return result;
+    }
+    result.reserve(size / 2);
+    for (size_t i = 0; i < size; i += 2) {
+      uint16_t value = ReadBigEndianUInt16(data + i);
+      if (value == 0 || value > 0x7F) {
+        return "";
+      }
+      result.push_back(static_cast<char>(value));
+    }
+    return result;
+  }
+
+  result.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    if (data[i] == 0 || data[i] > 0x7F) {
+      return "";
+    }
+    result.push_back(static_cast<char>(data[i]));
+  }
+  return result;
+}
+
+int NameRecordPriority(uint16_t platform_id, uint16_t encoding_id,
+                       uint16_t language_id) {
+  if (platform_id == 3 && (encoding_id == 1 || encoding_id == 10) &&
+      language_id == 0x0409) {
+    return 0;
+  }
+  if (platform_id == 3 && (encoding_id == 1 || encoding_id == 10)) {
+    return 1;
+  }
+  if (platform_id == 1 && encoding_id == 0) {
+    return 2;
+  }
+  return 3;
+}
+
+std::string GetNameTablePostScriptName(IDWriteFontFace* font_face) {
+  if (!font_face) {
+    return "";
+  }
+
+  static constexpr FontTableTag kNameTag = SetFourByteTag('n', 'a', 'm', 'e');
+  static constexpr uint16_t kPostScriptNameId = 6;
+  static constexpr size_t kHeaderSize = 6;
+  static constexpr size_t kRecordSize = 12;
+
+  AutoDWriteTable name_table(font_face, EndianSwap32(kNameTag));
+  if (!name_table.exists || name_table.size < kHeaderSize) {
+    return "";
+  }
+
+  const uint8_t* data = name_table.data;
+  const size_t table_size = static_cast<size_t>(name_table.size);
+  uint16_t count = ReadBigEndianUInt16(data + 2);
+  uint16_t string_offset = ReadBigEndianUInt16(data + 4);
+  const size_t record_table_size = static_cast<size_t>(count) * kRecordSize;
+  if (!RangeInBounds(kHeaderSize, record_table_size, table_size) ||
+      string_offset >= table_size) {
+    return "";
+  }
+
+  std::string best_name;
+  int best_priority = 4;
+  for (uint16_t i = 0; i < count; ++i) {
+    const size_t record_offset =
+        kHeaderSize + static_cast<size_t>(i) * kRecordSize;
+    const uint8_t* record = data + record_offset;
+    uint16_t platform_id = ReadBigEndianUInt16(record);
+    uint16_t encoding_id = ReadBigEndianUInt16(record + 2);
+    uint16_t language_id = ReadBigEndianUInt16(record + 4);
+    uint16_t name_id = ReadBigEndianUInt16(record + 6);
+    uint16_t length = ReadBigEndianUInt16(record + 8);
+    uint16_t offset = ReadBigEndianUInt16(record + 10);
+    if (name_id != kPostScriptNameId) {
+      continue;
+    }
+
+    const size_t name_offset =
+        static_cast<size_t>(string_offset) + static_cast<size_t>(offset);
+    if (!RangeInBounds(name_offset, length, table_size)) {
+      continue;
+    }
+
+    std::string name =
+        DecodeNameTableString(data + name_offset, length, platform_id);
+    if (name.empty()) {
+      continue;
+    }
+
+    int priority = NameRecordPriority(platform_id, encoding_id, language_id);
+    if (priority < best_priority) {
+      best_name = std::move(name);
+      best_priority = priority;
+    }
+  }
+
+  return best_name;
+}
+
+std::shared_ptr<Data> CopyDWriteFontFileStreamData(
+    IDWriteFontFileStream* stream) {
+  if (!stream) {
+    return nullptr;
+  }
+
+  UINT64 file_size = 0;
+  if (FAILED(stream->GetFileSize(&file_size)) || file_size == 0 ||
+      file_size > static_cast<UINT64>(std::numeric_limits<size_t>::max())) {
+    return nullptr;
+  }
+
+  const void* fragment_start = nullptr;
+  void* fragment_context = nullptr;
+  if (FAILED(stream->ReadFileFragment(&fragment_start, 0, file_size,
+                                      &fragment_context)) ||
+      !fragment_start) {
+    return nullptr;
+  }
+
+  auto data =
+      Data::MakeWithCopy(fragment_start, static_cast<size_t>(file_size));
+  stream->ReleaseFileFragment(fragment_context);
+  return data && !data->IsEmpty() ? data : nullptr;
+}
+
+std::shared_ptr<Data> CopyDWriteFontFileData(IDWriteFontFile* font_file) {
+  if (!font_file) {
+    return nullptr;
+  }
+
+  const void* key = nullptr;
+  UINT32 key_size = 0;
+  font_file->GetReferenceKey(&key, &key_size);
+
+  ScopedComPtr<IDWriteFontFileLoader> loader;
+  if (FAILED(font_file->GetLoader(&loader))) {
+    return nullptr;
+  }
+
+  ScopedComPtr<IDWriteFontFileStream> stream;
+  if (FAILED(loader->CreateStreamFromKey(key, key_size, &stream))) {
+    return nullptr;
+  }
+
+  return CopyDWriteFontFileStreamData(stream.get());
+}
+
+std::shared_ptr<Data> CopyDWriteFontFaceData(IDWriteFontFace* font_face) {
+  std::vector<ScopedComPtr<IDWriteFontFile>> files;
+  if (!font_face || !GetDWriteFontFiles(font_face, files) ||
+      files.size() != 1) {
+    return nullptr;
+  }
+
+  return CopyDWriteFontFileData(files[0].get());
+}
+
+FontStyle FontStyleFromDWriteFontFace(IDWriteFontFace* font_face) {
+  if (!font_face) {
+    return FontStyle::Normal();
+  }
+
+  auto table_style = FontStyleFromOS2Table(font_face);
+  if (table_style) {
+    return ApplyVariationStyle(font_face, *table_style);
+  }
+
+  int weight = FontStyle::kNormal_Weight;
+  FontStyle::Slant slant = FontStyle::kUpright_Slant;
+  DWRITE_FONT_SIMULATIONS simulations = font_face->GetSimulations();
+  if (simulations & DWRITE_FONT_SIMULATIONS_BOLD) {
+    weight = FontStyle::kBold_Weight;
+  }
+  if (simulations & DWRITE_FONT_SIMULATIONS_OBLIQUE) {
+    slant = FontStyle::kOblique_Slant;
+  }
+
+  return ApplyVariationStyle(
+      font_face, FontStyle(weight, FontStyle::kNormal_Width, slant));
+}
+
+FontStyle FontStyleFromDWriteTypeface(IDWriteFont* font,
+                                      IDWriteFontFace* font_face) {
+  auto table_style = FontStyleFromOS2Table(font_face);
+  if (table_style) {
+    return ApplyVariationStyle(font_face, *table_style);
+  }
+  FontStyle style = font ? FontStyleFromDWriteFont(font)
+                         : FontStyleFromDWriteFontFace(font_face);
+  return ApplyVariationStyle(font_face, style);
+}
+
+class TypefaceDWrite : public Typeface {
+ public:
+  TypefaceDWrite(
+      IDWriteFactory* factory, IDWriteFontFace* font_face, IDWriteFont* font,
+      IDWriteFontFamily* font_family, std::wstring locale_name,
+      bool prefer_directwrite_post_script_name = false,
+      std::shared_ptr<RegisteredFontFileLoader> registered_loader = nullptr,
+      std::shared_ptr<RegisteredFontCollectionLoader>
+          registered_collection_loader = nullptr,
+      std::string directwrite_post_script_name_override = {},
+      std::shared_ptr<Data> source_data = nullptr)
+      : Typeface(FontStyleFromDWriteTypeface(font, font_face)),
+        factory_(RefComPtr(factory)),
+        registered_loader_(std::move(registered_loader)),
+        registered_collection_loader_(std::move(registered_collection_loader)),
+        font_face_(RefComPtr(font_face)),
+        font_(SafeRefComPtr(font)),
+        font_family_(SafeRefComPtr(font_family)),
+        locale_name_(std::move(locale_name)),
+        prefer_directwrite_post_script_name_(
+            prefer_directwrite_post_script_name),
+        directwrite_post_script_name_override_(
+            std::move(directwrite_post_script_name_override)),
+        source_data_(std::move(source_data)) {
+    (void)font_face_->QueryInterface(&font_face2_);
+    (void)font_face_->QueryInterface(&font_face3_);
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+    (void)font_face_->QueryInterface(&font_face5_);
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+  }
+
+ protected:
+  int OnGetTableTags(FontTableTag tags[]) const override {
+    auto data =
+        source_data_ ? source_data_ : CopyDWriteFontFaceData(font_face_.get());
+    return GetSfntTableTags(data, font_face_->GetIndex(), tags);
+  }
+
+  size_t OnGetTableData(FontTableTag tag, size_t offset, size_t length,
+                        void* data) const override {
+    AutoDWriteTable table(font_face_.get(), EndianSwap32(tag));
+    if (!table.exists) {
+      return 0;
+    }
+
+    size_t table_size = static_cast<size_t>(table.size);
+    if (offset > table_size) {
+      return 0;
+    }
+
+    size_t copy_size = std::min(length, table_size - offset);
+    if (data) {
+      std::memcpy(data, table.data + offset, copy_size);
+    }
+
+    return copy_size;
+  }
+
+  void OnCharsToGlyphs(const uint32_t* chars, int count,
+                       GlyphID glyphs[]) const override {
+    if (!chars || !glyphs || count <= 0) {
+      return;
+    }
+
+    ScopedComPtr<IDWriteTextAnalyzer> analyzer;
+    if (FAILED(factory_->CreateTextAnalyzer(&analyzer))) {
+      std::memset(glyphs, 0, static_cast<size_t>(count) * sizeof(GlyphID));
+      return;
+    }
+
+    for (int i = 0; i < count; i++) {
+      glyphs[i] = MapUnicharToGlyph(analyzer.get(), chars[i]);
+    }
+  }
+
+  std::shared_ptr<Data> OnGetData() override {
+    if (!source_data_) {
+      source_data_ = CopyDWriteFontFaceData(font_face_.get());
+    }
+    return source_data_;
+  }
+
+  uint32_t OnGetUPEM() const override {
+    DWRITE_FONT_METRICS metrics;
+    font_face_->GetMetrics(&metrics);
+    return metrics.designUnitsPerEm;
+  }
+
+  bool OnContainsColorTable() const override {
+    if (font_face2_) {
+      return font_face2_->IsColorFont();
+    }
+
+    static constexpr FontTableTag kColrTag = SetFourByteTag('C', 'O', 'L', 'R');
+    static constexpr FontTableTag kCpalTag = SetFourByteTag('C', 'P', 'A', 'L');
+    static constexpr FontTableTag kCbdtTag = SetFourByteTag('C', 'B', 'D', 'T');
+    static constexpr FontTableTag kSbixTag = SetFourByteTag('s', 'b', 'i', 'x');
+    AutoDWriteTable colr_table(font_face_.get(), EndianSwap32(kColrTag));
+    AutoDWriteTable cpal_table(font_face_.get(), EndianSwap32(kCpalTag));
+    AutoDWriteTable cbdt_table(font_face_.get(), EndianSwap32(kCbdtTag));
+    AutoDWriteTable sbix_table(font_face_.get(), EndianSwap32(kSbixTag));
+    return (colr_table.exists && cpal_table.exists) || cbdt_table.exists ||
+           sbix_table.exists;
+  }
+
+  std::unique_ptr<ScalerContext> OnCreateScalerContext(
+      const ScalerContextDesc* desc) const override {
+    return MakeScalerContextDWrite(
+        const_cast<TypefaceDWrite*>(this)->shared_from_this(), factory_.get(),
+        font_face_.get(), desc);
+  }
+
+  VariationPosition OnGetVariationDesignPosition() const override {
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+    if (font_face5_ && font_face5_->HasVariations()) {
+      return GetDWriteVariationDesignPosition(font_face5_.get());
+    }
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+    return VariationPosition{};
+  }
+
+  std::vector<VariationAxis> OnGetVariationDesignParameters() const override {
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+    if (font_face5_ && font_face5_->HasVariations()) {
+      return GetDWriteVariationDesignParameters(font_face5_.get());
+    }
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+    return {};
+  }
+
+  std::shared_ptr<Typeface> OnMakeVariation(
+      const FontArguments& args) const override {
+    if (font_face_->GetIndex() != args.GetCollectionIndex()) {
+      if (args.GetCollectionIndex() >
+          static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return nullptr;
+      }
+
+      auto data = source_data_ ? source_data_
+                               : CopyDWriteFontFaceData(font_face_.get());
+      auto typeface = MakeDWriteTypefaceFromData(
+          factory_.get(), locale_name_, std::move(data),
+          static_cast<int>(args.GetCollectionIndex()));
+      return typeface ? typeface->MakeVariation(args) : nullptr;
+    }
+
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+    if (font_face5_ && font_face5_->HasVariations()) {
+      auto new_font_face = MakeDWriteVariationFontFace(font_face5_.get(), args);
+      if (new_font_face) {
+        std::string post_script_name_override =
+            directwrite_post_script_name_override_;
+        if (post_script_name_override.empty() &&
+            prefer_directwrite_post_script_name_) {
+          post_script_name_override =
+              GetDWritePostScriptName(font_face3_.get(), locale_name_);
+        }
+        return std::make_shared<TypefaceDWrite>(
+            factory_.get(), new_font_face.get(), font_.get(),
+            font_family_.get(), locale_name_,
+            prefer_directwrite_post_script_name_, registered_loader_,
+            registered_collection_loader_, std::move(post_script_name_override),
+            source_data_);
+      }
+    }
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+    return const_cast<TypefaceDWrite*>(this)->shared_from_this();
+  }
+
+  void OnGetFontDescriptor(FontDescriptor& desc) const override {
+    desc.style = GetFontStyle();
+
+    std::string family_name = GetDWriteFamilyName(
+        font_face3_.get(), font_family_.get(), locale_name_);
+    if (!family_name.empty()) {
+      desc.family_name = std::move(family_name);
+    }
+
+    desc.full_name.clear();
+    std::string post_script_name = directwrite_post_script_name_override_;
+    if (post_script_name.empty()) {
+      if (prefer_directwrite_post_script_name_) {
+        post_script_name =
+            GetDWritePostScriptName(font_face3_.get(), locale_name_);
+        if (post_script_name.empty()) {
+          post_script_name = GetDWritePostScriptName(font_.get(), locale_name_);
+        }
+        if (post_script_name.empty()) {
+          post_script_name = GetNameTablePostScriptName(font_face_.get());
+        }
+      } else {
+        post_script_name = GetNameTablePostScriptName(font_face_.get());
+        if (post_script_name.empty()) {
+          post_script_name = GetDWritePostScriptName(font_.get(), locale_name_);
+        }
+        if (post_script_name.empty()) {
+          post_script_name =
+              GetDWritePostScriptName(font_face3_.get(), locale_name_);
+        }
+      }
+    }
+    if (!post_script_name.empty()) {
+      desc.post_script_name = std::move(post_script_name);
+    }
+
+    desc.collection_index = static_cast<int32_t>(font_face_->GetIndex());
+    desc.factory_id = kDWriteFactoryID;
+  }
+
+ private:
+  GlyphID MapUnicharToGlyph(IDWriteTextAnalyzer* analyzer,
+                            uint32_t codepoint) const {
+    if (!analyzer || codepoint > 0x10FFFF ||
+        (codepoint >= 0xD800 && codepoint <= 0xDFFF)) {
+      return 0;
+    }
+
+    WCHAR text[2] = {};
+    UINT32 text_length = 0;
+    if (codepoint <= 0xFFFF) {
+      text[0] = static_cast<WCHAR>(codepoint);
+      text_length = 1;
+    } else {
+      codepoint -= 0x10000;
+      text[0] = static_cast<WCHAR>(0xD800 + (codepoint >> 10));
+      text[1] = static_cast<WCHAR>(0xDC00 + (codepoint & 0x3FF));
+      text_length = 2;
+    }
+
+    DWRITE_SCRIPT_ANALYSIS script_analysis = {};
+    UINT16 cluster_map[2] = {};
+    DWRITE_SHAPING_TEXT_PROPERTIES text_props[2] = {};
+    UINT16 glyph_indices[8] = {};
+    DWRITE_SHAPING_GLYPH_PROPERTIES glyph_props[8] = {};
+    UINT32 actual_glyph_count = 0;
+    HRESULT hr = analyzer->GetGlyphs(
+        text, text_length, font_face_.get(), FALSE, FALSE, &script_analysis,
+        locale_name_.empty() ? nullptr : locale_name_.c_str(), nullptr, nullptr,
+        nullptr, 0,
+        static_cast<UINT32>(sizeof(glyph_indices) / sizeof(glyph_indices[0])),
+        cluster_map, text_props, glyph_indices, glyph_props,
+        &actual_glyph_count);
+    if (FAILED(hr) || actual_glyph_count == 0) {
+      return 0;
+    }
+
+    return glyph_indices[0];
+  }
+
+  ScopedComPtr<IDWriteFactory> factory_;
+  std::shared_ptr<RegisteredFontFileLoader> registered_loader_;
+  std::shared_ptr<RegisteredFontCollectionLoader> registered_collection_loader_;
+  ScopedComPtr<IDWriteFontFace> font_face_;
+  ScopedComPtr<IDWriteFontFace2> font_face2_;
+  ScopedComPtr<IDWriteFontFace3> font_face3_;
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+  ScopedComPtr<IDWriteFontFace5> font_face5_;
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+  ScopedComPtr<IDWriteFont> font_;
+  ScopedComPtr<IDWriteFontFamily> font_family_;
+  std::wstring locale_name_;
+  bool prefer_directwrite_post_script_name_;
+  std::string directwrite_post_script_name_override_;
+  std::shared_ptr<Data> source_data_;
+};
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromCollection(
+    IDWriteFactory* factory, const std::wstring& locale_name,
+    IDWriteFontCollection* font_collection, int ttc_index,
+    std::shared_ptr<RegisteredFontFileLoader> registered_loader,
+    std::shared_ptr<RegisteredFontCollectionLoader>
+        registered_collection_loader,
+    std::shared_ptr<Data> source_data) {
+  if (!factory || !font_collection || ttc_index < 0) {
+    return nullptr;
+  }
+
+  UINT32 family_count = font_collection->GetFontFamilyCount();
+  for (UINT32 family_index = 0; family_index < family_count; ++family_index) {
+    ScopedComPtr<IDWriteFontFamily> font_family;
+    HRNM(font_collection->GetFontFamily(family_index, &font_family),
+         "Could not get DirectWrite custom font family.");
+
+    UINT32 font_count = font_family->GetFontCount();
+    for (UINT32 font_index = 0; font_index < font_count; ++font_index) {
+      ScopedComPtr<IDWriteFont> font;
+      HRNM(font_family->GetFont(font_index, &font),
+           "Could not get DirectWrite custom font.");
+
+      ScopedComPtr<IDWriteFontFace> font_face;
+      HRNM(font->CreateFontFace(&font_face),
+           "Could not create DirectWrite custom font face.");
+      if (font_face->GetIndex() != static_cast<UINT32>(ttc_index)) {
+        continue;
+      }
+
+#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
+      auto default_font_face =
+          MakeDWriteDefaultVariationFontFace(font_face.get());
+      if (default_font_face) {
+        font_face = std::move(default_font_face);
+      }
+#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
+
+      return std::make_shared<TypefaceDWrite>(
+          factory, font_face.get(), font.get(), font_family.get(), locale_name,
+          true, std::move(registered_loader),
+          std::move(registered_collection_loader), std::string{},
+          std::move(source_data));
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace
+
+std::string CopyLocalizedString(IDWriteLocalizedStrings* strings,
+                                const std::wstring& locale_name) {
+  if (strings == nullptr || strings->GetCount() == 0) {
+    return "";
+  }
+
+  UINT32 index = 0;
+  BOOL exists = FALSE;
+  bool found = false;
+  if (!locale_name.empty() &&
+      SUCCEEDED(
+          strings->FindLocaleName(locale_name.c_str(), &index, &exists)) &&
+      exists) {
+    found = true;
+  }
+  if (!found && SUCCEEDED(strings->FindLocaleName(L"en-us", &index, &exists)) &&
+      exists) {
+    found = true;
+  }
+  if (!found) {
+    index = 0;
+  }
+
+  UINT32 length = 0;
+  if (FAILED(strings->GetStringLength(index, &length))) {
+    return "";
+  }
+
+  std::wstring value(length + 1, L'\0');
+  if (FAILED(strings->GetString(index, &value[0],
+                                static_cast<UINT32>(value.size())))) {
+    return "";
+  }
+  value.resize(length);
+
+  std::string result;
+  if (FAILED(StrConversion::WideStringToString(value, &result))) {
+    return "";
+  }
+  return result;
+}
+
+std::shared_ptr<Typeface> MakeDWriteTypeface(
+    IDWriteFactory* factory, IDWriteFontFace* font_face, IDWriteFont* font,
+    IDWriteFontFamily* font_family, std::wstring locale_name,
+    bool prefer_directwrite_post_script_name,
+    std::string directwrite_post_script_name_override,
+    std::shared_ptr<Data> source_data) {
+  return std::make_shared<TypefaceDWrite>(
+      factory, font_face, font, font_family, std::move(locale_name),
+      prefer_directwrite_post_script_name, nullptr, nullptr,
+      std::move(directwrite_post_script_name_override), std::move(source_data));
+}
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromDWriteFont(
+    IDWriteFactory* factory, const std::wstring& locale_name,
+    IDWriteFontFace* font_face, IDWriteFont* font,
+    IDWriteFontFamily* font_family) {
+  return MakeDWriteTypeface(factory, font_face, font, font_family, locale_name,
+                            false, std::string{},
+                            CopyDWriteFontFaceData(font_face));
+}
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromFileReference(
+    IDWriteFactory* factory, const std::wstring& locale_name, const char* path,
+    int ttc_index) {
+  if (!factory || !path || ttc_index < 0) {
+    return nullptr;
+  }
+
+  std::wstring w_path;
+  if (FAILED(StrConversion::StringToWideString(path, &w_path))) {
+    return nullptr;
+  }
+
+  ScopedComPtr<IDWriteFontFile> font_file;
+  if (FAILED(factory->CreateFontFileReference(w_path.c_str(), nullptr,
+                                              &font_file))) {
+    return nullptr;
+  }
+
+  BOOL is_supported = FALSE;
+  DWRITE_FONT_FILE_TYPE file_type = DWRITE_FONT_FILE_TYPE_UNKNOWN;
+  DWRITE_FONT_FACE_TYPE face_type = DWRITE_FONT_FACE_TYPE_UNKNOWN;
+  UINT32 face_count = 0;
+  if (FAILED(font_file->Analyze(&is_supported, &file_type, &face_type,
+                                &face_count)) ||
+      !is_supported || static_cast<UINT32>(ttc_index) >= face_count) {
+    return nullptr;
+  }
+
+  IDWriteFontFile* font_files[] = {font_file.get()};
+  ScopedComPtr<IDWriteFontFace> font_face;
+  if (FAILED(factory->CreateFontFace(
+          face_type, 1, font_files, static_cast<UINT32>(ttc_index),
+          DWRITE_FONT_SIMULATIONS_NONE, &font_face))) {
+    return nullptr;
+  }
+
+  auto source_data = Data::MakeFromFileMapping(path);
+  return std::make_shared<TypefaceDWrite>(
+      factory, font_face.get(), nullptr, nullptr, locale_name, true, nullptr,
+      nullptr, std::string{}, std::move(source_data));
+}
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromData(
+    IDWriteFactory* factory, const std::wstring& locale_name,
+    std::shared_ptr<Data> data, int ttc_index) {
+  if (!factory || !data || data->IsEmpty() || ttc_index < 0) {
+    return nullptr;
+  }
+
+  ScopedComPtr<DataFontFileLoader> loader(new DataFontFileLoader(data));
+  auto registered_loader =
+      RegisteredFontFileLoader::Make(factory, loader.get());
+  if (!registered_loader) {
+    return nullptr;
+  }
+
+  ScopedComPtr<DataFontCollectionLoader> collection_loader(
+      new DataFontCollectionLoader(loader.get()));
+  auto registered_collection_loader =
+      RegisteredFontCollectionLoader::Make(factory, collection_loader.get());
+  if (!registered_collection_loader) {
+    return nullptr;
+  }
+
+  ScopedComPtr<IDWriteFontCollection> font_collection;
+  if (FAILED(factory->CreateCustomFontCollection(
+          collection_loader.get(), nullptr, 0, &font_collection))) {
+    return nullptr;
+  }
+
+  return MakeDWriteTypefaceFromCollection(
+      factory, locale_name, font_collection.get(), ttc_index,
+      std::move(registered_loader), std::move(registered_collection_loader),
+      std::move(data));
+}
+
+}  // namespace skity

--- a/src/text/ports/win/typeface_win.hpp
+++ b/src/text/ports/win/typeface_win.hpp
@@ -1,0 +1,60 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_TEXT_PORTS_WIN_TYPEFACE_WIN_HPP
+#define SRC_TEXT_PORTS_WIN_TYPEFACE_WIN_HPP
+
+// clang-format off
+#include "src/text/ports/win/dwrite_version.hpp"
+#include <dwrite.h>
+// clang-format on
+
+#include <memory>
+#include <skity/io/data.hpp>
+#include <skity/text/font_arguments.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/typeface.hpp>
+#include <string>
+#include <vector>
+
+#include "src/text/ports/win/dwrite_utils.hpp"
+#include "src/text/ports/win/scoped_com_ptr.hpp"
+
+namespace skity {
+
+bool HasBitmapStrikes(const ScopedComPtr<IDWriteFont>& font);
+bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs);
+
+HRESULT FirstMatchingFontWithoutSimulations(
+    const ScopedComPtr<IDWriteFontFamily>& family, DWriteStyle dwStyle,
+    ScopedComPtr<IDWriteFont>& font);
+
+FontStyle FontStyleFromDWriteFont(IDWriteFont* font);
+
+std::string CopyLocalizedString(IDWriteLocalizedStrings* strings,
+                                const std::wstring& locale_name);
+
+std::shared_ptr<Typeface> MakeDWriteTypeface(
+    IDWriteFactory* factory, IDWriteFontFace* font_face, IDWriteFont* font,
+    IDWriteFontFamily* font_family, std::wstring locale_name,
+    bool prefer_directwrite_post_script_name = false,
+    std::string directwrite_post_script_name_override = {},
+    std::shared_ptr<Data> source_data = nullptr);
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromDWriteFont(
+    IDWriteFactory* factory, const std::wstring& locale_name,
+    IDWriteFontFace* font_face, IDWriteFont* font,
+    IDWriteFontFamily* font_family);
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromFileReference(
+    IDWriteFactory* factory, const std::wstring& locale_name, const char* path,
+    int ttc_index);
+
+std::shared_ptr<Typeface> MakeDWriteTypefaceFromData(
+    IDWriteFactory* factory, const std::wstring& locale_name,
+    std::shared_ptr<Data> data, int ttc_index);
+
+}  // namespace skity
+
+#endif  // SRC_TEXT_PORTS_WIN_TYPEFACE_WIN_HPP

--- a/src/text/scaler_context_desc.cc
+++ b/src/text/scaler_context_desc.cc
@@ -13,8 +13,30 @@
 
 namespace skity {
 
+namespace {
+
+Color GetPaintTextColor(const Paint& paint) {
+  return Color4fToColor(paint.GetStyle() == Paint::kStroke_Style
+                            ? paint.GetStrokeColor()
+                            : paint.GetFillColor());
+}
+
+}  // namespace
+
 size_t ScalerContextDesc::hash() const {
   return skity::Hash32(this, sizeof(ScalerContextDesc));
+}
+
+Color ScalerContextDesc::GetGlyphImageForegroundColor(const Font& font,
+                                                      const Paint& paint) {
+#if defined(SKITY_WIN)
+  return GetPaintTextColor(paint);
+#else
+  if (font.GetTypeface()->ContainsColorTable()) {
+    return GetPaintTextColor(paint);
+  }
+  return Color_TRANSPARENT;
+#endif
 }
 
 ScalerContextDesc ScalerContextDesc::MakeCanonicalized(const Font& font,
@@ -47,13 +69,7 @@ ScalerContextDesc ScalerContextDesc::MakeTransformed(
   desc.scale_x = font.GetScaleX();
   desc.skew_x = font.GetSkewX();
   desc.transform = transform;
-  if (font.GetTypeface()->ContainsColorTable()) {
-    desc.foreground_color = paint.GetStyle() == Paint::kStroke_Style
-                                ? Color4fToColor(paint.GetStrokeColor())
-                                : Color4fToColor(paint.GetFillColor());
-  } else {
-    desc.foreground_color = Color_TRANSPARENT;
-  }
+  desc.foreground_color = GetGlyphImageForegroundColor(font, paint);
 
   desc.stroke_width =
       paint.GetStyle() == Paint::kStroke_Style ? paint.GetStrokeWidth() : 0.f;

--- a/src/text/scaler_context_desc.hpp
+++ b/src/text/scaler_context_desc.hpp
@@ -60,6 +60,9 @@ struct ScalerContextDesc {
 
   size_t hash() const;
 
+  static Color GetGlyphImageForegroundColor(const Font& font,
+                                            const Paint& paint);
+
   static ScalerContextDesc MakeCanonicalized(const Font& font,
                                              const Paint& paint);
 

--- a/src/utils/settings.cc
+++ b/src/utils/settings.cc
@@ -24,4 +24,12 @@ void Settings::SetAnyWeightEnabled(bool enable) {
   enable_any_weight_.store(enable);
 }
 
+bool Settings::EnableDWriteFontManager() const {
+  return enable_dwrite_font_manager_.load();
+}
+
+void Settings::SetEnableDWriteFontManager(bool enable) {
+  enable_dwrite_font_manager_.store(enable);
+}
+
 }  // namespace skity


### PR DESCRIPTION
Add an optional Windows DirectWrite font manager backend that returns DirectWrite-backed typefaces and scaler contexts.

Route the default Windows font manager through the new backend when enabled, while keeping the existing implementation available as the fallback path.