### PR TITLE
fix(text): render radial gradients in glyph atlas

### DIFF
--- a/src/render/hw/draw/fragment/wgsl_text_fragment.cc
+++ b/src/render/hw/draw/fragment/wgsl_text_fragment.cc
@@ -282,7 +282,7 @@ std::string WGSLGradientTextFragment::GenSourceWGSL() const {
       @group(1) @binding(6) var<uniform> uRadialInfo    : vec3<f32>;
 
       fn gradient_text_color(fs_in : GradientTextFSInput) -> vec4<f32> {
-        var mixValue  : vec2<f32> = fs_in.v_pos - uRadialInfo.xy;
+        var mixValue  : f32       = distance(fs_in.v_pos, uRadialInfo.xy);
         var radius    : f32       = uRadialInfo.z;
         var t         : f32       = mixValue / radius;
         var color     : vec4<f32> = calculate_gradient_color(t);

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(skity_unit_test
     render/hw/dst_read_strategy_test.cc
     render/hw/hw_texture_copy_info_test.cc
     render/hw/draw/hw_wgsl_shader_writer_test.cc
+    render/hw/draw/wgsl_text_fragment_test.cc
     wgx/wgx_backend_name_resolution_test.cc
     wgx/wgx_resolver_test.cc
     wgx/wgx_uniform_layout_test.cc

--- a/test/ut/render/hw/draw/wgsl_text_fragment_test.cc
+++ b/test/ut/render/hw/draw/wgsl_text_fragment_test.cc
@@ -1,0 +1,36 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/hw/draw/fragment/wgsl_text_fragment.hpp"
+
+#include <gtest/gtest.h>
+#include <wgsl_cross.h>
+
+#include "skity/effect/shader.hpp"
+#include "skity/graphic/color.hpp"
+
+namespace skity {
+
+TEST(WGSLTextFragmentTest, RadialGradient) {
+  Color4f colors[3] = {Colors::kYellow, Colors::kRed, Colors::kBlue};
+  float positions[3] = {0.0f, 0.5f, 1.0f};
+  auto shader = Shader::MakeRadial({400.0f, 250.0f, 0.0f, 1.0f}, 320.0f, colors,
+                                   positions, 3);
+  Shader::GradientInfo info;
+  auto type = shader->AsGradient(&info);
+  WGSLGradientTextFragment fragment({}, {}, info, type, 1.0f);
+
+  auto program = wgx::Program::Parse(fragment.GenSourceWGSL());
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::MslOptions msl_options;
+  EXPECT_TRUE(program->WriteToMsl("fs_main", msl_options).success);
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  EXPECT_TRUE(program->WriteToGlsl("fs_main", glsl_options).success);
+}
+
+}  // namespace skity


### PR DESCRIPTION
Compute the radial interpolation parameter with distance(), matching the path shader implementation.

Add a dedicated text fragment test covering WGSL parsing and MSL/GLSL generation.