### PR TITLE
feat(gpu): support native advanced blend via GL_KHR/VK_EXT

### DIFF
--- a/module/wgx/glsl/glsl_ast_printer.cpp
+++ b/module/wgx/glsl/glsl_ast_printer.cpp
@@ -647,7 +647,9 @@ bool AstPrinter::Write() {
 
   ss_ << std::endl;
 
-  // Check if we need framebuffer fetch extension
+  // Detect framebuffer fetch from the AST: a @color fragment input means the
+  // shader reads the current pixel, which requires the extension and turns the
+  // color output into an inout (handled in WriteOutput).
   needs_fb_fetch_ = false;
   if (func_->GetFunction()->GetPipelineStage() ==
       ast::PipelineStage::kFragment) {
@@ -658,8 +660,35 @@ bool AstPrinter::Write() {
       }
     }
   }
+
+  // Gather every extension to declare: caller-requested ones
+  // (GlslOptions::extensions) plus framebuffer fetch inferred from the source.
+  std::vector<std::string> extensions = options_.extensions;
   if (needs_fb_fetch_) {
-    ss_ << "#extension GL_EXT_shader_framebuffer_fetch : require" << std::endl;
+    extensions.push_back("GL_EXT_shader_framebuffer_fetch");
+  }
+
+  // GL_KHR_blend_equation_advanced additionally requires the fragment color
+  // output to carry blend_support_all_equations (handled in WriteOutput).
+  // Detect it by name so callers only need to list the extension.
+  needs_advanced_blend_ = false;
+  if (func_->GetFunction()->GetPipelineStage() ==
+      ast::PipelineStage::kFragment) {
+    for (const auto& extension : extensions) {
+      if (extension == "GL_KHR_blend_equation_advanced") {
+        needs_advanced_blend_ = true;
+        break;
+      }
+    }
+  }
+
+  // Emit every required #extension on a single generic path. New extensions
+  // that only need a declaration can be added through GlslOptions::extensions
+  // without touching this code.
+  for (const auto& extension : extensions) {
+    ss_ << "#extension " << extension << " : require" << std::endl;
+  }
+  if (!extensions.empty()) {
     ss_ << std::endl;
   }
 
@@ -1001,7 +1030,16 @@ void AstPrinter::WriteOutput() {
       return;
     }
 
-    WriteLocation(attr, entry_point->GetPipelineStage(), false);
+    if (needs_advanced_blend_ &&
+        entry_point->GetPipelineStage() == ast::PipelineStage::kFragment) {
+      // Mark the fragment color output as supporting every advanced blend
+      // equation, which GL_KHR_blend_equation_advanced requires before any
+      // advanced blend equation can be applied to this output.
+      ss_ << "layout(blend_support_all_equations) out;" << std::endl;
+      ss_ << "layout(location = " << attr->index << ") ";
+    } else {
+      WriteLocation(attr, entry_point->GetPipelineStage(), false);
+    }
     if (needs_fb_fetch_) {
       ss_ << " inout ";
     } else {

--- a/module/wgx/glsl/glsl_ast_printer.h
+++ b/module/wgx/glsl/glsl_ast_printer.h
@@ -133,6 +133,7 @@ class AstPrinter : public ast::AstVisitor {
   uint32_t ubo_index_ = 0;
   uint32_t texture_index_ = 0;
   bool needs_fb_fetch_ = false;
+  bool needs_advanced_blend_ = false;
 };
 
 }  // namespace glsl

--- a/module/wgx/include/wgsl_cross.h
+++ b/module/wgx/include/wgsl_cross.h
@@ -48,6 +48,16 @@ struct WGX_API GlslOptions {
   Standard standard = Standard::kDesktop;
   uint32_t major_version = 3;
   uint32_t minor_version = 3;
+  // GL extension names to emit verbatim as
+  // `#extension <name> : require` at the top of the generated shader. This is
+  // the single entry point for extension declarations:
+  //  - Extensions that only need a declaration are listed here directly.
+  //  - GL_EXT_shader_framebuffer_fetch is added automatically when the fragment
+  //    shader has a @color input (and turns its color output into an inout).
+  //  - Listing GL_KHR_blend_equation_advanced here also marks the fragment
+  //    color output with `blend_support_all_equations`, so the fixed function
+  //    advanced blend equations can be applied to it.
+  std::vector<std::string> extensions = {};
 };
 
 struct WGX_API MslOptions {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -314,6 +314,7 @@ if(${SKITY_HW_RENDERER})
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/layer/hw_sub_layer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/dst_read_strategy.cc
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/dst_read_strategy.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/render/hw/native_blend.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_buffer_layout_map.cc
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_buffer_layout_map.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_canvas.cc

--- a/src/gpu/gl/formats_gl.h
+++ b/src/gpu/gl/formats_gl.h
@@ -100,6 +100,43 @@ constexpr GLenum ToBlendFactor(GPUBlendFactor factor) {
   }
 }
 
