### PR TITLE
[BugFix] Align italic Darwin glyph raster origins

### DIFF
--- a/src/text/ports/darwin/scaler_context_darwin.cc
+++ b/src/text/ports/darwin/scaler_context_darwin.cc
@@ -488,8 +488,10 @@ void ScalerContextDarwin::GenerateImageInfo(GlyphData *glyph,
   // rasterizing into the bitmap context. Keep the atlas origin in the same
   // coordinate system; otherwise the fractional glyph bound is applied again
   // when DirectGlyphRun places the bitmap, producing glyph-dependent vertical
-  // offsets.
-  if (transform_.b == 0 && transform_.c == 0) {
+  // offsets. An X-axis skew (transform_.c), as used by synthetic italic text,
+  // does not affect the device-space Y coordinate and still needs the same
+  // alignment. Only transforms that mix X into Y (transform_.b) are excluded.
+  if (transform_.b == 0) {
     point.y = std::floor(point.y * context_scale_) / context_scale_;
   }
 


### PR DESCRIPTION
## Summary

- Apply vertical pixel alignment to X-axis-skewed glyphs used by synthetic italic text.
- Continue excluding transforms that mix X into the device-space Y coordinate.

## Root cause

The previous fix required both CGAffineTransform b and c to be zero. Synthetic italic text uses an X-axis skew with b = 0 and c = 0.25, so it skipped vertical origin alignment even though c does not affect the device-space Y coordinate. Glyph-dependent fractional bounds then produced visible vertical offsets.

## Verification

- Built LynxDesktop with Skity.
- Verified the original single-text ReactLynx repro with normal, italic, bold, and bold italic variants.
- Diagnostic output confirmed synthetic italic uses transform {1, 0, 0.25, 1} and previously produced varying fractional point.y values.