### PR TITLE
chore(ci): standardize headless Vulkan test builds

### DIFF
--- a/test/ut/gpu/vk/gpu_context_vk_test.cc
+++ b/test/ut/gpu/vk/gpu_context_vk_test.cc
@@ -1493,6 +1493,9 @@ TEST_F(VulkanSharedContextTest, BeginAndEndRenderPassWithoutCommands) {
 }
 
 TEST_F(VulkanSharedContextTest, EnablesValidationLayerWhenAvailable) {
+#if !defined(SKITY_VK_DEBUG_RUNTIME)
+  GTEST_SKIP() << "Vulkan debug runtime is disabled in this build";
+#else
   ASSERT_NE(GetContext(), nullptr);
   const auto* state = GetState();
   ASSERT_NE(state, nullptr);
@@ -1505,6 +1508,7 @@ TEST_F(VulkanSharedContextTest, EnablesValidationLayerWhenAvailable) {
 
   EXPECT_TRUE(
       ContainsLayer(state->GetEnabledInstanceLayers(), kValidationLayer));
+#endif
 }
 
 TEST_F(VulkanSharedContextTest, EnablesPortabilitySubsetWhenAvailable) {

--- a/tools/test-runner.py
+++ b/tools/test-runner.py
@@ -147,22 +147,27 @@ class TestRunner:
     def configure_cmake(self) -> Tuple[bool, str]:
         self.print_status(Colors.YELLOW, "🔧 Configuring with CMake...")
         os.makedirs(self.build_dir, exist_ok=True)
-        cmd = ["cmake", "-B", self.build_dir, "-DSKITY_TEST=ON", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
+        cmd = [
+            "cmake",
+            "-B",
+            self.build_dir,
+            "-DSKITY_TEST=ON",
+            "-DSKITY_GOLDEN_GUI=OFF",
+            "-DSKITY_VK_BACKEND=ON",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+        ]
         vk_test_loader = os.environ.get("SKITY_VK_TEST_USE_SYSTEM_LOADER", "")
         if vk_test_loader.upper() not in ("", "0", "OFF", "FALSE", "NO"):
             cmd.append("-DSKITY_VK_TEST_USE_SYSTEM_LOADER=ON")
         else:
             cmd.append("-DSKITY_VK_TEST_USE_SYSTEM_LOADER=OFF")
-        
+
         if self.suite.startswith("golden"):
             cmd.extend([
                 "-DSKITY_MTL_BACKEND=ON",
                 "-DSKITY_CODEC_MODULE=ON",
-                "-DSKITY_GOLDEN_GUI=OFF"
             ])
-            if self.backend == "vulkan":
-                cmd.append("-DSKITY_VK_BACKEND=ON")
-            
+
         exit_code, stdout, stderr = self.run_command(cmd)
         if exit_code != 0:
             self.print_status(Colors.RED, "❌ CMake configuration failed!")


### PR DESCRIPTION
Disable the golden comparison GUI and enable Vulkan for every automated test configuration so build artifacts can be reused across backend runs.

Skip the validation-layer assertion when the Vulkan debug runtime is not compiled in.