+constexpr GLenum ToGLBlendEquation(GPUBlendOperation op) {
+  switch (op) {
+    case GPUBlendOperation::kAdd:
+      return GL_FUNC_ADD;
+    case GPUBlendOperation::kMultiply:
+      return GL_MULTIPLY_KHR;
+    case GPUBlendOperation::kScreen:
+      return GL_SCREEN_KHR;
+    case GPUBlendOperation::kOverlay:
+      return GL_OVERLAY_KHR;
+    case GPUBlendOperation::kDarken:
+      return GL_DARKEN_KHR;
+    case GPUBlendOperation::kLighten:
+      return GL_LIGHTEN_KHR;
+    case GPUBlendOperation::kColorDodge:
+      return GL_COLORDODGE_KHR;
+    case GPUBlendOperation::kColorBurn:
+      return GL_COLORBURN_KHR;
+    case GPUBlendOperation::kHardLight:
+      return GL_HARDLIGHT_KHR;
+    case GPUBlendOperation::kSoftLight:
+      return GL_SOFTLIGHT_KHR;
+    case GPUBlendOperation::kDifference:
+      return GL_DIFFERENCE_KHR;
+    case GPUBlendOperation::kExclusion:
+      return GL_EXCLUSION_KHR;
+    case GPUBlendOperation::kHslHue:
+      return GL_HSL_HUE_KHR;
+    case GPUBlendOperation::kHslSaturation:
+      return GL_HSL_SATURATION_KHR;
+    case GPUBlendOperation::kHslColor:
+      return GL_HSL_COLOR_KHR;
+    case GPUBlendOperation::kHslLuminosity:
+      return GL_HSL_LUMINOSITY_KHR;
+  }
+}
+
 constexpr GLint ExternalFormatFrom(GPUTextureFormat format) {
   switch (format) {
     case GPUTextureFormat::kR8Unorm:

--- a/src/gpu/gl/gl_interface.cc
+++ b/src/gpu/gl/gl_interface.cc
@@ -32,12 +32,12 @@ struct GLExtensions {
   }
 };
 
-GLInterface *g_interface = nullptr;
+GLInterface* g_interface = nullptr;
 
 #define GET_PROC(F) \
   g_interface->f##F = (decltype(g_interface->f##F))loader("gl" #F)
 
-void GLInterface::InitGlobalInterface(void *proc_loader) {
+void GLInterface::InitGlobalInterface(void* proc_loader) {
   static std::mutex g_mutex = {};
 
   std::lock_guard<std::mutex> lock(g_mutex);
@@ -63,6 +63,7 @@ void GLInterface::InitGlobalInterface(void *proc_loader) {
   GET_PROC(BlendColor);
   GET_PROC(BlendFunc);
   GET_PROC(BlendEquation);
+  GET_PROC(BlendEquationSeparate);
   GET_PROC(BlitFramebuffer);
   GET_PROC(BufferData);
   GET_PROC(BufferSubData);
@@ -165,7 +166,7 @@ void GLInterface::InitGlobalInterface(void *proc_loader) {
   g_interface->LoadExtensions(loader);
 }
 
-GLInterface *GLInterface::GlobalInterface() { return g_interface; }
+GLInterface* GLInterface::GlobalInterface() { return g_interface; }
 
 bool GLInterface::CanUseMSAA() {
   return ext_multisampled_render_to_texture ||
@@ -182,10 +183,10 @@ bool GLInterface::LoadExtensions(GLADloadfunc loader) {
     extensions.extensions.resize(num_extensions);
 
     for (int32_t i = 0; i < num_extensions; i++) {
-      extensions.extensions[i] = (const char *)fGetStringi(GL_EXTENSIONS, i);
+      extensions.extensions[i] = (const char*)fGetStringi(GL_EXTENSIONS, i);
     }
   } else if (fGetString != nullptr) {
-    auto extensions_str = (const char *)fGetString(GL_EXTENSIONS);
+    auto extensions_str = (const char*)fGetString(GL_EXTENSIONS);
 
     // split extensions_str
     std::string_view extensions_view{extensions_str};
@@ -232,6 +233,15 @@ bool GLInterface::LoadExtensions(GLADloadfunc loader) {
   // GL_EXT_shader_framebuffer_fetch
   ext_shader_framebuffer_fetch =
       extensions.Contains("GL_EXT_shader_framebuffer_fetch");
+
+  // GL_KHR_blend_equation_advanced
+  ext_khr_blend_equation_advanced =
+      extensions.Contains("GL_KHR_blend_equation_advanced");
+  ext_khr_blend_equation_advanced_coherent =
+      extensions.Contains("GL_KHR_blend_equation_advanced_coherent");
+  if (ext_khr_blend_equation_advanced) {
+    fBlendBarrierKHR = (PFNGLBLENDBARRIERKHRPROC)loader("glBlendBarrierKHR");
+  }
 
   return true;
 }

--- a/src/gpu/gl/gl_interface.hpp
+++ b/src/gpu/gl/gl_interface.hpp
@@ -56,6 +56,9 @@ struct GLInterface {
   PFNGLBLENDCOLORPROC fBlendColor = nullptr;
   PFNGLBLENDEQUATIONPROC fBlendEquation = nullptr;
   PFNGLBLENDFUNCPROC fBlendFunc = nullptr;
+  PFNGLBLENDEQUATIONSEPARATEPROC fBlendEquationSeparate = nullptr;
+  // GL_KHR_blend_equation_advanced
+  PFNGLBLENDBARRIERKHRPROC fBlendBarrierKHR = nullptr;
   PFNGLBLITFRAMEBUFFERPROC fBlitFramebuffer = nullptr;
   PFNGLBUFFERDATAPROC fBufferData = nullptr;
   PFNGLBUFFERSUBDATAPROC fBufferSubData = nullptr;
@@ -170,6 +173,8 @@ struct GLInterface {
   bool ext_multisampled_render_to_texture = false;
   bool oes_egl_image_external = false;
   bool ext_shader_framebuffer_fetch = false;
+  bool ext_khr_blend_equation_advanced = false;
+  bool ext_khr_blend_equation_advanced_coherent = false;
 
  private:
   bool LoadExtensions(GLADloadfunc loader);

--- a/src/gpu/gl/gpu_device_gl.cc
+++ b/src/gpu/gl/gpu_device_gl.cc
@@ -19,8 +19,15 @@ namespace skity {
 
 GPUDeviceGL::GPUDeviceGL() {
   auto gpu_caps = std::make_unique<GPUCaps>();
+  auto* gl_interface = GLInterface::GlobalInterface();
   gpu_caps->supports_framebuffer_fetch =
-      GLInterface::GlobalInterface()->ext_shader_framebuffer_fetch;
+      gl_interface->ext_shader_framebuffer_fetch;
+  gpu_caps->supports_native_advanced_blend =
+      gl_interface->ext_khr_blend_equation_advanced;
+  gpu_caps->supports_native_advanced_blend_coherent =
+      gl_interface->ext_khr_blend_equation_advanced_coherent;
+  gpu_caps->native_blend_shader_variant =
+      gl_interface->ext_khr_blend_equation_advanced;
   InitCaps(std::move(gpu_caps));
 }
 
@@ -179,6 +186,9 @@ std::shared_ptr<GPUShaderFunction> GPUDeviceGL::CreateShaderFunctionFromModule(
                               : wgx::GlslOptions::Standard::kDesktop;
   options.major_version = gl_version_major_;
   options.minor_version = gl_version_minor_;
+  if (source->needs_native_advanced_blend) {
+    options.extensions.push_back("GL_KHR_blend_equation_advanced");
+  }
 
   auto wgx_result = source->module->GetProgram()->WriteToGlsl(
       source->entry_point, options, source->context);

--- a/src/gpu/gl/gpu_render_pass_gl.cc
+++ b/src/gpu/gl/gpu_render_pass_gl.cc
@@ -91,6 +91,8 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
     SetBlendFunc(
         ToBlendFactor(pipeline->GetDescriptor().target.src_blend_factor),
         ToBlendFactor(pipeline->GetDescriptor().target.dst_blend_factor));
+    SetBlendEquation(
+        ToGLBlendEquation(pipeline->GetDescriptor().target.blend_op));
 
     // color mask
     SetColorWriteMask(pipeline->GetDescriptor().target.write_mask != 0);
@@ -196,6 +198,16 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
     BindBuffer(
         GL_ELEMENT_ARRAY_BUFFER,
         static_cast<GPUBufferGL*>(command->index_buffer.buffer)->GetBufferId());
+
+    // Non-coherent advanced blend needs a barrier so the next draw/blit reads
+    // the blended result. Coherent mode issues no barrier.
+    auto const& target = pipeline->GetDescriptor().target;
+    auto* gl = GLInterface::GlobalInterface();
+    if (target.blend_op != GPUBlendOperation::kAdd &&
+        gl->ext_khr_blend_equation_advanced &&
+        !gl->ext_khr_blend_equation_advanced_coherent && gl->fBlendBarrierKHR) {
+      gl->fBlendBarrierKHR();
+    }
 
     // Draw elements
     if (command->IsInstanced()) {
@@ -378,6 +390,27 @@ void GPURenderPassGL::SetBlendFunc(uint32_t src, uint32_t dst) {
 
   blend_src_ = src;
   blend_dst_ = dst;
+}
+
+void GPURenderPassGL::SetBlendEquation(uint32_t eq) {
+  if (eq == blend_equation_) {
+    return;
+  }
+  blend_equation_ = eq;
+
+  auto* gl = GLInterface::GlobalInterface();
+  // The GL_KHR_blend_equation_advanced spec requires the advanced equations
+  // (GL_MULTIPLY_KHR ...) to be set through glBlendEquation.
+  // glBlendEquationSeparate rejects them with GL_INVALID_ENUM (0x500): its base
+  // spec only accepts the five basic equations
+  // (ADD/SUBTRACT/REVERSE_SUBTRACT/MIN/MAX). Under an advanced equation the
+  // spec composites alpha as source-over and ignores the blend factors, so a
+  // single glBlendEquation call covers both channels and matches the shader.
+  // For the plain GL_FUNC_ADD case it is equivalent to the previous
+  // separate(FUNC_ADD, FUNC_ADD).
+  if (gl->fBlendEquation) {
+    gl->fBlendEquation(eq);
+  }
 }
 
 void GPURenderPassGL::BindBuffer(uint32_t target, uint32_t buffer) {

--- a/src/gpu/gl/gpu_render_pass_gl.hpp
+++ b/src/gpu/gl/gpu_render_pass_gl.hpp
@@ -45,6 +45,8 @@ class GPURenderPassGL : public GPURenderPass {
 
   void SetBlendFunc(uint32_t src, uint32_t dst);
 
+  void SetBlendEquation(uint32_t eq);
+
   void BindBuffer(uint32_t target, uint32_t buffer);
 
   void SetDepthState(bool enable, bool writable, GPUCompareFunction func);
@@ -58,6 +60,7 @@ class GPURenderPassGL : public GPURenderPass {
   uint32_t stencil_reference_ = 0;
   uint32_t blend_src_ = 0;
   uint32_t blend_dst_ = 0;
+  uint32_t blend_equation_ = 0;
   bool disable_blend_ = false;
   GPUStencilState stencil_state_ = {};
   GPUScissorRect scissor_box_ = {};

--- a/src/gpu/gpu_caps.hpp
+++ b/src/gpu/gpu_caps.hpp
@@ -12,6 +12,14 @@ namespace skity {
 struct GPUCaps {
   bool supports_framebuffer_fetch = false;
   bool supports_host_visible_buffer = false;
+  bool supports_native_advanced_blend = false;
+  // true => advanced blend is coherent, no per-draw barrier required.
+  bool supports_native_advanced_blend_coherent = false;
+  // Native advanced blend needs a distinct shader variant only on GL (it must
+  // inject #extension GL_KHR_blend_equation_advanced). Vulkan/Metal express it
+  // purely through pipeline blend state, so their native-blend fragment shader
+  // is identical to the plain one and must NOT occupy a separate cache slot.
+  bool native_blend_shader_variant = false;
 };
 
 }  // namespace skity

--- a/src/gpu/gpu_render_pipeline.hpp
+++ b/src/gpu/gpu_render_pipeline.hpp
@@ -132,17 +132,41 @@ enum class GPUBlendFactor {
   kSrcAlphaSaturated,
 };
 
+// Fixed-function blend equation. kAdd is the default and covers every
+// Porter-Duff mode; the advanced ops map to GL_KHR_blend_equation_advanced /
+// VK_EXT_blend_operation_advanced. kModulate has no hardware equivalent and is
+// intentionally absent (handled via the shader fallback path).
+enum class GPUBlendOperation {
+  kAdd,
+  kMultiply,
+  kScreen,
+  kOverlay,
+  kDarken,
+  kLighten,
+  kColorDodge,
+  kColorBurn,
+  kHardLight,
+  kSoftLight,
+  kDifference,
+  kExclusion,
+  kHslHue,
+  kHslSaturation,
+  kHslColor,
+  kHslLuminosity,
+};
+
 struct GPUColorTargetState {
   GPUTextureFormat format = GPUTextureFormat::kBGRA8Unorm;
   GPUBlendFactor src_blend_factor = GPUBlendFactor::kOne;
   GPUBlendFactor dst_blend_factor = GPUBlendFactor::kOneMinusSrcAlpha;
+  GPUBlendOperation blend_op = GPUBlendOperation::kAdd;
   int32_t write_mask = 0xF;
 
   bool operator==(const GPUColorTargetState& other) const {
     return format == other.format &&
            src_blend_factor == other.src_blend_factor &&
            dst_blend_factor == other.dst_blend_factor &&
-           write_mask == other.write_mask;
+           blend_op == other.blend_op && write_mask == other.write_mask;
   }
 };
 

--- a/src/gpu/gpu_shader_module.hpp
+++ b/src/gpu/gpu_shader_module.hpp
@@ -46,6 +46,9 @@ struct GPUShaderSourceWGX {
 
   const char* entry_point = nullptr;
   wgx::CompilerContext context = {};
+  // True when this fragment shader must be emitted with
+  // GL_KHR_blend_equation_advanced support (native advanced-blend path).
+  bool needs_native_advanced_blend = false;
 };
 
 }  // namespace skity

--- a/src/gpu/vk/gpu_device_vk.cc
+++ b/src/gpu/vk/gpu_device_vk.cc
@@ -87,6 +87,45 @@ VkBlendFactor ToVkBlendFactor(GPUBlendFactor factor) {
   return VK_BLEND_FACTOR_ONE;
 }
 
+VkBlendOp ToVkBlendOp(GPUBlendOperation op) {
+  switch (op) {
+    case GPUBlendOperation::kAdd:
+      return VK_BLEND_OP_ADD;
+    case GPUBlendOperation::kMultiply:
+      return VK_BLEND_OP_MULTIPLY_EXT;
+    case GPUBlendOperation::kScreen:
+      return VK_BLEND_OP_SCREEN_EXT;
+    case GPUBlendOperation::kOverlay:
+      return VK_BLEND_OP_OVERLAY_EXT;
+    case GPUBlendOperation::kDarken:
+      return VK_BLEND_OP_DARKEN_EXT;
+    case GPUBlendOperation::kLighten:
+      return VK_BLEND_OP_LIGHTEN_EXT;
+    case GPUBlendOperation::kColorDodge:
+      return VK_BLEND_OP_COLORDODGE_EXT;
+    case GPUBlendOperation::kColorBurn:
+      return VK_BLEND_OP_COLORBURN_EXT;
+    case GPUBlendOperation::kHardLight:
+      return VK_BLEND_OP_HARDLIGHT_EXT;
+    case GPUBlendOperation::kSoftLight:
+      return VK_BLEND_OP_SOFTLIGHT_EXT;
+    case GPUBlendOperation::kDifference:
+      return VK_BLEND_OP_DIFFERENCE_EXT;
+    case GPUBlendOperation::kExclusion:
+      return VK_BLEND_OP_EXCLUSION_EXT;
+    case GPUBlendOperation::kHslHue:
+      return VK_BLEND_OP_HSL_HUE_EXT;
+    case GPUBlendOperation::kHslSaturation:
+      return VK_BLEND_OP_HSL_SATURATION_EXT;
+    case GPUBlendOperation::kHslColor:
+      return VK_BLEND_OP_HSL_COLOR_EXT;
+    case GPUBlendOperation::kHslLuminosity:
+      return VK_BLEND_OP_HSL_LUMINOSITY_EXT;
+  }
+
+  return VK_BLEND_OP_ADD;
+}
+
 VkCompareOp ToVkCompareOp(GPUCompareFunction compare) {
   switch (compare) {
     case GPUCompareFunction::kNever:
@@ -459,6 +498,15 @@ GPUDeviceVK::GPUDeviceVK(std::shared_ptr<const VulkanContextState> state)
     : state_(std::move(state)) {
   auto gpu_caps = std::make_unique<GPUCaps>();
   gpu_caps->supports_framebuffer_fetch = false;
+  // Report native advanced blend whenever the extension is enabled, including
+  // non-coherent devices. The render pass inserts a per-draw
+  // vkCmdPipelineBarrier (NONCOHERENT access) when coherent is unavailable, so
+  // non-coherent native is still correct and stays cheaper than texture_copy
+  // (no main-memory round-trip on TBDR, thanks to BY_REGION).
+  gpu_caps->supports_native_advanced_blend =
+      state_ && state_->IsAdvancedBlendEnabled();
+  gpu_caps->supports_native_advanced_blend_coherent =
+      state_ && state_->IsAdvancedBlendCoherent();
   InitCaps(std::move(gpu_caps));
 
   if (state_ == nullptr || state_->GetPhysicalDevice() == VK_NULL_HANDLE ||
@@ -835,27 +883,60 @@ std::unique_ptr<GPURenderPipelineVK> GPUDeviceVK::CreateRenderPipelineInternal(
       static_cast<VkSampleCountFlagBits>(desc.sample_count);
 
   VkPipelineColorBlendAttachmentState color_blend_attachment = {};
-  color_blend_attachment.blendEnable =
-      desc.target.src_blend_factor != GPUBlendFactor::kOne ||
-      desc.target.dst_blend_factor != GPUBlendFactor::kZero;
-  color_blend_attachment.srcColorBlendFactor =
-      ToVkBlendFactor(desc.target.src_blend_factor);
-  color_blend_attachment.dstColorBlendFactor =
-      ToVkBlendFactor(desc.target.dst_blend_factor);
-  color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
-  color_blend_attachment.srcAlphaBlendFactor =
-      ToVkBlendFactor(desc.target.src_blend_factor);
-  color_blend_attachment.dstAlphaBlendFactor =
-      ToVkBlendFactor(desc.target.dst_blend_factor);
-  color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
-  color_blend_attachment.colorWriteMask =
-      ToVkColorWriteMask(desc.target.write_mask);
+  VkPipelineColorBlendAdvancedStateCreateInfoEXT advanced_blend_state = {};
+  if (desc.target.blend_op != GPUBlendOperation::kAdd) {
+    // Native advanced blend: the advanced equation ignores the RGB blend
+    // factors, and the spec blends alpha "as if VK_BLEND_OP_ADD" (source-over)
+    // regardless of alphaBlendOp. VUID-...-advancedBlendAlphaBlendOp-01409
+    // still requires alphaBlendOp == colorBlendOp when an advanced op is used,
+    // so both carry the advanced op; the alpha result is unchanged. skity is
+    // premultiplied end-to-end, so srcPremultiplied/dstPremultiplied are both
+    // VK_TRUE.
+    color_blend_attachment.blendEnable = VK_TRUE;
+    color_blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    color_blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    const VkBlendOp advanced_op = ToVkBlendOp(desc.target.blend_op);
+    color_blend_attachment.colorBlendOp = advanced_op;
+    color_blend_attachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    color_blend_attachment.dstAlphaBlendFactor =
+        VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    color_blend_attachment.alphaBlendOp = advanced_op;
+    color_blend_attachment.colorWriteMask =
+        ToVkColorWriteMask(desc.target.write_mask);
+
+    advanced_blend_state.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT;
+    advanced_blend_state.srcPremultiplied = VK_TRUE;
+    advanced_blend_state.dstPremultiplied = VK_TRUE;
+    advanced_blend_state.blendOverlap = VK_BLEND_OVERLAP_UNCORRELATED_EXT;
+  } else {
+    color_blend_attachment.blendEnable =
+        desc.target.src_blend_factor != GPUBlendFactor::kOne ||
+        desc.target.dst_blend_factor != GPUBlendFactor::kZero;
+    color_blend_attachment.srcColorBlendFactor =
+        ToVkBlendFactor(desc.target.src_blend_factor);
+    color_blend_attachment.dstColorBlendFactor =
+        ToVkBlendFactor(desc.target.dst_blend_factor);
+    color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
+    color_blend_attachment.srcAlphaBlendFactor =
+        ToVkBlendFactor(desc.target.src_blend_factor);
+    color_blend_attachment.dstAlphaBlendFactor =
+        ToVkBlendFactor(desc.target.dst_blend_factor);
+    color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
+    color_blend_attachment.colorWriteMask =
+        ToVkColorWriteMask(desc.target.write_mask);
+  }
 
   VkPipelineColorBlendStateCreateInfo color_blend_state = {};
   color_blend_state.sType =
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
   color_blend_state.attachmentCount = 1;
   color_blend_state.pAttachments = &color_blend_attachment;
+  // The advanced-state struct must hang off the state create-info pNext, not
+  // the attachment pNext.
+  if (desc.target.blend_op != GPUBlendOperation::kAdd) {
+    color_blend_state.pNext = &advanced_blend_state;
+  }
 
   VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {};
   depth_stencil_state.sType =

--- a/src/gpu/vk/gpu_render_pass_vk.cc
+++ b/src/gpu/vk/gpu_render_pass_vk.cc
@@ -700,6 +700,27 @@ bool RecordDrawCommands(const std::shared_ptr<const VulkanContextState>& state,
         VK_STENCIL_FACE_FRONT_BIT | VK_STENCIL_FACE_BACK_BIT,
         command->stencil_reference);
 
+    // Non-coherent advanced blend reads dst incoherently: it only sees writes
+    // made available by a prior barrier (or the subpass loadOp). The barrier
+    // must PRECEDE the draw so this draw's blend read observes all prior
+    // color-attachment writes (advanced or plain). BY_REGION keeps the
+    // dependency tile-local on TBDR hardware (no main-memory round-trip).
+    const auto& blend_target = pipeline->GetDescriptor().target;
+    if (blend_target.blend_op != GPUBlendOperation::kAdd &&
+        state->IsAdvancedBlendEnabled() && !state->IsAdvancedBlendCoherent()) {
+      VkMemoryBarrier blend_barrier = {};
+      blend_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+      blend_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+      blend_barrier.dstAccessMask =
+          VK_ACCESS_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT;
+      state->DeviceFns().vkCmdPipelineBarrier(
+          command_buffer.GetCommandBuffer(),
+          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+          VK_DEPENDENCY_BY_REGION_BIT, 1, &blend_barrier, 0, nullptr, 0,
+          nullptr);
+    }
+
     state->DeviceFns().vkCmdDrawIndexed(
         command_buffer.GetCommandBuffer(), command->index_count,
         command->instance_count == 0 ? 1 : command->instance_count, 0, 0, 0);

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -1096,6 +1096,8 @@ bool VulkanContextState::InitializeDevice(const GPUContextInfoVK& info) {
   enabled_device_extensions_known_ = false;
   synchronization2_enabled_ = false;
   dynamic_rendering_enabled_ = false;
+  advanced_blend_enabled_ = false;
+  advanced_blend_coherent_ = false;
   pipeline_cache_ = VK_NULL_HANDLE;
 
   if (!LoadAvailableDeviceExtensions()) {
@@ -1122,6 +1124,17 @@ bool VulkanContextState::InitializeDevice(const GPUContextInfoVK& info) {
           enabled_device_extensions_, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
       dynamic_rendering_enabled_ = ContainsExtension(
           enabled_device_extensions_, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+      advanced_blend_enabled_ =
+          ContainsExtension(enabled_device_extensions_,
+                            VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
+      // advancedBlendCoherentOperations cannot be confirmed for an
+      // already-created user device: only the extension string is known, not
+      // which features the host enabled at vkCreateDevice time. Assume
+      // non-coherent so the render pass inserts the per-draw NONCOHERENT
+      // barrier. This is correct at a small perf cost; assuming coherent on a
+      // device that did not enable the feature yields undefined results on
+      // overlapping draws.
+      advanced_blend_coherent_ = false;
       if (dynamic_rendering_enabled_ &&
           (functions_.device.vkCmdBeginRendering == nullptr ||
            functions_.device.vkCmdEndRendering == nullptr)) {
@@ -1187,6 +1200,11 @@ bool VulkanContextState::InitializeOwnedDevice() {
     enabled_device_extensions_.emplace_back(
         VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
   }
+  if (HasAvailableDeviceExtension(
+          VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME)) {
+    enabled_device_extensions_.emplace_back(
+        VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
+  }
   if (HasAvailableDeviceExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME)) {
     enabled_device_extensions_.emplace_back(
         VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
@@ -1226,6 +1244,11 @@ bool VulkanContextState::InitializeOwnedDevice() {
   VkPhysicalDeviceSynchronization2Features synchronization2_features = {};
   synchronization2_features.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+  const bool has_advanced_blend_extension = HasAvailableDeviceExtension(
+      VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
+  VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT adv_blend_features = {};
+  adv_blend_features.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT;
 
   void** feature_query_next = &physical_device_features.pNext;
   if (has_dynamic_rendering_extension) {
@@ -1235,6 +1258,10 @@ bool VulkanContextState::InitializeOwnedDevice() {
   if (HasAvailableDeviceExtension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
     *feature_query_next = &synchronization2_features;
     feature_query_next = &synchronization2_features.pNext;
+  }
+  if (has_advanced_blend_extension) {
+    *feature_query_next = &adv_blend_features;
+    feature_query_next = &adv_blend_features.pNext;
   }
 
   if (physical_device_features.pNext != nullptr) {
@@ -1272,6 +1299,17 @@ bool VulkanContextState::InitializeOwnedDevice() {
           "Vulkan synchronization2 extension is present but feature is not "
           "supported, disabling extension request");
     }
+  }
+
+  if (has_advanced_blend_extension) {
+    // Advanced blending itself is a core 1.1 capability; the extension only
+    // gates the advanced ops, so keep it enabled even when coherent is
+    // unsupported. advancedBlendCoherentOperations is optional: when false we
+    // still enable the extension but report coherent == false so the render
+    // pass can insert the required per-draw barrier.
+    advanced_blend_enabled_ = true;
+    advanced_blend_coherent_ =
+        adv_blend_features.advancedBlendCoherentOperations == VK_TRUE;
   }
 
   auto enabled_extension_ptrs = BuildNamePtrs(enabled_device_extensions_);
@@ -1317,6 +1355,10 @@ bool VulkanContextState::InitializeOwnedDevice() {
   if (synchronization2_enabled_) {
     *enabled_feature_next = &synchronization2_features;
     enabled_feature_next = &synchronization2_features.pNext;
+  }
+  if (has_advanced_blend_extension) {
+    *enabled_feature_next = &adv_blend_features;
+    enabled_feature_next = &adv_blend_features.pNext;
   }
   if (enabled_feature_chain != nullptr) {
     device_info.pNext = enabled_feature_chain;

--- a/src/gpu/vk/vulkan_context_state.hpp
+++ b/src/gpu/vk/vulkan_context_state.hpp
@@ -85,6 +85,12 @@ class VulkanContextState {
 
   bool IsDynamicRenderingEnabled() const { return dynamic_rendering_enabled_; }
 
+  bool IsAdvancedBlendEnabled() const { return advanced_blend_enabled_; }
+
+  // Whether advanced blend operations are coherent (no per-draw barrier
+  // needed).
+  bool IsAdvancedBlendCoherent() const { return advanced_blend_coherent_; }
+
 #if defined(SKITY_ANDROID)
   using Fn_AHardwareBuffer_describe = void (*)(const ::AHardwareBuffer*,
                                                AHardwareBuffer_Desc*);
@@ -169,6 +175,8 @@ class VulkanContextState {
   bool enabled_device_extensions_known_ = false;
   bool synchronization2_enabled_ = false;
   bool dynamic_rendering_enabled_ = false;
+  bool advanced_blend_enabled_ = false;
+  bool advanced_blend_coherent_ = false;
   VulkanDebugRuntimeState debug_runtime_ = {};
 #if defined(SKITY_ANDROID)
   Fn_AHardwareBuffer_describe fn_ahb_describe_ = nullptr;

--- a/src/render/hw/draw/hw_dynamic_path_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_path_draw.cc
@@ -31,8 +31,8 @@ HWDynamicPathDraw::HWDynamicPathDraw(Matrix transform, Path path, Paint paint,
       is_stroke_(is_stroke),
       use_gpu_tessellation_(use_gpu_tessellation) {}
 
-void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
-                                           HWDrawContext *context) {
+void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
+                                           HWDrawContext* context) {
   bool single_pass = !is_stroke_ && path_.IsConvex() && !paint_.IsAntiAlias();
 
   auto geom = GenGeometry(context, false);
@@ -44,8 +44,19 @@ void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
   }
 
   if (IsAdvancedBlendMode(paint_.GetBlendMode())) {
-    frag->SetProgrammableBlending(WGXProgrammableBlending::Make(
-        paint_.GetBlendMode(), GetDstReadStrategy()));
+    if (GetDstReadStrategy() == DstReadStrategy::kNativeBlend) {
+      // Only GL needs a distinct shader variant (extension injection). On
+      // Vulkan the fragment stays plain and the native equation is applied
+      // through the pipeline blend-state variant.
+      if (context->gpuContext->GetGPUDevice()
+              ->GetCaps()
+              .native_blend_shader_variant) {
+        frag->SetUsesNativeAdvancedBlend(true);
+      }
+    } else {
+      frag->SetProgrammableBlending(WGXProgrammableBlending::Make(
+          paint_.GetBlendMode(), GetDstReadStrategy()));
+    }
   }
 
   CoverageType coverage = CoverageType::kNone;
@@ -79,8 +90,16 @@ void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
     }
 
     if (IsAdvancedBlendMode(paint_.GetBlendMode())) {
-      fragment->SetProgrammableBlending(WGXProgrammableBlending::Make(
-          paint_.GetBlendMode(), GetDstReadStrategy()));
+      if (GetDstReadStrategy() == DstReadStrategy::kNativeBlend) {
+        if (context->gpuContext->GetGPUDevice()
+                ->GetCaps()
+                .native_blend_shader_variant) {
+          fragment->SetUsesNativeAdvancedBlend(true);
+        }
+      } else {
+        fragment->SetProgrammableBlending(WGXProgrammableBlending::Make(
+            paint_.GetBlendMode(), GetDstReadStrategy()));
+      }
     }
 
     steps.emplace_back(context->arena_allocator->Make<ColorAAStep>(
@@ -91,7 +110,7 @@ void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep *, 2> &steps,
       std::move(geom), std::move(frag), coverage));
 }
 
-HWWGSLGeometry *HWDynamicPathDraw::GenGeometry(HWDrawContext *context,
+HWWGSLGeometry* HWDynamicPathDraw::GenGeometry(HWDrawContext* context,
                                                bool aa) const {
   auto arena_allocator = context->arena_allocator;
   if (use_gpu_tessellation_) {

--- a/src/render/hw/draw/hw_dynamic_rrect_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_rrect_draw.cc
@@ -5,6 +5,7 @@
 #include "src/render/hw/draw/hw_dynamic_rrect_draw.hpp"
 
 #include "src/effect/pixmap_shader.hpp"
+#include "src/gpu/gpu_context_impl.hpp"
 #include "src/graphic/blend_mode_priv.hpp"
 #include "src/render/hw/draw/geometry/wgsl_rrect_geometry.hpp"
 #include "src/render/hw/draw/step/color_step.hpp"
@@ -65,8 +66,16 @@ void HWDynamicRRectDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
   }
 
   if (IsAdvancedBlendMode(paint.GetBlendMode())) {
-    frag->SetProgrammableBlending(WGXProgrammableBlending::Make(
-        paint.GetBlendMode(), GetDstReadStrategy()));
+    if (GetDstReadStrategy() == DstReadStrategy::kNativeBlend) {
+      if (context->gpuContext->GetGPUDevice()
+              ->GetCaps()
+              .native_blend_shader_variant) {
+        frag->SetUsesNativeAdvancedBlend(true);
+      }
+    } else {
+      frag->SetProgrammableBlending(WGXProgrammableBlending::Make(
+          paint.GetBlendMode(), GetDstReadStrategy()));
+    }
   }
 
   steps.emplace_back(context->arena_allocator->Make<ColorStep>(

--- a/src/render/hw/draw/hw_wgsl_fragment.hpp
+++ b/src/render/hw/draw/hw_wgsl_fragment.hpp
@@ -182,6 +182,16 @@ class HWWGSLFragment {
     return blending_ ? blending_.get() : nullptr;
   }
 
+  // Marks that this draw blends via the hardware-native advanced-blend path.
+  // No programmable-blending object is attached in that case, so this flag is
+  // what lets the pipeline key/encoder know the fragment shader must be built
+  // with GL_KHR_blend_equation_advanced support.
+  void SetUsesNativeAdvancedBlend(bool uses) {
+    uses_native_advanced_blend_ = uses;
+  }
+
+  bool UsesNativeAdvancedBlend() const { return uses_native_advanced_blend_; }
+
   WGXFilterFragment* GetFilter() const { return filter_.get(); }
 
   constexpr bool IsSnippet() const { return (flags_ & Flags::kSnippet) > 0; }
@@ -196,6 +206,7 @@ class HWWGSLFragment {
 
  private:
   uint32_t flags_;
+  bool uses_native_advanced_blend_ = false;
 };
 
 }  // namespace skity

--- a/src/render/hw/draw/hw_wgsl_shader_writer.hpp
+++ b/src/render/hw/draw/hw_wgsl_shader_writer.hpp
@@ -37,7 +37,8 @@ class HWWGSLShaderWriter {
     key.programmable_blending =
         fragment_->GetProgrammableBlending()
             ? fragment_->GetProgrammableBlending()->GetProgrammableBlendingKey()
-            : 0;
+        : fragment_->UsesNativeAdvancedBlend() ? kNativeAdvancedBlendKey
+                                               : 0;
     return key;
   }
 

--- a/src/render/hw/draw/wgx_programmable_blending.hpp
+++ b/src/render/hw/draw/wgx_programmable_blending.hpp
@@ -18,6 +18,11 @@ enum class DstReadStrategy {
   kNonRequired,
   kFramebufferFetch,
   kTextureCopy,
+  // Hardware-native advanced blend (GL_KHR_blend_equation_advanced /
+  // VK_EXT_blend_operation_advanced). Highest priority; never creates a
+  // programmable-blending object, so GetProgrammableBlendingKey is unused for
+  // it.
+  kNativeBlend,
 };
 
 /**

--- a/src/render/hw/dst_read_strategy.cc
+++ b/src/render/hw/dst_read_strategy.cc
@@ -5,6 +5,7 @@
 #include "src/render/hw/dst_read_strategy.hpp"
 
 #include "src/graphic/blend_mode_priv.hpp"
+#include "src/render/hw/native_blend.hpp"
 
 namespace skity {
 
@@ -14,8 +15,30 @@ DstReadStrategy ResolveDstReadStrategy(BlendMode blend_mode,
     return DstReadStrategy::kNonRequired;
   }
 
-  return caps.supports_framebuffer_fetch ? DstReadStrategy::kFramebufferFetch
-                                         : DstReadStrategy::kTextureCopy;
+  const bool has_native = caps.supports_native_advanced_blend &&
+                          ToNativeBlendOp(blend_mode).has_value();
+
+  // 1. Coherent native is strictly optimal: no flush, no shader math, no pass
+  //    split. Highest priority everywhere.
+  if (has_native && caps.supports_native_advanced_blend_coherent) {
+    return DstReadStrategy::kNativeBlend;
+  }
+
+  // 2. framebuffer_fetch is tile-friendly. On tile-based GPUs it beats
+  //    non-coherent native (whose per-draw barrier forces a tile flush), so it
+  //    is the main path on mobile. kModulate (has_native == false) lands here.
+  if (caps.supports_framebuffer_fetch) {
+    return DstReadStrategy::kFramebufferFetch;
+  }
+
+  // 3. Non-coherent native is still cheap on desktop immediate-mode renderers
+  //    (the barrier is not a tile flush there), so prefer it over texture_copy
+  //    where framebuffer_fetch is unavailable (typical desktop GL).
+  if (has_native) {
+    return DstReadStrategy::kNativeBlend;
+  }
+
+  return DstReadStrategy::kTextureCopy;
 }
 
 DstReadStrategy ResolveDstReadStrategy(BlendMode blend_mode,

--- a/src/render/hw/hw_pipeline_key.hpp
+++ b/src/render/hw/hw_pipeline_key.hpp
@@ -113,6 +113,16 @@ constexpr HWPipelineBaseKey MakePipelineBaseKey(
 struct HWPipelineKey;
 using HWFunctionKey = HWPipelineKey;
 
+// Sentinel stored in HWPipelineKey::programmable_blending to mark a draw that
+// takes the hardware-native advanced-blend path. The genuine
+// programmable-blending key packs (blend_mode | dst_read_strategy << 8) into
+// the low bits, so the top bit never collides. It reserves a distinct
+// fragment-shader cache slot: native-blend GLSL must carry
+// #extension GL_KHR_blend_equation_advanced + blend_support_all_equations,
+// which ordinary draws must not. See GetFunctionKey(kFragment), which folds
+// programmable_blending into the fragment shader key.
+constexpr uint32_t kNativeAdvancedBlendKey = 0x80000000u;
+
 struct HWPipelineKey {
   uint64_t base_key;
   std::optional<std::vector<uint32_t>> compose_keys;

--- a/src/render/hw/hw_pipeline_lib.cc
+++ b/src/render/hw/hw_pipeline_lib.cc
@@ -4,12 +4,15 @@
 
 #include "src/render/hw/hw_pipeline_lib.hpp"
 
+#include "src/gpu/gpu_caps.hpp"
 #include "src/gpu/gpu_device.hpp"
 #include "src/gpu/gpu_shader_function.hpp"
 #include "src/gpu/gpu_shader_module.hpp"
+#include "src/graphic/blend_mode_priv.hpp"
 #include "src/logging.hpp"
 #include "src/render/hw/hw_pipeline_key.hpp"
 #include "src/render/hw/hw_shader_generator.hpp"
+#include "src/render/hw/native_blend.hpp"
 #include "src/tracing.hpp"
 
 namespace skity {
@@ -48,21 +51,66 @@ static std::pair<GPUBlendFactor, GPUBlendFactor> get_gpu_blending(
   }
 }
 
+struct BlendState {
+  GPUBlendFactor src_factor;
+  GPUBlendFactor dst_factor;
+  GPUBlendOperation op;
+};
+
+// programmable_blending packs (blend_mode | dst_read_strategy<<8) when the draw
+// reads dst inside the shader (framebuffer-fetch / texture-copy). It is 0 for
+// ordinary blends and the kNativeAdvancedBlendKey sentinel for GL's native
+// variant; neither of those is shader-side blending.
+static bool IsShaderSideBlending(uint32_t programmable_blending) {
+  return programmable_blending != 0 &&
+         programmable_blending != kNativeAdvancedBlendKey;
+}
+
+// Unified blend-state resolution shared by pipeline creation and cache matching
+// so they cannot drift apart. Native advanced blend returns
+// {kOne, kOneMinusSrcAlpha, native_op}: the GL/Vulkan advanced equations ignore
+// the RGB blend factors, while the alpha channel (kept on ADD with those
+// factors) computes exactly source-over, matching every advanced shader branch.
+//
+// shader_side_blending is true for the framebuffer-fetch / texture-copy
+// pipeline (programmable_blending holds a packed key): those draws blend inside
+// the shader, so the fixed-function equation must stay on ADD regardless of
+// mode. For every other pipeline the native equation is selected purely from
+// blend_mode + caps — which is what lets the Vulkan native path share one
+// pipeline with ordinary blends and differ only by a blend-state variant.
+static BlendState resolve_blend_state(BlendMode blend_mode, const GPUCaps& caps,
+                                      bool shader_side_blending) {
+  if (!shader_side_blending && caps.supports_native_advanced_blend &&
+      IsAdvancedBlendMode(blend_mode)) {
+    if (auto op = ToNativeBlendOp(blend_mode)) {
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kOneMinusSrcAlpha, *op};
+    }
+  }
+  auto factors = get_gpu_blending(blend_mode);
+  return {factors.first, factors.second, GPUBlendOperation::kAdd};
+}
+
 static void setup_blending_state(GPURenderPipelineDescriptor& gpu_desc,
-                                 const HWPipelineDescriptor& hw_desc) {
+                                 const HWPipelineDescriptor& hw_desc,
+                                 const GPUCaps& caps,
+                                 bool shader_side_blending) {
   gpu_desc.target.format = hw_desc.color_format;
   gpu_desc.target.write_mask = hw_desc.color_mask;
 
-  auto blend_factor = get_gpu_blending(hw_desc.blend_mode);
-  gpu_desc.target.src_blend_factor = blend_factor.first;
-  gpu_desc.target.dst_blend_factor = blend_factor.second;
-
-  // need to support other advance blending in the future
+  auto blend_state =
+      resolve_blend_state(hw_desc.blend_mode, caps, shader_side_blending);
+  gpu_desc.target.src_blend_factor = blend_state.src_factor;
+  gpu_desc.target.dst_blend_factor = blend_state.dst_factor;
+  gpu_desc.target.blend_op = blend_state.op;
 }
 
 HWPipeline::HWPipeline(GPUDevice* device, GPUBackendType backend,
-                       std::unique_ptr<GPURenderPipeline> base_pipeline)
-    : gpu_device_(device), backend_(backend), gpu_pipelines_() {
+                       std::unique_ptr<GPURenderPipeline> base_pipeline,
+                       bool shader_side_blending)
+    : gpu_device_(device),
+      backend_(backend),
+      gpu_pipelines_(),
+      shader_side_blending_(shader_side_blending) {
   gpu_pipelines_.emplace_back(std::move(base_pipeline));
 }
 
@@ -77,7 +125,8 @@ GPURenderPipeline* HWPipeline::GetPipeline(const HWPipelineDescriptor& desc) {
 
   auto gpu_desc = base_pipeline->GetDescriptor();
 
-  setup_blending_state(gpu_desc, desc);
+  setup_blending_state(gpu_desc, desc, gpu_device_->GetCaps(),
+                       shader_side_blending_);
   gpu_desc.depth_stencil = desc.depth_stencil;
   gpu_desc.sample_count = desc.sample_count;
 
@@ -100,11 +149,13 @@ bool HWPipeline::PipelineMatch(GPURenderPipeline* pipeline,
 
   const auto& gpu_desc = pipeline->GetDescriptor();
 
-  auto blend_function = get_gpu_blending(desc.blend_mode);
+  auto blend_state = resolve_blend_state(
+      desc.blend_mode, gpu_device_->GetCaps(), shader_side_blending_);
 
   return gpu_desc.target.write_mask == desc.color_mask &&
-         gpu_desc.target.src_blend_factor == blend_function.first &&
-         gpu_desc.target.dst_blend_factor == blend_function.second &&
+         gpu_desc.target.src_blend_factor == blend_state.src_factor &&
+         gpu_desc.target.dst_blend_factor == blend_state.dst_factor &&
+         gpu_desc.target.blend_op == blend_state.op &&
          gpu_desc.sample_count == static_cast<int32_t>(desc.sample_count) &&
          gpu_desc.target.format == desc.color_format;
 }
@@ -199,7 +250,10 @@ std::unique_ptr<HWPipeline> HWPipelineLib::CreatePipeline(
     return std::unique_ptr<HWPipeline>();
   }
 
-  setup_blending_state(gpu_pso_desc, desc);
+  bool shader_side_blending = IsShaderSideBlending(key.programmable_blending);
+
+  setup_blending_state(gpu_pso_desc, desc, gpu_device_->GetCaps(),
+                       shader_side_blending);
   gpu_pso_desc.depth_stencil = desc.depth_stencil;
 
   auto gpu_pipeline = gpu_device_->CreateRenderPipeline(gpu_pso_desc);
@@ -208,8 +262,8 @@ std::unique_ptr<HWPipeline> HWPipelineLib::CreatePipeline(
     return std::unique_ptr<HWPipeline>();
   }
 
-  return std::make_unique<HWPipeline>(gpu_device_, backend_,
-                                      std::move(gpu_pipeline));
+  return std::make_unique<HWPipeline>(
+      gpu_device_, backend_, std::move(gpu_pipeline), shader_side_blending);
 }
 
 void HWPipelineLib::SetupShaderFunction(GPURenderPipelineDescriptor& desc,
@@ -284,6 +338,15 @@ std::shared_ptr<GPUShaderFunction> HWPipelineLib::GetShaderFunction(
     return {};
   }
   source.context = wgx_context;
+
+  // Native-blend fragment shaders must be translated with the
+  // GL_KHR_blend_equation_advanced extension injected; signal that through the
+  // source. The sentinel lives only in the fragment key (GetFunctionKey does
+  // not fold programmable_blending into the vertex key), so gate on fragment.
+  if (stage == GPUShaderStage::kFragment &&
+      pipeline_key.programmable_blending == kNativeAdvancedBlendKey) {
+    source.needs_native_advanced_blend = true;
+  }
 
   desc.shader_source = &source;
 

--- a/src/render/hw/hw_pipeline_lib.hpp
+++ b/src/render/hw/hw_pipeline_lib.hpp
@@ -44,7 +44,8 @@ struct HWPipelineDescriptor {
 class HWPipeline {
  public:
   HWPipeline(GPUDevice* device, GPUBackendType backend,
-             std::unique_ptr<GPURenderPipeline> base_pipeline);
+             std::unique_ptr<GPURenderPipeline> base_pipeline,
+             bool shader_side_blending);
 
   ~HWPipeline() = default;
 
@@ -62,6 +63,12 @@ class HWPipeline {
   GPUDevice* gpu_device_;
   GPUBackendType backend_;
   std::vector<std::unique_ptr<GPURenderPipeline>> gpu_pipelines_;
+  // Fixed per key: true only when this pipeline serves shader-side blending
+  // draws (framebuffer-fetch / texture-copy, i.e. programmable_blending holds a
+  // packed key), which must keep the fixed-function equation on ADD. Ordinary
+  // blends and the GL native-blend variant are all false; their native equation
+  // (if any) is resolved per-draw from blend_mode + caps.
+  bool shader_side_blending_ = false;
 };
 
 class HWPipelineLib final {

--- a/src/render/hw/native_blend.hpp
+++ b/src/render/hw/native_blend.hpp
@@ -1,0 +1,66 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_HW_NATIVE_BLEND_HPP
+#define SRC_RENDER_HW_NATIVE_BLEND_HPP
+
+#include <optional>
+#include <skity/graphic/blend_mode.hpp>
+
+#include "src/gpu/gpu_render_pipeline.hpp"
+
+namespace skity {
+
+// Maps a BlendMode to its fixed-function advanced blend operation, used when
+// the hardware exposes GL_KHR_blend_equation_advanced /
+// VK_EXT_blend_operation_advanced.
+//
+// Returns std::nullopt for kModulate: GL_MULTIPLY_KHR (s*(1-da)+d*(1-sa)+s*d)
+// is NOT equal to skity's kModulate (s*d), which is used mainly for saveLayer
+// compositing and must stay on the shader path.
+//
+// Modes <= kPlus (Porter-Duff) never reach this function — they use
+// fixed-function ADD. Callers are expected to gate with IsAdvancedBlendMode
+// first.
+constexpr std::optional<GPUBlendOperation> ToNativeBlendOp(BlendMode mode) {
+  switch (mode) {
+    case BlendMode::kScreen:
+      return GPUBlendOperation::kScreen;
+    case BlendMode::kOverlay:
+      return GPUBlendOperation::kOverlay;
+    case BlendMode::kDarken:
+      return GPUBlendOperation::kDarken;
+    case BlendMode::kLighten:
+      return GPUBlendOperation::kLighten;
+    case BlendMode::kColorDodge:
+      return GPUBlendOperation::kColorDodge;
+    case BlendMode::kColorBurn:
+      return GPUBlendOperation::kColorBurn;
+    case BlendMode::kHardLight:
+      return GPUBlendOperation::kHardLight;
+    case BlendMode::kSoftLight:
+      return GPUBlendOperation::kSoftLight;
+    case BlendMode::kDifference:
+      return GPUBlendOperation::kDifference;
+    case BlendMode::kExclusion:
+      return GPUBlendOperation::kExclusion;
+    case BlendMode::kMultiply:
+      return GPUBlendOperation::kMultiply;
+    case BlendMode::kHue:
+      return GPUBlendOperation::kHslHue;
+    case BlendMode::kSaturation:
+      return GPUBlendOperation::kHslSaturation;
+    case BlendMode::kColor:
+      return GPUBlendOperation::kHslColor;
+    case BlendMode::kLuminosity:
+      return GPUBlendOperation::kHslLuminosity;
+    default:
+      // kModulate has no hardware equivalent; modes <= kPlus stay on ADD.
+      return std::nullopt;
+  }
+}
+
+}  // namespace skity
+
+#endif  // SRC_RENDER_HW_NATIVE_BLEND_HPP

--- a/src/render/hw/precompile_context.cc
+++ b/src/render/hw/precompile_context.cc
@@ -108,10 +108,16 @@ HWWGSLFragment* ApplyPaintEffects(HWWGSLFragment* fragment, const Paint& paint,
   }
 
   if (IsAdvancedBlendMode(paint.GetBlendMode())) {
-    auto strategy = ResolveDstReadStrategy(
-        paint.GetBlendMode(), gpu_context->GetGPUDevice()->GetCaps());
-    fragment->SetProgrammableBlending(
-        WGXProgrammableBlending::Make(paint.GetBlendMode(), strategy));
+    const auto& caps = gpu_context->GetGPUDevice()->GetCaps();
+    auto strategy = ResolveDstReadStrategy(paint.GetBlendMode(), caps);
+    if (strategy == DstReadStrategy::kNativeBlend) {
+      if (caps.native_blend_shader_variant) {
+        fragment->SetUsesNativeAdvancedBlend(true);
+      }
+    } else {
+      fragment->SetProgrammableBlending(
+          WGXProgrammableBlending::Make(paint.GetBlendMode(), strategy));
+    }
   }
 
   return fragment;

--- a/test/golden/cases/blend_mode/blend_mode.cc
+++ b/test/golden/cases/blend_mode/blend_mode.cc
@@ -173,6 +173,8 @@ static skity::testing::GoldenTestEnvConfig TextureCopyConfig(
     uint32_t sample_count) {
   skity::testing::GoldenTestEnvConfig config;
   config.supports_framebuffer_fetch = false;
+  config.supports_native_advanced_blend = false;
+  config.supports_native_advanced_blend_coherent = false;
   config.sample_count = sample_count;
   return config;
 }
@@ -238,6 +240,22 @@ static skity::testing::GoldenTestEnvConfig FramebufferFetchConfig(
     uint32_t sample_count) {
   skity::testing::GoldenTestEnvConfig config;
   config.supports_framebuffer_fetch = true;
+  config.supports_native_advanced_blend = false;
+  config.supports_native_advanced_blend_coherent = false;
+  config.sample_count = sample_count;
+  return config;
+}
+
+static skity::testing::GoldenTestEnvConfig NativeBlendConfig(
+    uint32_t sample_count) {
+  skity::testing::GoldenTestEnvConfig config;
+  config.supports_native_advanced_blend = true;
+  config.supports_framebuffer_fetch = false;
+  // Leave supports_native_advanced_blend_coherent unset (nullopt) so the test
+  // keeps the device's real coherent value and exercises the actual native
+  // tier it reports — coherent (tier 1) or non-coherent (tier 3, with barrier).
+  // Forcing coherent would mismatch a non-coherent backend such as Angle,
+  // which reports GL_KHR_blend_equation_advanced_coherent == false.
   config.sample_count = sample_count;
   return config;
 }
@@ -259,6 +277,48 @@ static void RunBlendModeTextureCopyTest(skity::BlendMode mode, const char* name,
       TextureCopyConfig(sample_count)));
 }
 
+// Native advanced blend (GL_KHR_blend_equation_advanced /
+// VK_EXT_blend_operation_advanced). The result is mathematically identical to
+// the texture-copy / framebuffer-fetch paths, so the baseline
+// blend_mode_<Mode>.png is reused directly under default tolerance.
+static void RunBlendModeNativeBlendTest(skity::BlendMode mode,
+                                        const char* name) {
+  if (skity::testing::IsNativeAdvancedBlendUnsupported()) {
+    GTEST_SKIP() << "Device does not expose native advanced blend";
+  }
+
+  skity::PictureRecorder recorder;
+  recorder.BeginRecording(skity::Rect::MakeWH(100.f, 100.f));
+  auto canvas = recorder.GetRecordingCanvas();
+
+  DrawBlendMode(canvas, mode);
+
+  auto golden_path =
+      MakeBlendModeGoldenPath(std::string("blend_mode_") + name + ".png");
+  auto dl = recorder.FinishRecording();
+  EXPECT_TRUE(skity::testing::CompareGoldenTexture(
+      dl.get(), 100.f, 100.f, golden_path.c_str(), NativeBlendConfig(4)));
+}
+
+static void RunBlendModeFramebufferFetchTest(skity::BlendMode mode,
+                                             const char* name) {
+  if (IsFramebufferFetchUnsupported()) {
+    GTEST_SKIP() << "Framebuffer fetch is not supported on this backend";
+  }
+
+  skity::PictureRecorder recorder;
+  recorder.BeginRecording(skity::Rect::MakeWH(100.f, 100.f));
+  auto canvas = recorder.GetRecordingCanvas();
+
+  DrawBlendMode(canvas, mode);
+
+  auto golden_path =
+      MakeBlendModeGoldenPath(std::string("blend_mode_") + name + ".png");
+  auto dl = recorder.FinishRecording();
+  EXPECT_TRUE(skity::testing::CompareGoldenTexture(
+      dl.get(), 100.f, 100.f, golden_path.c_str(), FramebufferFetchConfig(4)));
+}
+
 #define BLEND_MODE_TEST(mode_name)                                \
   TEST(BlendModeGolden, mode_name) {                              \
     RunBlendModeTest(skity::BlendMode::k##mode_name, #mode_name); \
@@ -272,6 +332,17 @@ static void RunBlendModeTextureCopyTest(skity::BlendMode mode, const char* name,
   TEST(BlendModeGolden, TextureCopySampleCount4_##mode_name) {              \
     RunBlendModeTextureCopyTest(skity::BlendMode::k##mode_name, #mode_name, \
                                 4);                                         \
+  }
+
+#define BLEND_MODE_NATIVE_BLEND_TEST(mode_name)                              \
+  TEST(BlendModeGolden, NativeBlend_##mode_name) {                           \
+    RunBlendModeNativeBlendTest(skity::BlendMode::k##mode_name, #mode_name); \
+  }
+
+#define BLEND_MODE_FRAMEBUFFER_FETCH_TEST(mode_name)                 \
+  TEST(BlendModeGolden, FramebufferFetch_##mode_name) {              \
+    RunBlendModeFramebufferFetchTest(skity::BlendMode::k##mode_name, \
+                                     #mode_name);                    \
   }
 
 #define BLEND_MODE_DRAW_TEXTURE_MODE_TEXTURE_COPY_TEST(mode_name)              \
@@ -317,6 +388,43 @@ BLEND_MODE_TEXTURE_COPY_TEST(Hue)
 BLEND_MODE_TEXTURE_COPY_TEST(Saturation)
 BLEND_MODE_TEXTURE_COPY_TEST(Color)
 BLEND_MODE_TEXTURE_COPY_TEST(Luminosity)
+
+// Native advanced-blend path. Modulate is excluded: ToNativeBlendOp returns
+// nullopt for it, so it never takes the native path.
+BLEND_MODE_NATIVE_BLEND_TEST(Screen)
+BLEND_MODE_NATIVE_BLEND_TEST(Overlay)
+BLEND_MODE_NATIVE_BLEND_TEST(Darken)
+BLEND_MODE_NATIVE_BLEND_TEST(Lighten)
+BLEND_MODE_NATIVE_BLEND_TEST(ColorDodge)
+BLEND_MODE_NATIVE_BLEND_TEST(ColorBurn)
+BLEND_MODE_NATIVE_BLEND_TEST(HardLight)
+BLEND_MODE_NATIVE_BLEND_TEST(SoftLight)
+BLEND_MODE_NATIVE_BLEND_TEST(Difference)
+BLEND_MODE_NATIVE_BLEND_TEST(Exclusion)
+BLEND_MODE_NATIVE_BLEND_TEST(Multiply)
+BLEND_MODE_NATIVE_BLEND_TEST(Hue)
+BLEND_MODE_NATIVE_BLEND_TEST(Saturation)
+BLEND_MODE_NATIVE_BLEND_TEST(Color)
+BLEND_MODE_NATIVE_BLEND_TEST(Luminosity)
+
+// Framebuffer-fetch path (all advanced modes, including Modulate, which has no
+// native equivalent and therefore falls through to fetch/copy).
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Modulate)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Screen)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Overlay)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Darken)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Lighten)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(ColorDodge)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(ColorBurn)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(HardLight)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(SoftLight)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Difference)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Exclusion)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Multiply)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Hue)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Saturation)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Color)
+BLEND_MODE_FRAMEBUFFER_FETCH_TEST(Luminosity)
 
 BLEND_MODE_DRAW_TEXTURE_MODE_TEXTURE_COPY_TEST(Overlay)
 

--- a/test/golden/common/golden_test_check.cc
+++ b/test/golden/common/golden_test_check.cc
@@ -212,13 +212,31 @@ struct AutoRestoreConfig {
     gpu_context->SetEnableSimpleShapePipeline(
         config.enable_simple_shape_pipeline);
 
-    if (config.supports_framebuffer_fetch.has_value()) {
+    if (config.supports_framebuffer_fetch.has_value() ||
+        config.supports_native_advanced_blend.has_value() ||
+        config.supports_native_advanced_blend_coherent.has_value()) {
       auto* gpu_context_impl = static_cast<GPUContextImpl*>(gpu_context);
       auto* gpu_device = gpu_context_impl->GetGPUDevice();
-      restore_config.supports_framebuffer_fetch =
-          gpu_device->GetCaps().supports_framebuffer_fetch;
-      const_cast<GPUCaps&>(gpu_device->GetCaps()).supports_framebuffer_fetch =
-          config.supports_framebuffer_fetch.value();
+      auto& caps = const_cast<GPUCaps&>(gpu_device->GetCaps());
+
+      if (config.supports_framebuffer_fetch.has_value()) {
+        restore_config.supports_framebuffer_fetch =
+            caps.supports_framebuffer_fetch;
+        caps.supports_framebuffer_fetch =
+            config.supports_framebuffer_fetch.value();
+      }
+      if (config.supports_native_advanced_blend.has_value()) {
+        restore_config.supports_native_advanced_blend =
+            caps.supports_native_advanced_blend;
+        caps.supports_native_advanced_blend =
+            config.supports_native_advanced_blend.value();
+      }
+      if (config.supports_native_advanced_blend_coherent.has_value()) {
+        restore_config.supports_native_advanced_blend_coherent =
+            caps.supports_native_advanced_blend_coherent;
+        caps.supports_native_advanced_blend_coherent =
+            config.supports_native_advanced_blend_coherent.value();
+      }
     }
   }
 
@@ -231,11 +249,25 @@ struct AutoRestoreConfig {
     gpu_context->SetEnableSimpleShapePipeline(
         restore_config.enable_simple_shape_pipeline);
 
-    if (restore_config.supports_framebuffer_fetch.has_value()) {
+    if (restore_config.supports_framebuffer_fetch.has_value() ||
+        restore_config.supports_native_advanced_blend.has_value() ||
+        restore_config.supports_native_advanced_blend_coherent.has_value()) {
       auto* gpu_context_impl = static_cast<GPUContextImpl*>(gpu_context);
       auto* gpu_device = gpu_context_impl->GetGPUDevice();
-      const_cast<GPUCaps&>(gpu_device->GetCaps()).supports_framebuffer_fetch =
-          restore_config.supports_framebuffer_fetch.value();
+      auto& caps = const_cast<GPUCaps&>(gpu_device->GetCaps());
+
+      if (restore_config.supports_framebuffer_fetch.has_value()) {
+        caps.supports_framebuffer_fetch =
+            restore_config.supports_framebuffer_fetch.value();
+      }
+      if (restore_config.supports_native_advanced_blend.has_value()) {
+        caps.supports_native_advanced_blend =
+            restore_config.supports_native_advanced_blend.value();
+      }
+      if (restore_config.supports_native_advanced_blend_coherent.has_value()) {
+        caps.supports_native_advanced_blend_coherent =
+            restore_config.supports_native_advanced_blend_coherent.value();
+      }
     }
   }
 
@@ -255,6 +287,20 @@ struct AutoRestoreConfig {
   GPUContext* gpu_context = nullptr;
   GoldenTestEnvConfig restore_config;
 };
+
+bool IsNativeAdvancedBlendUnsupported() {
+  auto* env = GoldenTestEnv::GetInstance();
+  if (env == nullptr) {
+    return true;
+  }
+  auto* gpu_context_impl = static_cast<GPUContextImpl*>(env->GetGPUContext());
+  if (gpu_context_impl == nullptr) {
+    return true;
+  }
+  auto* gpu_device = gpu_context_impl->GetGPUDevice();
+  return gpu_device == nullptr ||
+         !gpu_device->GetCaps().supports_native_advanced_blend;
+}
 
 std::shared_ptr<Pixmap> ReadImage(const char* path) {
   auto data = skity::Data::MakeFromFileName(path);

--- a/test/golden/common/golden_test_check.hpp
+++ b/test/golden/common/golden_test_check.hpp
@@ -30,11 +30,19 @@ struct GoldenTestEnvConfig {
   bool enable_gpu_tessellation = false;
   bool enable_simple_shape_pipeline = false;
   std::optional<bool> supports_framebuffer_fetch = std::nullopt;
+  std::optional<bool> supports_native_advanced_blend = std::nullopt;
+  std::optional<bool> supports_native_advanced_blend_coherent = std::nullopt;
   std::optional<GLSurfaceMode> gl_surface_mode = std::nullopt;
   std::optional<bool> gl_has_stencil_attachment = std::nullopt;
   uint32_t sample_count = 4;
   bool use_backend_specific_golden = false;
 };
+
+// True when the real (pre-override) device caps lack native advanced blend
+// (GL_KHR_blend_equation_advanced / VK_EXT_blend_operation_advanced). Native
+// cases skip on such devices, since the per-test cap override would otherwise
+// force the extension on and issue invalid GL/Vulkan calls.
+bool IsNativeAdvancedBlendUnsupported();
 
 /**
  * @brief compare the display list with the golden texture. If the golden_test

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(skity_unit_test
     render/hw/hw_buffer_layout_test.cc
     render/hw/hw_pipeline_key_test.cc
     render/hw/precompile_test.cc
+    render/hw/dst_read_strategy_test.cc
     render/hw/hw_texture_copy_info_test.cc
     render/hw/draw/hw_wgsl_shader_writer_test.cc
     wgx/wgx_backend_name_resolution_test.cc

--- a/test/ut/render/hw/dst_read_strategy_test.cc
+++ b/test/ut/render/hw/dst_read_strategy_test.cc
@@ -1,0 +1,123 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/hw/dst_read_strategy.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// native_advanced: KHR_blend_equation_advanced exposed.
+// coherent: the _coherent sub-extension / advancedBlendCoherentOperations.
+// framebuffer_fetch: EXT_shader_framebuffer_fetch.
+skity::GPUCaps MakeCaps(bool native_advanced, bool coherent,
+                        bool framebuffer_fetch) {
+  skity::GPUCaps caps;
+  caps.supports_native_advanced_blend = native_advanced;
+  caps.supports_native_advanced_blend_coherent = native_advanced && coherent;
+  caps.supports_framebuffer_fetch = framebuffer_fetch;
+  return caps;
+}
+
+}  // namespace
+
+TEST(DstReadStrategy, NonAdvancedModeIsNonRequired) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kSrcOver,
+                                          MakeCaps(true, true, false)),
+            skity::DstReadStrategy::kNonRequired);
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kPlus,
+                                          MakeCaps(true, true, true)),
+            skity::DstReadStrategy::kNonRequired);
+}
+
+// Tier 1: coherent native beats everything (even framebuffer_fetch).
+TEST(DstReadStrategy, CoherentNativeHasHighestPriority) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(true, true, true)),
+            skity::DstReadStrategy::kNativeBlend);
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(true, true, false)),
+            skity::DstReadStrategy::kNativeBlend);
+  // A few native-able modes resolve identically.
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kScreen,
+                                          MakeCaps(true, true, false)),
+            skity::DstReadStrategy::kNativeBlend);
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kLuminosity,
+                                          MakeCaps(true, true, false)),
+            skity::DstReadStrategy::kNativeBlend);
+}
+
+// Tier 2: framebuffer_fetch beats non-coherent native — the key mobile fix.
+// A tile-based GPU exposing KHR_blend_equation_advanced without the _coherent
+// sub-extension must use framebuffer_fetch, not native + per-draw barrier.
+TEST(DstReadStrategy, NonCoherentNativeYieldsToFramebufferFetch) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(true, false, true)),
+            skity::DstReadStrategy::kFramebufferFetch);
+}
+
+// Tier 3: non-coherent native is still used when framebuffer_fetch is absent
+// (typical desktop GL, where glBlendBarrierKHR is cheap).
+TEST(DstReadStrategy, NonCoherentNativeUsedWhenNoFramebufferFetch) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(true, false, false)),
+            skity::DstReadStrategy::kNativeBlend);
+}
+
+// Tier 4: texture_copy fallback when nothing better is available.
+TEST(DstReadStrategy, AdvancedModeFallsBackToTextureCopy) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(false, false, false)),
+            skity::DstReadStrategy::kTextureCopy);
+}
+
+TEST(DstReadStrategy, AdvancedModeFallsBackToFramebufferFetch) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kMultiply,
+                                          MakeCaps(false, false, true)),
+            skity::DstReadStrategy::kFramebufferFetch);
+}
+
+TEST(DstReadStrategy, ModulateNeverUsesNativeBlend) {
+  // kModulate has no hardware equivalent (ToNativeBlendOp == nullopt), so it
+  // never enters the native tiers even when native advanced blend is supported.
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kModulate,
+                                          MakeCaps(true, true, false)),
+            skity::DstReadStrategy::kTextureCopy);
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kModulate,
+                                          MakeCaps(true, true, true)),
+            skity::DstReadStrategy::kFramebufferFetch);
+  EXPECT_EQ(skity::ResolveDstReadStrategy(skity::BlendMode::kModulate,
+                                          MakeCaps(true, false, true)),
+            skity::DstReadStrategy::kFramebufferFetch);
+}
+
+TEST(DstReadStrategy, ThreeArgOverloadDoesNotDowngradeCoherentNative) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(
+                skity::BlendMode::kMultiply, MakeCaps(true, true, false),
+                /*supports_texture_copy_dst_read=*/false),
+            skity::DstReadStrategy::kNativeBlend);
+}
+
+TEST(DstReadStrategy, ThreeArgOverloadDoesNotDowngradeNonCoherentNative) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(
+                skity::BlendMode::kMultiply, MakeCaps(true, false, false),
+                /*supports_texture_copy_dst_read=*/false),
+            skity::DstReadStrategy::kNativeBlend);
+}
+
+TEST(DstReadStrategy, ThreeArgOverloadDoesNotDowngradeFramebufferFetch) {
+  // Non-coherent native + fb_fetch resolves to fb_fetch, which the texture_copy
+  // gate must not downgrade.
+  EXPECT_EQ(skity::ResolveDstReadStrategy(
+                skity::BlendMode::kMultiply, MakeCaps(true, false, true),
+                /*supports_texture_copy_dst_read=*/false),
+            skity::DstReadStrategy::kFramebufferFetch);
+}
+
+TEST(DstReadStrategy, ThreeArgOverloadDowngradesTextureCopyWhenUnsupported) {
+  EXPECT_EQ(skity::ResolveDstReadStrategy(
+                skity::BlendMode::kMultiply, MakeCaps(false, false, false),
+                /*supports_texture_copy_dst_read=*/false),
+            skity::DstReadStrategy::kNonRequired);
+}

--- a/test/ut/render/hw/hw_pipeline_key_test.cc
+++ b/test/ut/render/hw/hw_pipeline_key_test.cc
@@ -638,6 +638,66 @@ TEST(HWPipelineKey, ProgrammableBlendingKeyIncludesDstReadStrategy) {
             texture_copy_hard_light->GetProgrammableBlendingKey());
 }
 
+// The kNativeAdvancedBlendKey sentinel marks the GL native-blend shader
+// variant (SetUsesNativeAdvancedBlend is only set when
+// caps.native_blend_shader_variant is true, i.e. GL). These tests lock down
+// the pipeline-cache identity invariants of the sentinel so GL native draws
+// never collide with other paths at the cache-key level.
+
+TEST(HWPipelineKey, NativeAdvancedBlendKeyDiffersFromOrdinary) {
+  // The sentinel must not collide with the ordinary-blend key
+  // (programmable_blending == 0), or GL native draws would reuse a
+  // plain-blend shader.
+  HWPipelineKey native_key;
+  native_key.base_key = 1;
+  native_key.programmable_blending = kNativeAdvancedBlendKey;
+
+  HWPipelineKey ordinary_key;
+  ordinary_key.base_key = 1;  // programmable_blending defaults to 0
+
+  EXPECT_NE(native_key, ordinary_key);
+}
+
+TEST(HWPipelineKey, NativeAdvancedBlendKeyDiffersFromShaderBlending) {
+  // The sentinel must also stay distinct from a packed shader-blending key
+  // (framebuffer-fetch / texture-copy packs mode | strategy<<8 into the low
+  // bits); the top-bit sentinel never overlaps that range.
+  HWPipelineKey native_key;
+  native_key.base_key = 1;
+  native_key.programmable_blending = kNativeAdvancedBlendKey;
+
+  HWPipelineKey shader_key;
+  shader_key.base_key = 1;
+  shader_key.programmable_blending =
+      skity::WGXProgrammableBlending::Make(
+          skity::BlendMode::kOverlay, skity::DstReadStrategy::kFramebufferFetch)
+          ->GetProgrammableBlendingKey();
+
+  EXPECT_NE(native_key, shader_key);
+}
+
+TEST(HWPipelineKey, NativeAdvancedBlendKeyHashIsStable) {
+  // Two identical sentinel keys must compare equal and hash identically.
+  //
+  // Note: the Vulkan native path deliberately does NOT set the sentinel
+  // (caps.native_blend_shader_variant is false on Vulkan), so its
+  // programmable_blending stays 0 and it shares the pipeline key with ordinary
+  // blends. That cache-sharing invariant is enforced by the draw layer (which
+  // gates SetUsesNativeAdvancedBlend on the caps flag), not by the key type,
+  // so it cannot be asserted at this layer.
+  HWPipelineKey a;
+  a.base_key = 1;
+  a.programmable_blending = kNativeAdvancedBlendKey;
+
+  HWPipelineKey b;
+  b.base_key = 1;
+  b.programmable_blending = kNativeAdvancedBlendKey;
+
+  EXPECT_EQ(a, b);
+  HWPipelineKeyHash hasher;
+  EXPECT_EQ(hasher(a), hasher(b));
+}
+
 TEST(HWPipelineKey, Text) {
   {
     auto geometry = WGSLTextSolidColorGeometry(Matrix{}, {}, Paint{});


### PR DESCRIPTION
Add a hardware-native advanced-blend path (DstReadStrategy::kNativeBlend) that uses GL_KHR_blend_equation_advanced / VK_EXT_blend_operation_advanced, letting the fixed-function pipeline blend advanced modes with no shader math, no destination read, and no pass split on devices that expose the extensions.

Strategy resolution uses a four-tier priority:
  coherent native > framebuffer_fetch > non-coherent native > texture_copy.
On tile-based GPUs a non-coherent native blend needs a per-draw barrier that forces a tile flush, so it yields to framebuffer_fetch (tile-local); coherent native stays strictly optimal, and non-coherent native still wins on desktop where the barrier is cheap.

Notable details:
- GPUBlendOperation enum + GPUColorTargetState.blend_op; ToNativeBlendOp maps the 15 native-able modes (kModulate has no hardware equivalent, falls back).
- resolve_blend_state returns {kOne, kOneMinusSrcAlpha, native_op}: advanced equations ignore RGB blend factors, and alpha (kept on ADD with those factors) computes source-over, matching the advanced shader branches.
- GL: SetBlendEquation via glBlendEquationSeparate (alpha on ADD); per-draw glBlendBarrierKHR when the coherent sub-extension is missing.
- Vulkan: ToVkBlendOp + VkPipelineColorBlendAdvancedStateCreateInfoEXT on the color-blend-state pNext; coherent-only native cap reporting in this round.
- PipelineMatch compares blend_op to avoid first-level cache collisions.
- ResolveDstReadStrategy unit tests (11 cases) cover the four tiers.