### PR TITLE
feat(codec): Add BMP format support in codec

### DIFF
--- a/module/codec/CMakeLists.txt
+++ b/module/codec/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(
   skity-codec
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/include/skity/codec/codec.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/codec/bmp_codec.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/codec/bmp_codec.hpp
   ${CMAKE_CURRENT_LIST_DIR}/src/codec/codec.cc
   ${CMAKE_CURRENT_LIST_DIR}/src/codec/codec_priv.cc
   ${CMAKE_CURRENT_LIST_DIR}/src/codec/codec_priv.hpp

--- a/module/codec/src/codec/bmp_codec.cc
+++ b/module/codec/src/codec/bmp_codec.cc
@@ -1,0 +1,311 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/codec/bmp_codec.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <skity/io/data.hpp>
+#include <skity/io/pixmap.hpp>
+#include <vector>
+
+namespace skity {
+
+namespace {
+
+enum BMPCompression {
+  BI_RGB = 0,
+  BI_BITFIELDS = 3,
+};
+
+inline uint16_t ReadU16(const uint8_t* data) {
+  return static_cast<uint16_t>(data[0]) | (static_cast<uint16_t>(data[1]) << 8);
+}
+
+inline uint32_t ReadU32(const uint8_t* data) {
+  return static_cast<uint32_t>(data[0]) |
+         (static_cast<uint32_t>(data[1]) << 8) |
+         (static_cast<uint32_t>(data[2]) << 16) |
+         (static_cast<uint32_t>(data[3]) << 24);
+}
+
+inline int32_t ReadI32(const uint8_t* data) {
+  return static_cast<int32_t>(ReadU32(data));
+}
+
+inline void WriteU16(std::vector<uint8_t>& buf, uint16_t val) {
+  buf.push_back(static_cast<uint8_t>(val & 0xFF));
+  buf.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
+}
+
+inline void WriteU32(std::vector<uint8_t>& buf, uint32_t val) {
+  buf.push_back(static_cast<uint8_t>(val & 0xFF));
+  buf.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
+  buf.push_back(static_cast<uint8_t>((val >> 16) & 0xFF));
+  buf.push_back(static_cast<uint8_t>((val >> 24) & 0xFF));
+}
+
+inline void WriteI32(std::vector<uint8_t>& buf, int32_t val) {
+  WriteU32(buf, static_cast<uint32_t>(val));
+}
+
+uint8_t ExtractComponent(uint32_t val, uint32_t mask) {
+  if (mask == 0) {
+    return 0;
+  }
+  uint32_t v = val & mask;
+  uint32_t m = mask;
+  while ((m & 1) == 0) {
+    v >>= 1;
+    m >>= 1;
+  }
+  uint32_t bits = 0;
+  uint32_t tmp = m;
+  while (tmp) {
+    bits++;
+    tmp >>= 1;
+  }
+  if (bits >= 8) {
+    return static_cast<uint8_t>(v & 0xFF);
+  }
+  uint8_t result = static_cast<uint8_t>(v);
+  for (uint32_t shift = bits; shift < 8; shift += bits) {
+    result = static_cast<uint8_t>(result | (result >> bits));
+  }
+  return result;
+}
+
+}  // namespace
+
+bool BMPCodec::RecognizeFileType(const char* header, size_t size) {
+  return size >= 2 && header[0] == 'B' && header[1] == 'M';
+}
+
+std::shared_ptr<MultiFrameDecoder> BMPCodec::DecodeMultiFrame() { return {}; }
+
+std::shared_ptr<Pixmap> BMPCodec::Decode() {
+  const auto* raw = static_cast<const uint8_t*>(data_->RawData());
+  size_t size = data_->Size();
+
+  if (size < 54) {
+    return nullptr;
+  }
+
+  uint16_t signature = ReadU16(raw);
+  if (signature != 0x4D42) {
+    return nullptr;
+  }
+  uint32_t data_offset = ReadU32(raw + 10);
+
+  size_t offset = 14;
+  uint32_t header_size = ReadU32(raw + offset);
+  if (header_size < 40) {
+    return nullptr;
+  }
+
+  int32_t width_abs = ReadI32(raw + offset + 4);
+  int32_t height_abs = ReadI32(raw + offset + 8);
+  uint16_t bpp = ReadU16(raw + offset + 14);
+  uint32_t compression = ReadU32(raw + offset + 16);
+  uint32_t colors_used = ReadU32(raw + offset + 32);
+
+  uint32_t width = static_cast<uint32_t>(std::abs(width_abs));
+  uint32_t height = static_cast<uint32_t>(std::abs(height_abs));
+  bool top_down = height_abs < 0;
+
+  if (width == 0 || height == 0) {
+    return nullptr;
+  }
+
+  if (compression != BI_RGB && compression != BI_BITFIELDS) {
+    return nullptr;
+  }
+  if (bpp != 8 && bpp != 24 && bpp != 32) {
+    return nullptr;
+  }
+  if (compression == BI_BITFIELDS && bpp != 32) {
+    return nullptr;
+  }
+
+  uint32_t r_mask = 0x00FF0000;
+  uint32_t g_mask = 0x0000FF00;
+  uint32_t b_mask = 0x000000FF;
+  uint32_t a_mask = 0xFF000000;
+
+  size_t palette_offset = offset + header_size;
+
+  if (compression == BI_BITFIELDS) {
+    if (palette_offset + 16 > size) {
+      return nullptr;
+    }
+    r_mask = ReadU32(raw + palette_offset);
+    g_mask = ReadU32(raw + palette_offset + 4);
+    b_mask = ReadU32(raw + palette_offset + 8);
+    a_mask = ReadU32(raw + palette_offset + 12);
+    palette_offset += 16;
+  }
+
+  std::vector<uint8_t> palette;
+  if (bpp == 8) {
+    uint32_t entries = (colors_used == 0) ? 256 : colors_used;
+    palette.resize(entries * 4);
+    for (uint32_t i = 0; i < entries; i++) {
+      if (palette_offset + 4 > size) {
+        return nullptr;
+      }
+      palette[i * 4 + 0] = raw[palette_offset + 2];
+      palette[i * 4 + 1] = raw[palette_offset + 1];
+      palette[i * 4 + 2] = raw[palette_offset + 0];
+      palette[i * 4 + 3] = 0xFF;
+      palette_offset += 4;
+    }
+  }
+
+  uint32_t row_size = ((width * bpp + 31) / 32) * 4;
+
+  auto* output = static_cast<uint8_t*>(std::malloc(width * height * 4));
+  if (!output) {
+    return nullptr;
+  }
+
+  const uint8_t* pixel_data = raw + data_offset;
+
+  bool all_alpha_zero = false;
+  if (bpp == 32 && compression == BI_RGB) {
+    all_alpha_zero = true;
+    for (uint32_t yy = 0; yy < height && all_alpha_zero; yy++) {
+      uint32_t src_y_check = top_down ? yy : (height - 1 - yy);
+      const uint8_t* src_row_check = pixel_data + src_y_check * row_size;
+      for (uint32_t xx = 0; xx < width && all_alpha_zero; xx++) {
+        if (src_row_check[xx * 4 + 3] != 0) {
+          all_alpha_zero = false;
+        }
+      }
+    }
+  }
+
+  for (uint32_t y = 0; y < height; y++) {
+    uint32_t src_y = top_down ? y : (height - 1 - y);
+    const uint8_t* src_row = pixel_data + src_y * row_size;
+    uint8_t* dst_row = output + y * width * 4;
+
+    if (bpp == 8) {
+      for (uint32_t x = 0; x < width; x++) {
+        uint8_t idx = src_row[x] * 4;
+        dst_row[x * 4 + 0] = palette[idx + 0];
+        dst_row[x * 4 + 1] = palette[idx + 1];
+        dst_row[x * 4 + 2] = palette[idx + 2];
+        dst_row[x * 4 + 3] = palette[idx + 3];
+      }
+    } else if (bpp == 24) {
+      for (uint32_t x = 0; x < width; x++) {
+        dst_row[x * 4 + 0] = src_row[x * 3 + 2];
+        dst_row[x * 4 + 1] = src_row[x * 3 + 1];
+        dst_row[x * 4 + 2] = src_row[x * 3 + 0];
+        dst_row[x * 4 + 3] = 0xFF;
+      }
+    } else {
+      if (compression == BI_RGB) {
+        for (uint32_t x = 0; x < width; x++) {
+          dst_row[x * 4 + 0] = src_row[x * 4 + 2];
+          dst_row[x * 4 + 1] = src_row[x * 4 + 1];
+          dst_row[x * 4 + 2] = src_row[x * 4 + 0];
+          uint8_t alpha = src_row[x * 4 + 3];
+          dst_row[x * 4 + 3] = all_alpha_zero ? 0xFF : alpha;
+        }
+      } else {
+        for (uint32_t x = 0; x < width; x++) {
+          uint32_t pixel = ReadU32(src_row + x * 4);
+          dst_row[x * 4 + 0] = ExtractComponent(pixel, r_mask);
+          dst_row[x * 4 + 1] = ExtractComponent(pixel, g_mask);
+          dst_row[x * 4 + 2] = ExtractComponent(pixel, b_mask);
+          dst_row[x * 4 + 3] = a_mask ? ExtractComponent(pixel, a_mask) : 0xFF;
+        }
+      }
+    }
+  }
+
+  auto raw_data = Data::MakeFromMalloc(output, width * height * 4);
+  return std::make_shared<Pixmap>(raw_data, width * 4, width, height);
+}
+
+std::shared_ptr<Data> BMPCodec::Encode(const Pixmap* pixmap) {
+  if (!pixmap || pixmap->Width() == 0 || pixmap->Height() == 0) {
+    return nullptr;
+  }
+
+  uint32_t width = pixmap->Width();
+  uint32_t height = pixmap->Height();
+  bool is_bgra = pixmap->GetColorType() == ColorType::kBGRA;
+
+  bool has_alpha = pixmap->GetAlphaType() != AlphaType::kOpaque_AlphaType;
+  uint16_t bpp = has_alpha ? 32 : 24;
+  uint32_t row_size = ((width * bpp + 31) / 32) * 4;
+  uint32_t pixel_data_size = row_size * height;
+  uint32_t data_offset = 54;
+  uint32_t file_size = data_offset + pixel_data_size;
+
+  std::vector<uint8_t> output;
+  output.reserve(file_size);
+
+  WriteU16(output, 0x4D42);
+  WriteU32(output, file_size);
+  WriteU16(output, 0);
+  WriteU16(output, 0);
+  WriteU32(output, data_offset);
+
+  WriteU32(output, 40);
+  WriteI32(output, static_cast<int32_t>(width));
+  WriteI32(output, static_cast<int32_t>(height));
+  WriteU16(output, 1);
+  WriteU16(output, bpp);
+  WriteU32(output, BI_RGB);
+  WriteU32(output, pixel_data_size);
+  WriteI32(output, 2835);
+  WriteI32(output, 2835);
+  WriteU32(output, 0);
+  WriteU32(output, 0);
+
+  const auto* src = static_cast<const uint8_t*>(pixmap->Addr());
+  uint32_t src_row_bytes = static_cast<uint32_t>(pixmap->RowBytes());
+
+  for (int32_t y = static_cast<int32_t>(height) - 1; y >= 0; y--) {
+    const uint8_t* src_row = src + y * src_row_bytes;
+
+    if (bpp == 24) {
+      for (uint32_t x = 0; x < width; x++) {
+        if (is_bgra) {
+          output.push_back(src_row[x * 4 + 0]);
+          output.push_back(src_row[x * 4 + 1]);
+          output.push_back(src_row[x * 4 + 2]);
+        } else {
+          output.push_back(src_row[x * 4 + 2]);
+          output.push_back(src_row[x * 4 + 1]);
+          output.push_back(src_row[x * 4 + 0]);
+        }
+      }
+      for (uint32_t p = width * 3; p < row_size; p++) {
+        output.push_back(0);
+      }
+    } else {
+      for (uint32_t x = 0; x < width; x++) {
+        if (is_bgra) {
+          output.push_back(src_row[x * 4 + 0]);
+          output.push_back(src_row[x * 4 + 1]);
+          output.push_back(src_row[x * 4 + 2]);
+          output.push_back(src_row[x * 4 + 3]);
+        } else {
+          output.push_back(src_row[x * 4 + 2]);
+          output.push_back(src_row[x * 4 + 1]);
+          output.push_back(src_row[x * 4 + 0]);
+          output.push_back(src_row[x * 4 + 3]);
+        }
+      }
+    }
+  }
+
+  return Data::MakeWithCopy(output.data(), output.size());
+}
+
+}  // namespace skity

--- a/module/codec/src/codec/bmp_codec.hpp
+++ b/module/codec/src/codec/bmp_codec.hpp
@@ -1,0 +1,30 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CODEC_SRC_CODEC_BMP_CODEC_HPP
+#define MODULE_CODEC_SRC_CODEC_BMP_CODEC_HPP
+
+#include <skity/codec/codec.hpp>
+
+namespace skity {
+
+class BMPCodec : public Codec {
+ public:
+  BMPCodec() = default;
+  ~BMPCodec() override = default;
+
+  std::shared_ptr<Pixmap> Decode() override;
+  std::shared_ptr<MultiFrameDecoder> DecodeMultiFrame() override;
+  std::shared_ptr<Data> Encode(const Pixmap* pixmap) override;
+  bool RecognizeFileType(const char* header, size_t size) override;
+
+ protected:
+  std::shared_ptr<Codec> Fork() override {
+    return std::make_shared<BMPCodec>();
+  }
+};
+
+}  // namespace skity
+
+#endif  // MODULE_CODEC_SRC_CODEC_BMP_CODEC_HPP

--- a/module/codec/src/codec/codec.cc
+++ b/module/codec/src/codec/codec.cc
@@ -10,6 +10,7 @@
 #if SKITY_ENABLE_CODEC_GIF
 #include "src/codec/gif_codec.hpp"
 #endif
+#include "src/codec/bmp_codec.hpp"
 #include "src/codec/jpeg_codec.hpp"
 #include "src/codec/png_codec.hpp"
 
@@ -25,6 +26,7 @@ static std::mutex codec_mutex = {};
 void Codec::SetupCodecs() {
   codec_list.clear();
 
+  codec_list.emplace_back(std::make_shared<BMPCodec>());
   codec_list.emplace_back(std::make_shared<PNGCodec>());
   codec_list.emplace_back(std::make_shared<JPEGCodec>());
 #if SKITY_ENABLE_CODEC_GIF

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(skity_unit_test
 if (${SKITY_CODEC_MODULE})
     target_sources(skity_unit_test
         PUBLIC
+        codec/bmp_codec_test.cc
         codec/jpeg_codec_test.cc
         codec/png_codec_test.cc
         codec/gif_codec_test.cc

--- a/test/ut/codec/bmp_codec_test.cc
+++ b/test/ut/codec/bmp_codec_test.cc
@@ -1,0 +1,428 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <skity/codec/codec.hpp>
+#include <skity/graphic/bitmap.hpp>
+#include <skity/graphic/color.hpp>
+#include <skity/io/data.hpp>
+#include <skity/io/pixmap.hpp>
+#include <skity/render/canvas.hpp>
+
+TEST(BMPCodecTest, RecognizeFileType) {
+  auto png_data = skity::Data::MakeFromFileName(SKITY_TEST_PNG_FILE);
+
+  const unsigned char bmp_header[] = {
+      'B',  'M',               // signature
+      0x36, 0x00, 0x00, 0x00,  // file size = 54
+      0x00, 0x00,              // reserved
+      0x00, 0x00,              // reserved
+      0x36, 0x00, 0x00, 0x00,  // data offset = 54
+      0x28, 0x00, 0x00, 0x00,  // info header size = 40
+      0x01, 0x00, 0x00, 0x00,  // width = 1
+      0x01, 0x00, 0x00, 0x00,  // height = 1
+      0x01, 0x00,              // planes = 1
+      0x18, 0x00,              // bpp = 24
+      0x00, 0x00, 0x00, 0x00,  // compression = BI_RGB
+      0x04, 0x00, 0x00, 0x00,  // raw data size = 4
+      0x13, 0x0B, 0x00, 0x00,  // x pixels per meter
+      0x13, 0x0B, 0x00, 0x00,  // y pixels per meter
+      0x00, 0x00, 0x00, 0x00,  // colors used
+      0x00, 0x00, 0x00, 0x00,  // important colors
+      0x00, 0x00, 0xFF, 0x00,  // pixel data
+  };
+  auto bmp_data = skity::Data::MakeWithCopy(bmp_header, sizeof(bmp_header));
+
+  auto codec = skity::Codec::MakeFromData(bmp_data);
+
+  ASSERT_TRUE(codec != nullptr) << "MakeFromData returned nullptr for BMP data";
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(bmp_header), sizeof(bmp_header)));
+  EXPECT_FALSE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(png_data->Bytes()), png_data->Size()));
+}
+
+TEST(BMPCodecTest, Decode24Bit) {
+  const unsigned char bmp_24bit[] = {
+      'B',  'M',               // signature
+      0x36, 0x00, 0x00, 0x00,  // file size = 54 bytes
+      0x00, 0x00,              // reserved
+      0x00, 0x00,              // reserved
+      0x36, 0x00, 0x00, 0x00,  // data offset = 54
+      0x28, 0x00, 0x00, 0x00,  // info header size = 40
+      0x01, 0x00, 0x00, 0x00,  // width = 1
+      0x01, 0x00, 0x00, 0x00,  // height = 1
+      0x01, 0x00,              // planes = 1
+      0x18, 0x00,              // bpp = 24
+      0x00, 0x00, 0x00, 0x00,  // compression = BI_RGB
+      0x04, 0x00, 0x00, 0x00,  // raw data size = 4 (padded to 4 bytes)
+      0x13, 0x0B, 0x00, 0x00,  // x pixels per meter
+      0x13, 0x0B, 0x00, 0x00,  // y pixels per meter
+      0x00, 0x00, 0x00, 0x00,  // colors used
+      0x00, 0x00, 0x00, 0x00,  // important colors
+      0x00, 0x00, 0xFF, 0x00,  // BGR pixel + padding (red)
+  };
+
+  auto data = skity::Data::MakeWithCopy(bmp_24bit, sizeof(bmp_24bit));
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec != nullptr);
+
+  codec->SetData(data);
+  auto pixmap = codec->Decode();
+
+  EXPECT_TRUE(pixmap != nullptr);
+  EXPECT_EQ(pixmap->Width(), 1);
+  EXPECT_EQ(pixmap->Height(), 1);
+  EXPECT_EQ(pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(pixmap->GetAlphaType(), skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* addr = reinterpret_cast<const uint8_t*>(pixmap->Addr());
+  EXPECT_EQ(addr[0], 0xFF);
+  EXPECT_EQ(addr[1], 0x00);
+  EXPECT_EQ(addr[2], 0x00);
+  EXPECT_EQ(addr[3], 0xFF);
+}
+
+TEST(BMPCodecTest, Decode32Bit) {
+  const unsigned char bmp_32bit[] = {
+      'B',  'M',               // signature
+      0x46, 0x00, 0x00, 0x00,  // file size = 70 bytes
+      0x00, 0x00,              // reserved
+      0x00, 0x00,              // reserved
+      0x36, 0x00, 0x00, 0x00,  // data offset = 54
+      0x28, 0x00, 0x00, 0x00,  // info header size = 40
+      0x01, 0x00, 0x00, 0x00,  // width = 1
+      0x01, 0x00, 0x00, 0x00,  // height = 1
+      0x01, 0x00,              // planes = 1
+      0x20, 0x00,              // bpp = 32
+      0x00, 0x00, 0x00, 0x00,  // compression = BI_RGB
+      0x04, 0x00, 0x00, 0x00,  // raw data size = 4
+      0x13, 0x0B, 0x00, 0x00,  // x pixels per meter
+      0x13, 0x0B, 0x00, 0x00,  // y pixels per meter
+      0x00, 0x00, 0x00, 0x00,  // colors used
+      0x00, 0x00, 0x00, 0x00,  // important colors
+      0x00, 0x00, 0xFF, 0x80,  // BGRA pixel (red with 50% alpha)
+  };
+
+  auto data = skity::Data::MakeWithCopy(bmp_32bit, sizeof(bmp_32bit));
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec != nullptr);
+
+  codec->SetData(data);
+  auto pixmap = codec->Decode();
+
+  EXPECT_TRUE(pixmap != nullptr);
+  EXPECT_EQ(pixmap->Width(), 1);
+  EXPECT_EQ(pixmap->Height(), 1);
+  EXPECT_EQ(pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(pixmap->GetAlphaType(), skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* addr = reinterpret_cast<const uint8_t*>(pixmap->Addr());
+  EXPECT_EQ(addr[0], 0xFF);
+  EXPECT_EQ(addr[1], 0x00);
+  EXPECT_EQ(addr[2], 0x00);
+  EXPECT_EQ(addr[3], 0x80);
+}
+
+TEST(BMPCodecTest, Decode8BitWithPalette) {
+  std::vector<uint8_t> bmp_8bit(262 + 8, 0);
+
+  bmp_8bit[0] = 'B';
+  bmp_8bit[1] = 'M';
+  uint32_t file_size = static_cast<uint32_t>(bmp_8bit.size());
+  memcpy(bmp_8bit.data() + 2, &file_size, 4);
+  uint32_t data_offset = 262;
+  memcpy(bmp_8bit.data() + 10, &data_offset, 4);
+
+  uint32_t header_size = 40;
+  memcpy(bmp_8bit.data() + 14, &header_size, 4);
+  uint32_t width = 2;
+  memcpy(bmp_8bit.data() + 18, &width, 4);
+  uint32_t height = 2;
+  memcpy(bmp_8bit.data() + 22, &height, 4);
+  bmp_8bit[26] = 1;
+  bmp_8bit[28] = 8;
+  uint32_t compression = 0;
+  memcpy(bmp_8bit.data() + 30, &compression, 4);
+  uint32_t raw_size = 8;
+  memcpy(bmp_8bit.data() + 34, &raw_size, 4);
+  uint32_t colors_used = 2;
+  memcpy(bmp_8bit.data() + 46, &colors_used, 4);
+
+  size_t palette_offset = 54;
+  bmp_8bit[palette_offset + 0] = 0x00;
+  bmp_8bit[palette_offset + 1] = 0x00;
+  bmp_8bit[palette_offset + 2] = 0xFF;
+  bmp_8bit[palette_offset + 3] = 0x00;
+
+  bmp_8bit[palette_offset + 4] = 0xFF;
+  bmp_8bit[palette_offset + 5] = 0xFF;
+  bmp_8bit[palette_offset + 6] = 0xFF;
+  bmp_8bit[palette_offset + 7] = 0x00;
+
+  size_t pixel_offset = 262;
+  bmp_8bit[pixel_offset + 0] = 0x00;
+  bmp_8bit[pixel_offset + 1] = 0x01;
+
+  bmp_8bit[pixel_offset + 4] = 0x00;
+  bmp_8bit[pixel_offset + 5] = 0x01;
+
+  auto data = skity::Data::MakeWithCopy(bmp_8bit.data(), bmp_8bit.size());
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec != nullptr);
+
+  codec->SetData(data);
+  auto pixmap = codec->Decode();
+
+  EXPECT_TRUE(pixmap != nullptr);
+  EXPECT_EQ(pixmap->Width(), 2);
+  EXPECT_EQ(pixmap->Height(), 2);
+  EXPECT_EQ(pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(pixmap->GetAlphaType(), skity::AlphaType::kUnpremul_AlphaType);
+}
+
+TEST(BMPCodecTest, DecodeTopDown) {
+  const unsigned char bmp_topdown[] = {
+      'B',  'M',               // signature
+      0x36, 0x00, 0x00, 0x00,  // file size = 54 bytes
+      0x00, 0x00,              // reserved
+      0x00, 0x00,              // reserved
+      0x36, 0x00, 0x00, 0x00,  // data offset = 54
+      0x28, 0x00, 0x00, 0x00,  // info header size = 40
+      0x01, 0x00, 0x00, 0x00,  // width = 1
+      0xFF, 0xFF, 0xFF, 0xFF,  // height = -1 (top-down)
+      0x01, 0x00,              // planes = 1
+      0x18, 0x00,              // bpp = 24
+      0x00, 0x00, 0x00, 0x00,  // compression = BI_RGB
+      0x04, 0x00, 0x00, 0x00,  // raw data size = 4
+      0x13, 0x0B, 0x00, 0x00,  // x pixels per meter
+      0x13, 0x0B, 0x00, 0x00,  // y pixels per meter
+      0x00, 0x00, 0x00, 0x00,  // colors used
+      0x00, 0x00, 0x00, 0x00,  // important colors
+      0x00, 0xFF, 0x00, 0x00,  // BGR pixel + padding (green)
+  };
+
+  auto data = skity::Data::MakeWithCopy(bmp_topdown, sizeof(bmp_topdown));
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec != nullptr);
+
+  codec->SetData(data);
+  auto pixmap = codec->Decode();
+
+  EXPECT_TRUE(pixmap != nullptr);
+  EXPECT_EQ(pixmap->Width(), 1);
+  EXPECT_EQ(pixmap->Height(), 1);
+
+  const auto* addr = reinterpret_cast<const uint8_t*>(pixmap->Addr());
+  EXPECT_EQ(addr[0], 0x00);
+  EXPECT_EQ(addr[1], 0xFF);
+  EXPECT_EQ(addr[2], 0x00);
+  EXPECT_EQ(addr[3], 0xFF);
+}
+
+TEST(BMPCodecTest, Encode24Bit) {
+  skity::Pixmap pixmap(1, 1, skity::AlphaType::kOpaque_AlphaType,
+                       skity::ColorType::kRGBA);
+
+  {
+    auto addr = reinterpret_cast<uint8_t*>(pixmap.WritableAddr());
+    addr[0] = 0xFF;
+    addr[1] = 0x00;
+    addr[2] = 0x00;
+    addr[3] = 0xFF;
+  }
+
+  const unsigned char bmp_header[] = {
+      'B',  'M',  0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36,
+      0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+  };
+  auto codec_data = skity::Data::MakeWithCopy(bmp_header, sizeof(bmp_header));
+  auto codec = skity::Codec::MakeFromData(codec_data);
+
+  ASSERT_TRUE(codec != nullptr);
+
+  auto data = codec->Encode(&pixmap);
+
+  EXPECT_TRUE(data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(data->Bytes()), data->Size()));
+
+  codec->SetData(data);
+
+  auto decode_pixmap = codec->Decode();
+
+  EXPECT_TRUE(decode_pixmap != nullptr);
+  EXPECT_EQ(decode_pixmap->Width(), 1);
+  EXPECT_EQ(decode_pixmap->Height(), 1);
+  EXPECT_EQ(decode_pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(decode_pixmap->GetAlphaType(),
+            skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* decode_addr =
+      reinterpret_cast<const uint8_t*>(decode_pixmap->Addr());
+  EXPECT_EQ(decode_addr[0], 0xFF);
+  EXPECT_EQ(decode_addr[1], 0x00);
+  EXPECT_EQ(decode_addr[2], 0x00);
+  EXPECT_EQ(decode_addr[3], 0xFF);
+}
+
+TEST(BMPCodecTest, Encode32BitWithAlpha) {
+  skity::Pixmap pixmap(1, 1, skity::AlphaType::kUnpremul_AlphaType,
+                       skity::ColorType::kRGBA);
+
+  {
+    auto addr = reinterpret_cast<uint8_t*>(pixmap.WritableAddr());
+    addr[0] = 0xFF;
+    addr[1] = 0x00;
+    addr[2] = 0x00;
+    addr[3] = 0x80;
+  }
+
+  const unsigned char bmp_header[] = {
+      'B',  'M',  0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36,
+      0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+  };
+  auto codec_data = skity::Data::MakeWithCopy(bmp_header, sizeof(bmp_header));
+  auto codec = skity::Codec::MakeFromData(codec_data);
+
+  ASSERT_TRUE(codec != nullptr);
+
+  auto data = codec->Encode(&pixmap);
+
+  EXPECT_TRUE(data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(data->Bytes()), data->Size()));
+
+  codec->SetData(data);
+
+  auto decode_pixmap = codec->Decode();
+
+  EXPECT_TRUE(decode_pixmap != nullptr);
+  EXPECT_EQ(decode_pixmap->Width(), 1);
+  EXPECT_EQ(decode_pixmap->Height(), 1);
+  EXPECT_EQ(decode_pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(decode_pixmap->GetAlphaType(),
+            skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* decode_addr =
+      reinterpret_cast<const uint8_t*>(decode_pixmap->Addr());
+  EXPECT_EQ(decode_addr[0], 0xFF);
+  EXPECT_EQ(decode_addr[1], 0x00);
+  EXPECT_EQ(decode_addr[2], 0x00);
+  EXPECT_EQ(decode_addr[3], 0x80);
+}
+
+TEST(BMPCodecTest, EncodeBGRA) {
+  skity::Pixmap pixmap(1, 1, skity::AlphaType::kUnpremul_AlphaType,
+                       skity::ColorType::kBGRA);
+
+  {
+    auto addr = reinterpret_cast<uint8_t*>(pixmap.WritableAddr());
+    addr[0] = 0x00;
+    addr[1] = 0x00;
+    addr[2] = 0xFF;
+    addr[3] = 0x80;
+  }
+
+  const unsigned char bmp_header[] = {
+      'B',  'M',  0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36,
+      0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+  };
+  auto codec_data = skity::Data::MakeWithCopy(bmp_header, sizeof(bmp_header));
+  auto codec = skity::Codec::MakeFromData(codec_data);
+
+  ASSERT_TRUE(codec != nullptr);
+
+  auto data = codec->Encode(&pixmap);
+
+  EXPECT_TRUE(data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(data->Bytes()), data->Size()));
+
+  codec->SetData(data);
+
+  auto decode_pixmap = codec->Decode();
+
+  EXPECT_TRUE(decode_pixmap != nullptr);
+  EXPECT_EQ(decode_pixmap->Width(), 1);
+  EXPECT_EQ(decode_pixmap->Height(), 1);
+  EXPECT_EQ(decode_pixmap->GetColorType(), skity::ColorType::kRGBA);
+  EXPECT_EQ(decode_pixmap->GetAlphaType(),
+            skity::AlphaType::kUnpremul_AlphaType);
+
+  const auto* decode_addr =
+      reinterpret_cast<const uint8_t*>(decode_pixmap->Addr());
+  EXPECT_EQ(decode_addr[0], 0xFF);
+  EXPECT_EQ(decode_addr[1], 0x00);
+  EXPECT_EQ(decode_addr[2], 0x00);
+  EXPECT_EQ(decode_addr[3], 0x80);
+}
+
+TEST(BMPCodecTest, EncodeWithCanvas) {
+  skity::Bitmap bitmap(128, 128, skity::AlphaType::kUnpremul_AlphaType,
+                       skity::ColorType::kRGBA);
+
+  auto canvas = skity::Canvas::MakeSoftwareCanvas(&bitmap);
+
+  canvas->Clear(skity::Color_TRANSPARENT);
+
+  skity::Paint paint;
+  paint.SetColor(skity::Color_RED);
+  paint.SetAlphaF(0.5f);
+  paint.SetStyle(skity::Paint::kStroke_Style);
+  paint.SetStrokeWidth(5.f);
+
+  canvas->DrawCircle(64, 64, 50, paint);
+
+  const unsigned char bmp_header[] = {
+      'B',  'M',  0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36,
+      0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+  };
+  auto codec_data = skity::Data::MakeWithCopy(bmp_header, sizeof(bmp_header));
+  auto codec = skity::Codec::MakeFromData(codec_data);
+
+  ASSERT_TRUE(codec != nullptr);
+
+  auto data = codec->Encode(bitmap.GetPixmap().get());
+
+  EXPECT_TRUE(data != nullptr);
+
+  EXPECT_TRUE(codec->RecognizeFileType(
+      reinterpret_cast<const char*>(data->Bytes()), data->Size()));
+
+  codec->SetData(data);
+
+  auto decode_pixmap = codec->Decode();
+
+  EXPECT_TRUE(decode_pixmap != nullptr);
+  EXPECT_EQ(decode_pixmap->Width(), 128);
+  EXPECT_EQ(decode_pixmap->Height(), 128);
+}
+
+TEST(BMPCodecTest, InvalidHeader) {
+  const unsigned char invalid_bmp[] = {'X', 'Y', 0x00, 0x00, 0x00, 0x00};
+
+  auto data = skity::Data::MakeWithCopy(invalid_bmp, sizeof(invalid_bmp));
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec == nullptr);
+}
+
+TEST(BMPCodecTest, InvalidSize) {
+  const unsigned char too_short[] = {'B', 'M'};
+
+  auto data = skity::Data::MakeWithCopy(too_short, sizeof(too_short));
+  auto codec = skity::Codec::MakeFromData(data);
+
+  EXPECT_TRUE(codec == nullptr);
+}


### PR DESCRIPTION
Add BMP format support to the codec module with the following features:

**Supported Formats:**
- 24 bpp BI_RGB: Full decode and encode support
- 32 bpp BI_RGB: Full decode and encode support
- 8 bpp BI_RGB: Decode support with palette
- 32 bpp BI_BITFIELDS: Decode support with custom masks

**Key Features:**
- Handle top-down BMP files (negative height)
- Automatic 4-byte row padding handling
- Smart alpha channel detection for 32-bit BI_RGB (fixes all-zero alpha issue)
- Support for both RGBA and BGRA source formats in encoding