### PR TITLE
[Feature] Expose uncached CoreText typeface conversion

### DIFF
--- a/include/skity/text/ports/typeface_ct.hpp
+++ b/include/skity/text/ports/typeface_ct.hpp
@@ -17,6 +17,8 @@ class SKITY_API TypefaceCT {
   static CTFontRef CTFontFromTypeface(
       const std::shared_ptr<Typeface>& typeface);
   static std::shared_ptr<Typeface> TypefaceFromCTFont(CTFontRef ct_font);
+  static std::shared_ptr<Typeface> TypefaceFromCTFontWithoutCache(
+      CTFontRef ct_font);
 };
 
 }  // namespace skity

--- a/src/text/ports/darwin/typeface_darwin.cc
+++ b/src/text/ports/darwin/typeface_darwin.cc
@@ -511,6 +511,18 @@ std::shared_ptr<Typeface> TypefaceCT::TypefaceFromCTFont(CTFontRef ct_font) {
   return TypefaceDarwin::Make(style, UniqueCTFontRef(ct_font));
 }
 
+std::shared_ptr<Typeface> TypefaceCT::TypefaceFromCTFontWithoutCache(
+    CTFontRef ct_font) {
+  CFRetain(ct_font);
+  UniqueCFRef<CTFontDescriptorRef> desc(CTFontCopyFontDescriptor(ct_font));
+
+  FontStyle style;
+
+  ct_desc_to_font_style(desc.get(), &style);
+
+  return TypefaceDarwin::MakeWithoutCache(style, UniqueCTFontRef(ct_font));
+}
+
 void TypefaceDarwin::SerializeData() {
   auto font_type = get_font_type_tag(ct_font_.get());
 

--- a/test/ut/text/coretext_typeface_test.cc
+++ b/test/ut/text/coretext_typeface_test.cc
@@ -7,6 +7,7 @@
 #include <skity/io/data.hpp>
 #include <skity/text/font_arguments.hpp>
 #include <skity/text/font_manager.hpp>
+#include <skity/text/ports/typeface_ct.hpp>
 #include <skity/text/typeface.hpp>
 #include <string>
 
@@ -67,6 +68,20 @@ TEST(CoreTextTypefaceTest, MakeVariationRejectsTtcIndexMismatch) {
   args.SetCollectionIndex(1);
 
   EXPECT_EQ(typeface->MakeVariation(args), nullptr);
+}
+
+TEST(CoreTextTypefaceTest, FromCTFontWithoutCacheCreatesIndependentTypefaces) {
+  CTFontRef ct_font =
+      CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 16.0, nullptr);
+  ASSERT_NE(ct_font, nullptr);
+
+  auto first = TypefaceCT::TypefaceFromCTFontWithoutCache(ct_font);
+  auto second = TypefaceCT::TypefaceFromCTFontWithoutCache(ct_font);
+  CFRelease(ct_font);
+
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_NE(first->TypefaceId(), second->TypefaceId());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- expose a public `TypefaceCT` conversion that bypasses the Darwin typeface cache
- forward the conversion to the existing `TypefaceDarwin::MakeWithoutCache` implementation
- verify that repeated conversion of the same `CTFontRef` creates independent typefaces

## Motivation

Callers with page-scoped font ownership need a CoreText-backed Skity typeface without retaining it in Skity's process-wide Darwin typeface cache. The existing internal factory already supports this behavior, but it was not reachable through the public CoreText port API.

## Testing

- `python3 tools/code_format_check.py --fix --json`: passed
- GitHub CI: triggered; workflow execution requires maintainer approval for this fork PR
- focused `CoreTextTypefaceTest.*`: not run locally
