### PR TITLE
fix(win): harden DWrite text rendering path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,23 @@ jobs:
           - name: Sync Dependencies
             run: |
                 powershell -File "./tools/hab.ps1" sync -f --target dev,module,ci
+          - name: Print Windows SDK Versions
+            run: |
+                Write-Host "Installed Windows SDK Include versions:"
+                Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\Include" -Directory | Select-Object -ExpandProperty Name
+                Write-Host "Installed Windows SDK Lib versions:"
+                Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\Lib" -Directory | Select-Object -ExpandProperty Name
+                Write-Host "Installed Windows SDK bin versions:"
+                Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Directory | Select-Object -ExpandProperty Name
           - name: Run Build
             run: |
-                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON  -DCMAKE_POLICY_VERSION_MINIMUM='3.5'
+                $WindowsSdkVersion = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\Include" -Directory | Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1 -ExpandProperty Name
+                Write-Host "Using Windows SDK version: $WindowsSdkVersion"
+                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON  -DCMAKE_POLICY_VERSION_MINIMUM='3.5'
+                Select-String -Path out/cmake_host_build/skity.vcxproj -Pattern "WindowsTargetPlatformVersion"
                 ./buildtools/cmake/bin/cmake --build out/cmake_host_build --target skity_unit_test
                 cd out/cmake_host_build/Debug
-                ./skity_unit_test
+                ./skity_unit_test --gtest_color=no --gtest_print_time=1
 
     osx_metal_golden_test:
         runs-on: lynx-darwin-14-medium

--- a/example/case/text/CMakeLists.txt
+++ b/example/case/text/CMakeLists.txt
@@ -23,5 +23,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     )
     target_link_libraries(dwrite_text_example PUBLIC skity::example_common)
     target_compile_definitions(dwrite_text_example PRIVATE
-        -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")
+        -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/"
+        -DTEST_FONT_ROOT="${CMAKE_SOURCE_DIR}/test/fonts/resources/")
 endif()

