### PR TITLE
refactor(gpu): introduce GPUShaderFeature to request shader features

### DIFF
--- a/module/wgx/glsl/glsl_ast_printer.cpp
+++ b/module/wgx/glsl/glsl_ast_printer.cpp
@@ -647,37 +647,24 @@ bool AstPrinter::Write() {
 
   ss_ << std::endl;
 
-  // Detect framebuffer fetch from the AST: a @color fragment input means the
-  // shader reads the current pixel, which requires the extension and turns the
-  // color output into an inout (handled in WriteOutput).
-  needs_fb_fetch_ = false;
-  if (func_->GetFunction()->GetPipelineStage() ==
-      ast::PipelineStage::kFragment) {
-    for (auto& param : func_->GetFunction()->params) {
-      if (param->GetAttribute(ast::AttributeType::kColor)) {
-        needs_fb_fetch_ = true;
-        break;
-      }
-    }
-  }
+  // Every extension is caller-requested through GlslOptions::extensions.
+  // Extensions that need extra source-side handling are detected by name:
+  //  - GL_KHR_blend_equation_advanced marks the output with blend_support.
+  //  - GL_EXT_shader_framebuffer_fetch turns the color output into inout; the
+  //    @color input that reads the current pixel is handled in WriteMainFunc.
+  // The two flags are inferred purely from the extension list, matching how the
+  // caller signals these paths — no AST scan needed.
+  const auto& extensions = options_.extensions;
 
-  // Gather every extension to declare: caller-requested ones
-  // (GlslOptions::extensions) plus framebuffer fetch inferred from the source.
-  std::vector<std::string> extensions = options_.extensions;
-  if (needs_fb_fetch_) {
-    extensions.push_back("GL_EXT_shader_framebuffer_fetch");
-  }
-
-  // GL_KHR_blend_equation_advanced additionally requires the fragment color
-  // output to carry blend_support_all_equations (handled in WriteOutput).
-  // Detect it by name so callers only need to list the extension.
   needs_advanced_blend_ = false;
+  needs_fb_fetch_ = false;
   if (func_->GetFunction()->GetPipelineStage() ==
       ast::PipelineStage::kFragment) {
     for (const auto& extension : extensions) {
       if (extension == "GL_KHR_blend_equation_advanced") {
         needs_advanced_blend_ = true;
-        break;
+      } else if (extension == "GL_EXT_shader_framebuffer_fetch") {
+        needs_fb_fetch_ = true;
       }
     }
   }

--- a/module/wgx/include/wgsl_cross.h
+++ b/module/wgx/include/wgsl_cross.h
@@ -52,8 +52,10 @@ struct WGX_API GlslOptions {
   // `#extension <name> : require` at the top of the generated shader. This is
   // the single entry point for extension declarations:
   //  - Extensions that only need a declaration are listed here directly.
-  //  - GL_EXT_shader_framebuffer_fetch is added automatically when the fragment
-  //    shader has a @color input (and turns its color output into an inout).
+  //  - GL_EXT_shader_framebuffer_fetch must be listed here by the caller when
+  //    the fragment shader reads back the framebuffer; a @color input still
+  //    turns the color output into an inout, but the declaration is no longer
+  //    inferred automatically.
   //  - Listing GL_KHR_blend_equation_advanced here also marks the fragment
   //    color output with `blend_support_all_equations`, so the fixed function
   //    advanced blend equations can be applied to it.

--- a/src/gpu/gl/gpu_device_gl.cc
+++ b/src/gpu/gl/gpu_device_gl.cc
@@ -186,8 +186,11 @@ std::shared_ptr<GPUShaderFunction> GPUDeviceGL::CreateShaderFunctionFromModule(
                               : wgx::GlslOptions::Standard::kDesktop;
   options.major_version = gl_version_major_;
   options.minor_version = gl_version_minor_;
-  if (source->needs_native_advanced_blend) {
+  if (desc.features.native_advanced_blend) {
     options.extensions.push_back("GL_KHR_blend_equation_advanced");
+  }
+  if (desc.features.framebuffer_fetch) {
+    options.extensions.push_back("GL_EXT_shader_framebuffer_fetch");
   }
 
   auto wgx_result = source->module->GetProgram()->WriteToGlsl(

--- a/src/gpu/gpu_caps.hpp
+++ b/src/gpu/gpu_caps.hpp
@@ -22,6 +22,20 @@ struct GPUCaps {
   bool native_blend_shader_variant = false;
 };
 
+// Features a shader function may request at CreateShaderFunction time.
+// Each member mirrors a capability in GPUCaps (supports_*): a device must
+// advertise the matching capability before a shader may request the feature.
+// How a backend satisfies a request (extension declaration, pipeline state,
+// ...) is an implementation detail and is not described here.
+struct GPUShaderFeature {
+  // Mirrors GPUCaps::supports_framebuffer_fetch — the fragment shader reads
+  // back the current destination pixel.
+  bool framebuffer_fetch = false;
+  // Mirrors GPUCaps::supports_native_advanced_blend — the fragment shader
+  // uses the device's native advanced blend equations.
+  bool native_advanced_blend = false;
+};
+
 }  // namespace skity
 
 #endif  // SRC_GPU_GPU_CAPS_HPP

--- a/src/gpu/gpu_shader_function.hpp
+++ b/src/gpu/gpu_shader_function.hpp
@@ -12,6 +12,9 @@
 #include <functional>
 #include <string>
 #include <vector>
+
+#include "src/gpu/gpu_caps.hpp"
+
 namespace skity {
 
 typedef std::function<void(char const*)> GPUShaderFunctionErrorCallback;
@@ -61,6 +64,10 @@ struct GPUShaderFunctionDescriptor {
 
   GPUShaderSourceType source_type = GPUShaderSourceType::kRaw;
   void* shader_source = nullptr;
+
+  // Features this shader function requests (see GPUShaderFeature). Backends
+  // use it to declare the required extensions / pipeline state.
+  GPUShaderFeature features = {};
 };
 
 struct GPUShaderSourceRaw {

--- a/src/gpu/gpu_shader_module.hpp
+++ b/src/gpu/gpu_shader_module.hpp
@@ -46,9 +46,6 @@ struct GPUShaderSourceWGX {
 
   const char* entry_point = nullptr;
   wgx::CompilerContext context = {};
-  // True when this fragment shader must be emitted with
-  // GL_KHR_blend_equation_advanced support (native advanced-blend path).
-  bool needs_native_advanced_blend = false;
 };
 
 }  // namespace skity

--- a/src/render/hw/hw_pipeline_lib.cc
+++ b/src/render/hw/hw_pipeline_lib.cc
@@ -10,6 +10,7 @@
 #include "src/gpu/gpu_shader_module.hpp"
 #include "src/graphic/blend_mode_priv.hpp"
 #include "src/logging.hpp"
+#include "src/render/hw/draw/wgx_programmable_blending.hpp"
 #include "src/render/hw/hw_pipeline_key.hpp"
 #include "src/render/hw/hw_shader_generator.hpp"
 #include "src/render/hw/native_blend.hpp"
@@ -64,6 +65,15 @@ struct BlendState {
 static bool IsShaderSideBlending(uint32_t programmable_blending) {
   return programmable_blending != 0 &&
          programmable_blending != kNativeAdvancedBlendKey;
+}
+
+// framebuffer-fetch reads dst inside the shader via @color; texture-copy
+// samples dst from a bound texture. See GetProgrammableBlendingKey for the
+// (blend_mode | dst_read_strategy<<8) packing.
+static bool UsesFramebufferFetch(uint32_t programmable_blending) {
+  return IsShaderSideBlending(programmable_blending) &&
+         (programmable_blending >> 8) ==
+             static_cast<uint32_t>(DstReadStrategy::kFramebufferFetch);
 }
 
 // Unified blend-state resolution shared by pipeline creation and cache matching
@@ -339,13 +349,17 @@ std::shared_ptr<GPUShaderFunction> HWPipelineLib::GetShaderFunction(
   }
   source.context = wgx_context;
 
-  // Native-blend fragment shaders must be translated with the
-  // GL_KHR_blend_equation_advanced extension injected; signal that through the
-  // source. The sentinel lives only in the fragment key (GetFunctionKey does
-  // not fold programmable_blending into the vertex key), so gate on fragment.
-  if (stage == GPUShaderStage::kFragment &&
-      pipeline_key.programmable_blending == kNativeAdvancedBlendKey) {
-    source.needs_native_advanced_blend = true;
+  // Feature flags travel on the descriptor (see GPUShaderFeature) so any
+  // backend can react to them, not just GL. The sentinels live only in the
+  // fragment key (GetFunctionKey does not fold programmable_blending into the
+  // vertex key), so gate on fragment.
+  if (stage == GPUShaderStage::kFragment) {
+    if (pipeline_key.programmable_blending == kNativeAdvancedBlendKey) {
+      desc.features.native_advanced_blend = true;
+    }
+    if (UsesFramebufferFetch(pipeline_key.programmable_blending)) {
+      desc.features.framebuffer_fetch = true;
+    }
   }
 
   desc.shader_source = &source;


### PR DESCRIPTION
Shader features that need backend support — framebuffer fetch and native.  
advanced blend — were previously signaled by dedicated `needs_*` bools on
`GPUShaderSourceWGX`, read ad-hoc by each backend. Adding a feature meant
touching the source struct, the pipeline layer, and every backend.
    
Introduce `GPUShaderFeature`, a bool struct mirroring `GPUCaps`, carried on
`GPUShaderFunctionDescriptor::features`. It is passed at CreateShaderFunction
time and is backend-agnostic: the pipeline layer requests the features it
needs, and each backend translates them into the mechanism it requires
(GL declares the matching #extension, etc.).
    
This also moves `GL_EXT_shader_framebuffer_fetch` off the automatic @color
detection path: the extension is now requested explicitly via the
`framebuffer_fetch` feature, symmetric to native advanced blend. @color
keeps driving only the inout rewrite in the GLSL printer.
    
VK/Metal/Web backends are unchanged — they ignore the new field.