### PR TITLE
feat(text): Support transformed atlas glyph rendering and batching

### DIFF
--- a/example/case/fake_3d/CMakeLists.txt
+++ b/example/case/fake_3d/CMakeLists.txt
@@ -10,3 +10,5 @@ add_executable(fake_3d_example
 
 target_link_libraries(fake_3d_example PUBLIC skity::example_common)
 target_link_libraries(fake_3d_example PRIVATE glm::glm-header-only)
+target_compile_definitions(fake_3d_example PRIVATE
+    -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")

--- a/example/case/fake_3d/fake_3d_example.cc
+++ b/example/case/fake_3d/fake_3d_example.cc
@@ -12,6 +12,25 @@
 
 namespace skity::example::basic {
 
+namespace {
+
+std::shared_ptr<skity::TextBlob> BuildStarTextBlob(
+    const skity::Paint& text_paint) {
+  skity::TextBlobBuilder builder;
+  auto emoji_typeface =
+      skity::Typeface::MakeFromFile(EXAMPLE_IMAGE_ROOT "/NotoColorEmoji.ttf");
+
+  if (emoji_typeface) {
+    auto delegate =
+        skity::TypefaceDelegate::CreateSimpleFallbackDelegate({emoji_typeface});
+    return builder.BuildTextBlob("Skity 😀", text_paint, delegate.get());
+  }
+
+  return builder.BuildTextBlob("Skity 😀", text_paint);
+}
+
+}  // namespace
+
 void draw_even_odd_fill(skity::Canvas* canvas) {
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   skity::Paint paint;
@@ -48,12 +67,32 @@ void draw_even_odd_fill(skity::Canvas* canvas) {
   glm::mat4 posM =
       glm::translate(glm::mat4(1.f), {anchor_point.x, anchor_point.y, 0.f});
 
+  skity::Paint text_paint;
+  text_paint.SetStyle(skity::Paint::kFill_Style);
+  text_paint.SetColor(skity::Color_BLACK);
+  text_paint.SetAntiAlias(true);
+  text_paint.SetTextSize(20.f);
+  text_paint.SetTypeface(skity::Typeface::GetDefaultTypeface());
+  static auto text_blob = BuildStarTextBlob(text_paint);
+  if (text_blob) {
+    auto text_bounds = text_blob->GetBoundsRect();
+    canvas->DrawTextBlob(text_blob.get(), 100 - text_bounds.CenterX(),
+                         10 - text_bounds.CenterY(), text_paint);
+  }
+
   canvas->Save();
 
   auto result = posM * invOrth * proj * view * midM_X * midM_Y * orth * preM;
   canvas->Concat(reinterpret_cast<skity::Matrix&>(result));
 
   canvas->DrawPath(path, paint);
+
+  if (text_blob) {
+    auto text_bounds = text_blob->GetBoundsRect();
+    canvas->DrawTextBlob(text_blob.get(),
+                         anchor_point.x - text_bounds.CenterX(),
+                         anchor_point.y - text_bounds.CenterY(), text_paint);
+  }
 
   canvas->Restore();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,8 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/render/text/atlas/atlas_texture.hpp
   ${CMAKE_CURRENT_LIST_DIR}/render/text/glyph_run.cc
   ${CMAKE_CURRENT_LIST_DIR}/render/text/glyph_run.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/render/text/transformed_mask_glyph_run.cc
+  ${CMAKE_CURRENT_LIST_DIR}/render/text/transformed_mask_glyph_run.hpp
   ${CMAKE_CURRENT_LIST_DIR}/render/text/sdf_gen.cc
   ${CMAKE_CURRENT_LIST_DIR}/render/text/sdf_gen.hpp
   ${CMAKE_CURRENT_LIST_DIR}/render/text/text_render_control.cc

--- a/src/render/hw/draw/hw_dynamic_text_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_text_draw.cc
@@ -45,6 +45,10 @@ bool HWDynamicTextDraw::OnMergeIfPossible(HWDraw* draw) {
     return false;
   }
   auto other = static_cast<HWDynamicTextDraw*>(draw);
+  // One merged draw uploads one common-slot transform for all glyph instances.
+  if (GetTransform() != other->GetTransform()) {
+    return false;
+  }
   if (!geometry_->CanMerge(other->geometry_) ||
       !fragment_->CanMerge(other->fragment_)) {
     return false;

--- a/src/render/text/glyph_run.cc
+++ b/src/render/text/glyph_run.cc
@@ -17,6 +17,7 @@
 #include "src/render/hw/hw_path_raster.hpp"
 #include "src/render/hw/hw_stage_buffer.hpp"
 #include "src/render/text/text_render_control.hpp"
+#include "src/render/text/transformed_mask_glyph_run.hpp"
 #include "src/tracing.hpp"
 #include "src/utils/arena_allocator.hpp"
 
@@ -26,109 +27,6 @@ struct GlyphRegionWithIndex {
   uint32_t index;
   GlyphRegion region;
 };
-
-namespace {
-
-constexpr float kCreationScaleBucketsPerOctave = 4.f;
-constexpr float kMinCreationScale = 1.f / 65536.f;
-constexpr float kAtlasDimensionSafetyMargin = 8.f;
-
-bool IsFinite(const Vec2& point) {
-  return std::isfinite(point.x) && std::isfinite(point.y);
-}
-
-float QuantizeCreationScaleDown(float scale) {
-  if (!std::isfinite(scale) || scale < kMinCreationScale) {
-    return 0.f;
-  }
-
-  float bucket = std::floor(std::log2(scale) * kCreationScaleBucketsPerOctave);
-  return std::exp2(bucket / kCreationScaleBucketsPerOctave);
-}
-
-float EstimatePerspectiveScale(const Matrix& position_matrix,
-                               const uint32_t count, const float* position_x,
-                               const float* position_y) {
-  Vec2 center{};
-  uint32_t finite_position_count = 0;
-  for (uint32_t index = 0; index < count; ++index) {
-    Vec2 position{position_x[index], position_y[index]};
-    if (IsFinite(position)) {
-      center += position;
-      finite_position_count++;
-    }
-  }
-  if (finite_position_count > 0) {
-    center /= static_cast<float>(finite_position_count);
-  }
-
-  Vec2 source[3] = {center, center + Vec2{1.f, 0.f}, center + Vec2{0.f, 1.f}};
-  Vec2 device[3];
-  position_matrix.MapPoints(device, source, 3);
-  if (!IsFinite(device[0]) || !IsFinite(device[1]) || !IsFinite(device[2])) {
-    return 1.f;
-  }
-
-  float scale_x = (device[1] - device[0]).Length();
-  float scale_y = (device[2] - device[0]).Length();
-  float scale = std::max(scale_x, scale_y);
-  return std::isfinite(scale) && scale > 0.f ? scale : 1.f;
-}
-
-float ComputeCreationScale(const uint32_t count, const GlyphID* glyphs,
-                           const float* position_x, const float* position_y,
-                           const Font& font, const Paint& paint,
-                           float context_scale, const Matrix& position_matrix,
-                           const AtlasConfig& atlas_config) {
-  if (count == 0 || !position_matrix.IsFinite() ||
-      !std::isfinite(context_scale) || context_scale <= 0.f) {
-    return 0.f;
-  }
-
-  float creation_scale = std::max(
-      1.f,
-      EstimatePerspectiveScale(position_matrix, count, position_x, position_y));
-
-  std::vector<const GlyphData*> glyph_info(count);
-  Paint metrics_paint = paint;
-  metrics_paint.SetStyle(Paint::kFill_Style);
-  font.LoadGlyphMetrics(glyphs, count, glyph_info.data(), metrics_paint);
-
-  float max_logical_dimension = std::max(font.GetSize(), 1.f);
-  for (const GlyphData* info : glyph_info) {
-    if (info != nullptr) {
-      max_logical_dimension = std::max(
-          {max_logical_dimension, info->GetWidth(), info->GetHeight()});
-    }
-  }
-
-  float max_bitmap_dimension =
-      static_cast<float>(atlas_config.max_bitmap_size) -
-      kAtlasDimensionSafetyMargin;
-  if (max_bitmap_dimension <= 0.f) {
-    return 0.f;
-  }
-
-  float fit_scale =
-      max_bitmap_dimension / (max_logical_dimension * context_scale);
-  creation_scale = std::min(creation_scale, fit_scale);
-  return QuantizeCreationScaleDown(creation_scale);
-}
-
-class HWUnmergeableTransformedTextDraw final : public HWDynamicTextDraw {
- public:
-  HWUnmergeableTransformedTextDraw(const Matrix& transform,
-                                   BlendMode blend_mode,
-                                   HWWGSLGeometry* geometry,
-                                   HWWGSLFragment* fragment)
-      : HWDynamicTextDraw(transform, blend_mode, geometry, fragment) {}
-
-  // Existing text batching assumes that merged geometry shares one draw
-  // transform. Keep this temporary perspective path isolated.
-  HWDrawType GetDrawType() const override { return HWDrawType::kUnknow; }
-};
-
-}  // namespace
 
 class DirectGlyphRun : public GlyphRun {
  public:
@@ -407,251 +305,6 @@ GlyphRunList DirectGlyphRun::SubRunListByTexture(
           std::move(glyph_region_groups[group_index]), group_index, atlas,
           glyph_format));
     }
-  }
-
-  return run_list;
-}
-
-class TransformedColorGlyphRun : public GlyphRun {
- public:
-  TransformedColorGlyphRun(const uint32_t count, const GlyphID* glyphs,
-                           const Point& origin, const float* position_x,
-                           const float* position_y, const Font& font,
-                           float context_scale, const Matrix& creation_matrix,
-                           const Paint& paint,
-                           std::vector<GlyphRegionWithIndex> glyph_locs,
-                           uint32_t group_index, Atlas* atlas,
-                           GlyphFormat glyph_format)
-      : count_(count),
-        glyphs_(glyphs, glyphs + count),
-        origin_(origin),
-        position_x_(position_x, position_x + count),
-        position_y_(position_y, position_y + count),
-        font_(font),
-        context_scale_(context_scale),
-        creation_matrix_(creation_matrix),
-        paint_(paint),
-        glyph_locs_(std::move(glyph_locs)),
-        group_index_(group_index),
-        atlas_(atlas),
-        glyph_format_(glyph_format) {}
-
-  ~TransformedColorGlyphRun() override = default;
-
-  ArrayList<GlyphRect, 16> Raster(ArenaAllocator* arena_allocator);
-
-  HWDraw* Draw(Matrix transform, ArenaAllocator* arena_allocator,
-               float canvas_scale, bool use_linear_text_filter) override;
-
-  Rect GetBounds() override { return bounds_; }
-
-  bool IsStroke() override { return false; }
-
-  static GlyphRunList SubRunListByTexture(
-      const uint32_t count, const GlyphID* glyphs, const Point& origin,
-      const float* position_x, const float* position_y, const Font& font,
-      const Paint& paint, float context_scale, const Matrix& transform,
-      AtlasManager* atlas_manager, ArenaAllocator* arena_allocator);
-
- private:
-  uint32_t count_;
-  std::vector<GlyphID> glyphs_;
-  const Point origin_;
-  std::vector<float> position_x_;
-  std::vector<float> position_y_;
-  const Font font_;
-  float context_scale_;
-  Matrix creation_matrix_;
-  const Paint paint_;
-  std::vector<GlyphRegionWithIndex> glyph_locs_;
-  uint32_t group_index_;
-  Atlas* atlas_;
-  GlyphFormat glyph_format_;
-  Rect bounds_;
-};
-
-ArrayList<GlyphRect, 16> TransformedColorGlyphRun::Raster(
-    ArenaAllocator* arena_allocator) {
-  ArrayList<GlyphRect, 16> glyph_rects;
-  glyph_rects.SetArenaAllocator(arena_allocator);
-  bounds_ = Rect::MakeEmpty();
-  if (glyph_locs_.empty() || context_scale_ <= 0.f) {
-    return glyph_rects;
-  }
-
-  std::vector<const GlyphData*> glyph_info(count_);
-  font_.LoadGlyphBitmapInfo(glyphs_.data(), count_, glyph_info.data(), paint_,
-                            context_scale_, creation_matrix_);
-
-  for (const auto& glyph_loc : glyph_locs_) {
-    const GlyphData* info = glyph_info[glyph_loc.index];
-    if (info == nullptr) {
-      continue;
-    }
-
-    Vec2 uv_lt =
-        atlas_->CalculateUV(glyph_loc.region.index_in_group,
-                            glyph_loc.region.loc.x, glyph_loc.region.loc.y);
-    Vec2 uv_rb =
-        atlas_->CalculateUV(glyph_loc.region.index_in_group,
-                            glyph_loc.region.loc.x + glyph_loc.region.loc.z,
-                            glyph_loc.region.loc.y + glyph_loc.region.loc.w);
-
-    const Vec2 run_position{position_x_[glyph_loc.index],
-                            position_y_[glyph_loc.index]};
-    Vec2 creation_position{};
-    creation_matrix_.MapPoints(&creation_position, &run_position, 1);
-    if (!IsFinite(creation_position)) {
-      continue;
-    }
-
-    const auto& image = info->Image();
-    float left = creation_position.x + image.origin_x;
-    float top = creation_position.y - image.origin_y;
-    float width = static_cast<float>(glyph_loc.region.loc.z) / context_scale_;
-    float height = static_cast<float>(glyph_loc.region.loc.w) / context_scale_;
-    if (!std::isfinite(left) || !std::isfinite(top) || !std::isfinite(width) ||
-        !std::isfinite(height) || width <= 0.f || height <= 0.f) {
-      continue;
-    }
-
-    bounds_.Join(Rect::MakeXYWH(left, top, width, height));
-    glyph_rects.emplace_back(Vec4{left, top, left + width, top + height}, uv_lt,
-                             uv_rb);
-  }
-
-  return glyph_rects;
-}
-
-HWDraw* TransformedColorGlyphRun::Draw(Matrix transform,
-                                       ArenaAllocator* arena_allocator,
-                                       float canvas_scale,
-                                       bool use_linear_text_filter) {
-  SKITY_TRACE_EVENT(TransformedColorGlyphRun_Draw);
-  (void)canvas_scale;
-  (void)use_linear_text_filter;
-  if (!transform.IsFinite()) {
-    return nullptr;
-  }
-
-  ArrayList<GlyphRect, 16> glyph_rects = Raster(arena_allocator);
-  if (glyph_rects.empty()) {
-    return nullptr;
-  }
-
-  Matrix creation_inverse;
-  if (!creation_matrix_.Invert(&creation_inverse)) {
-    return nullptr;
-  }
-  Matrix position_matrix = transform * Matrix::Translate(origin_.x, origin_.y);
-  Matrix view_difference = position_matrix * creation_inverse;
-  if (!view_difference.IsFinite()) {
-    return nullptr;
-  }
-
-  atlas_->UploadAtlas(group_index_);
-  auto gpu_texture = atlas_->GetGPUTexture(group_index_);
-  auto gpu_sampler =
-      atlas_->GetGPUSampler(group_index_, GPUFilterMode::kLinear);
-
-  Paint paint_copy = paint_;
-  paint_copy.SetStyle(Paint::kFill_Style);
-  auto geometry = arena_allocator->Make<WGSLTextSolidColorGeometry>(
-      Matrix(), std::move(glyph_rects), paint_copy);
-  HWWGSLFragment* fragment = arena_allocator->Make<WGSLColorEmojiFragment>(
-      std::move(gpu_texture), std::move(gpu_sampler),
-      glyph_format_ == GlyphFormat::BGRA32, paint_.GetAlphaF());
-  if (paint_.GetColorFilter()) {
-    fragment->SetFilter(WGXFilterFragment::Make(paint_.GetColorFilter().get()));
-  }
-
-  auto draw = arena_allocator->Make<HWUnmergeableTransformedTextDraw>(
-      view_difference, paint_.GetBlendMode(), geometry, fragment);
-  bounds_ = view_difference.MapRect(bounds_);
-  return draw;
-}
-
-GlyphRunList TransformedColorGlyphRun::SubRunListByTexture(
-    const uint32_t count, const GlyphID* glyphs, const Point& origin,
-    const float* position_x, const float* position_y, const Font& font,
-    const Paint& paint, float context_scale, const Matrix& transform,
-    AtlasManager* atlas_manager, ArenaAllocator* arena_allocator) {
-  GlyphRunList run_list;
-  run_list.SetArenaAllocator(arena_allocator);
-  if (count == 0 || atlas_manager == nullptr || !transform.IsFinite()) {
-    return run_list;
-  }
-
-  Atlas* atlas = atlas_manager->GetAtlas(AtlasFormat::RGBA32);
-  Matrix position_matrix = transform * Matrix::Translate(origin.x, origin.y);
-  float creation_scale =
-      ComputeCreationScale(count, glyphs, position_x, position_y, font, paint,
-                           context_scale, position_matrix, atlas->GetConfig());
-  if (creation_scale <= 0.f) {
-    return run_list;
-  }
-  Matrix creation_matrix = Matrix::Scale(creation_scale, creation_scale);
-
-  Paint working_paint = paint;
-  working_paint.SetStyle(Paint::kFill_Style);
-  std::vector<const GlyphData*> glyph_info(count);
-  font.LoadGlyphMetrics(glyphs, count, glyph_info.data(), working_paint);
-  GlyphFormat glyph_format = GlyphFormat::RGBA32;
-  for (const GlyphData* info : glyph_info) {
-    if (info != nullptr && info->GetFormat().has_value()) {
-      glyph_format = *info->GetFormat();
-      break;
-    }
-  }
-
-  std::vector<GlyphRegionWithIndex> glyph_regions;
-  uint32_t max_index = 0;
-  for (uint32_t index = 0; index < count; ++index) {
-    if (glyph_info[index] == nullptr) {
-      continue;
-    }
-    GlyphRegion glyph_region =
-        atlas->GetGlyphRegion(font, glyph_info[index]->Id(), working_paint,
-                              false, context_scale, creation_matrix);
-    if (glyph_region.loc.z <= 0 || glyph_region.loc.w <= 0) {
-      continue;
-    }
-    max_index = std::max(max_index, glyph_region.index_in_group);
-    glyph_regions.push_back({index, glyph_region});
-  }
-  if (glyph_regions.empty()) {
-    return run_list;
-  }
-
-  uint32_t max_per_atlas = atlas->GetConfig().max_num_bitmap_per_atlas;
-  uint32_t draw_count = max_index / max_per_atlas + 1;
-  if (draw_count == 1) {
-    run_list.push_back(arena_allocator->Make<TransformedColorGlyphRun>(
-        count, glyphs, origin, position_x, position_y, font, context_scale,
-        creation_matrix, working_paint, std::move(glyph_regions),
-        static_cast<uint32_t>(0), atlas, glyph_format));
-    return run_list;
-  }
-
-  std::vector<std::vector<GlyphRegionWithIndex>> glyph_region_groups(
-      draw_count);
-  for (const auto& glyph_region : glyph_regions) {
-    uint32_t group_index = glyph_region.region.index_in_group / max_per_atlas;
-    GlyphRegion grouped_region = glyph_region.region;
-    grouped_region.index_in_group %= max_per_atlas;
-    glyph_region_groups[group_index].push_back(
-        {glyph_region.index, grouped_region});
-  }
-
-  for (uint32_t group_index = 0; group_index < draw_count; ++group_index) {
-    if (glyph_region_groups[group_index].empty()) {
-      continue;
-    }
-    run_list.push_back(arena_allocator->Make<TransformedColorGlyphRun>(
-        count, glyphs, origin, position_x, position_y, font, context_scale,
-        creation_matrix, working_paint,
-        std::move(glyph_region_groups[group_index]), group_index, atlas,
-        glyph_format));
   }
 
   return run_list;
@@ -1033,12 +686,70 @@ GlyphRunList GlyphRun::MakeInternal(
         }
       }
     }
-  } else if (format == AtlasFormat::RGBA32 && transform.HasPersp()) {
-    Paint working_paint = paint;
-    working_paint.SetStyle(Paint::kFill_Style);
-    run_list = TransformedColorGlyphRun::SubRunListByTexture(
-        count, glyphs, origin, position_x, position_y, font, working_paint,
-        context_scale, transform, atlas_manager, arena_allocator);
+  } else if (transform.HasPersp()) {
+    if (format == AtlasFormat::RGBA32) {
+      Paint working_paint = paint;
+      working_paint.SetStyle(Paint::kFill_Style);
+      run_list = transformed_mask::MakeGlyphRunList(
+          count, glyphs, origin, position_x, position_y, font, working_paint,
+          format, context_scale, transform, false, atlas_manager,
+          arena_allocator);
+    } else {
+      std::vector<const GlyphData*> glyph_data(count);
+      font.LoadGlyphPath(glyphs, count, glyph_data.data());
+
+      std::vector<GlyphID> mask_glyphs;
+      std::vector<float> mask_position_x;
+      std::vector<float> mask_position_y;
+      mask_glyphs.reserve(count);
+      mask_position_x.reserve(count);
+      mask_position_y.reserve(count);
+
+      auto append_mask_runs = [&](const Paint& working_paint) {
+        GlyphRunList mask_runs = transformed_mask::MakeGlyphRunList(
+            static_cast<uint32_t>(mask_glyphs.size()), mask_glyphs.data(),
+            origin, mask_position_x.data(), mask_position_y.data(), font,
+            working_paint, format, context_scale, transform, false,
+            atlas_manager, arena_allocator);
+        for (auto* mask_run : mask_runs) {
+          run_list.push_back(mask_run);
+        }
+      };
+
+      auto flush_mask_runs = [&]() {
+        if (mask_glyphs.empty()) {
+          return;
+        }
+        // Bitmap-only glyphs have no outline to stroke. Match the bitmap text
+        // fallback by drawing a single fill mask for every paint style.
+        Paint working_paint = transformed_mask::MakeBitmapOnlyFillPaint(paint);
+        append_mask_runs(working_paint);
+        mask_glyphs.clear();
+        mask_position_x.clear();
+        mask_position_y.clear();
+      };
+
+      for (uint32_t index = 0; index < count; ++index) {
+        if (glyph_data[index] != nullptr &&
+            !glyph_data[index]->GetPath().IsEmpty()) {
+          // Preserve paint order when outline and bitmap-only glyphs overlap.
+          flush_mask_runs();
+          Path path = glyph_data[index]->GetPath().CopyWithMatrix(
+              Matrix::Translate(origin.x, origin.y));
+          run_list.push_back(arena_allocator->Make<PathGlyphRun>(
+              path, position_x[index], position_y[index], paint,
+              draw_path_func));
+        } else {
+          // Bitmap-only glyphs (for example bitmap emoji in an A8 font) have
+          // no outline to feed the path renderer. Keep them in local text
+          // coordinates and let the transformed-mask path rasterize them.
+          mask_glyphs.push_back(glyphs[index]);
+          mask_position_x.push_back(position_x[index]);
+          mask_position_y.push_back(position_y[index]);
+        }
+      }
+      flush_mask_runs();
+    }
   } else if (control.CanUseSDF(maximun_text_scale, paint,  // NOLINT
                                font.GetTypeface())) {
     // sdf

--- a/src/render/text/transformed_mask_glyph_run.cc
+++ b/src/render/text/transformed_mask_glyph_run.cc
@@ -1,0 +1,563 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/text/transformed_mask_glyph_run.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "src/render/hw/draw/fragment/wgsl_text_fragment.hpp"
+#include "src/render/hw/draw/geometry/wgsl_text_geometry.hpp"
+#include "src/render/hw/draw/hw_dynamic_text_draw.hpp"
+#include "src/render/hw/draw/wgx_filter.hpp"
+#include "src/tracing.hpp"
+
+namespace skity {
+namespace transformed_mask {
+
+namespace {
+
+constexpr float kCreationScaleBucketsPerOctave = 4.f;
+constexpr float kMinimumCreationScale = 1.f / 65536.f;
+constexpr uint32_t kMaximumScaleFitAttempts = 8;
+constexpr float kPerspectiveWEpsilon = 1.f / 65536.f;
+constexpr float kConservativeBounds = 1E9F;
+
+struct GlyphRegionWithIndex {
+  uint32_t index;
+  GlyphRegion region;
+};
+
+struct GlyphRegionGroup {
+  uint32_t group_index;
+  GlyphFormat glyph_format;
+  std::vector<GlyphRegionWithIndex> glyph_regions;
+};
+
+bool IsFinite(const Vec2& point) {
+  return std::isfinite(point.x) && std::isfinite(point.y);
+}
+
+bool IsFinite(const Vec4& point) {
+  return std::isfinite(point.x) && std::isfinite(point.y) &&
+         std::isfinite(point.z) && std::isfinite(point.w);
+}
+
+float EstimateScaleAt(const Matrix& position_matrix, const Vec2& position) {
+  std::array<Vec2, 3> source = {
+      position,
+      position + Vec2{1.f, 0.f},
+      position + Vec2{0.f, 1.f},
+  };
+  std::array<Vec2, 3> device;
+  position_matrix.MapPoints(device.data(), source.data(),
+                            static_cast<int>(source.size()));
+  if (!IsFinite(device[0]) || !IsFinite(device[1]) || !IsFinite(device[2])) {
+    return 0.f;
+  }
+
+  float scale_x = (device[1] - device[0]).Length();
+  float scale_y = (device[2] - device[0]).Length();
+  float scale = std::max(scale_x, scale_y);
+  return std::isfinite(scale) && scale > 0.f ? scale : 0.f;
+}
+
+float EstimatePerspectiveScale(
+    const Matrix& position_matrix, uint32_t count, const float* position_x,
+    const float* position_y, const std::vector<const GlyphData*>& glyph_info) {
+  float scale = 1.f;
+  for (uint32_t index = 0; index < count; ++index) {
+    const GlyphData* info = glyph_info[index];
+    if (info == nullptr) {
+      continue;
+    }
+
+    float left = position_x[index] + info->GetHoriBearingX();
+    float top = position_y[index] - info->GetHoriBearingY();
+    float right = left + info->GetWidth();
+    float bottom = top + info->GetHeight();
+    std::array<Vec2, 5> samples = {
+        Vec2{left, top},
+        Vec2{right, top},
+        Vec2{right, bottom},
+        Vec2{left, bottom},
+        Vec2{position_x[index], position_y[index]},
+    };
+    for (const Vec2& sample : samples) {
+      if (IsFinite(sample)) {
+        scale = std::max(scale, EstimateScaleAt(position_matrix, sample));
+      }
+    }
+  }
+  return scale;
+}
+
+float MaximumLogicalGlyphDimension(
+    const Font& font, const Paint& paint,
+    const std::vector<const GlyphData*>& glyph_info) {
+  float dimension = std::max(font.GetSize(), 1.f);
+  for (const GlyphData* info : glyph_info) {
+    if (info != nullptr) {
+      dimension = std::max({dimension, info->GetWidth(), info->GetHeight()});
+    }
+  }
+  if (paint.GetStyle() == Paint::kStroke_Style) {
+    dimension += std::abs(paint.GetStrokeWidth()) * 2.f;
+  }
+  return dimension;
+}
+
+float FitCreationScaleToBitmapInfos(uint32_t count, const GlyphID* glyphs,
+                                    const Font& font, const Paint& paint,
+                                    float context_scale,
+                                    uint32_t maximum_dimension,
+                                    float creation_scale) {
+  std::vector<const GlyphData*> glyph_info(count);
+  for (uint32_t attempt = 0; attempt < kMaximumScaleFitAttempts; ++attempt) {
+    Matrix creation_matrix = Matrix::Scale(creation_scale, creation_scale);
+    font.LoadGlyphBitmapInfo(glyphs, count, glyph_info.data(), paint,
+                             context_scale, creation_matrix);
+
+    float actual_maximum_dimension = 0.f;
+    for (const GlyphData* info : glyph_info) {
+      if (info != nullptr) {
+        actual_maximum_dimension =
+            std::max({actual_maximum_dimension, info->Image().width,
+                      info->Image().height});
+      }
+    }
+
+    // FreeType currently has no lightweight bitmap-info implementation. Its
+    // conservative metrics fit above remains the source of truth until the
+    // atlas request rasterizes the glyph.
+    if (actual_maximum_dimension <= 0.f ||
+        actual_maximum_dimension <= maximum_dimension) {
+      return creation_scale;
+    }
+
+    float next_scale = QuantizeCreationScaleDown(
+        creation_scale * static_cast<float>(maximum_dimension) /
+        actual_maximum_dimension);
+    if (next_scale >= creation_scale) {
+      next_scale = QuantizeCreationScaleDown(
+          creation_scale / std::exp2(1.f / kCreationScaleBucketsPerOctave));
+    }
+    if (next_scale <= 0.f || next_scale >= creation_scale) {
+      return 0.f;
+    }
+    creation_scale = next_scale;
+  }
+  return 0.f;
+}
+
+float ComputeCreationScale(uint32_t count, const GlyphID* glyphs,
+                           const float* position_x, const float* position_y,
+                           const Font& font, const Paint& paint,
+                           float context_scale, const Matrix& position_matrix,
+                           const AtlasConfig& atlas_config) {
+  if (count == 0 || glyphs == nullptr || position_x == nullptr ||
+      position_y == nullptr || !position_matrix.IsFinite() ||
+      !std::isfinite(context_scale) || context_scale <= 0.f) {
+    return 0.f;
+  }
+
+  std::vector<const GlyphData*> glyph_info(count);
+  font.LoadGlyphMetrics(glyphs, count, glyph_info.data(), paint);
+
+  float creation_scale = EstimatePerspectiveScale(
+      position_matrix, count, position_x, position_y, glyph_info);
+  uint32_t maximum_dimension = MaximumAtlasGlyphDimension(atlas_config);
+  if (maximum_dimension == 0) {
+    return 0.f;
+  }
+
+  float logical_dimension =
+      MaximumLogicalGlyphDimension(font, paint, glyph_info);
+  creation_scale = FitCreationScaleToAtlas(creation_scale, logical_dimension,
+                                           context_scale, maximum_dimension);
+  if (creation_scale <= 0.f) {
+    return 0.f;
+  }
+
+  return FitCreationScaleToBitmapInfos(count, glyphs, font, paint,
+                                       context_scale, maximum_dimension,
+                                       creation_scale);
+}
+
+GlyphFormat ResolveGlyphFormat(AtlasFormat atlas_format,
+                               const GlyphData* glyph_info) {
+  if (atlas_format == AtlasFormat::A8) {
+    return GlyphFormat::A8;
+  }
+  if (glyph_info != nullptr && glyph_info->GetFormat().has_value() &&
+      *glyph_info->GetFormat() == GlyphFormat::BGRA32) {
+    return GlyphFormat::BGRA32;
+  }
+  return GlyphFormat::RGBA32;
+}
+
+class TransformedMaskGlyphRun final : public GlyphRun {
+ public:
+  TransformedMaskGlyphRun(uint32_t count, const GlyphID* glyphs,
+                          const Point& origin, const float* position_x,
+                          const float* position_y, const Font& font,
+                          float context_scale, const Matrix& creation_matrix,
+                          const Paint& paint, bool is_stroke,
+                          std::vector<GlyphRegionWithIndex> glyph_locs,
+                          uint32_t group_index, Atlas* atlas,
+                          GlyphFormat glyph_format)
+      : count_(count),
+        glyphs_(glyphs, glyphs + count),
+        origin_(origin),
+        position_x_(position_x, position_x + count),
+        position_y_(position_y, position_y + count),
+        font_(font),
+        context_scale_(context_scale),
+        creation_matrix_(creation_matrix),
+        paint_(paint),
+        is_stroke_(is_stroke),
+        glyph_locs_(std::move(glyph_locs)),
+        group_index_(group_index),
+        atlas_(atlas),
+        glyph_format_(glyph_format) {}
+
+  HWDraw* Draw(Matrix transform, ArenaAllocator* arena_allocator,
+               float canvas_scale, bool use_linear_text_filter) override;
+
+  Rect GetBounds() override { return bounds_; }
+
+  bool IsStroke() override { return is_stroke_; }
+
+ private:
+  ArrayList<GlyphRect, 16> Raster(ArenaAllocator* arena_allocator);
+
+  uint32_t count_;
+  std::vector<GlyphID> glyphs_;
+  Point origin_;
+  std::vector<float> position_x_;
+  std::vector<float> position_y_;
+  Font font_;
+  float context_scale_;
+  Matrix creation_matrix_;
+  Paint paint_;
+  bool is_stroke_;
+  std::vector<GlyphRegionWithIndex> glyph_locs_;
+  uint32_t group_index_;
+  Atlas* atlas_;
+  GlyphFormat glyph_format_;
+  Rect bounds_ = Rect::MakeEmpty();
+};
+
+ArrayList<GlyphRect, 16> TransformedMaskGlyphRun::Raster(
+    ArenaAllocator* arena_allocator) {
+  ArrayList<GlyphRect, 16> glyph_rects;
+  glyph_rects.SetArenaAllocator(arena_allocator);
+  bounds_ = Rect::MakeEmpty();
+  if (glyph_locs_.empty() || context_scale_ <= 0.f) {
+    return glyph_rects;
+  }
+
+  std::vector<const GlyphData*> glyph_info(count_);
+  font_.LoadGlyphBitmapInfo(glyphs_.data(), count_, glyph_info.data(), paint_,
+                            context_scale_, creation_matrix_);
+
+  for (const auto& glyph_loc : glyph_locs_) {
+    const GlyphData* info = glyph_info[glyph_loc.index];
+    if (info == nullptr) {
+      continue;
+    }
+
+    Vec2 uv_lt =
+        atlas_->CalculateUV(glyph_loc.region.index_in_group,
+                            glyph_loc.region.loc.x, glyph_loc.region.loc.y);
+    Vec2 uv_rb =
+        atlas_->CalculateUV(glyph_loc.region.index_in_group,
+                            glyph_loc.region.loc.x + glyph_loc.region.loc.z,
+                            glyph_loc.region.loc.y + glyph_loc.region.loc.w);
+
+    const Vec2 run_position{position_x_[glyph_loc.index],
+                            position_y_[glyph_loc.index]};
+    Vec2 creation_position{};
+    creation_matrix_.MapPoints(&creation_position, &run_position, 1);
+    if (!IsFinite(creation_position)) {
+      continue;
+    }
+
+    const GlyphBitmapData& image = info->Image();
+    float left = creation_position.x + image.origin_x;
+    float top = creation_position.y - image.origin_y;
+    float width = static_cast<float>(glyph_loc.region.loc.z) / context_scale_;
+    float height = static_cast<float>(glyph_loc.region.loc.w) / context_scale_;
+    if (!std::isfinite(left) || !std::isfinite(top) || !std::isfinite(width) ||
+        !std::isfinite(height) || width <= 0.f || height <= 0.f) {
+      continue;
+    }
+
+    bounds_.Join(Rect::MakeXYWH(left, top, width, height));
+    glyph_rects.emplace_back(Vec4{left, top, left + width, top + height}, uv_lt,
+                             uv_rb);
+  }
+
+  return glyph_rects;
+}
+
+HWDraw* TransformedMaskGlyphRun::Draw(Matrix transform,
+                                      ArenaAllocator* arena_allocator,
+                                      float canvas_scale,
+                                      bool use_linear_text_filter) {
+  SKITY_TRACE_EVENT(TransformedMaskGlyphRun_Draw);
+  (void)canvas_scale;
+  (void)use_linear_text_filter;
+  if (!transform.IsFinite()) {
+    return nullptr;
+  }
+
+  ArrayList<GlyphRect, 16> glyph_rects = Raster(arena_allocator);
+  if (glyph_rects.empty()) {
+    return nullptr;
+  }
+
+  Matrix position_matrix = transform * Matrix::Translate(origin_.x, origin_.y);
+  Matrix view_difference;
+  // Atlas quads are stored in creation space (C * local). The vertex shader
+  // applies V = P * inverse(C), replacing C with the full perspective position
+  // matrix P. Surface density remains in MVP, so the final relation is
+  // MVP(D) * V * C * local = D * P * local.
+  if (!ComputeViewDifference(position_matrix, creation_matrix_,
+                             &view_difference)) {
+    return nullptr;
+  }
+
+  atlas_->UploadAtlas(group_index_);
+  auto gpu_texture = atlas_->GetGPUTexture(group_index_);
+  auto gpu_sampler =
+      atlas_->GetGPUSampler(group_index_, GPUFilterMode::kLinear);
+
+  HWWGSLGeometry* geometry = nullptr;
+  if (atlas_->GetFormat() == AtlasFormat::A8 && paint_.GetShader()) {
+    geometry = arena_allocator->Make<WGSLTextGradientGeometry>(
+        Matrix(), std::move(glyph_rects), paint_.GetShader()->GetLocalMatrix(),
+        position_matrix);
+  } else {
+    Vector color = is_stroke_ ? paint_.GetStrokeColor() : paint_.GetFillColor();
+    Paint paint_copy = paint_;
+    paint_copy.SetFillColor(color);
+    paint_copy.SetStrokeColor(color);
+    geometry = arena_allocator->Make<WGSLTextSolidColorGeometry>(
+        Matrix(), std::move(glyph_rects), paint_copy);
+  }
+
+  HWWGSLFragment* fragment = nullptr;
+  if (atlas_->GetFormat() == AtlasFormat::A8) {
+    if (paint_.GetShader() && paint_.GetShader()->AsGradient(nullptr) !=
+                                  Shader::GradientType::kNone) {
+      Shader::GradientInfo info{};
+      auto type = paint_.GetShader()->AsGradient(&info);
+      fragment = arena_allocator->Make<WGSLGradientTextFragment>(
+          std::move(gpu_texture), std::move(gpu_sampler), info, type,
+          paint_.GetAlphaF());
+    } else {
+      fragment = arena_allocator->Make<WGSLColorTextFragment>(
+          std::move(gpu_texture), std::move(gpu_sampler));
+    }
+  } else {
+    fragment = arena_allocator->Make<WGSLColorEmojiFragment>(
+        std::move(gpu_texture), std::move(gpu_sampler),
+        glyph_format_ == GlyphFormat::BGRA32, paint_.GetAlphaF());
+  }
+
+  if (paint_.GetColorFilter()) {
+    fragment->SetFilter(WGXFilterFragment::Make(paint_.GetColorFilter().get()));
+  }
+
+  auto* draw = arena_allocator->Make<HWDynamicTextDraw>(
+      view_difference, paint_.GetBlendMode(), geometry, fragment);
+  bounds_ = MapBounds(view_difference, bounds_);
+  return draw;
+}
+
+GlyphRegionGroup* GetOrAppendContiguousGroup(
+    uint32_t group_index, GlyphFormat glyph_format,
+    std::vector<GlyphRegionGroup>* groups) {
+  if (groups->empty() || groups->back().group_index != group_index ||
+      groups->back().glyph_format != glyph_format) {
+    groups->push_back({group_index, glyph_format, {}});
+  }
+  return &groups->back();
+}
+
+}  // namespace
+
+Paint MakeBitmapOnlyFillPaint(const Paint& paint) {
+  Paint fill_paint = paint;
+  if (paint.GetStyle() == Paint::kStroke_Style) {
+    fill_paint.SetFillColor(paint.GetStrokeColor());
+  }
+  fill_paint.SetStyle(Paint::kFill_Style);
+  return fill_paint;
+}
+
+float QuantizeCreationScaleDown(float scale) {
+  if (!std::isfinite(scale) || scale < kMinimumCreationScale) {
+    return 0.f;
+  }
+
+  float bucket = std::floor(std::log2(scale) * kCreationScaleBucketsPerOctave);
+  float quantized = std::exp2(bucket / kCreationScaleBucketsPerOctave);
+  return std::isfinite(quantized) && quantized >= kMinimumCreationScale
+             ? quantized
+             : 0.f;
+}
+
+uint32_t MaximumAtlasGlyphDimension(const AtlasConfig& atlas_config) {
+  uint32_t reserved_dimension = Atlas_Padding + 2;
+  return atlas_config.max_bitmap_size > reserved_dimension
+             ? atlas_config.max_bitmap_size - reserved_dimension
+             : 0;
+}
+
+float FitCreationScaleToAtlas(float requested_scale, float logical_dimension,
+                              float context_scale, uint32_t maximum_dimension) {
+  if (!std::isfinite(requested_scale) || requested_scale <= 0.f ||
+      !std::isfinite(logical_dimension) || logical_dimension <= 0.f ||
+      !std::isfinite(context_scale) || context_scale <= 0.f ||
+      maximum_dimension == 0) {
+    return 0.f;
+  }
+
+  // Two pixels are reserved for the rasterizer's AA expansion. The atlas
+  // allocator's own padding is already accounted for by maximum_dimension.
+  float fit_numerator =
+      std::max(static_cast<float>(maximum_dimension) - 2.f, 1.f);
+  float fit_scale = fit_numerator / (logical_dimension * context_scale);
+  return QuantizeCreationScaleDown(std::min(requested_scale, fit_scale));
+}
+
+bool ComputeViewDifference(const Matrix& position_matrix,
+                           const Matrix& creation_matrix,
+                           Matrix* view_difference) {
+  if (view_difference == nullptr || !position_matrix.IsFinite() ||
+      !creation_matrix.IsFinite()) {
+    return false;
+  }
+  Matrix creation_inverse;
+  if (!creation_matrix.Invert(&creation_inverse)) {
+    return false;
+  }
+  *view_difference = position_matrix * creation_inverse;
+  return view_difference->IsFinite();
+}
+
+Rect MapBounds(const Matrix& transform, const Rect& bounds) {
+  if (bounds.IsEmpty()) {
+    return Rect::MakeEmpty();
+  }
+
+  std::array<Vec4, 4> source = {
+      Vec4{bounds.Left(), bounds.Top(), 0.f, 1.f},
+      Vec4{bounds.Right(), bounds.Top(), 0.f, 1.f},
+      Vec4{bounds.Right(), bounds.Bottom(), 0.f, 1.f},
+      Vec4{bounds.Left(), bounds.Bottom(), 0.f, 1.f},
+  };
+  std::array<Vec2, 4> projected;
+  bool has_positive_w = false;
+  bool has_negative_w = false;
+  for (size_t index = 0; index < source.size(); ++index) {
+    Vec4 point = transform * source[index];
+    if (!IsFinite(point) || std::abs(point.w) <= kPerspectiveWEpsilon) {
+      return Rect::MakeLTRB(-kConservativeBounds, -kConservativeBounds,
+                            kConservativeBounds, kConservativeBounds);
+    }
+    has_positive_w |= point.w > 0.f;
+    has_negative_w |= point.w < 0.f;
+    projected[index] = Vec2{point.x / point.w, point.y / point.w};
+    if (!IsFinite(projected[index])) {
+      return Rect::MakeLTRB(-kConservativeBounds, -kConservativeBounds,
+                            kConservativeBounds, kConservativeBounds);
+    }
+  }
+  if (has_positive_w && has_negative_w) {
+    return Rect::MakeLTRB(-kConservativeBounds, -kConservativeBounds,
+                          kConservativeBounds, kConservativeBounds);
+  }
+
+  float left = projected[0].x;
+  float top = projected[0].y;
+  float right = projected[0].x;
+  float bottom = projected[0].y;
+  for (size_t index = 1; index < projected.size(); ++index) {
+    left = std::min(left, projected[index].x);
+    top = std::min(top, projected[index].y);
+    right = std::max(right, projected[index].x);
+    bottom = std::max(bottom, projected[index].y);
+  }
+  Rect result = Rect::MakeLTRB(left, top, right, bottom);
+  return result.IsFinite()
+             ? result
+             : Rect::MakeLTRB(-kConservativeBounds, -kConservativeBounds,
+                              kConservativeBounds, kConservativeBounds);
+}
+
+GlyphRunList MakeGlyphRunList(uint32_t count, const GlyphID* glyphs,
+                              const Point& origin, const float* position_x,
+                              const float* position_y, const Font& font,
+                              const Paint& paint, AtlasFormat format,
+                              float context_scale, const Matrix& transform,
+                              bool is_stroke, AtlasManager* atlas_manager,
+                              ArenaAllocator* arena_allocator) {
+  GlyphRunList run_list;
+  run_list.SetArenaAllocator(arena_allocator);
+  if (count == 0 || glyphs == nullptr || position_x == nullptr ||
+      position_y == nullptr || atlas_manager == nullptr ||
+      arena_allocator == nullptr || !transform.IsFinite()) {
+    return run_list;
+  }
+
+  Atlas* atlas = atlas_manager->GetAtlas(format);
+  Matrix position_matrix = transform * Matrix::Translate(origin.x, origin.y);
+  float creation_scale =
+      ComputeCreationScale(count, glyphs, position_x, position_y, font, paint,
+                           context_scale, position_matrix, atlas->GetConfig());
+  if (creation_scale <= 0.f) {
+    return run_list;
+  }
+  Matrix creation_matrix = Matrix::Scale(creation_scale, creation_scale);
+
+  std::vector<const GlyphData*> glyph_info(count);
+  font.LoadGlyphMetrics(glyphs, count, glyph_info.data(), paint);
+
+  uint32_t max_per_atlas = atlas->GetConfig().max_num_bitmap_per_atlas;
+  std::vector<GlyphRegionGroup> groups;
+  for (uint32_t index = 0; index < count; ++index) {
+    if (glyph_info[index] == nullptr) {
+      continue;
+    }
+    GlyphRegion glyph_region =
+        atlas->GetGlyphRegion(font, glyph_info[index]->Id(), paint, false,
+                              context_scale, creation_matrix);
+    if (glyph_region.loc.z <= 0 || glyph_region.loc.w <= 0) {
+      continue;
+    }
+
+    uint32_t group_index = glyph_region.index_in_group / max_per_atlas;
+    glyph_region.index_in_group %= max_per_atlas;
+    GlyphFormat glyph_format = ResolveGlyphFormat(format, glyph_info[index]);
+    GetOrAppendContiguousGroup(group_index, glyph_format, &groups)
+        ->glyph_regions.push_back({index, glyph_region});
+  }
+
+  for (auto& group : groups) {
+    run_list.push_back(arena_allocator->Make<TransformedMaskGlyphRun>(
+        count, glyphs, origin, position_x, position_y, font, context_scale,
+        creation_matrix, paint, is_stroke, std::move(group.glyph_regions),
+        group.group_index, atlas, group.glyph_format));
+  }
+  return run_list;
+}
+
+}  // namespace transformed_mask
+}  // namespace skity

--- a/src/render/text/transformed_mask_glyph_run.hpp
+++ b/src/render/text/transformed_mask_glyph_run.hpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_TEXT_TRANSFORMED_MASK_GLYPH_RUN_HPP
+#define SRC_RENDER_TEXT_TRANSFORMED_MASK_GLYPH_RUN_HPP
+
+#include <cstdint>
+
+#include "src/render/text/glyph_run.hpp"
+
+namespace skity {
+namespace transformed_mask {
+
+GlyphRunList MakeGlyphRunList(uint32_t count, const GlyphID* glyphs,
+                              const Point& origin, const float* position_x,
+                              const float* position_y, const Font& font,
+                              const Paint& paint, AtlasFormat format,
+                              float context_scale, const Matrix& transform,
+                              bool is_stroke, AtlasManager* atlas_manager,
+                              ArenaAllocator* arena_allocator);
+
+Paint MakeBitmapOnlyFillPaint(const Paint& paint);
+
+float QuantizeCreationScaleDown(float scale);
+
+uint32_t MaximumAtlasGlyphDimension(const AtlasConfig& atlas_config);
+
+float FitCreationScaleToAtlas(float requested_scale, float logical_dimension,
+                              float context_scale, uint32_t maximum_dimension);
+
+bool ComputeViewDifference(const Matrix& position_matrix,
+                           const Matrix& creation_matrix,
+                           Matrix* view_difference);
+
+Rect MapBounds(const Matrix& transform, const Rect& bounds);
+
+}  // namespace transformed_mask
+}  // namespace skity
+
+#endif  // SRC_RENDER_TEXT_TRANSFORMED_MASK_GLYPH_RUN_HPP

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(skity_unit_test
     text/text_blob_test.cc
     text/text_run_test.cc
     text/text_test.cc
+    text/transformed_mask_glyph_run_test.cc
     utils/arena_allocator_test.cc
     utils/array_list_test.cc
 )

--- a/test/ut/text/transformed_mask_glyph_run_test.cc
+++ b/test/ut/text/transformed_mask_glyph_run_test.cc
@@ -1,0 +1,188 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/text/transformed_mask_glyph_run.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include "src/render/hw/draw/fragment/wgsl_text_fragment.hpp"
+#include "src/render/hw/draw/geometry/wgsl_text_geometry.hpp"
+#include "src/render/hw/draw/hw_dynamic_text_draw.hpp"
+
+namespace skity {
+namespace transformed_mask {
+
+TEST(TransformedMaskGlyphRunTest, BitmapOnlyStrokeFallsBackToStrokeColorFill) {
+  Paint paint;
+  paint.SetStyle(Paint::kStroke_Style);
+  paint.SetFillColor(Color_RED);
+  paint.SetStrokeColor(Color_BLUE);
+
+  Paint fallback = MakeBitmapOnlyFillPaint(paint);
+
+  EXPECT_EQ(fallback.GetStyle(), Paint::kFill_Style);
+  EXPECT_EQ(fallback.GetFillColor(), paint.GetStrokeColor());
+}
+
+TEST(TransformedMaskGlyphRunTest,
+     BitmapOnlyFillAndCombinedStylesFallBackToFillColor) {
+  Paint paint;
+  paint.SetFillColor(Color_RED);
+  paint.SetStrokeColor(Color_BLUE);
+
+  for (Paint::Style style : {Paint::kFill_Style, Paint::kStrokeAndFill_Style,
+                             Paint::kStrokeThenFill_Style}) {
+    paint.SetStyle(style);
+    Paint fallback = MakeBitmapOnlyFillPaint(paint);
+
+    EXPECT_EQ(fallback.GetStyle(), Paint::kFill_Style);
+    EXPECT_EQ(fallback.GetFillColor(), paint.GetFillColor());
+  }
+}
+
+TEST(TransformedMaskGlyphRunTest, QuantizesCreationScaleDown) {
+  constexpr float kBucketsPerOctave = 4.f;
+  float input = 3.9f;
+  float quantized = QuantizeCreationScaleDown(input);
+
+  EXPECT_GT(quantized, 0.f);
+  EXPECT_LE(quantized, input);
+  EXPECT_GT(quantized * std::exp2(1.f / kBucketsPerOctave), input);
+  EXPECT_FLOAT_EQ(QuantizeCreationScaleDown(1.f), 1.f);
+  EXPECT_FLOAT_EQ(QuantizeCreationScaleDown(0.f), 0.f);
+  EXPECT_FLOAT_EQ(
+      QuantizeCreationScaleDown(std::numeric_limits<float>::infinity()), 0.f);
+}
+
+TEST(TransformedMaskGlyphRunTest, AccountsForAtlasAllocatorPadding) {
+  AtlasConfig a8_config{AtlasFormat::A8, false};
+  AtlasConfig rgba_config{AtlasFormat::RGBA32, false};
+
+  EXPECT_EQ(MaximumAtlasGlyphDimension(a8_config), 508u);
+  EXPECT_EQ(MaximumAtlasGlyphDimension(rgba_config), 252u);
+}
+
+TEST(TransformedMaskGlyphRunTest, ReducesScaleToFitPhysicalAtlasPixels) {
+  constexpr float kLogicalGlyphDimension = 64.f;
+  constexpr float kContextScale = 2.f;
+  constexpr uint32_t kMaximumDimension = 252;
+  float creation_scale = FitCreationScaleToAtlas(
+      8.f, kLogicalGlyphDimension, kContextScale, kMaximumDimension);
+
+  ASSERT_GT(creation_scale, 0.f);
+  EXPECT_LT(creation_scale, 8.f);
+  EXPECT_LE(kLogicalGlyphDimension * kContextScale * creation_scale + 2.f,
+            static_cast<float>(kMaximumDimension));
+}
+
+TEST(TransformedMaskGlyphRunTest,
+     ViewDifferenceReplacesCreationMatrixWithPositionMatrix) {
+  Matrix perspective;
+  perspective.SetPersp1(0.002f);
+  Matrix position_matrix = Matrix::Translate(120.f, 80.f) * perspective *
+                           Matrix::RotateDeg(-35.f, Vec3{1.f, 0.f, 0.f});
+  Matrix creation_matrix = Matrix::Scale(2.25f, 2.25f);
+  Matrix view_difference;
+
+  ASSERT_TRUE(ComputeViewDifference(position_matrix, creation_matrix,
+                                    &view_difference));
+
+  Vec4 local_point{23.f, -11.f, 0.f, 1.f};
+  Vec4 through_creation = view_difference * (creation_matrix * local_point);
+  Vec4 through_position = position_matrix * local_point;
+  for (int index = 0; index < 4; ++index) {
+    EXPECT_NEAR(through_creation[index], through_position[index], 0.0001f);
+  }
+
+  // Context scale belongs to the surface MVP. Applying it after both sides
+  // preserves the same relation; it must not be folded into view_difference.
+  Matrix context_scale = Matrix::Scale(2.f, 2.f);
+  Vec4 device_from_creation = context_scale * through_creation;
+  Vec4 device_from_position = context_scale * through_position;
+  for (int index = 0; index < 4; ++index) {
+    EXPECT_NEAR(device_from_creation[index], device_from_position[index],
+                0.0001f);
+  }
+}
+
+TEST(TransformedMaskGlyphRunTest, RejectsSingularCreationMatrix) {
+  Matrix view_difference;
+  EXPECT_FALSE(ComputeViewDifference(Matrix(), Matrix::Scale(0.f, 1.f),
+                                     &view_difference));
+}
+
+TEST(TransformedMaskGlyphRunTest, MapsFiniteBounds) {
+  Matrix transform = Matrix::Translate(8.f, -5.f) * Matrix::Scale(2.f, 3.f);
+  Rect mapped = MapBounds(transform, Rect::MakeLTRB(1.f, 2.f, 4.f, 6.f));
+
+  EXPECT_EQ(mapped, Rect::MakeLTRB(10.f, 1.f, 16.f, 13.f));
+}
+
+TEST(TransformedMaskGlyphRunTest, UsesConservativeBoundsAcrossHorizon) {
+  Matrix perspective;
+  perspective.SetPersp0(-0.1f);
+  Rect mapped = MapBounds(perspective, Rect::MakeLTRB(0.f, 0.f, 20.f, 10.f));
+
+  EXPECT_LE(mapped.Left(), -1E8F);
+  EXPECT_LE(mapped.Top(), -1E8F);
+  EXPECT_GE(mapped.Right(), 1E8F);
+  EXPECT_GE(mapped.Bottom(), 1E8F);
+}
+
+TEST(TransformedMaskGlyphRunTest, MergesTextDrawsWithSamePerspectiveTransform) {
+  Matrix perspective;
+  perspective.SetPersp0(0.002f);
+  Matrix transform = Matrix::Translate(120.f, 80.f) * perspective *
+                     Matrix::RotateDeg(-35.f, Vec3{1.f, 0.f, 0.f});
+  WGSLTextSolidColorGeometry first_geometry(Matrix{}, {}, Paint{});
+  WGSLTextSolidColorGeometry second_geometry(Matrix{}, {}, Paint{});
+  WGSLColorEmojiFragment first_fragment({}, nullptr, false, 1.f);
+  WGSLColorEmojiFragment second_fragment({}, nullptr, false, 1.f);
+  HWDynamicTextDraw first_draw(transform, BlendMode::kSrcOver, &first_geometry,
+                               &first_fragment);
+  HWDynamicTextDraw second_draw(transform, BlendMode::kSrcOver,
+                                &second_geometry, &second_fragment);
+  first_draw.SetLayerSpaceBounds(Rect::MakeLTRB(0.f, 0.f, 10.f, 10.f));
+  second_draw.SetLayerSpaceBounds(Rect::MakeLTRB(20.f, 20.f, 30.f, 30.f));
+
+  EXPECT_TRUE(first_draw.MergeIfPossible(&second_draw));
+  EXPECT_EQ(first_draw.GetLayerSpaceBounds(),
+            Rect::MakeLTRB(0.f, 0.f, 30.f, 30.f));
+}
+
+TEST(TransformedMaskGlyphRunTest, RejectsTextDrawsWithDifferentTransforms) {
+  Matrix first_transform;
+  first_transform.SetPersp0(0.002f);
+  Matrix second_transform = first_transform;
+  second_transform.PostTranslate(1.f, 0.f);
+  WGSLTextSolidColorGeometry first_geometry(Matrix{}, {}, Paint{});
+  WGSLTextSolidColorGeometry second_geometry(Matrix{}, {}, Paint{});
+  WGSLColorEmojiFragment first_fragment({}, nullptr, false, 1.f);
+  WGSLColorEmojiFragment second_fragment({}, nullptr, false, 1.f);
+  HWDynamicTextDraw first_draw(first_transform, BlendMode::kSrcOver,
+                               &first_geometry, &first_fragment);
+  HWDynamicTextDraw second_draw(second_transform, BlendMode::kSrcOver,
+                                &second_geometry, &second_fragment);
+
+  EXPECT_FALSE(first_draw.MergeIfPossible(&second_draw));
+}
+
+TEST(TransformedMaskGlyphRunTest, KeepsIdentityTextDrawMerging) {
+  WGSLTextSolidColorGeometry first_geometry(Matrix{}, {}, Paint{});
+  WGSLTextSolidColorGeometry second_geometry(Matrix{}, {}, Paint{});
+  WGSLColorTextFragment first_fragment({}, nullptr);
+  WGSLColorTextFragment second_fragment({}, nullptr);
+  HWDynamicTextDraw first_draw(Matrix{}, BlendMode::kSrcOver, &first_geometry,
+                               &first_fragment);
+  HWDynamicTextDraw second_draw(Matrix{}, BlendMode::kSrcOver, &second_geometry,
+                                &second_fragment);
+
+  EXPECT_TRUE(first_draw.MergeIfPossible(&second_draw));
+}
+
+}  // namespace transformed_mask
+}  // namespace skity


### PR DESCRIPTION
Generalize perspective atlas rendering to A8, RGBA, and BGRA glyphs. Keep outline glyphs on the existing path renderer and render bitmap-only glyphs through transformed atlas quads, with fill-compatible fallbacks for unsupported stroke styles.

Account for creation scale, atlas limits, context scale, glyph format grouping, and conservative perspective bounds. Reuse dynamic text batching only when draw transforms match exactly, preserving existing DirectAtlas batching while rejecting incompatible transformed draws.

Add focused unit coverage for scale fitting, transform composition, bounds handling, bitmap-only paint fallback, and batching behavior.