### PR TITLE
test(graphic): add unit test for Image public API

### DIFF
--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(skity_unit_test
     geometry/vector_test.cc
     graphic/bitmap_test.cc
     graphic/color_test.cc
+    graphic/image_test.cc
     graphic/path_measure_test.cc
     graphic/path_test.cc
     graphic/texture_format_test.cc

--- a/test/ut/graphic/image_test.cc
+++ b/test/ut/graphic/image_test.cc
@@ -1,0 +1,82 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <skity/graphic/image.hpp>
+#include <skity/io/pixmap.hpp>
+
+using namespace skity;
+
+namespace {
+
+// A GetPromiseTexture2 callback that never actually produces a texture. This
+// keeps the PromiseTextureImage test fully GPU-free: no real Texture or
+// GPUContext is ever constructed.
+std::shared_ptr<Texture> NullPromiseTexture(PromiseTextureContext,
+                                            GPUContext*) {
+  return nullptr;
+}
+
+void NoopReleaseCallback(ReleaseUserData) {}
+
+}  // namespace
+
+TEST(ImageTest, MakeImageFromCpuPixmap) {
+  auto pixmap = std::make_shared<Pixmap>(100, 200);
+
+  auto image = Image::MakeImage(pixmap);
+
+  ASSERT_NE(image, nullptr);
+  EXPECT_FALSE(image->IsTextureBackend());
+  EXPECT_EQ(image->GetTexture(), nullptr);
+
+  auto image_pixmap = image->GetPixmap();
+  ASSERT_NE(image_pixmap, nullptr);
+  ASSERT_NE(*image_pixmap, nullptr);
+  EXPECT_EQ((*image_pixmap)->Width(), pixmap->Width());
+  EXPECT_EQ((*image_pixmap)->Height(), pixmap->Height());
+
+  EXPECT_EQ(image->Width(), pixmap->Width());
+  EXPECT_EQ(image->Height(), pixmap->Height());
+  EXPECT_EQ(image->GetAlphaType(), pixmap->GetAlphaType());
+  EXPECT_EQ(image->GetImageType(), ImageType::kPixmap);
+  EXPECT_FALSE(image->IsLazy());
+}
+
+TEST(ImageTest, MakeDeferredTextureImage) {
+  auto image = Image::MakeDeferredTextureImage(TextureFormat::kRGBA, 64, 128,
+                                               AlphaType::kPremul_AlphaType);
+
+  ASSERT_NE(image, nullptr);
+  EXPECT_TRUE(image->IsTextureBackend());
+  EXPECT_EQ(image->GetPixmap(), nullptr);
+  // No texture has been set yet, so GetTexture() must report null.
+  EXPECT_EQ(image->GetTexture(), nullptr);
+
+  EXPECT_EQ(image->Width(), 64u);
+  EXPECT_EQ(image->Height(), 128u);
+  EXPECT_EQ(image->GetAlphaType(), AlphaType::kPremul_AlphaType);
+  EXPECT_EQ(image->GetFormat(), TextureFormat::kRGBA);
+  EXPECT_EQ(image->GetImageType(), ImageType::kDeferredTexture);
+  EXPECT_FALSE(image->IsLazy());
+}
+
+TEST(ImageTest, MakePromiseTextureImage2IsLazy) {
+  auto image = Image::MakePromiseTextureImage2(
+      TextureFormat::kRGBA, 32, 32, AlphaType::kPremul_AlphaType,
+      &NullPromiseTexture, &NoopReleaseCallback, nullptr);
+
+  ASSERT_NE(image, nullptr);
+  EXPECT_TRUE(image->IsTextureBackend());
+  EXPECT_TRUE(image->IsLazy());
+  EXPECT_EQ(image->GetImageType(), ImageType::kPromiseTexture);
+  EXPECT_EQ(image->GetPixmap(), nullptr);
+
+  // Resolving the promise texture with a null GPUContext should simply
+  // forward to the callback (which returns nullptr) without crashing.
+  auto texture = image->GetTextureByContext(nullptr);
+  EXPECT_EQ(texture, nullptr);
+}


### PR DESCRIPTION
Closes #53

Adds unit test coverage for Image's public API using the GPU-free code paths: `MakeImage(pixmap)` (CPU `PixmapImage` backend), `MakeDeferredTextureImage`, and `MakePromiseTextureImage2`'s lazy-eval contract.

- `ImageTest.MakeImageFromCpuPixmap`: `Image::MakeImage(pixmap)` with `context = nullptr` returns a CPU-only `PixmapImage`; verifies `IsTextureBackend() == false`, `GetTexture() == nullptr`, `GetPixmap()` matches the source pixmap's dimensions, `Width()`/`Height()`/`GetAlphaType()` match, `GetImageType() == ImageType::kPixmap`, `IsLazy() == false`.
- `ImageTest.MakeDeferredTextureImage`: pure CPU-side holder; verifies `IsTextureBackend() == true`, `GetPixmap() == nullptr`, `GetTexture() == nullptr` before any texture is set, and that `Width()`/`Height()`/`GetAlphaType()`/`GetFormat()` echo the constructor inputs, plus `GetImageType() == ImageType::kDeferredTexture`.
- `ImageTest.MakePromiseTextureImage2IsLazy`: uses a `GetPromiseTexture2` callback that returns `nullptr` and a no-op `ReleaseCallback`; verifies `IsLazy() == true`, `GetImageType() == ImageType::kPromiseTexture`, and that `GetTextureByContext(nullptr)` safely forwards to the callback and returns `nullptr` without touching a real GPUContext.

Tested locally:
- Compiles cleanly (no warnings) with the exact required flags: `cmake -B build -DSKITY_TEST=ON -DSKITY_TEST_UT=ON -DSKITY_TEST_BENCH=OFF -DSKITY_TEST_GOLDEN=OFF && cmake --build build --target skity_unit_test`.
- On this local macOS sandbox, the resulting `-fsanitize=thread` binary (built with the host's Apple Clang 17 on macOS 26.5.1) segfaults during ThreadSanitizer's own runtime initialization (`__tsan::InitializePlatform`/`CheckAndProtect`, a dyld-shared-cache introspection crash) for *any* test, including pre-existing ones like `PixmapTest.Constructor` and even `--gtest_list_tests` before any test runs — confirming this is a pre-existing local TSAN/Apple-Clang/macOS-beta incompatibility unrelated to this change. This project's CI only runs `skity_unit_test` on `ubuntu-22.04` with gcc, never this TSAN+Apple-Clang combination, so it isn't expected to reproduce there.
- To verify the actual test logic, I rebuilt with the identical CMake test flags plus `-DSKITY_TEST_COVERAGE=ON` (which swaps `-fsanitize=thread` for `--coverage`, avoiding the local TSAN crash) and ran the full suite: `[==========] 519 tests from 59 test suites ran. ... [ PASSED ] 519 tests.`, including all 3 new `ImageTest.*` cases passing individually via `--gtest_filter="ImageTest.*"`.