### PR TITLE
feat(path): Fix StrokeThenFill draw order in render paths

### DIFF
--- a/src/render/hw/hw_canvas.cc
+++ b/src/render/hw/hw_canvas.cc
@@ -21,6 +21,7 @@
 #include "src/render/hw/dst_read_strategy.hpp"
 #include "src/render/hw/filters/hw_filters.hpp"
 #include "src/render/hw/layer/hw_filter_layer.hpp"
+#include "src/render/paint_order.hpp"
 #include "src/render/shape.hpp"
 #include "src/render/text/glyph_run.hpp"
 #include "src/tracing.hpp"
@@ -421,7 +422,7 @@ void HWCanvas::DrawPathInternal(const Path& path, const Paint& paint,
     CurrentLayer()->AddDraw(draw);
   };
 
-  if (need_fill) {
+  auto draw_fill = [&]() {
     Paint work_paint(paint);
     work_paint.SetStyle(Paint::kFill_Style);
     work_paint.SetAntiAlias(need_contour_aa);
@@ -434,9 +435,9 @@ void HWCanvas::DrawPathInternal(const Path& path, const Paint& paint,
     }
 
     draw_op_handler(*dst, work_paint, false);
-  }
+  };
 
-  if (need_stroke) {
+  auto draw_stroke = [&]() {
     Paint work_paint(paint);
     work_paint.SetStyle(Paint::kStroke_Style);
     work_paint.SetAntiAlias(need_contour_aa);
@@ -461,7 +462,10 @@ void HWCanvas::DrawPathInternal(const Path& path, const Paint& paint,
     } else {
       draw_op_handler(*dst, work_paint, true);
     }
-  }
+  };
+
+  DrawFillStrokeInPaintOrder(paint.GetStyle(), need_fill, need_stroke,
+                             draw_fill, draw_stroke);
 }
 
 bool HWCanvas::NeedsFallbackToPathDraw(const RRect& rrect, const Paint& paint,
@@ -535,17 +539,20 @@ void HWCanvas::DrawRRectInternal(const RRect& rrect, const Paint& paint,
     CurrentLayer()->AddDraw(draw);
   };
 
-  if (need_fill) {
+  auto draw_fill = [&]() {
     Paint work_paint(paint);
     work_paint.SetStyle(Paint::kFill_Style);
     draw_op_handler(rrect, work_paint, false);
-  }
+  };
 
-  if (need_stroke) {
+  auto draw_stroke = [&]() {
     Paint work_paint(paint);
     work_paint.SetStyle(Paint::kStroke_Style);
     draw_op_handler(rrect, work_paint, true);
-  }
+  };
+
+  DrawFillStrokeInPaintOrder(paint.GetStyle(), need_fill, need_stroke,
+                             draw_fill, draw_stroke);
 }
 
 void HWCanvas::OnSave() {

--- a/src/render/paint_order.hpp
+++ b/src/render/paint_order.hpp
@@ -1,0 +1,35 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_PAINT_ORDER_HPP
+#define SRC_RENDER_PAINT_ORDER_HPP
+
+#include <skity/graphic/paint.hpp>
+
+namespace skity {
+
+template <typename FillFunc, typename StrokeFunc>
+void DrawFillStrokeInPaintOrder(Paint::Style style, bool need_fill,
+                                bool need_stroke, FillFunc&& draw_fill,
+                                StrokeFunc&& draw_stroke) {
+  if (style == Paint::kStrokeThenFill_Style) {
+    if (need_stroke) {
+      draw_stroke();
+    }
+    if (need_fill) {
+      draw_fill();
+    }
+  } else {
+    if (need_fill) {
+      draw_fill();
+    }
+    if (need_stroke) {
+      draw_stroke();
+    }
+  }
+}
+
+}  // namespace skity
+
+#endif  // SRC_RENDER_PAINT_ORDER_HPP

--- a/src/render/sw/sw_canvas.cc
+++ b/src/render/sw/sw_canvas.cc
@@ -18,6 +18,7 @@
 #include "src/effect/image_filter_base.hpp"
 #include "src/effect/mask_filter_priv.hpp"
 #include "src/effect/pixmap_shader.hpp"
+#include "src/render/paint_order.hpp"
 #include "src/render/sw/sw_raster.hpp"
 #include "src/render/sw/sw_span_brush.hpp"
 #include "src/render/sw/sw_stack_blur.hpp"
@@ -370,8 +371,7 @@ void SWCanvas::OnDrawPath(const Path& path, const Paint& paint) {
   bool need_fill = paint.GetStyle() != Paint::kStroke_Style;
   bool need_stroke = paint.GetStyle() != Paint::kFill_Style;
 
-  // Fill first
-  if (need_fill) {
+  auto draw_fill = [&]() {
     SWRaster raster;
 
     Path temp;
@@ -383,9 +383,9 @@ void SWCanvas::OnDrawPath(const Path& path, const Paint& paint) {
     }
 
     DoBrush(raster, paint, false);
-  }
+  };
 
-  if (need_stroke) {
+  auto draw_stroke = [&]() {
     Stroke stroke(paint);
 
     Path temp;
@@ -404,7 +404,10 @@ void SWCanvas::OnDrawPath(const Path& path, const Paint& paint) {
     raster.RastePath(outline, CurrentTransform(), GetScanClipBounds());
 
     DoBrush(raster, paint, true);
-  }
+  };
+
+  DrawFillStrokeInPaintOrder(paint.GetStyle(), need_fill, need_stroke,
+                             draw_fill, draw_stroke);
 }
 
 void SWCanvas::OnDrawPaint(const Paint& paint) {
@@ -550,13 +553,20 @@ void SWCanvas::DrawGlyphsInternal(uint32_t count, const GlyphID* glyphs,
     return;
   }
 
-  if (need_fill || font.GetTypeface()->ContainsColorTable()) {
-    FillGlyphs(count, glyphs, position_x, position_y, font, paint);
-  }
+  bool draw_fill = need_fill || font.GetTypeface()->ContainsColorTable();
+  auto fill_glyphs = [&]() {
+    if (draw_fill) {
+      FillGlyphs(count, glyphs, position_x, position_y, font, paint);
+    }
+  };
+  auto stroke_glyphs = [&]() {
+    if (need_stroke) {
+      StrokeGlyphs(count, glyphs, position_x, position_y, font, paint);
+    }
+  };
 
-  if (need_stroke) {
-    StrokeGlyphs(count, glyphs, position_x, position_y, font, paint);
-  }
+  DrawFillStrokeInPaintOrder(paint.GetStyle(), draw_fill, need_stroke,
+                             fill_glyphs, stroke_glyphs);
 }
 
 void SWCanvas::FillGlyphs(uint32_t count, const GlyphID* glyphs,

--- a/test/ut/render/sw_canvas_test.cc
+++ b/test/ut/render/sw_canvas_test.cc
@@ -63,3 +63,24 @@ TEST(SWCanvas, SaveLayerHugeBoundsPreservesRotatedDraw) {
     }
   }
 }
+
+TEST(SWCanvas, StrokeThenFillDrawsFillAfterStroke) {
+  skity::Bitmap bitmap(48, 48, skity::AlphaType::kPremul_AlphaType,
+                       skity::ColorType::kRGBA);
+  auto canvas = skity::Canvas::MakeSoftwareCanvas(&bitmap);
+  ASSERT_TRUE(canvas);
+
+  skity::Paint paint;
+  paint.SetStyle(skity::Paint::kStrokeThenFill_Style);
+  paint.SetStrokeWidth(10.f);
+  paint.SetStrokeColor(skity::Color_RED);
+  paint.SetFillColor(skity::Color_WHITE);
+  paint.SetAntiAlias(false);
+
+  skity::Path path;
+  path.AddRect(skity::Rect::MakeXYWH(10.f, 10.f, 24.f, 24.f));
+  canvas->DrawPath(path, paint);
+
+  EXPECT_EQ(bitmap.GetPixel(12, 20), skity::Color_WHITE);
+  EXPECT_EQ(bitmap.GetPixel(7, 20), skity::Color_RED);
+}


### PR DESCRIPTION
Share fill/stroke ordering through a small render helper and apply it to HW path, HW simple-shape rrect, SW path, and SW glyph drawing. Add SW regression coverage for stroke-then-fill ordering.