--- a/example/case/text/win/dwrite_text_example.cc
+++ b/example/case/text/win/dwrite_text_example.cc
@@ -17,8 +17,9 @@
 
 namespace {
 
-constexpr float kWindowWidth = 1700.f;
-constexpr float kWindowHeight = 1120.f;
+constexpr float kWindowWidth = 2800.f;
+constexpr float kWindowHeight = 1880.f;
+constexpr bool kEnableDWriteFontManager = true;
 
 skity::Color Color(uint8_t r, uint8_t g, uint8_t b) {
   return skity::ColorSetARGB(0xFF, r, g, b);
@@ -105,6 +106,18 @@ std::string TypefaceSummary(const std::shared_ptr<skity::Typeface>& typeface) {
   return stream.str();
 }
 
+std::string AxisSummary(const std::shared_ptr<skity::Typeface>& typeface) {
+  if (!typeface) {
+    return "axes=0";
+  }
+
+  std::ostringstream stream;
+  stream << "axes=" << typeface->GetVariationDesignParameters().size();
+  stream << " pos="
+         << typeface->GetVariationDesignPosition().GetCoordinates().size();
+  return stream.str();
+}
+
 std::shared_ptr<skity::Typeface> MatchOrDefault(
     const std::shared_ptr<skity::FontManager>& font_manager, const char* family,
     skity::FontStyle style) {
@@ -128,6 +141,34 @@ void AddTypeface(std::vector<std::shared_ptr<skity::Typeface>>* typefaces,
       typefaces->end()) {
     typefaces->push_back(std::move(typeface));
   }
+}
+
+std::shared_ptr<skity::Typeface> MakeVariation(
+    const std::shared_ptr<skity::Typeface>& typeface,
+    std::initializer_list<std::pair<skity::FourByteTag, float>> coordinates) {
+  if (!typeface) {
+    return nullptr;
+  }
+
+  skity::VariationPosition position;
+  for (const auto& coordinate : coordinates) {
+    position.AddCoordinate(coordinate.first, coordinate.second);
+  }
+
+  skity::FontArguments arguments;
+  arguments.SetVariationDesignPosition(position);
+  auto variation = typeface->MakeVariation(arguments);
+  return variation ? variation : typeface;
+}
+
+std::shared_ptr<skity::Typeface> MakeDataTypeface(
+    const std::shared_ptr<skity::FontManager>& font_manager, const char* path,
+    int ttc_index = 0) {
+  auto data = skity::Data::MakeFromFileName(path);
+  if (!data) {
+    return nullptr;
+  }
+  return font_manager->MakeFromData(data, ttc_index);
 }
 
 std::shared_ptr<skity::Typeface> MatchCharacter(
@@ -227,19 +268,42 @@ void DrawGlyphText(skity::Canvas* canvas, const std::string& text, float x,
 void DrawLabel(skity::Canvas* canvas, const std::string& text, float x, float y,
                float width, std::shared_ptr<skity::Typeface> label_typeface) {
   skity::Paint paint =
-      PaintForText(std::move(label_typeface), 13.f, Color(72, 82, 96));
-  const size_t max_chars = static_cast<size_t>(std::max(20.f, width / 7.2f));
-  std::string line = text;
-  if (line.size() > max_chars) {
-    line = line.substr(0, max_chars - 3) + "...";
+      PaintForText(std::move(label_typeface), 19.f, Color(72, 82, 96));
+  const size_t max_chars = static_cast<size_t>(std::max(24.f, width / 10.2f));
+  const auto trim_left = [](std::string line) {
+    while (!line.empty() && line.front() == ' ') {
+      line.erase(line.begin());
+    }
+    return line;
+  };
+  auto wrap_line = [max_chars](const std::string& line) {
+    if (line.size() <= max_chars) {
+      return std::make_pair(line, std::string());
+    }
+
+    const size_t preferred = line.rfind(' ', max_chars);
+    const size_t split = preferred == std::string::npos || preferred < 12
+                             ? max_chars
+                             : preferred;
+    return std::make_pair(line.substr(0, split), line.substr(split));
+  };
+
+  auto lines = wrap_line(text);
+  std::string second = trim_left(lines.second);
+  if (second.size() > max_chars) {
+    second = second.substr(0, max_chars - 3) + "...";
   }
-  DrawText(canvas, line, x, y, paint);
+
+  DrawText(canvas, lines.first, x, y, paint);
+  if (!second.empty()) {
+    DrawText(canvas, second, x, y + 24.f, paint);
+  }
 }
 
 void DrawSectionTitle(skity::Canvas* canvas, const std::string& title, float x,
                       float y,
                       const std::shared_ptr<skity::Typeface>& typeface) {
-  auto paint = PaintForText(typeface, 22.f, Color(28, 38, 50));
+  auto paint = PaintForText(typeface, 30.f, Color(28, 38, 50));
   DrawText(canvas, title, x, y, paint);
 }
 
@@ -289,13 +353,13 @@ void DrawFamilyCases(skity::Canvas* canvas,
   for (const auto& family_case : cases) {
     auto typeface =
         MatchOrDefault(font_manager, family_case.family, family_case.style);
-    auto paint = PaintForText(typeface, 24.f, Color(20, 25, 33));
+    auto paint = PaintForText(typeface, 32.f, Color(20, 25, 33));
     DrawText(canvas, family_case.sample, x, y, paint);
     DrawLabel(
         canvas,
         std::string(family_case.family) + " -> " + TypefaceSummary(typeface), x,
-        y + 18.f, column_width, label_typeface);
-    y += 55.f;
+        y + 28.f, column_width, label_typeface);
+    y += 82.f;
   }
 }
 
@@ -312,25 +376,118 @@ void DrawWeightSweep(skity::Canvas* canvas,
   for (auto weight : weights) {
     auto style = MakeStyle(weight);
     auto typeface = MatchOrDefault(font_manager, "Segoe UI", style);
-    auto paint = PaintForText(typeface, 23.f, Color(18, 65, 95));
+    auto paint = PaintForText(typeface, 31.f, Color(18, 65, 95));
     std::ostringstream sample;
     sample << "Segoe UI weight " << weight << " AaBbCc 123";
     DrawText(canvas, sample.str(), x, y, paint);
-    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 17.f, column_width,
+    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 28.f, column_width,
               label_typeface);
-    y += 48.f;
+    y += 68.f;
   }
 
   y += 8.f;
   for (auto weight : {300, 400, 700, 900}) {
     auto style = MakeStyle(weight);
     auto typeface = MatchOrDefault(font_manager, "Microsoft YaHei", style);
-    auto paint = PaintForText(typeface, 23.f, Color(40, 83, 45));
+    auto paint = PaintForText(typeface, 31.f, Color(40, 83, 45));
     auto sample = AppendUtf8Text("YaHei weight ", {0x4E2D, 0x6587, 0x95E8});
     DrawText(canvas, sample + " " + std::to_string(weight), x, y, paint);
-    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 17.f, column_width,
+    DrawLabel(canvas, TypefaceSummary(typeface), x, y + 28.f, column_width,
               label_typeface);
-    y += 48.f;
+    y += 68.f;
+  }
+}
+
+void DrawVariationCases(skity::Canvas* canvas,
+                        const std::shared_ptr<skity::FontManager>& font_manager,
+                        const std::shared_ptr<skity::Typeface>& label_typeface,
+                        float x, float y, float column_width) {
+  DrawSectionTitle(canvas, "Variable font probes", x, y, label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 30.f;
+
+  auto flex =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/RobotoFlex-Regular.ttf");
+  auto flex_light =
+      MakeVariation(flex, {{skity::SetFourByteTag('w', 'g', 'h', 't'), 100.f}});
+  auto flex_bold =
+      MakeVariation(flex, {{skity::SetFourByteTag('w', 'g', 'h', 't'), 900.f}});
+  auto flex_multi = MakeVariation(
+      flex, {
+                {skity::SetFourByteTag('w', 'g', 'h', 't'), 700.f},
+                {skity::SetFourByteTag('w', 'd', 't', 'h'), 125.f},
+                {skity::SetFourByteTag('o', 'p', 's', 'z'), 72.f},
+                {skity::SetFourByteTag('G', 'R', 'A', 'D'), 50.f},
+            });
+  auto flex_data =
+      MakeDataTypeface(font_manager, TEST_FONT_ROOT "/RobotoFlex-Regular.ttf");
+  flex_data = MakeVariation(
+      flex_data, {{skity::SetFourByteTag('w', 'g', 'h', 't'), 700.f}});
+
+  const std::vector<std::pair<std::string, std::shared_ptr<skity::Typeface>>>
+      cases = {
+          {"RobotoFlex default AaBbCc123", flex},
+          {"RobotoFlex wght100 AaBbCc123", flex_light},
+          {"RobotoFlex wght900 AaBbCc123", flex_bold},
+          {"RobotoFlex multi-axis AaBbCc123", flex_multi},
+          {"RobotoFlex data wght700 AaBbCc123", flex_data},
+      };
+
+  for (const auto& item : cases) {
+    auto paint = PaintForText(item.second, 32.f, Color(35, 66, 102));
+    DrawText(canvas, item.first, x, y, paint);
+    DrawLabel(canvas,
+              AxisSummary(item.second) + " | " + TypefaceSummary(item.second),
+              x, y + 28.f, column_width, label_typeface);
+    y += 84.f;
+  }
+}
+
+void DrawCollectionAndDataCases(
+    skity::Canvas* canvas,
+    const std::shared_ptr<skity::FontManager>& font_manager,
+    const std::shared_ptr<skity::Typeface>& label_typeface, float x, float y,
+    float column_width) {
+  DrawSectionTitle(canvas, "Collection and data fonts", x, y, label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 30.f;
+
+  auto cjk_index0 =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/NotoSansCJK-Regular.ttc", 0);
+  auto cjk_index1 =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/NotoSansCJK-Regular.ttc", 1);
+  auto cjk_index2 =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/NotoSansCJK-Regular.ttc", 2);
+  auto cjk_index3 =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/NotoSansCJK-Regular.ttc", 3);
+  auto cjk_index4 =
+      font_manager->MakeFromFile(TEST_FONT_ROOT "/NotoSansCJK-Regular.ttc", 4);
+  auto emoji_data =
+      MakeDataTypeface(font_manager, TEST_FONT_ROOT "/NotoColorEmoji.ttf");
+
+  const std::vector<std::pair<std::string, std::shared_ptr<skity::Typeface>>>
+      cases = {
+          {AppendUtf8Text("TTC index0 JP U+95E8 ", {0x95E8, 0x20, 0x95E8}),
+           cjk_index0},
+          {AppendUtf8Text("TTC index1 KR U+95E8 ", {0x95E8, 0x20, 0x95E8}),
+           cjk_index1},
+          {AppendUtf8Text("TTC index2 SC U+95E8 ", {0x95E8, 0x20, 0x95E8}),
+           cjk_index2},
+          {AppendUtf8Text("TTC index3 TC U+95E8 ", {0x95E8, 0x20, 0x95E8}),
+           cjk_index3},
+          {AppendUtf8Text("TTC index4 HK U+95E8 ", {0x95E8, 0x20, 0x95E8}),
+           cjk_index4},
+          {Utf8({0x1F600, 0x20, 0x1F680, 0x20, 0x1F4A9}), emoji_data},
+      };
+
+  for (const auto& item : cases) {
+    auto paint = PaintForText(item.second, 33.f, Color(59, 76, 45));
+    DrawText(canvas, item.first, x, y, paint);
+    DrawLabel(canvas, TypefaceSummary(item.second), x, y + 28.f, column_width,
+              label_typeface);
+    y += 80.f;
   }
 }
 
@@ -350,36 +507,55 @@ void DrawFallbackAndEmoji(
   auto fallback_delegate = BuildFallbackDelegate(font_manager, base_typeface);
 
   auto mixed = AppendUtf8Text(
-      "Arial fallback: ",
-      {0x4E2D, 0x6587, 0x20,   0x65E5, 0x672C, 0x8A9E, 0x20,   0xD55C,
-       0xAD6D, 0xC5B4, 0x20,   0x0639, 0x0631, 0x0628, 0x064A, 0x20,
-       0x0939, 0x093F, 0x0928, 0x094D, 0x0926, 0x0940, 0x20,   0x1F600});
-  auto paint = PaintForText(base_typeface, 26.f, Color(27, 49, 79));
+      "Fallback: ", {0x4E2D, 0x6587, 0x20, 0x65E5, 0x672C, 0x8A9E, 0x20, 0xD55C,
+                     0xAD6D, 0xC5B4, 0x20, 0x1F600});
+  std::string spacing_mixed = "Spacing: [A]   [";
+  AppendUtf8(&spacing_mixed, 0x4E2D);
+  spacing_mixed += "]   [";
+  AppendUtf8(&spacing_mixed, 0x1F600);
+  spacing_mixed += "]   [B]";
+  auto complex_mixed = AppendUtf8Text(
+      "Arabic/Hindi: ", {0x0639, 0x0631, 0x0628, 0x064A, 0x20, 0x0939, 0x093F,
+                         0x0928, 0x094D, 0x0926, 0x0940});
+  auto paint = PaintForText(base_typeface, 34.f, Color(27, 49, 79));
   DrawBlobText(canvas, mixed, x, y, paint, fallback_delegate.get());
+  y += 48.f;
+  DrawBlobText(canvas, spacing_mixed, x, y, paint, fallback_delegate.get());
+  y += 48.f;
+  DrawBlobText(canvas, complex_mixed, x, y, paint, fallback_delegate.get());
   DrawLabel(canvas,
-            "TextBlob fallback from Arial across CJK/Arabic/Hindi/emoji", x,
-            y + 20.f, column_width, label_typeface);
-  y += 68.f;
+            "TextBlob fallback from Arial, with visible inter-run spaces", x,
+            y + 34.f, column_width, label_typeface);
+  y += 114.f;
 
   auto emoji_text = Utf8({0x1F600, 0x20, 0x1F642, 0x20, 0x1F680, 0x20, 0x1F4A9,
                           0x20, 0x1F469, 0x200D, 0x1F4BB});
+  auto short_emoji_text = Utf8({0x1F600, 0x20, 0x1F680, 0x20, 0x1F4A9});
   auto emoji_system = MatchOrDefault(font_manager, "Segoe UI Emoji",
                                      skity::FontStyle::Normal());
   auto emoji_file =
       skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT "/NotoColorEmoji.ttf");
   auto emoji_mono = skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT
                                                   "/NotoEmoji-Regular.ttf");
-  for (const auto& item :
-       std::vector<std::pair<std::string, std::shared_ptr<skity::Typeface>>>{
-           {"system Segoe UI Emoji", emoji_system},
-           {"file NotoColorEmoji.ttf", emoji_file},
-           {"file NotoEmoji-Regular.ttf", emoji_mono},
-       }) {
-    auto emoji_paint = PaintForText(item.second, 38.f, Color(23, 68, 66));
-    DrawText(canvas, item.first + ": " + emoji_text, x, y, emoji_paint);
-    DrawLabel(canvas, TypefaceSummary(item.second), x, y + 24.f, column_width,
-              label_typeface);
-    y += 72.f;
+  struct EmojiCase {
+    const char* label;
+    std::string text;
+    std::shared_ptr<skity::Typeface> typeface;
+  };
+  const std::vector<EmojiCase> emoji_cases = {
+      {"system Segoe UI Emoji", emoji_text, emoji_system},
+      {"file NotoColorEmoji.ttf", short_emoji_text, emoji_file},
+      {"file NotoEmoji-Regular.ttf", short_emoji_text, emoji_mono},
+  };
+  for (const auto& item : emoji_cases) {
+    auto name_paint = PaintForText(label_typeface, 28.f, Color(27, 49, 79));
+    DrawText(canvas, item.label, x, y, name_paint);
+    auto emoji_paint = PaintForText(item.typeface, 54.f, Color(23, 68, 66));
+    DrawText(canvas, item.text, x, y + 56.f, emoji_paint);
+    DrawLabel(canvas,
+              std::string(item.label) + " | " + TypefaceSummary(item.typeface),
+              x, y + 96.f, column_width, label_typeface);
+    y += 144.f;
   }
 
   auto locale_cjk = MatchCharacter(font_manager, 0x95E8, "Arial", "zh-CN");
@@ -396,7 +572,7 @@ void DrawFallbackAndEmoji(
   for (const auto& item : locale_cases) {
     DrawLabel(canvas, item.first + " -> " + TypefaceSummary(item.second), x, y,
               column_width, label_typeface);
-    y += 22.f;
+    y += 46.f;
   }
 }
 
@@ -434,41 +610,41 @@ void DrawPaintModes(skity::Canvas* canvas,
   };
 
   for (const auto& mode : modes) {
-    auto paint = PaintForText(typeface, 34.f, mode.fill_color, mode.style);
+    auto paint = PaintForText(typeface, 45.f, mode.fill_color, mode.style);
     paint.SetStrokeWidth(mode.stroke_width);
     paint.SetFillColor(mode.fill_color);
     paint.SetStrokeColor(mode.stroke_color);
     DrawText(canvas, sample, x, y, paint);
-    DrawLabel(canvas, mode.label, x, y + 24.f, column_width, label_typeface);
-    y += 68.f;
+    DrawLabel(canvas, mode.label, x, y + 38.f, column_width, label_typeface);
+    y += 98.f;
   }
 
-  skity::Font normal_font(typeface, 38.f);
-  skity::Font fake_bold_font(typeface, 38.f);
+  skity::Font normal_font(typeface, 50.f);
+  skity::Font fake_bold_font(typeface, 50.f);
   fake_bold_font.SetEmbolden(true);
 
-  auto normal_paint = PaintForText(typeface, 38.f, Color(64, 64, 74),
+  auto normal_paint = PaintForText(typeface, 50.f, Color(64, 64, 74),
                                    skity::Paint::kFill_Style);
   DrawGlyphText(canvas, "DrawGlyphs normal", x, y, normal_font, normal_paint);
-  DrawLabel(canvas, "DrawGlyphs without embolden", x, y + 24.f, column_width,
+  DrawLabel(canvas, "DrawGlyphs without embolden", x, y + 38.f, column_width,
             label_typeface);
-  y += 70.f;
+  y += 100.f;
 
-  auto bold_paint = PaintForText(typeface, 38.f, Color(82, 42, 86),
+  auto bold_paint = PaintForText(typeface, 50.f, Color(82, 42, 86),
                                  skity::Paint::kFill_Style);
   DrawGlyphText(canvas, "DrawGlyphs fake bold", x, y, fake_bold_font,
                 bold_paint);
-  DrawLabel(canvas, "DrawGlyphs with Font::SetEmbolden(true)", x, y + 24.f,
+  DrawLabel(canvas, "DrawGlyphs with Font::SetEmbolden(true)", x, y + 38.f,
             column_width, label_typeface);
-  y += 70.f;
+  y += 100.f;
 
-  auto bold_stroke_paint = PaintForText(typeface, 38.f, Color(95, 62, 24),
+  auto bold_stroke_paint = PaintForText(typeface, 50.f, Color(95, 62, 24),
                                         skity::Paint::kStroke_Style);
   bold_stroke_paint.SetStrokeWidth(1.8f);
   bold_stroke_paint.SetStrokeColor(Color(95, 62, 24));
   DrawGlyphText(canvas, "Fake bold stroke", x, y, fake_bold_font,
                 bold_stroke_paint);
-  DrawLabel(canvas, "embolden plus stroke mask", x, y + 24.f, column_width,
+  DrawLabel(canvas, "embolden plus stroke mask", x, y + 38.f, column_width,
             label_typeface);
 }
 
@@ -484,44 +660,44 @@ void DrawTransforms(skity::Canvas* canvas,
 
   auto typeface =
       MatchOrDefault(font_manager, "Consolas", skity::FontStyle::Normal());
-  auto paint = PaintForText(typeface, 34.f, Color(25, 72, 84));
+  auto paint = PaintForText(typeface, 45.f, Color(25, 72, 84));
 
   canvas->Save();
   canvas->Translate(x, y);
   canvas->Scale(1.25f, 1.25f);
   DrawText(canvas, "scaled text", 0.f, 0.f, paint);
   canvas->Restore();
-  DrawLabel(canvas, "canvas scale 1.25x", x, y + 46.f, column_width,
+  DrawLabel(canvas, "canvas scale 1.25x", x, y + 68.f, column_width,
             label_typeface);
-  y += 90.f;
+  y += 128.f;
 
   canvas->Save();
   canvas->Translate(x, y);
   canvas->Skew(-0.25f, 0.f);
   DrawText(canvas, "skewed text", 0.f, 0.f, paint);
   canvas->Restore();
-  DrawLabel(canvas, "canvas skew", x, y + 30.f, column_width, label_typeface);
-  y += 84.f;
+  DrawLabel(canvas, "canvas skew", x, y + 46.f, column_width, label_typeface);
+  y += 116.f;
 
   canvas->Save();
   canvas->Rotate(-9.f, x + 160.f, y);
   DrawText(canvas, "rotated text", x, y, paint);
   canvas->Restore();
-  DrawLabel(canvas, "canvas rotate around baseline", x, y + 34.f, column_width,
+  DrawLabel(canvas, "canvas rotate around baseline", x, y + 54.f, column_width,
             label_typeface);
-  y += 90.f;
+  y += 128.f;
 
-  auto large_paint = PaintForText(typeface, 92.f, Color(65, 52, 98),
+  auto large_paint = PaintForText(typeface, 122.f, Color(65, 52, 98),
                                   skity::Paint::kFill_Style);
-  large_paint.SetFontThreshold(48.f);
+  large_paint.SetFontThreshold(64.f);
   DrawText(canvas, "PATH", x, y, large_paint);
-  DrawLabel(canvas, "large text with low font threshold", x, y + 42.f,
+  DrawLabel(canvas, "large text with low font threshold", x, y + 68.f,
             column_width, label_typeface);
-  y += 120.f;
+  y += 172.f;
 
   auto emoji_typeface = MatchOrDefault(font_manager, "Segoe UI Emoji",
                                        skity::FontStyle::Normal());
-  auto emoji_paint = PaintForText(emoji_typeface, 54.f, Color(24, 78, 74),
+  auto emoji_paint = PaintForText(emoji_typeface, 72.f, Color(24, 78, 74),
                                   skity::Paint::kFill_Style);
   auto emoji_text = Utf8({0x1F600, 0x20, 0x1F680, 0x20, 0x1F4A9});
   canvas->Save();
@@ -529,8 +705,67 @@ void DrawTransforms(skity::Canvas* canvas,
   canvas->Scale(1.35f, 0.85f);
   DrawText(canvas, emoji_text, 0.f, 0.f, emoji_paint);
   canvas->Restore();
-  DrawLabel(canvas, "color emoji under non-uniform transform", x, y + 54.f,
+  DrawLabel(canvas, "color emoji under non-uniform transform", x, y + 78.f,
             column_width, label_typeface);
+}
+
+void DrawColorRegressionCases(
+    skity::Canvas* canvas,
+    const std::shared_ptr<skity::FontManager>& font_manager,
+    const std::shared_ptr<skity::Typeface>& label_typeface, float x, float y,
+    float column_width) {
+  DrawSectionTitle(canvas, "Color glyph regressions", x, y, label_typeface);
+  y += 28.f;
+  DrawDivider(canvas, x, y, column_width);
+  y += 34.f;
+
+  auto segoe =
+      MatchOrDefault(font_manager, "Segoe UI", skity::FontStyle::Normal());
+  auto emoji_typeface = MatchOrDefault(font_manager, "Segoe UI Emoji",
+                                       skity::FontStyle::Normal());
+  auto colrv1_candidate =
+      Utf8({0x1FAE0, 0x20, 0x1FAE1, 0x20, 0x1FAF6, 0x20, 0x1F600});
+  auto name_paint = PaintForText(label_typeface, 30.f, Color(20, 79, 73));
+  DrawText(canvas, "Segoe UI Emoji COLRv1 candidate", x, y, name_paint);
+  auto emoji_paint = PaintForText(emoji_typeface, 54.f, Color(20, 79, 73));
+  DrawText(canvas, colrv1_candidate, x, y + 58.f, emoji_paint);
+  DrawLabel(canvas, "COLRv1 candidate via system emoji font", x, y + 100.f,
+            column_width, label_typeface);
+  y += 152.f;
+
+  skity::Font normal_emoji_font(emoji_typeface, 56.f);
+  skity::Font fake_bold_emoji_font(emoji_typeface, 56.f);
+  fake_bold_emoji_font.SetEmbolden(true);
+  auto fake_bold_emoji_text = Utf8({0x1F600, 0x20, 0x1F642, 0x20, 0x1F680});
+  auto normal_emoji_paint =
+      PaintForText(emoji_typeface, 56.f, Color(20, 79, 73));
+  DrawGlyphText(canvas, fake_bold_emoji_text, x, y, normal_emoji_font,
+                normal_emoji_paint);
+  DrawLabel(canvas, "color glyphs without Font::SetEmbolden", x, y + 44.f,
+            column_width, label_typeface);
+  y += 100.f;
+
+  auto fake_bold_emoji_paint =
+      PaintForText(emoji_typeface, 56.f, Color(88, 52, 112));
+  DrawGlyphText(canvas, fake_bold_emoji_text, x, y, fake_bold_emoji_font,
+                fake_bold_emoji_paint);
+  DrawLabel(canvas, "color glyphs with Font::SetEmbolden(true)", x, y + 44.f,
+            column_width, label_typeface);
+  y += 110.f;
+
+  const std::string cache_sample = "CacheColor AaAa";
+  for (const auto& item : std::vector<std::pair<skity::Color, const char*>>{
+           {Color(209, 53, 68), "red"},
+           {Color(34, 123, 77), "green"},
+           {Color(35, 92, 179), "blue"},
+           {Color(209, 53, 68), "red again"},
+       }) {
+    auto paint = PaintForText(segoe, 42.f, item.first);
+    DrawText(canvas, cache_sample, x, y, paint);
+    DrawLabel(canvas, std::string("same glyph atlas key, ") + item.second, x,
+              y + 38.f, column_width, label_typeface);
+    y += 78.f;
+  }
 }
 
 void DrawOverview(skity::Canvas* canvas,
@@ -538,7 +773,7 @@ void DrawOverview(skity::Canvas* canvas,
                   const std::shared_ptr<skity::Typeface>& label_typeface) {
   auto title_typeface =
       MatchOrDefault(font_manager, "Segoe UI", skity::FontStyle::Bold());
-  auto title_paint = PaintForText(title_typeface, 28.f, Color(18, 27, 38));
+  auto title_paint = PaintForText(title_typeface, 40.f, Color(18, 27, 38));
   DrawText(canvas, "Windows text example", 36.f, 42.f, title_paint);
 
   const char* mode = skity::Settings::GetSettings().EnableDWriteFontManager()
@@ -563,23 +798,31 @@ class DWriteTextExample : public skity::example::WindowClient {
 
     DrawOverview(canvas, font_manager, label_typeface);
 
-    constexpr float column_width = 370.f;
-    DrawFamilyCases(canvas, font_manager, label_typeface, 36.f, 110.f,
+    constexpr float column_width = 630.f;
+    DrawFamilyCases(canvas, font_manager, label_typeface, 40.f, 110.f,
                     column_width);
-    DrawWeightSweep(canvas, font_manager, label_typeface, 446.f, 110.f,
+    DrawWeightSweep(canvas, font_manager, label_typeface, 720.f, 110.f,
                     column_width);
-    DrawFallbackAndEmoji(canvas, font_manager, label_typeface, 856.f, 110.f,
+    DrawVariationCases(canvas, font_manager, label_typeface, 40.f, 1160.f,
+                       column_width);
+    DrawCollectionAndDataCases(canvas, font_manager, label_typeface, 720.f,
+                               1160.f, column_width);
+    DrawFallbackAndEmoji(canvas, font_manager, label_typeface, 1400.f, 110.f,
                          column_width);
-    DrawPaintModes(canvas, font_manager, label_typeface, 856.f, 610.f,
+    DrawPaintModes(canvas, font_manager, label_typeface, 1400.f, 1080.f,
                    column_width);
-    DrawTransforms(canvas, font_manager, label_typeface, 1266.f, 110.f,
+    DrawTransforms(canvas, font_manager, label_typeface, 2080.f, 110.f,
                    column_width);
+    DrawColorRegressionCases(canvas, font_manager, label_typeface, 2080.f,
+                             980.f, column_width);
   }
 };
 
 }  // namespace
 
 int main(int argc, const char** argv) {
+  skity::Settings::GetSettings().SetEnableDWriteFontManager(
+      kEnableDWriteFontManager);
   DWriteTextExample example;
   std::string title = skity::Settings::GetSettings().EnableDWriteFontManager()
                           ? "Windows Text Example - DWrite"

--- a/src/text/ports/win/font_manager_win.cc
+++ b/src/text/ports/win/font_manager_win.cc
@@ -216,7 +216,6 @@ bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
 
   // IDWriteFontFace5::Equals accounts for newer face identity such as variation
   // axis values. Older DirectWrite versions can only compare file identity.
-#if defined(__IDWriteFontFace5_INTERFACE_DEFINED__)
   ScopedComPtr<IDWriteFontFace5> lhsFace5;
   if (SUCCEEDED(lhs->QueryInterface(&lhsFace5))) {
     return lhsFace5->Equals(rhs);
@@ -226,7 +225,6 @@ bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
   if (SUCCEEDED(rhs->QueryInterface(&rhsFace5))) {
     return rhsFace5->Equals(lhs);
   }
-#endif
 
   return DWriteFontFaceEqualByFiles(lhs, rhs);
 }

--- a/src/text/ports/win/scaler_context_win.cc
+++ b/src/text/ports/win/scaler_context_win.cc
@@ -42,6 +42,13 @@
 #include "src/logging.hpp"
 #include "src/render/auto_canvas.hpp"
 
+#if (defined(DWRITE_CORE) && DWRITE_CORE) || \
+    (defined(NTDDI_WIN11_ZN) && NTDDI_VERSION >= NTDDI_WIN11_ZN)
+#define SKITY_DWRITE_HAS_COLOR_V1_PAINT_TREE 1
+#else
+#define SKITY_DWRITE_HAS_COLOR_V1_PAINT_TREE 0
+#endif
+
 namespace skity {
 namespace {
 
@@ -92,7 +99,6 @@ Color DWriteColorToColor(const DWRITE_COLOR_F& color) {
       DWriteColorChannelToByte(color.g), DWriteColorChannelToByte(color.b));
 }
 
-#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
 DWRITE_COLOR_F ColorToDWriteColor(Color color) {
   DWRITE_COLOR_F dwrite_color;
   dwrite_color.r = static_cast<float>(ColorGetR(color)) / 255.0f;
@@ -114,6 +120,7 @@ TileMode DWriteExtendModeToTileMode(D2D1_EXTEND_MODE mode) {
   }
 }
 
+#if SKITY_DWRITE_HAS_COLOR_V1_PAINT_TREE
 BlendMode DWriteCompositeModeToBlendMode(DWRITE_COLOR_COMPOSITE_MODE mode) {
   switch (mode) {
     case DWRITE_COLOR_COMPOSITE_CLEAR:
@@ -176,6 +183,7 @@ BlendMode DWriteCompositeModeToBlendMode(DWRITE_COLOR_COMPOSITE_MODE mode) {
       return BlendMode::kDst;
   }
 }
+#endif
 
 float Vec2Cross(const Vec2& lhs, const Vec2& rhs) {
   return lhs.x * rhs.y - lhs.y * rhs.x;
@@ -193,7 +201,6 @@ Vec2 Vec2Projection(const Vec2& lhs, const Vec2& rhs) {
 }
 
 bool Color4fHasAlpha(const Color4f& color) { return color.a > 0.0f; }
-#endif
 
 bool DWriteRectIsEmpty(const D2D_RECT_F& rect) {
   return rect.left >= rect.right || rect.top >= rect.bottom;
@@ -1264,7 +1271,7 @@ class ScalerContextDWrite : public ScalerContext {
     return true;
   }
 
-#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+#if SKITY_DWRITE_HAS_COLOR_V1_PAINT_TREE
   bool GenerateDWriteColorV1PaintBounds(IDWritePaintReader* paint_reader,
                                         const DWRITE_PAINT_ELEMENT& element,
                                         float text_size, Matrix* ctm,
@@ -1331,11 +1338,9 @@ class ScalerContextDWrite : public ScalerContext {
         return false;
     }
   }
-#endif
 
   bool GenerateDWriteColorV1Bounds(UINT16 glyph_id, float text_size,
                                    const Matrix22& transform, Rect* bounds) {
-#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
     ScopedComPtr<IDWriteFontFace7> font_face7;
     if (FAILED(font_face_->QueryInterface(&font_face7))) {
       return false;
@@ -1369,9 +1374,6 @@ class ScalerContextDWrite : public ScalerContext {
     }
 
     return !bounds->IsEmpty();
-#else
-    return false;
-#endif
   }
 
   bool GenerateDWritePaintGlyphPath(UINT32 glyph_index, float text_size,
@@ -1394,7 +1396,6 @@ class ScalerContextDWrite : public ScalerContext {
     return true;
   }
 
-#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
   bool FetchDWriteGradientStops(IDWritePaintReader* paint_reader,
                                 UINT32 stop_count, std::vector<Color4f>* colors,
                                 std::vector<float>* positions) {
@@ -1786,11 +1787,9 @@ class ScalerContextDWrite : public ScalerContext {
         return false;
     }
   }
-#endif
 
   bool DrawDWriteColorV1Image(UINT16 glyph_id, float text_size,
                               const Matrix22& transform, Canvas* canvas) {
-#ifdef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
     ScopedComPtr<IDWriteFontFace7> font_face7;
     if (!canvas || FAILED(font_face_->QueryInterface(&font_face7))) {
       return false;
@@ -1825,10 +1824,16 @@ class ScalerContextDWrite : public ScalerContext {
     return DrawDWriteColorV1Paint(paint_reader.get(), paint_element, text_size,
                                   canvas, &did_draw) &&
            did_draw;
-#else
-    return false;
-#endif
   }
+#else
+  bool GenerateDWriteColorV1Bounds(UINT16, float, const Matrix22&, Rect*) {
+    return false;
+  }
+
+  bool DrawDWriteColorV1Image(UINT16, float, const Matrix22&, Canvas*) {
+    return false;
+  }
+#endif
 
   bool GenerateDWritePngImageBounds(UINT16 glyph_id, float text_size,
                                     const Matrix22& transform, Rect* bounds) {
@@ -2399,16 +2404,16 @@ class ScalerContextDWrite : public ScalerContext {
     Vec2 advance = transform * Vec2{advance_x, 0.0f};
 
     Rect bounds;
+    if (GenerateDWriteColorBounds(glyph_id, text_size, transform, &bounds)) {
+      GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
+                                     GlyphFormat::BGRA32);
+      return true;
+    }
+
     if (desc_.fake_bold &&
         GenerateDWriteFakeBoldBounds(glyph_id, text_size, transform, &bounds)) {
       GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
                                      GlyphFormat::A8);
-      return true;
-    }
-
-    if (GenerateDWriteColorBounds(glyph_id, text_size, transform, &bounds)) {
-      GlyphDataWinAccess::SetMetrics(glyph, advance.x, advance.y, bounds,
-                                     GlyphFormat::BGRA32);
       return true;
     }
 

--- a/src/text/ports/win/typeface_win.cc
+++ b/src/text/ports/win/typeface_win.cc
@@ -157,7 +157,6 @@ int GetSfntTableTags(const std::shared_ptr<Data>& data, UINT32 face_index,
   return table_count;
 }
 
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
 FourByteTag DWriteAxisTagToFourByteTag(DWRITE_FONT_AXIS_TAG tag) {
   return EndianSwap32(static_cast<uint32_t>(tag));
 }
@@ -326,7 +325,6 @@ ScopedComPtr<IDWriteFontFace> MakeDWriteDefaultVariationFontFace(
   }
   return default_font_face;
 }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
 
 // Korean fonts Gulim, Dotum, Batang, Gungsuh have bitmap strikes that get
 // artifically emboldened by Windows without antialiasing. Korean users prefer
@@ -457,7 +455,6 @@ bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
 
   // IDWriteFontFace5::Equals accounts for newer face identity such as variation
   // axis values. Older DirectWrite versions can only compare file identity.
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
   ScopedComPtr<IDWriteFontFace5> lhsFace5;
   if (SUCCEEDED(lhs->QueryInterface(&lhsFace5))) {
     return lhsFace5->Equals(rhs);
@@ -467,7 +464,6 @@ bool DWriteFontFaceEqual(IDWriteFontFace* lhs, IDWriteFontFace* rhs) {
   if (SUCCEEDED(rhs->QueryInterface(&rhsFace5))) {
     return rhsFace5->Equals(lhs);
   }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
 
   return DWriteFontFaceEqualByFiles(lhs, rhs);
 }
@@ -882,7 +878,6 @@ int FontWidthFromVariationWidth(float width) {
 
 FontStyle ApplyVariationStyle(IDWriteFontFace* font_face,
                               const FontStyle& style) {
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
   ScopedComPtr<IDWriteFontFace5> font_face5;
   if (!font_face || FAILED(font_face->QueryInterface(&font_face5)) ||
       !font_face5->HasVariations()) {
@@ -918,10 +913,6 @@ FontStyle ApplyVariationStyle(IDWriteFontFace* font_face,
   }
 
   return FontStyle(weight, width, slant);
-#else
-  (void)font_face;
-  return style;
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
 }
 
 std::optional<FontStyle> FontStyleFromOS2Table(IDWriteFontFace* font_face) {
@@ -1243,9 +1234,7 @@ class TypefaceDWrite : public Typeface {
         source_data_(std::move(source_data)) {
     (void)font_face_->QueryInterface(&font_face2_);
     (void)font_face_->QueryInterface(&font_face3_);
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
     (void)font_face_->QueryInterface(&font_face5_);
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
   }
 
  protected:
@@ -1330,20 +1319,16 @@ class TypefaceDWrite : public Typeface {
   }
 
   VariationPosition OnGetVariationDesignPosition() const override {
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
     if (font_face5_ && font_face5_->HasVariations()) {
       return GetDWriteVariationDesignPosition(font_face5_.get());
     }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
     return VariationPosition{};
   }
 
   std::vector<VariationAxis> OnGetVariationDesignParameters() const override {
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
     if (font_face5_ && font_face5_->HasVariations()) {
       return GetDWriteVariationDesignParameters(font_face5_.get());
     }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
     return {};
   }
 
@@ -1363,7 +1348,6 @@ class TypefaceDWrite : public Typeface {
       return typeface ? typeface->MakeVariation(args) : nullptr;
     }
 
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
     if (font_face5_ && font_face5_->HasVariations()) {
       auto new_font_face = MakeDWriteVariationFontFace(font_face5_.get(), args);
       if (new_font_face) {
@@ -1382,7 +1366,6 @@ class TypefaceDWrite : public Typeface {
             source_data_);
       }
     }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
     return const_cast<TypefaceDWrite*>(this)->shared_from_this();
   }
 
@@ -1472,9 +1455,7 @@ class TypefaceDWrite : public Typeface {
   ScopedComPtr<IDWriteFontFace> font_face_;
   ScopedComPtr<IDWriteFontFace2> font_face2_;
   ScopedComPtr<IDWriteFontFace3> font_face3_;
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
   ScopedComPtr<IDWriteFontFace5> font_face5_;
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
   ScopedComPtr<IDWriteFont> font_;
   ScopedComPtr<IDWriteFontFamily> font_family_;
   std::wstring locale_name_;
@@ -1513,13 +1494,11 @@ std::shared_ptr<Typeface> MakeDWriteTypefaceFromCollection(
         continue;
       }
 
-#ifdef __IDWriteFontFace5_INTERFACE_DEFINED__
       auto default_font_face =
           MakeDWriteDefaultVariationFontFace(font_face.get());
       if (default_font_face) {
         font_face = std::move(default_font_face);
       }
-#endif  // __IDWriteFontFace5_INTERFACE_DEFINED__
 
       return std::make_shared<TypefaceDWrite>(
           factory, font_face.get(), font.get(), font_family.get(), locale_name,

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -49,7 +49,13 @@ add_executable(skity_unit_test
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    target_sources(skity_unit_test PRIVATE base/platform/win/str_conversion_test.cc)
+    target_sources(skity_unit_test PRIVATE
+        base/platform/win/str_conversion_test.cc
+        text/dwrite_stability_test.cc
+    )
+    target_compile_definitions(skity_unit_test PRIVATE
+        -DSKITY_TEST_FONT_ROOT="${CMAKE_SOURCE_DIR}/test/fonts/resources"
+    )
 endif()
 
 # Place the cases that depend on specific fonts here.

--- a/test/ut/text/dwrite_stability_test.cc
+++ b/test/ut/text/dwrite_stability_test.cc
@@ -1,0 +1,443 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <skity/geometry/matrix.hpp>
+#include <skity/graphic/color.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/io/data.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/font_arguments.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/glyph.hpp>
+#include <skity/text/typeface.hpp>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "concurrent_runner.h"
+#include "src/render/text/text_transform.hpp"
+#include "src/text/scaler_context_desc.hpp"
+
+namespace skity {
+
+std::shared_ptr<FontManager> InitFontManagerDWrite();
+
+namespace {
+
+constexpr int kStressIterations = 32;
+constexpr int kThreadCount = 4;
+constexpr int kThreadIterations = 24;
+
+std::string FontPath(const char* name) {
+  return std::string(SKITY_TEST_FONT_ROOT) + "/" + name;
+}
+
+std::shared_ptr<Data> ReadFontData(const char* name) {
+  const std::string path = FontPath(name);
+  return Data::MakeFromFileName(path.c_str());
+}
+
+std::shared_ptr<Typeface> MakeDataTypeface(
+    const std::shared_ptr<FontManager>& manager, const char* name,
+    int ttc_index = 0) {
+  auto data = ReadFontData(name);
+  if (!data) {
+    return nullptr;
+  }
+  return manager->MakeFromData(data, ttc_index);
+}
+
+Paint MakePaint(Color color, Paint::Style style = Paint::kFill_Style,
+                float stroke_width = 1.5f) {
+  Paint paint;
+  paint.SetAntiAlias(true);
+  paint.SetColor(color);
+  paint.SetStyle(style);
+  paint.SetStrokeWidth(stroke_width);
+  return paint;
+}
+
+std::shared_ptr<Typeface> MakeWeightVariation(
+    const std::shared_ptr<Typeface>& typeface, float weight) {
+  if (!typeface) {
+    return nullptr;
+  }
+
+  VariationPosition position;
+  position.AddCoordinate(SetFourByteTag('w', 'g', 'h', 't'), weight);
+
+  FontArguments arguments;
+  arguments.SetVariationDesignPosition(position);
+  return typeface->MakeVariation(arguments);
+}
+
+const char* GlyphFormatName(GlyphFormat format) {
+  switch (format) {
+    case GlyphFormat::A8:
+      return "A8";
+    case GlyphFormat::RGBA32:
+      return "RGBA32";
+    case GlyphFormat::BGRA32:
+      return "BGRA32";
+  }
+  return "InvalidGlyphFormat";
+}
+
+const char* BitmapFormatName(BitmapFormat format) {
+  switch (format) {
+    case BitmapFormat::kUnknown:
+      return "Unknown";
+    case BitmapFormat::kGray8:
+      return "Gray8";
+    case BitmapFormat::kBGRA8:
+      return "BGRA8";
+    case BitmapFormat::kRGBA8:
+      return "RGBA8";
+  }
+  return "InvalidBitmapFormat";
+}
+
+std::string CodepointString(Unichar unichar) {
+  std::ostringstream stream;
+  stream << "U+" << std::hex << std::uppercase << unichar;
+  return stream.str();
+}
+
+std::string GlyphDebugString(const GlyphData* glyph) {
+  if (!glyph) {
+    return "glyph_data=null";
+  }
+
+  std::ostringstream stream;
+  stream << "glyph_id=" << glyph->Id();
+  auto format = glyph->GetFormat();
+  stream << ", glyph_format=" << (format ? GlyphFormatName(*format) : "none");
+  const auto& image = glyph->Image();
+  stream << ", bitmap_format=" << BitmapFormatName(image.format)
+         << ", image_size=" << image.width << "x" << image.height
+         << ", origin=(" << image.origin_x << "," << image.origin_y << ")"
+         << ", raster_origin=(" << image.origin_x_for_raster << ","
+         << image.origin_y_for_raster << ")"
+         << ", has_buffer=" << (image.buffer ? "yes" : "no")
+         << ", need_free=" << (image.need_free ? "yes" : "no");
+  return stream.str();
+}
+
+std::string JoinFailures(const std::vector<std::string>& failures) {
+  std::ostringstream stream;
+  stream << failures.size() << " failure(s):";
+  for (const auto& failure : failures) {
+    stream << "\n" << failure;
+  }
+  return stream.str();
+}
+
+void ReleaseOwnedImage(const GlyphData* glyph) {
+  if (!glyph || !glyph->NeedFree() || glyph->Image().buffer == nullptr) {
+    return;
+  }
+
+  std::free(glyph->Image().buffer);
+  auto& image = const_cast<GlyphBitmapData&>(glyph->Image());
+  image.buffer = nullptr;
+  image.need_free = false;
+}
+
+bool ExerciseGlyphPipeline(const std::shared_ptr<Typeface>& typeface,
+                           Unichar unichar, const Paint& paint, float size,
+                           bool embolden, const Matrix& transform = Matrix(),
+                           std::string* failure = nullptr) {
+  auto fail = [&](const std::string& message) {
+    if (failure) {
+      std::ostringstream stream;
+      stream << message << ", codepoint=" << CodepointString(unichar)
+             << ", size=" << size
+             << ", embolden=" << (embolden ? "true" : "false");
+      *failure = stream.str();
+    }
+    return false;
+  };
+
+  if (!typeface) {
+    return fail("typeface is null");
+  }
+
+  GlyphID glyph = typeface->UnicharToGlyph(unichar);
+  if (glyph == 0) {
+    return fail("UnicharToGlyph returned 0");
+  }
+
+  Font font(typeface, size);
+  font.SetEmbolden(embolden);
+
+  const GlyphData* glyph_data[1] = {};
+  font.LoadGlyphMetrics(&glyph, 1, glyph_data, paint);
+  if (glyph_data[0] == nullptr) {
+    return fail("LoadGlyphMetrics returned null");
+  }
+
+  font.LoadGlyphBitmapInfo(&glyph, 1, glyph_data, paint, 1.f, transform);
+  if (glyph_data[0] == nullptr) {
+    return fail("LoadGlyphBitmapInfo returned null");
+  }
+
+  font.LoadGlyphBitmap(&glyph, 1, glyph_data, paint, 1.f, transform);
+  if (glyph_data[0] == nullptr) {
+    return fail("LoadGlyphBitmap returned null");
+  }
+  ReleaseOwnedImage(glyph_data[0]);
+
+  font.LoadGlyphPath(&glyph, 1, glyph_data);
+  if (glyph_data[0] == nullptr) {
+    return fail("LoadGlyphPath returned null");
+  }
+  return true;
+}
+
+TEST(DWriteFontStabilityTest, DataBackedAndTtcFacesSurviveRepeatedUse) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr);
+
+  for (int i = 0; i < kStressIterations; ++i) {
+    auto flex = MakeDataTypeface(manager, "RobotoFlex-Regular.ttf");
+    ASSERT_NE(flex, nullptr);
+
+    auto variation = MakeWeightVariation(flex, (i & 1) == 0 ? 300.f : 800.f);
+    ASSERT_NE(variation, nullptr);
+    EXPECT_TRUE(ExerciseGlyphPipeline(variation, 'A',
+                                      MakePaint(ColorSetRGB(20, 70, 130)),
+                                      18.f + i % 5, (i & 1) != 0));
+
+    int ttc_index = i % 5;
+    auto cjk = MakeDataTypeface(manager, "NotoSansCJK-Regular.ttc", ttc_index);
+    ASSERT_NE(cjk, nullptr);
+    EXPECT_EQ(cjk->GetFontDescriptor().collection_index, ttc_index);
+    EXPECT_TRUE(ExerciseGlyphPipeline(
+        cjk, 0x95E8, MakePaint(ColorSetRGB(40, 80, 40)), 24.f + i % 3, false));
+  }
+}
+
+TEST(DWriteFontStabilityTest, TtcCollectionIndexCanSwitchInMakeVariation) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr);
+
+  auto data = ReadFontData("NotoSansCJK-Regular.ttc");
+  ASSERT_NE(data, nullptr);
+
+  auto face0 = manager->MakeFromData(data, 0);
+  ASSERT_NE(face0, nullptr);
+  ASSERT_EQ(face0->GetFontDescriptor().collection_index, 0);
+
+  FontArguments arguments;
+  arguments.SetCollectionIndex(1);
+
+  auto face1 = face0->MakeVariation(arguments);
+  ASSERT_NE(face1, nullptr);
+  EXPECT_EQ(face1->GetFontDescriptor().collection_index, 1);
+  EXPECT_TRUE(ExerciseGlyphPipeline(
+      face1, 0x95E8, MakePaint(ColorSetRGB(60, 90, 60)), 26.f, false));
+}
+
+TEST(DWriteFontStabilityTest, VariableFontCanBeCreatedAndReleasedRepeatedly) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr);
+
+  auto flex = MakeDataTypeface(manager, "RobotoFlex-Regular.ttf");
+  ASSERT_NE(flex, nullptr);
+  if (flex->GetVariationDesignParameters().empty()) {
+    GTEST_SKIP() << "DirectWrite variation APIs are unavailable.";
+  }
+
+  for (int i = 0; i < kStressIterations; ++i) {
+    auto data = ReadFontData("RobotoFlex-Regular.ttf");
+    ASSERT_NE(data, nullptr);
+
+    auto typeface = manager->MakeFromData(data);
+    ASSERT_NE(typeface, nullptr);
+
+    auto variation =
+        MakeWeightVariation(typeface, (i % 2 == 0) ? 100.f : 900.f);
+    ASSERT_NE(variation, nullptr);
+    EXPECT_FALSE(
+        variation->GetVariationDesignPosition().GetCoordinates().empty());
+    EXPECT_TRUE(ExerciseGlyphPipeline(variation, 'g',
+                                      MakePaint(ColorSetRGB(20, 50, 100)),
+                                      20.f + i % 4, false));
+  }
+}
+
+TEST(DWriteFontStabilityTest, ColorEmojiFakeBoldKeepsColorBitmapFormat) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr) << "InitFontManagerDWrite returned null.";
+
+  auto emoji = MakeDataTypeface(manager, "NotoColorEmoji.ttf");
+  ASSERT_NE(emoji, nullptr) << "Failed to create DirectWrite typeface from "
+                            << FontPath("NotoColorEmoji.ttf");
+
+  GlyphID glyph = emoji->UnicharToGlyph(0x1F600);
+  ASSERT_NE(glyph, 0) << "NotoColorEmoji.ttf has no glyph for U+1F600.";
+
+  Font regular_font(emoji, 48.f);
+  const Paint paint = MakePaint(Color_RED);
+  const GlyphData* regular_glyph_data[1] = {};
+  regular_font.LoadGlyphBitmapInfo(&glyph, 1, regular_glyph_data, paint, 1.f,
+                                   Matrix());
+  ASSERT_NE(regular_glyph_data[0], nullptr)
+      << "LoadGlyphBitmapInfo returned null for regular color emoji.";
+  if (!regular_glyph_data[0]->GetFormat().has_value()) {
+    GTEST_SKIP() << "DirectWrite color glyph image is unavailable: "
+                 << GlyphDebugString(regular_glyph_data[0]);
+  }
+  if (*regular_glyph_data[0]->GetFormat() != GlyphFormat::BGRA32) {
+    GTEST_SKIP() << "DirectWrite did not expose this emoji as color bitmap in "
+                    "this environment: "
+                 << GlyphDebugString(regular_glyph_data[0]);
+  }
+
+  Font font(emoji, 48.f);
+  font.SetEmbolden(true);
+
+  const GlyphData* glyph_data[1] = {};
+  font.LoadGlyphBitmapInfo(&glyph, 1, glyph_data, paint, 1.f, Matrix());
+  ASSERT_NE(glyph_data[0], nullptr)
+      << "LoadGlyphBitmapInfo returned null for fake-bold color emoji.";
+  if (!glyph_data[0]->GetFormat().has_value()) {
+    GTEST_SKIP() << "DirectWrite color glyph image is unavailable: "
+                 << GlyphDebugString(glyph_data[0]);
+  }
+  ASSERT_EQ(*glyph_data[0]->GetFormat(), GlyphFormat::BGRA32)
+      << "Expected fake-bold color emoji to keep BGRA32 format: "
+      << GlyphDebugString(glyph_data[0]);
+
+  font.LoadGlyphBitmap(&glyph, 1, glyph_data, paint, 1.f, Matrix());
+  ASSERT_NE(glyph_data[0], nullptr)
+      << "LoadGlyphBitmap returned null for fake-bold color emoji.";
+  EXPECT_EQ(glyph_data[0]->Image().format, BitmapFormat::kBGRA8)
+      << "Expected fake-bold color emoji bitmap to stay BGRA8: "
+      << GlyphDebugString(glyph_data[0]);
+  EXPECT_GT(glyph_data[0]->Image().width, 0.f)
+      << GlyphDebugString(glyph_data[0]);
+  EXPECT_GT(glyph_data[0]->Image().height, 0.f)
+      << GlyphDebugString(glyph_data[0]);
+  ReleaseOwnedImage(glyph_data[0]);
+}
+
+TEST(DWriteFontStabilityTest, DISABLED_ConcurrentManagerDataAndFallbackSmoke) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr);
+
+  const char* emoji_bcp47[] = {"und-Zsye"};
+  const bool has_emoji_fallback =
+      manager->MatchFamilyStyleCharacter(nullptr, FontStyle(), emoji_bcp47, 1,
+                                         0x1F600) != nullptr;
+  const char* cjk_bcp47[] = {"zh-CN"};
+  const bool has_cjk_fallback =
+      manager->MatchFamilyStyleCharacter(nullptr, FontStyle(), cjk_bcp47, 1,
+                                         0x95E8) != nullptr;
+
+  std::mutex failures_mutex;
+  std::vector<std::string> failures;
+  auto add_failure = [&](int iteration, const std::string& message) {
+    std::lock_guard<std::mutex> lock(failures_mutex);
+    if (failures.size() >= 64) {
+      return;
+    }
+    std::ostringstream stream;
+    stream << "iteration " << iteration << ": " << message;
+    failures.push_back(stream.str());
+  };
+
+  ConcurrentRunner runner(kThreadCount, kThreadIterations);
+  runner.Run([&](int i) {
+    auto thread_manager = InitFontManagerDWrite();
+    if (!thread_manager) {
+      add_failure(i, "InitFontManagerDWrite returned null");
+      return;
+    }
+
+    auto default_typeface = thread_manager->GetDefaultTypeface(FontStyle());
+    if (!default_typeface) {
+      add_failure(i, "GetDefaultTypeface(FontStyle()) returned null");
+    }
+
+    auto emoji_fallback = thread_manager->MatchFamilyStyleCharacter(
+        nullptr, FontStyle(), emoji_bcp47, 1, 0x1F600);
+    if (has_emoji_fallback && !emoji_fallback) {
+      add_failure(i,
+                  "emoji fallback returned null for U+1F600, bcp47=und-Zsye");
+    }
+
+    auto cjk_fallback = thread_manager->MatchFamilyStyleCharacter(
+        nullptr, FontStyle(), cjk_bcp47, 1, 0x95E8);
+    if (has_cjk_fallback && !cjk_fallback) {
+      add_failure(i, "CJK fallback returned null for U+95E8, bcp47=zh-CN");
+    }
+
+    auto data_typeface =
+        MakeDataTypeface(thread_manager, "RobotoFlex-Regular.ttf");
+    if (!data_typeface) {
+      add_failure(i, "MakeFromData(RobotoFlex-Regular.ttf) returned null");
+      return;
+    }
+
+    const Paint paint = MakePaint((i & 1) ? ColorSetRGB(180, 30, 30)
+                                          : ColorSetRGB(30, 80, 180));
+    std::string pipeline_failure;
+    if (!ExerciseGlyphPipeline(data_typeface, 'A', paint, 14.f + (i % 5),
+                               (i & 1) != 0, Matrix(), &pipeline_failure)) {
+      add_failure(i, "RobotoFlex glyph pipeline failed: " + pipeline_failure);
+    }
+  });
+
+  EXPECT_TRUE(failures.empty()) << JoinFailures(failures);
+}
+
+TEST(DWriteFontStabilityTest, CachePressureAcrossColorsTransformsAndStyles) {
+  auto manager = InitFontManagerDWrite();
+  ASSERT_NE(manager, nullptr);
+
+  auto typeface = MakeDataTypeface(manager, "RobotoFlex-Regular.ttf");
+  ASSERT_NE(typeface, nullptr);
+
+  Font font(typeface, 24.f);
+  Paint red = MakePaint(Color_RED);
+  Paint green = MakePaint(Color_GREEN);
+  Matrix22 transform;
+  ScalerContextDesc red_desc =
+      ScalerContextDesc::MakeTransformed(font, red, 1.f, transform);
+  ScalerContextDesc green_desc =
+      ScalerContextDesc::MakeTransformed(font, green, 1.f, transform);
+  EXPECT_NE(red_desc.foreground_color, green_desc.foreground_color);
+  EXPECT_NE(red_desc, green_desc);
+
+  std::array<Color, 4> colors = {Color_RED, Color_GREEN, Color_BLUE,
+                                 ColorSetRGB(120, 60, 10)};
+  std::array<Paint::Style, 4> styles = {
+      Paint::kFill_Style, Paint::kStroke_Style, Paint::kStrokeAndFill_Style,
+      Paint::kStrokeThenFill_Style};
+  std::array<Matrix, 4> transforms = {Matrix(), Matrix::Scale(1.25f, 0.85f),
+                                      Matrix::Skew(0.18f, 0.f),
+                                      Matrix::RotateDeg(8.f)};
+
+  for (int i = 0; i < 96; ++i) {
+    font.SetSize(12.f + static_cast<float>(i % 9));
+    font.SetEmbolden((i & 1) != 0);
+    Paint paint =
+        MakePaint(colors[i % colors.size()], styles[(i / 3) % styles.size()],
+                  1.f + static_cast<float>(i % 4));
+    EXPECT_TRUE(ExerciseGlyphPipeline(font.GetTypeface(), 'B', paint,
+                                      font.GetSize(), font.IsEmbolden(),
+                                      transforms[(i / 5) % transforms.size()]));
+  }
+}
+
+}  // namespace
+
+}  // namespace skity


### PR DESCRIPTION
Expand the Windows DWrite text example to cover fallback text, TTC and variable fonts, color glyphs, cache color keys, and stroke/fake-bold rendering.

Keep newer DirectWrite API handling on runtime checks and preserve color glyph bitmap rendering when fake bold is requested. Add Windows-only stability tests for data-backed fonts, TTC faces, variation faces, fallback, and glyph cache pressure.