### PR TITLE
fix(font): avoid embedded NULs in CoreText font names

### DIFF
--- a/src/text/ports/darwin/font_manager_darwin.cc
+++ b/src/text/ports/darwin/font_manager_darwin.cc
@@ -38,7 +38,7 @@ bool find_desc_str(CTFontDescriptorRef desc, CFStringRef name,
     return false;
   }
 
-  *value = CFStringGetCStringPtr(ref.get(), kCFStringEncodingUTF8);
+  *value = cf_string_to_string(ref.get());
   return true;
 }
 
@@ -384,18 +384,7 @@ std::string FontManagerDarwin::OnGetFamilyName(int index) const {
   CFStringRef cf_string =
       (CFStringRef)CFArrayGetValueAtIndex(cf_family_names_.get(), index);
 
-  CFIndex length = CFStringGetMaximumSizeForEncoding(
-                       CFStringGetLength(cf_string), kCFStringEncodingUTF8) +
-                   1;
-
-  std::vector<char> buffer(length);
-
-  Boolean ok = CFStringGetCString(cf_string, buffer.data(), length,
-                                  kCFStringEncodingUTF8);
-  if (!ok) {
-    return std::string{};
-  }
-  return std::string{buffer.data()};
+  return cf_string_to_string(cf_string);
 }
 
 std::shared_ptr<FontStyleSet> FontManagerDarwin::OnCreateStyleSet(

--- a/src/text/ports/darwin/typeface_darwin.cc
+++ b/src/text/ports/darwin/typeface_darwin.cc
@@ -28,22 +28,6 @@ T skity_cf_retain(T t) {
   return (T)CFRetain(t);
 }
 
-std::string cf_string_to_string(UniqueCFRef<CFStringRef> str) {
-  if (!str) {
-    return {};
-  }
-
-  CFIndex length = CFStringGetMaximumSizeForEncoding(
-                       CFStringGetLength(str.get()), kCFStringEncodingUTF8) +
-                   1;
-
-  std::vector<char> buffer(length);
-
-  CFStringGetCString(str.get(), buffer.data(), length, kCFStringEncodingUTF8);
-
-  return std::string(buffer.data(), length - 1);
-}
-
 SKITY_SFNT_ULONG get_font_type_tag(CTFontRef ct_font) {
   UniqueCFRef<CFNumberRef> fon_format(static_cast<CFNumberRef>(
       CTFontCopyAttribute(ct_font, kCTFontFormatAttribute)));
@@ -480,14 +464,14 @@ std::shared_ptr<Typeface> TypefaceDarwin::OnMakeVariation(
 }
 
 void TypefaceDarwin::OnGetFontDescriptor(FontDescriptor& desc) const {
-  // get family name
+  UniqueCFRef<CFStringRef> family_name(CTFontCopyFamilyName(ct_font_.get()));
+  UniqueCFRef<CFStringRef> full_name(CTFontCopyFullName(ct_font_.get()));
+  UniqueCFRef<CFStringRef> post_script_name(
+      CTFontCopyPostScriptName(ct_font_.get()));
 
-  desc.family_name = cf_string_to_string(
-      UniqueCFRef<CFStringRef>(CTFontCopyFamilyName(ct_font_.get())));
-  desc.full_name = cf_string_to_string(
-      UniqueCFRef<CFStringRef>(CTFontCopyFullName(ct_font_.get())));
-  desc.post_script_name = cf_string_to_string(
-      UniqueCFRef<CFStringRef>(CTFontCopyPostScriptName(ct_font_.get())));
+  desc.family_name = cf_string_to_string(family_name.get());
+  desc.full_name = cf_string_to_string(full_name.get());
+  desc.post_script_name = cf_string_to_string(post_script_name.get());
 
   desc.factory_id = kFontFactoryID;
 

--- a/src/text/ports/darwin/types_darwin.cc
+++ b/src/text/ports/darwin/types_darwin.cc
@@ -15,10 +15,28 @@
 #include <mutex>
 #include <skity/macros.hpp>
 #include <string>
+#include <vector>
 
 namespace skity {
 
 const CGFloat (&get_kit_font_weight_mapping())[11];  // NOLINT
+
+std::string cf_string_to_string(CFStringRef str) {
+  if (!str) {
+    return {};
+  }
+
+  CFIndex capacity = CFStringGetMaximumSizeForEncoding(CFStringGetLength(str),
+                                                       kCFStringEncodingUTF8) +
+                     1;
+  std::vector<char> buffer(capacity);
+  if (!CFStringGetCString(str, buffer.data(), capacity,
+                          kCFStringEncodingUTF8)) {
+    return {};
+  }
+
+  return std::string(buffer.data());
+}
 
 namespace {
 
@@ -135,7 +153,7 @@ bool find_desc_str(CTFontDescriptorRef desc, CFStringRef name,
     return false;
   }
 
-  *value = CFStringGetCStringPtr(ref.get(), kCFStringEncodingUTF8);
+  *value = cf_string_to_string(ref.get());
 
   return true;
 }

--- a/src/text/ports/darwin/types_darwin.hpp
+++ b/src/text/ports/darwin/types_darwin.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <skity/text/font_style.hpp>
+#include <string>
 #include <type_traits>
 
 namespace skity {
@@ -38,6 +39,8 @@ using UniqueCFRef =
 
 using UniqueCTFontRef = UniqueCFRef<CTFontRef>;
 using UniqueCTArrayRef = UniqueCFRef<CFArrayRef>;
+
+std::string cf_string_to_string(CFStringRef str);
 
 void ct_desc_to_font_style(CTFontDescriptorRef desc, FontStyle* style,
                            bool from_data_provider = false);

--- a/test/ut/text/coretext_typeface_test.cc
+++ b/test/ut/text/coretext_typeface_test.cc
@@ -4,11 +4,14 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <skity/io/data.hpp>
 #include <skity/text/font_arguments.hpp>
 #include <skity/text/font_manager.hpp>
 #include <skity/text/typeface.hpp>
 #include <string>
+
+#include "src/text/ports/darwin/types_darwin.hpp"
 
 namespace skity {
 namespace {
@@ -25,9 +28,26 @@ void ExpectNotoSansCjkIndex1(std::shared_ptr<Typeface> const& typeface) {
   EXPECT_NE(desc.post_script_name.find("NotoSansCJKKR-Regular"),
             std::string::npos);
   EXPECT_FALSE(desc.family_name.empty());
+  EXPECT_FALSE(desc.full_name.empty());
   EXPECT_FALSE(desc.post_script_name.empty());
+  EXPECT_EQ(desc.family_name.find('\0'), std::string::npos);
+  EXPECT_EQ(desc.full_name.find('\0'), std::string::npos);
+  EXPECT_EQ(desc.post_script_name.find('\0'), std::string::npos);
   EXPECT_NE(typeface->UnicharToGlyph(0x4E00), 0);
   EXPECT_GT(typeface->CountTables(), 0);
+}
+
+TEST(CoreTextTypefaceTest, ConvertsCFStringToExactUtf8Length) {
+  constexpr UniChar kCharacters[] = {'P', 'i', 'n', 'g', 'F',    'a',   'n',
+                                     'g', 'S', 'C', '-', 0x4E2D, 0x6587};
+  UniqueCFRef<CFStringRef> cf_string(CFStringCreateWithCharacters(
+      kCFAllocatorDefault, kCharacters, std::size(kCharacters)));
+  ASSERT_NE(cf_string, nullptr);
+
+  std::string converted = cf_string_to_string(cf_string.get());
+
+  EXPECT_EQ(converted, "PingFangSC-\xE4\xB8\xAD\xE6\x96\x87");
+  EXPECT_EQ(converted.find('\0'), std::string::npos);
 }
 
 TEST(CoreTextTypefaceTest, MakeFromFileSupportsTtcIndex) {


### PR DESCRIPTION
Construct strings from the actual NUL-terminated UTF-8 result instead of the maximum conversion buffer size. Reuse the safe conversion helper across Darwin font paths and add regression coverage for font descriptor names.