### PR TITLE
feat(text): render sweep gradients in glyph atlas

### DIFF
--- a/src/render/hw/draw/fragment/wgsl_text_fragment.cc
+++ b/src/render/hw/draw/fragment/wgsl_text_fragment.cc
@@ -315,6 +315,26 @@ std::string WGSLGradientTextFragment::GenSourceWGSL() const {
         }
       }
     )";
+  } else if (type_ == Shader::GradientType::kSweep) {
+    wgsl_code += R"(
+      @group(1) @binding(6) var<uniform> uSweepInfo     : vec4<f32>;
+
+      fn gradient_text_color(fs_in : GradientTextFSInput) -> vec4<f32> {
+        let k1Over2Pi : f32       = 0.1591549430918;
+        var center    : vec2<f32> = uSweepInfo.xy;
+        var bias      : f32       = uSweepInfo.z;
+        var scale     : f32       = uSweepInfo.w;
+        var coord     : vec2<f32> = fs_in.v_pos - center;
+        var angle     : f32       = atan(-coord.y, -coord.x);
+        var t         : f32       =
+            (angle * k1Over2Pi + 0.5 + bias) * scale;
+        var color     : vec4<f32> = calculate_gradient_color(t);
+        if gradient_info.flags == 0 {
+          color = vec4<f32>(color.xyz * color.w, color.w);
+        }
+        return color * gradient_info.global_alpha;
+      }
+    )";
   }
 
   if (filter_) {

--- a/test/ut/render/hw/draw/wgsl_text_fragment_test.cc
+++ b/test/ut/render/hw/draw/wgsl_text_fragment_test.cc
@@ -12,11 +12,78 @@
 
 namespace skity {
 
+TEST(WGSLTextFragmentTest, LinearGradient) {
+  Color4f colors[3] = {Colors::kYellow, Colors::kRed, Colors::kBlue};
+  float positions[3] = {0.0f, 0.5f, 1.0f};
+  Point points[2] = {
+      {80.0f, 100.0f, 0.0f, 1.0f},
+      {320.0f, 100.0f, 0.0f, 1.0f},
+  };
+  auto shader = Shader::MakeLinear(points, colors, positions, 3);
+  Shader::GradientInfo info;
+  auto type = shader->AsGradient(&info);
+  WGSLGradientTextFragment fragment({}, {}, info, type, 1.0f);
+
+  auto program = wgx::Program::Parse(fragment.GenSourceWGSL());
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::MslOptions msl_options;
+  EXPECT_TRUE(program->WriteToMsl("fs_main", msl_options).success);
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  EXPECT_TRUE(program->WriteToGlsl("fs_main", glsl_options).success);
+}
+
 TEST(WGSLTextFragmentTest, RadialGradient) {
   Color4f colors[3] = {Colors::kYellow, Colors::kRed, Colors::kBlue};
   float positions[3] = {0.0f, 0.5f, 1.0f};
   auto shader = Shader::MakeRadial({400.0f, 250.0f, 0.0f, 1.0f}, 320.0f, colors,
                                    positions, 3);
+  Shader::GradientInfo info;
+  auto type = shader->AsGradient(&info);
+  WGSLGradientTextFragment fragment({}, {}, info, type, 1.0f);
+
+  auto program = wgx::Program::Parse(fragment.GenSourceWGSL());
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::MslOptions msl_options;
+  EXPECT_TRUE(program->WriteToMsl("fs_main", msl_options).success);
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  EXPECT_TRUE(program->WriteToGlsl("fs_main", glsl_options).success);
+}
+
+TEST(WGSLTextFragmentTest, ConicalGradient) {
+  Color4f colors[3] = {Colors::kYellow, Colors::kRed, Colors::kBlue};
+  float positions[3] = {0.0f, 0.5f, 1.0f};
+  auto shader = Shader::MakeTwoPointConical({140.0f, 100.0f, 0.0f, 1.0f}, 0.0f,
+                                            {220.0f, 100.0f, 0.0f, 1.0f},
+                                            240.0f, colors, positions, 3);
+  Shader::GradientInfo info;
+  auto type = shader->AsGradient(&info);
+  WGSLGradientTextFragment fragment({}, {}, info, type, 1.0f);
+
+  auto program = wgx::Program::Parse(fragment.GenSourceWGSL());
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::MslOptions msl_options;
+  EXPECT_TRUE(program->WriteToMsl("fs_main", msl_options).success);
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  EXPECT_TRUE(program->WriteToGlsl("fs_main", glsl_options).success);
+}
+
+TEST(WGSLTextFragmentTest, SweepGradient) {
+  Color4f colors[3] = {Colors::kYellow, Colors::kRed, Colors::kBlue};
+  float positions[3] = {0.0f, 0.5f, 1.0f};
+  auto shader =
+      Shader::MakeSweep(400.0f, 250.0f, 0.0f, 360.0f, colors, positions, 3);
   Shader::GradientInfo info;
   auto type = shader->AsGradient(&info);
   WGSLGradientTextFragment fragment({}, {}, info, type, 1.0f);


### PR DESCRIPTION
Implement Sweep evaluation in the WGSL text fragment using the Path shader's angle, bias, and scale mapping.

Update the text example and add WGSL-to-MSL/GLSL compilation coverage.