### PR TITLE
[BugFix] Preserve Darwin glyph subpixel positions

### DIFF
--- a/src/render/text/atlas/atlas_bitmap.cc
+++ b/src/render/text/atlas/atlas_bitmap.cc
@@ -27,37 +27,37 @@ AtlasBitmap::~AtlasBitmap() {
   }
 }
 
-glm::ivec4 AtlasBitmap::GetGlyphRegion(GlyphKey key) {
+GlyphRegion AtlasBitmap::GetGlyphRegion(GlyphKey key) {
   auto it = glyph_regions_.find(key);
   if (it != glyph_regions_.end()) {
     return it->second;
   }
-  return INVALID_LOC;
+  return GlyphRegion{0, INVALID_LOC, 1.f};
 }
 
-glm::ivec4 AtlasBitmap::GenerateGlyphRegion(GlyphKey const& key,
-                                            const GlyphBitmapData& bitmap) {
+GlyphRegion AtlasBitmap::GenerateGlyphRegion(GlyphKey const& key,
+                                             const GlyphBitmapData& bitmap) {
   const uint32_t glyph_width = static_cast<uint32_t>(bitmap.width);
   const uint32_t glyph_height = static_cast<uint32_t>(bitmap.height);
   if (glyph_width == 0 || glyph_height == 0) {
-    return {0, 0, 0, 0};
+    return GlyphRegion{0, {0, 0, 0, 0}, 1.f};
   }
 
   const size_t data_row_size =
       static_cast<size_t>(glyph_width) * bytes_per_pixel_;
   const size_t source_row_size = bitmap.RowBytes();
   if (!bitmap.buffer || source_row_size < data_row_size) {
-    return {0, 0, 0, 0};
+    return GlyphRegion{0, {0, 0, 0, 0}, 1.f};
   }
 
   uint32_t width = glyph_width + Atlas_Padding;
   uint32_t height = glyph_height + Atlas_Padding;
   if (width > width_ - 2 || height > height_ - 2) {
-    return {0, 0, 0, 0};
+    return GlyphRegion{0, {0, 0, 0, 0}, 1.f};
   }
   glm::ivec4 region = allocator_->AllocateRegion(width, height);
   if (region == INVALID_LOC) {
-    return region;
+    return GlyphRegion{0, region, 1.f};
   }
 
   // Do not assume textures are zero-initialized on macOS — newly created
@@ -69,7 +69,8 @@ glm::ivec4 AtlasBitmap::GenerateGlyphRegion(GlyphKey const& key,
   region.y += Atlas_Padding / 2;
   region.z -= Atlas_Padding;
   region.w -= Atlas_Padding;
-  glyph_regions_.insert(std::make_pair(key, region));
+  GlyphRegion glyph_region{0, region, 1.f, bitmap.origin_x, bitmap.origin_y};
+  glyph_regions_.insert(std::make_pair(key, glyph_region));
 
   // Copy bitmap to memory storage
   size_t self_row_size = static_cast<size_t>(this->width_) * bytes_per_pixel_;
@@ -94,7 +95,7 @@ glm::ivec4 AtlasBitmap::GenerateGlyphRegion(GlyphKey const& key,
     dirty_rect_->w = std::max(dirty_rect_->w, dirty_region.y + dirty_region.w);
   }
 
-  return region;
+  return glyph_region;
 }
 
 }  // namespace skity

--- a/src/render/text/atlas/atlas_bitmap.hpp
+++ b/src/render/text/atlas/atlas_bitmap.hpp
@@ -23,11 +23,11 @@ class AtlasBitmap {
   ~AtlasBitmap();
 
   // query cache
-  glm::ivec4 GetGlyphRegion(GlyphKey key);
+  GlyphRegion GetGlyphRegion(GlyphKey key);
 
   // add one glyph to memory atlas
-  glm::ivec4 GenerateGlyphRegion(GlyphKey const& key,
-                                 const GlyphBitmapData& bitmap);
+  GlyphRegion GenerateGlyphRegion(GlyphKey const& key,
+                                  const GlyphBitmapData& bitmap);
 
   std::optional<glm::ivec4> DirtyRect() const { return dirty_rect_; }
 
@@ -42,9 +42,7 @@ class AtlasBitmap {
   [[maybe_unused]] uint32_t height_;
   uint32_t bytes_per_pixel_;
   std::unique_ptr<AtlasAllocator> allocator_;
-  // std::unordered_map<GlyphKey, glm::ivec4, GlyphKey::Hash, GlyphKey::Equal>
-  //     glyph_regions_ = {};
-  std::unordered_map<GlyphKey, glm::ivec4, GlyphKey::Hash, GlyphKey::Equal>
+  std::unordered_map<GlyphKey, GlyphRegion, GlyphKey::Hash, GlyphKey::Equal>
       glyph_regions_ = {};
   uint8_t* mem_data_ = nullptr;
   std::optional<glm::ivec4> dirty_rect_ = std::nullopt;

--- a/src/render/text/atlas/atlas_glyph.hpp
+++ b/src/render/text/atlas/atlas_glyph.hpp
@@ -56,6 +56,8 @@ struct GlyphRegion {
   uint32_t index_in_group;
   glm::ivec4 loc;
   float scale;
+  float origin_x = 0.f;
+  float origin_y = 0.f;
 };
 
 struct GlyphKey {

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -12,6 +12,8 @@
 #include "src/render/text/atlas/atlas_texture.hpp"
 #include "src/render/text/sdf_gen.hpp"
 #include "src/render/text/text_render_control.hpp"
+#include "src/text/scaler_context_cache.hpp"
+#include "src/text/scaler_context_container.hpp"
 #include "src/tracing.hpp"
 
 namespace skity {
@@ -20,6 +22,22 @@ namespace {
 
 bool valid_positive_float(float f) {
   return !(FloatIsNan(f) || !FloatIsFinite(f) || f < 0.f);
+}
+
+void LoadGlyphBitmap(const Font& font, GlyphID glyph_id,
+                     const GlyphData** glyph_data, const Paint& paint,
+                     float context_scale, const Matrix& transform,
+                     uint8_t subpixel_x_phase, uint8_t subpixel_y_phase) {
+  Matrix22 transform22{transform.GetScaleX(), transform.GetSkewX(),
+                       transform.GetSkewY(), transform.GetScaleY()};
+  ScalerContextDesc desc = ScalerContextDesc::MakeTransformed(
+      font, paint, context_scale, transform22);
+  desc.subpixel_x_phase = subpixel_x_phase;
+  desc.subpixel_y_phase = subpixel_y_phase;
+  auto scaler_context =
+      ScalerContextCache::GlobalScalerContextCache()->FindOrCreateScalerContext(
+          desc, font.GetTypeface());
+  scaler_context->PrepareImages(&glyph_id, 1, glyph_data, paint);
 }
 
 }  // namespace
@@ -65,8 +83,9 @@ Atlas::Atlas(AtlasFormat format, GPUDevice* gpu_device,
 
 GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
                                   const Paint& paint, bool load_sdf,
-                                  float context_scale,
-                                  const Matrix& transform) {
+                                  float context_scale, const Matrix& transform,
+                                  uint8_t subpixel_x_phase,
+                                  uint8_t subpixel_y_phase) {
   auto typeface = font.GetTypeface();
   float font_size = font.GetSize();
   float sdf_scale = 1.0f;
@@ -120,20 +139,24 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
                                  : Paint::kDefault_Join;
   scaler_context_desc.fake_bold = font.IsEmbolden() ? 1 : 0;
   scaler_context_desc.hinting = static_cast<uint8_t>(font.GetHinting());
+  scaler_context_desc.subpixel_x_phase = load_sdf ? 0 : subpixel_x_phase;
+  scaler_context_desc.subpixel_y_phase = load_sdf ? 0 : subpixel_y_phase;
   GlyphKey key(glyph_id, scaler_context_desc);
 
   for (uint32_t index = 0; index < atlas_bitmap_.size(); index++) {
     if (atlas_bitmap_[index]) {
       AtlasBitmap* memory_atlas = atlas_bitmap_[index].get();
       auto region = memory_atlas->GetGlyphRegion(key);
-      if (region != INVALID_LOC) {
-        return GlyphRegion{index, region, sdf_scale};
+      if (region.loc != INVALID_LOC) {
+        return GlyphRegion{index, region.loc, sdf_scale, region.origin_x,
+                           region.origin_y};
       }
     }
   }
 
   GlyphRegion gen_region = GenerateGlyphRegion(font, key, paint, load_sdf);
-  return GlyphRegion{gen_region.index_in_group, gen_region.loc, sdf_scale};
+  return GlyphRegion{gen_region.index_in_group, gen_region.loc, sdf_scale,
+                     gen_region.origin_x, gen_region.origin_y};
 }
 
 GlyphRegion Atlas::GenerateGlyphRegion(const Font& font, GlyphKey const& key,
@@ -150,19 +173,22 @@ GlyphRegion Atlas::GenerateGlyphRegion(const Font& font, GlyphKey const& key,
     fill_paint.SetStyle(Paint::kFill_Style);
   }
 
-  resized_font.LoadGlyphBitmap(&(key.glyph_id), 1, &glyph_data, fill_paint,
-                               key.scaler_context_desc.context_scale,
-                               key.scaler_context_desc.transform.ToMatrix());
+  LoadGlyphBitmap(resized_font, key.glyph_id, &glyph_data, fill_paint,
+                  key.scaler_context_desc.context_scale,
+                  key.scaler_context_desc.transform.ToMatrix(),
+                  key.scaler_context_desc.subpixel_x_phase,
+                  key.scaler_context_desc.subpixel_y_phase);
   const auto& bitmap_info = glyph_data->Image();
 
   if (fill_paint.GetStyle() == Paint::kStroke_Style &&
       fill_paint.IsAdjustStroke()) {
     const GlyphData* glyph_data_fill;
     fill_paint.SetStyle(Paint::kFill_Style);
-    resized_font.LoadGlyphBitmap(&(key.glyph_id), 1, &glyph_data_fill,
-                                 fill_paint,
-                                 key.scaler_context_desc.context_scale,
-                                 key.scaler_context_desc.transform.ToMatrix());
+    LoadGlyphBitmap(resized_font, key.glyph_id, &glyph_data_fill, fill_paint,
+                    key.scaler_context_desc.context_scale,
+                    key.scaler_context_desc.transform.ToMatrix(),
+                    key.scaler_context_desc.subpixel_x_phase,
+                    key.scaler_context_desc.subpixel_y_phase);
     fill_paint.SetStyle(Paint::kStroke_Style);
 
     if (valid_positive_float(bitmap_info.width) &&
@@ -250,12 +276,13 @@ GlyphRegion Atlas::GenerateGlyphRegionInternal(
   }
   AtlasBitmap* atlas_bitmap = atlas_bitmap_[current_bitmap_index_].get();
   auto region = atlas_bitmap->GenerateGlyphRegion(key, glyph_bitmap);
-  if (region != INVALID_LOC) {
+  if (region.loc != INVALID_LOC) {
     if (glyph_bitmap.need_free) {
       std::free(glyph_bitmap.buffer);
       const_cast<GlyphBitmapData&>(glyph_bitmap).need_free = false;
     }
-    return GlyphRegion{current_bitmap_index_, region, 1.f};
+    return GlyphRegion{current_bitmap_index_, region.loc, 1.f, region.origin_x,
+                       region.origin_y};
   } else {
     current_bitmap_index_ = atlas_bitmap_.size();
     return GenerateGlyphRegionInternal(key, glyph_bitmap);

--- a/src/render/text/atlas/atlas_manager.hpp
+++ b/src/render/text/atlas/atlas_manager.hpp
@@ -32,7 +32,9 @@ class Atlas {
 
   GlyphRegion GetGlyphRegion(const Font& font, GlyphID glyph_id,
                              const Paint& paint, bool load_sdf,
-                             float context_scale, const Matrix& transform);
+                             float context_scale, const Matrix& transform,
+                             uint8_t subpixel_x_phase = 0,
+                             uint8_t subpixel_y_phase = 0);
 
   // upload atlas from memory storage to gpu texture
   void UploadAtlas(uint32_t group_index);

--- a/src/render/text/glyph_raster_alignment.hpp
+++ b/src/render/text/glyph_raster_alignment.hpp
@@ -1,0 +1,37 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_TEXT_GLYPH_RASTER_ALIGNMENT_HPP
+#define SRC_RENDER_TEXT_GLYPH_RASTER_ALIGNMENT_HPP
+
+#include <cmath>
+#include <cstdint>
+
+namespace skity {
+
+// Bound the atlas variants while retaining subpixel positioning precision.
+constexpr uint32_t kGlyphSubpixelPhaseCount = 64;
+
+inline uint8_t QuantizeGlyphSubpixelPhase(float position, float scale) {
+  const float pixel_position = position * scale;
+  const float phase = pixel_position - std::floor(pixel_position);
+  return static_cast<uint8_t>(
+      std::floor(phase * static_cast<float>(kGlyphSubpixelPhaseCount)));
+}
+
+inline float GlyphSubpixelPhase(uint8_t phase) {
+  return static_cast<float>(phase) /
+         static_cast<float>(kGlyphSubpixelPhaseCount);
+}
+
+inline float AlignRasterPointAtOrAbove(float minimum_point, float scale,
+                                       uint8_t phase) {
+  const float minimum_pixel = minimum_point * scale;
+  const float pixel_phase = GlyphSubpixelPhase(phase);
+  return (std::ceil(minimum_pixel - pixel_phase) + pixel_phase) / scale;
+}
+
+}  // namespace skity
+
+#endif  // SRC_RENDER_TEXT_GLYPH_RASTER_ALIGNMENT_HPP

--- a/src/render/text/glyph_run.cc
+++ b/src/render/text/glyph_run.cc
@@ -7,6 +7,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <skity/geometry/matrix.hpp>
 #include <skity/graphic/paint.hpp>
+#include <skity/macros.hpp>
 
 #include "src/render/hw/draw/fragment/wgsl_text_fragment.hpp"
 #include "src/render/hw/draw/geometry/wgsl_text_geometry.hpp"
@@ -14,6 +15,7 @@
 #include "src/render/hw/draw/wgx_filter.hpp"
 #include "src/render/hw/hw_path_raster.hpp"
 #include "src/render/hw/hw_stage_buffer.hpp"
+#include "src/render/text/glyph_raster_alignment.hpp"
 #include "src/render/text/text_render_control.hpp"
 #include "src/tracing.hpp"
 #include "src/utils/arena_allocator.hpp"
@@ -107,9 +109,6 @@ ArrayList<GlyphRect, 16> DirectGlyphRun::Raster(
   }
   font_.LoadGlyphMetrics(glyphs_.data(), count_, glyph_info.data(),
                          metrics_paint);
-  font_.LoadGlyphBitmapInfo(glyphs_.data(), count_, glyph_info.data(),
-                            metrics_paint, context_scale_, transform_);
-
   ArrayList<GlyphRect, 16> glyph_rects;
   glyph_rects.SetArenaAllocator(arena_allocator);
   bounds_ = Rect::MakeEmpty();
@@ -128,18 +127,21 @@ ArrayList<GlyphRect, 16> DirectGlyphRun::Raster(
         glyph_locs_[k].region.loc.x + glyph_locs_[k].region.loc.z,
         glyph_locs_[k].region.loc.y + glyph_locs_[k].region.loc.w);
 
-    auto origin_x = info.Image().origin_x;
-    auto origin_y = info.Image().origin_y;
+    auto origin_x = glyph_locs_[k].region.origin_x;
+    auto origin_y = glyph_locs_[k].region.origin_y;
 
     const Vec2 run_pos{position_x_[glyph_locs_[k].index],
                        position_y_[glyph_locs_[k].index]};
     Vec2 device_run_pos{0, 0};
     transform_.MapPoints(&device_run_pos, &run_pos, 1);
 
-    float rounded_x = std::floor(device_run_pos.x + 0.5f);
-    float rounded_y = std::floor(device_run_pos.y + 0.5f);
-    float rx = rounded_x + origin_x;
-    float ry = rounded_y - origin_y;
+#if defined(SKITY_MACOS) || defined(SKITY_IOS)
+    float rx = device_run_pos.x + origin_x;
+    float ry = device_run_pos.y - origin_y;
+#else
+    float rx = std::floor(device_run_pos.x + 0.5f) + origin_x;
+    float ry = std::floor(device_run_pos.y + 0.5f) - origin_y;
+#endif
     float rw = (uv_rb.x - uv_lt.x) / canvas_scale;
     float rh = (uv_rb.y - uv_lt.y) / canvas_scale;
 
@@ -254,8 +256,17 @@ GlyphRunList DirectGlyphRun::SubRunListByTexture(
   uint32_t k = 0;
   while (k < count) {
     auto info = *(glyph_info[k]);
-    GlyphRegion glyph_region = atlas->GetGlyphRegion(
-        font, info.Id(), paint, false, context_scale, transform);
+    const Vec2 run_pos{position_x[k] + origin.x, position_y[k] + origin.y};
+    Vec2 device_run_pos{0, 0};
+    transform.MapPoints(&device_run_pos, &run_pos, 1);
+    uint8_t subpixel_x_phase = 0;
+#if defined(SKITY_MACOS) || defined(SKITY_IOS)
+    subpixel_x_phase =
+        QuantizeGlyphSubpixelPhase(device_run_pos.x, context_scale);
+#endif
+    GlyphRegion glyph_region =
+        atlas->GetGlyphRegion(font, info.Id(), paint, false, context_scale,
+                              transform, subpixel_x_phase, 0);
     if (glyph_region.loc.z == 0 || glyph_region.loc.w == 0) {
       k++;
       continue;
@@ -290,7 +301,8 @@ GlyphRunList DirectGlyphRun::SubRunListByTexture(
           {glyph_regions[k].index,
            {glyph_regions[k].region.index_in_group %
                 atlas->GetConfig().max_num_bitmap_per_atlas,
-            glyph_regions[k].region.loc, 1.0f}});
+            glyph_regions[k].region.loc, 1.0f, glyph_regions[k].region.origin_x,
+            glyph_regions[k].region.origin_y}});
       k++;
     }
 

--- a/src/text/ports/darwin/scaler_context_darwin.cc
+++ b/src/text/ports/darwin/scaler_context_darwin.cc
@@ -14,6 +14,7 @@
 #include <skity/geometry/stroke.hpp>
 #include <utility>
 
+#include "src/render/text/glyph_raster_alignment.hpp"
 #include "src/text/ports/darwin/typeface_darwin.hpp"
 
 namespace {
@@ -587,8 +588,10 @@ void ScalerContextDarwin::GenerateImageInfo(GlyphData *glyph,
 
   // extends one pixel for the bitmap bounds
   // it is used for the AA pixel and it is important
-  uint32_t width = std::ceil(cg_bounds.size.width * context_scale_) + 2;
-  uint32_t height = std::ceil(cg_bounds.size.height * context_scale_) + 2;
+  CGFloat raster_width = cg_bounds.size.width;
+  CGFloat raster_height = cg_bounds.size.height;
+  uint32_t width = std::ceil(raster_width * context_scale_) + 2;
+  uint32_t height = std::ceil(raster_height * context_scale_) + 2;
 
   if (working_stroke_desc.is_stroke) {
     if (glyph->GetPath().IsEmpty()) {
@@ -609,29 +612,35 @@ void ScalerContextDarwin::GenerateImageInfo(GlyphData *glyph,
     Rect stroke_bound = fill_path.GetBounds();
     point.x = -stroke_bound.Left();
     point.y = stroke_bound.Bottom();
-    width = std::ceil(stroke_bound.Width() * context_scale_) + 2;
-    height = std::ceil(stroke_bound.Height() * context_scale_) + 2;
+    raster_width = stroke_bound.Width();
+    raster_height = stroke_bound.Height();
+    width = std::ceil(raster_width * context_scale_) + 2;
+    height = std::ceil(raster_height * context_scale_) + 2;
   }
 
   // since bitmap extends one pixel, the origin point needs do the same move
   point.x += 1 / context_scale_;
   point.y += 1 / context_scale_;
 
-  // Core Graphics snaps the glyph baseline to the device pixel grid while
-  // rasterizing into the bitmap context. Keep the atlas origin in the same
-  // coordinate system; otherwise the fractional glyph bound is applied again
-  // when DirectGlyphRun places the bitmap, producing glyph-dependent vertical
-  // offsets. An X-axis skew (transform_.c), as used by synthetic italic text,
-  // does not affect the device-space Y coordinate and still needs the same
-  // alignment. Only transforms that mix X into Y (transform_.b) are excluded.
-  if (transform_.b == 0) {
-    point.y = std::floor(point.y * context_scale_) / context_scale_;
-  }
+  const CGFloat unaligned_point_x = point.x;
+  const CGFloat unaligned_point_y = point.y;
+  point.x = AlignRasterPointAtOrAbove(point.x, context_scale_,
+                                      desc_.subpixel_x_phase);
+  point.y = AlignRasterPointAtOrAbove(point.y, context_scale_,
+                                      desc_.subpixel_y_phase);
+
+  const CGFloat point_delta_x = point.x - unaligned_point_x;
+  const CGFloat point_delta_y = point.y - unaligned_point_y;
+  width = std::ceil((raster_width + point_delta_x) * context_scale_) + 2;
+  // CoreText antialiasing may cover the pixel immediately outside the
+  // typographic bounds. Preserve an extra vertical row after phase alignment.
+  height = std::ceil((raster_height + point_delta_y) * context_scale_) + 3;
 
   CGPoint src{point.x, point.y};
   CGPoint dst = CGPointApplyAffineTransform(src, invert_transform_);
   glyph->image_.origin_x = -point.x;
-  // the CoreGraphic coordinate needs to flip Y axis for our canvas rendering
+  // Core Graphics uses an upward Y axis while canvas placement uses a
+  // downward Y axis.
   glyph->image_.origin_y = -point.y + height / context_scale_;
   glyph->image_.origin_x_for_raster = dst.x;
   glyph->image_.origin_y_for_raster = dst.y;

--- a/src/text/scaler_context_desc.hpp
+++ b/src/text/scaler_context_desc.hpp
@@ -38,6 +38,9 @@ struct ScalerContextDesc {
 
   uint8_t fake_bold;
   uint8_t hinting;
+  uint8_t subpixel_x_phase = 0;
+  uint8_t subpixel_y_phase = 0;
+  uint16_t reserved_padding = 0;
   // hash end
 
   friend inline bool operator==(const ScalerContextDesc& lhs,
@@ -50,7 +53,10 @@ struct ScalerContextDesc {
            lhs.context_scale == rhs.context_scale && lhs.cap == rhs.cap &&
            lhs.join == rhs.join && lhs.fake_bold == rhs.fake_bold &&
            lhs.foreground_color == rhs.foreground_color &&
-           lhs.hinting == rhs.hinting;
+           lhs.hinting == rhs.hinting &&
+           lhs.subpixel_x_phase == rhs.subpixel_x_phase &&
+           lhs.subpixel_y_phase == rhs.subpixel_y_phase &&
+           lhs.reserved_padding == rhs.reserved_padding;
   }
 
   friend inline bool operator!=(const ScalerContextDesc& lhs,
@@ -93,7 +99,10 @@ static_assert(sizeof(ScalerContextDesc) ==
                       sizeof(ScalerContextDesc::cap) +
                       sizeof(ScalerContextDesc::join) +
                       sizeof(ScalerContextDesc::fake_bold) +
-                      sizeof(ScalerContextDesc::hinting),
+                      sizeof(ScalerContextDesc::hinting) +
+                      sizeof(ScalerContextDesc::subpixel_x_phase) +
+                      sizeof(ScalerContextDesc::subpixel_y_phase) +
+                      sizeof(ScalerContextDesc::reserved_padding),
               "ScalerContextDesc must have no padding");
 
 }  // namespace skity

--- a/test/ut/text/atlas_glyph_test.cc
+++ b/test/ut/text/atlas_glyph_test.cc
@@ -11,6 +11,7 @@
 #include <new>
 
 #include "src/render/text/atlas/atlas_bitmap.hpp"
+#include "src/render/text/glyph_raster_alignment.hpp"
 #include "src/text/scaler_context_desc.hpp"
 
 namespace skity {
@@ -68,6 +69,23 @@ TEST(GlyphBitmapDataTest, ResolvesTightAndExplicitRowBytes) {
   EXPECT_EQ(bitmap.RowBytes(), 16u);
 }
 
+TEST(GlyphRasterAlignmentTest, QuantizesAndAlignsPhysicalPixelPhase) {
+  constexpr float kScale = 2.f;
+  const uint8_t phase = QuantizeGlyphSubpixelPhase(10.25f, kScale);
+
+  EXPECT_EQ(phase, kGlyphSubpixelPhaseCount / 2);
+  EXPECT_FLOAT_EQ(AlignRasterPointAtOrAbove(1.1f, kScale, phase), 1.25f);
+}
+
+TEST(AtlasGlyphTest, SubpixelPhaseParticipatesInGlyphKeyEquality) {
+  ScalerContextDesc first_desc{};
+  ScalerContextDesc second_desc{};
+  second_desc.subpixel_x_phase = 1;
+
+  EXPECT_FALSE(
+      GlyphKey::Equal{}(GlyphKey(7, first_desc), GlyphKey(7, second_desc)));
+}
+
 TEST(AtlasBitmapTest, CopiesGlyphWithPaddedRows) {
   constexpr uint32_t kAtlasWidth = 16;
   constexpr uint32_t kGlyphWidth = 3;
@@ -83,20 +101,29 @@ TEST(AtlasBitmapTest, CopiesGlyphWithPaddedRows) {
   bitmap.buffer = source.data();
   bitmap.row_bytes = kSourceRowBytes;
   bitmap.format = BitmapFormat::kGray8;
+  bitmap.origin_x = -1.25f;
+  bitmap.origin_y = 3.5f;
 
   AtlasBitmap atlas(kAtlasWidth, kAtlasWidth, 1);
   ScalerContextDesc desc{};
   GlyphKey key(7, desc);
-  const glm::ivec4 region = atlas.GenerateGlyphRegion(key, bitmap);
-  ASSERT_NE(region, INVALID_LOC);
+  const GlyphRegion region = atlas.GenerateGlyphRegion(key, bitmap);
+  ASSERT_NE(region.loc, INVALID_LOC);
+  EXPECT_FLOAT_EQ(region.origin_x, bitmap.origin_x);
+  EXPECT_FLOAT_EQ(region.origin_y, bitmap.origin_y);
+
+  const GlyphRegion cached_region = atlas.GetGlyphRegion(key);
+  EXPECT_EQ(cached_region.loc, region.loc);
+  EXPECT_FLOAT_EQ(cached_region.origin_x, bitmap.origin_x);
+  EXPECT_FLOAT_EQ(cached_region.origin_y, bitmap.origin_y);
 
   for (uint32_t y = 0; y < kGlyphHeight; ++y) {
     const uint8_t* atlas_row =
-        atlas.MemData() + static_cast<size_t>(region.y + y) * kAtlasWidth;
+        atlas.MemData() + static_cast<size_t>(region.loc.y + y) * kAtlasWidth;
     for (uint32_t x = 0; x < kGlyphWidth; ++x) {
-      EXPECT_EQ(atlas_row[region.x + x], source[y * kSourceRowBytes + x]);
+      EXPECT_EQ(atlas_row[region.loc.x + x], source[y * kSourceRowBytes + x]);
     }
-    EXPECT_EQ(atlas_row[region.x + kGlyphWidth], 0u);
+    EXPECT_EQ(atlas_row[region.loc.x + kGlyphWidth], 0u);
   }
 }
 


### PR DESCRIPTION
## Summary

- Preserve Darwin glyph subpixel positions instead of rounding the final glyph quad.
- Quantize the horizontal device-pixel phase into the glyph/scaler cache key and carry the phase-specific raster origin through atlas lookup.
- Align CoreText raster bounds to the requested phase while retaining enough antialiasing padding.
- Keep the existing placement and cache behavior unchanged on non-Darwin platforms.

## Why

CoreText raster output depends on the device-pixel phase. Reusing one phase-agnostic atlas entry and rounding the final glyph position can produce uneven horizontal spacing and glyph-dependent vertical offsets. The atlas entry now matches the final horizontal phase, while the baseline remains aligned to the vertical pixel grid.

## Test plan

- `python3 tools/test-runner.py --suite=unit --build-dir=build-unit-ct --filter='GlyphRasterAlignmentTest.*:AtlasGlyphTest.*:AtlasBitmapTest.*' --parallel=8 --no-color --no-configure` (4/4 passed)
- Verified with a downstream macOS text-rendering regression suite.
