### PR TITLE
feat(capi): Vulkan-style C ABI wrapper for skity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,11 @@ jobs:
             run: |
                 export PATH=$PATH:$PWD/buildtools/cmake/CMake.app/Contents/bin
                 echo "PATH=$PATH" >> "$GITHUB_ENV"
-                cmake -B out/cmake_ios_release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_SYSTEM_NAME=iOS -DSKITY_MTL_BACKEND=ON -DSKITY_CT_FONT=ON -DSKITY_CODEC_MODULE=OFF
+                # capi ships inside the static skity_framework (see gen-xcframework
+                # below). The standalone libskity-capi dylib is not built on iOS:
+                # skity does not export symbols there (SKITY_DLL is off on iOS),
+                # so linking the dylib fails with undefined symbols.
+                cmake -B out/cmake_ios_release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_SYSTEM_NAME=iOS -DSKITY_MTL_BACKEND=ON -DSKITY_CT_FONT=ON -DSKITY_CODEC_MODULE=OFF -DSKITY_CAPI_MODULE=OFF
                 cmake --build out/cmake_ios_release
           - name: check build xcframework
             uses: ./.github/actions/gen-xcframework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ if(${SKITY_IO_MODULE})
   add_subdirectory(module/io)
 endif()
 
+if(${SKITY_CAPI_MODULE})
+  add_subdirectory(module/capi)
+endif()
+
 
 # header files
 add_subdirectory(include)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -8,4 +8,10 @@ if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/skityCodecTargets.cmake")
     add_library(skity::codec ALIAS skity::skity-codec)
 endif()
 
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/skityCapiTargets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/skityCapiTargets.cmake")
+
+    add_library(skity::capi ALIAS skity::skity-capi)
+endif()
+
 check_required_components(skity)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -26,6 +26,8 @@ cmake_dependent_option(
   OFF
 )
 
+option(SKITY_CAPI_MODULE "option for build C API wrapper module" ON)
+
 # option for building example
 # User can pass -DSKITY_EXAMPLE=ON to build example if needed
 option(SKITY_EXAMPLE "option for building example" OFF)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -41,6 +41,10 @@ add_subdirectory(case/save_layer)
 add_subdirectory(case/shape)
 add_subdirectory(case/text)
 
+if (${SKITY_CAPI_MODULE})
+  add_subdirectory(case/c_api)
+endif()
+
 if (${SKITY_IO_MODULE})
   add_subdirectory(case/skp_loader)
   add_subdirectory(case/skp_writer)

--- a/example/case/c_api/CMakeLists.txt
+++ b/example/case/c_api/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+# skity C API example: a GLFW + OpenGL window driven entirely through the C ABI.
+# glfw is provided by example/common/CMakeLists.txt.
+
+add_executable(skity-c-api main.c)
+
+target_link_libraries(skity-c-api PRIVATE skity::capi glfw)
+
+set_target_properties(skity-c-api PROPERTIES
+  C_STANDARD 11
+  C_STANDARD_REQUIRED ON
+)

--- a/example/case/c_api/main.c
+++ b/example/case/c_api/main.c
@@ -1,0 +1,162 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+//
+// Minimal end-to-end example of the skity C API.
+//
+// Opens a GLFW window with an OpenGL context, records the static scene into a
+// display list once (via skity_picture_recorder), then each frame replays it
+// and draws a dynamic element on top — the classic display-list use case:
+// record once, replay every frame.
+
+#include <GLFW/glfw3.h>
+#include <math.h>
+#include <skity_c/skity.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// skity loads GL symbols at runtime via this callback (same contract as
+// glfwGetProcAddress, just adapted to skity_gl_get_proc's return type).
+static void* get_gl_proc(const char* name) {
+  return (void*)glfwGetProcAddress(name);
+}
+
+int main(void) {
+  if (glfwInit() == GLFW_FALSE) {
+    return 1;
+  }
+
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+
+  GLFWwindow* window = glfwCreateWindow(800, 600, "skity-capi", NULL, NULL);
+  if (window == NULL) {
+    glfwTerminate();
+    return 1;
+  }
+  glfwMakeContextCurrent(window);
+
+  // -- skity GL context --
+  skity_context ctx;
+  if (skity_context_create_gl(get_gl_proc, &ctx) != SKITY_SUCCESS) {
+    fprintf(stderr, "skity_context_create_gl failed\n");
+    return 1;
+  }
+
+  // -- surface bound to the default framebuffer (gl_id = 0) --
+  int fbw = 0, fbh = 0, winw = 0, winh = 0;
+  glfwGetFramebufferSize(window, &fbw, &fbh);
+  glfwGetWindowSize(window, &winw, &winh);
+  float scale = sqrtf((float)(fbw * fbw + fbh * fbh) /
+                      (float)(winw * winw + winh * winh));
+
+  skity_surface_create_info_gl gl_ext = {
+      .s_type = SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL,
+      .surface_type = SKITY_GL_SURFACE_TYPE_FRAMEBUFFER,
+      .gl_id = 0,
+      .has_stencil = 1,
+  };
+  skity_surface_create_info surface_info = {
+      .s_type = SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO,
+      .p_next = &gl_ext,
+      .width = (uint32_t)winw,
+      .height = (uint32_t)winh,
+      .sample_count = 4,
+      .content_scale = scale,
+  };
+  skity_surface surface;
+  if (skity_surface_create(ctx, &surface_info, &surface) != SKITY_SUCCESS) {
+    fprintf(stderr, "skity_surface_create failed\n");
+    return 1;
+  }
+
+  // -- shared drawing resources --
+  skity_paint fill = skity_paint_create();
+  skity_paint_set_anti_alias(fill, 1);
+
+  skity_color4f grad_colors[] = {
+      {1.f, 0.2f, 0.2f, 1.f}, {0.2f, 1.f, 0.4f, 1.f}, {0.3f, 0.4f, 1.f, 1.f}};
+  float grad_pos[] = {0.f, 0.5f, 1.f};
+  skity_point grad_pts[2] = {{200.f, 200.f, 0.f, 0.f},
+                             {600.f, 520.f, 0.f, 0.f}};
+  skity_shader shader = skity_shader_create_linear(
+      grad_pts, grad_colors, grad_pos, 3, SKITY_TILE_MODE_CLAMP, 0);
+
+  skity_paint grad_paint = skity_paint_create();
+  skity_paint_set_anti_alias(grad_paint, 1);
+  skity_paint_set_shader(grad_paint, shader);
+
+  skity_path star = skity_path_create();
+  skity_path_move_to(star, 400.f, 150.f);
+  skity_path_line_to(star, 470.f, 330.f);
+  skity_path_line_to(star, 660.f, 330.f);
+  skity_path_line_to(star, 510.f, 440.f);
+  skity_path_line_to(star, 560.f, 620.f);
+  skity_path_line_to(star, 400.f, 510.f);
+  skity_path_line_to(star, 240.f, 620.f);
+  skity_path_line_to(star, 290.f, 440.f);
+  skity_path_line_to(star, 140.f, 330.f);
+  skity_path_line_to(star, 330.f, 330.f);
+  skity_path_close(star);
+
+  // -- record the static scene into a display list, once --
+  // The recording canvas is a regular skity_canvas, so any skity_canvas_*
+  // call records into the list instead of drawing immediately.
+  skity_picture_recorder recorder = skity_picture_recorder_create();
+  skity_rect cull = {0.f, 0.f, (float)winw, (float)winh};
+  skity_picture_recorder_begin(recorder, &cull);
+  skity_canvas rec_canvas = skity_picture_recorder_get_canvas(recorder);
+
+  skity_rect bg_rect = {80.f, 80.f, 320.f, 240.f};
+  skity_paint_set_color(fill, 0xFF48DBFBu);
+  skity_canvas_draw_rect(rec_canvas, &bg_rect, fill);
+  skity_canvas_draw_path(rec_canvas, star, grad_paint);
+
+  skity_display_list static_scene;
+  if (skity_picture_recorder_finish(recorder, &static_scene) != SKITY_SUCCESS) {
+    fprintf(stderr, "skity_picture_recorder_finish failed\n");
+    return 1;
+  }
+  // The display list is independent of the recorder now; the recorder and the
+  // recording-canvas handle are both invalid after finish.
+  skity_picture_recorder_destroy(recorder);
+
+  // -- render loop --
+  while (glfwWindowShouldClose(window) == GLFW_FALSE) {
+    skity_canvas canvas = skity_surface_lock_canvas(surface, 1);
+
+    skity_canvas_draw_color(canvas, 0xFF222222u, SKITY_BLEND_MODE_SRC);
+
+    // Replay the recorded static content.
+    skity_display_list_draw(static_scene, canvas);
+
+    // Dynamic content redrawn every frame: an orbiting dot.
+    float t = (float)glfwGetTime();
+    skity_paint_set_color(fill, 0xFFFFFFFFu);
+    skity_canvas_draw_circle(canvas, 400.f + 120.f * cosf(t),
+                             330.f + 70.f * sinf(t * 1.3f), 28.f, fill);
+
+    skity_canvas_flush(canvas);
+    skity_surface_flush(surface);
+    skity_canvas_destroy(canvas);
+
+    glfwSwapBuffers(window);
+    glfwPollEvents();
+  }
+
+  // -- teardown (reverse order of creation) --
+  skity_display_list_destroy(static_scene);
+  skity_path_destroy(star);
+  skity_paint_destroy(grad_paint);
+  skity_shader_destroy(shader);
+  skity_paint_destroy(fill);
+  skity_surface_destroy(surface);
+  skity_context_destroy(ctx);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+  return 0;
+}

--- a/module/capi/CMakeLists.txt
+++ b/module/capi/CMakeLists.txt
@@ -1,0 +1,109 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+# Vulkan-style C ABI wrapper around libskity. This is a thin forwarding layer
+# that links the core skity library and re-exports a stable C surface. See
+# docs/C_API_DESIGN.md for the full design.
+
+add_library(skity-capi SHARED)
+add_library(skity::capi ALIAS skity-capi)
+
+target_include_directories(skity-capi
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+# module root (for "src/..." includes) and skity public headers
+target_include_directories(skity-capi PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(skity-capi PRIVATE ${SKITY_ROOT}/include)
+
+target_link_libraries(skity-capi PUBLIC skity)
+
+target_compile_features(skity-capi PRIVATE cxx_std_17)
+
+# Match the core library's flags. -fno-strict-aliasing is required because the
+# wrapper reinterprets the binary-compatible POD structs (skity_rect/matrix/...)
+# as their skity:: C++ counterparts across the boundary.
+if (MSVC)
+  target_compile_options(skity-capi PRIVATE /EHs-c-)
+else()
+  target_compile_options(skity-capi PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -fno-strict-aliasing
+    -fvisibility=hidden
+    -fvisibility-inlines-hidden
+  )
+endif()
+
+# Make backend guards (SKITY_OPENGL / SKITY_VULKAN) visible to the wrapper
+# sources regardless of how skity exposes those definitions.
+if (${SKITY_GL_BACKEND})
+  target_compile_definitions(skity-capi PRIVATE -DSKITY_OPENGL)
+endif()
+
+if (${SKITY_VK_BACKEND})
+  target_compile_definitions(skity-capi PRIVATE -DSKITY_VULKAN)
+endif()
+
+# Android 16 KiB page-size alignment (arm64 / x86_64), required for the .so to
+# load on Android 15+ devices with 16 KiB pages. Mirrors the option applied to
+# the core skity target in cmake/Platform.cmake.
+if (ANDROID)
+  if (CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a" OR CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64")
+    target_link_options(skity-capi PRIVATE
+      "-Wl,-z,max-page-size=16384"
+      "-Wl,-z,common-page-size=16384"
+    )
+  endif()
+endif()
+
+target_sources(
+  skity-capi
+  PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/src/handle.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/context_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/surface_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/canvas_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/paint_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/path_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/path_measure_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/path_op_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/shader_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/filters_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/image_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/text_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/texture_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/precompile_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/font_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/bitmap_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/recorder_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/camera_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/quaternion_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/data_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/stroke_c.cpp
+)
+
+if (${SKITY_BUILD_INSTALL})
+  install(
+    DIRECTORY
+    "${CMAKE_CURRENT_LIST_DIR}/include/skity_c"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+  )
+
+  install(
+    TARGETS skity-capi EXPORT skity-capi-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(
+    EXPORT skity-capi-targets
+    FILE skityCapiTargets.cmake
+    NAMESPACE skity::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/skity
+  )
+endif()

--- a/module/capi/C_API_DESIGN.md
+++ b/module/capi/C_API_DESIGN.md
@@ -1,0 +1,472 @@
+# Skity C-API Design
+
+This document describes the design of Skity's C API — a stable, Vulkan-style
+ABI surface exposed by `libskity-capi.so`, intended to eventually replace the
+direct C++ symbol export of `libskity.so`.
+
+> Status: **Stage 1 — independent `libskity-capi.so`, GL + Vulkan core path.**
+> The existing C++ API under [`include/skity/`](../../include/skity/skity.hpp) is
+> untouched and remains the primary interface for current consumers.
+
+## 1. Motivation & Goals
+
+Skity's public C++ headers cross the shared-library boundary with types whose
+layout depends on the C++ compiler and standard library:
+
+- `std::unique_ptr` / `std::shared_ptr` return values
+  ([`GLContextCreate`](../../include/skity/gpu/gpu_context_gl.hpp),
+  [`GPUContext::CreateSurface`](../../include/skity/gpu/gpu_context.hpp),
+  [`Shader::MakeLinear`](../../include/skity/effect/shader.hpp), …);
+- virtual dispatch
+  ([`GPUContext`](../../include/skity/gpu/gpu_context.hpp),
+  [`GPUSurface`](../../include/skity/gpu/gpu_surface.hpp) are abstract bases);
+- `std::vector` / `std::string` / `std::function`
+  ([`Path`](../../include/skity/graphic/path.hpp),
+  [`Typeface`](../../include/skity/text/typeface.hpp), …).
+
+Because of this, linking against `libskity.so` from a different libstdc++ /
+libc++ flavor, a different compiler major version, or — most importantly — from
+a non-C++ language (Swift, Rust, Go, C#) is unsafe.
+
+### Goals
+
+- Provide a **C ABI surface** that is stable across compilers, standard
+  libraries, and languages.
+- Make the surface **extensible** without breaking binary compatibility, using
+  the Vulkan `sType` / `pNext` chaining pattern.
+- Add **runtime type safety** to opaque handles so that a mistaken cast between
+  handle types is rejected instead of corrupting memory.
+
+### Non-goals
+
+- Reducing `libskity.so`'s own binary size. The C wrapper is a thin forwarding
+  layer; the core library still ships in full. (See Stage 3 below for the
+  eventual size story.)
+- Replacing the C++ API in one step. Existing consumers must keep working
+  throughout the migration.
+
+## 2. Terminal Architecture
+
+```
+libskity.so              exports only extern "C" symbols (C API + render core)
+include/skity_c/*.h      pure C headers: handles + CreateInfo + POD types
+include/skity.hpp        header-only: RAII wrappers over C handles (a la vulkan.hpp)
+```
+
+The ABI is stable because only **C handles + POD structs** flow across the
+`.so` boundary. Every C++ type (smart pointers, containers, vtables) lives in
+the header-only `skity.hpp`, compiled into the *consumer's* translation unit
+with the consumer's own toolchain — so it never crosses the boundary at all.
+
+This is the same split Khronos uses between `vulkan.h` (C) and `vulkan.hpp`
+(C++ wrapper).
+
+## 3. Handle Model
+
+C++ objects are **not** exposed by `reinterpret_cast`-ing them directly — that
+would couple the handle layout to the C++ class layout and break the moment the
+class gains a member. Instead, the wrapper layer wraps each object in a small
+struct whose **first member is a shared header**:
+
+```c
+/* skity_c/skity_base.h */
+typedef enum {
+    SKITY_OBJECT_TYPE_CONTEXT = 1,
+    SKITY_OBJECT_TYPE_SURFACE,
+    SKITY_OBJECT_TYPE_CANVAS,
+    SKITY_OBJECT_TYPE_PAINT,
+    SKITY_OBJECT_TYPE_PATH,
+    SKITY_OBJECT_TYPE_SHADER,
+    SKITY_OBJECT_TYPE_COLOR_FILTER,
+    SKITY_OBJECT_TYPE_IMAGE_FILTER,
+    SKITY_OBJECT_TYPE_MASK_FILTER,
+    SKITY_OBJECT_TYPE_PATH_EFFECT,
+    SKITY_OBJECT_TYPE_TYPEFACE,
+    SKITY_OBJECT_TYPE_FONT_MANAGER,
+} skity_object_type;
+
+#define SKITY_HANDLE_OWNING 0x1u
+
+typedef struct skity_object_header {
+    uint32_t type;   /* skity_object_type — rejects wrong-type casts  */
+    uint32_t flags;  /* SKITY_HANDLE_OWNING bit + reserved             */
+} skity_object_header;
+```
+
+The `header` being the first member lets the wrapper treat any handle as a
+`skity_object_header*` to validate its type before use:
+
+```cpp
+/* internal to the wrapper (src/handle.hpp) */
+template <typename W>
+W* resolve(void* h, skity_object_type expected) {
+    auto* hdr = static_cast<skity_object_header*>(h);
+    return (hdr && hdr->type == expected) ? static_cast<W*>(h) : nullptr;
+}
+```
+
+Each concrete handle is header + an `impl` pointer to the real C++ object. The
+`impl` type is visible only inside the wrapper; C users see a fully opaque
+pointer:
+
+```c
+SKITY_C_DEFINE_HANDLE(skity_paint);   /* typedef struct skity_paint_s* skity_paint */
+```
+
+### Ownership
+
+The wrapper holds the underlying object as a type-erased
+`std::shared_ptr<void> impl`. Owning handles store a shared_ptr whose deleter
+releases the object; non-owning handles store the raw pointer with a no-op
+deleter. Destruction is therefore uniform — the deleter alone decides whether
+the object is touched:
+
+```cpp
+/* src/handle.hpp */
+template <typename Wrapper>
+inline void destroy_handle(void* handle, skity_object_type expected) {
+    auto* w = resolve<Wrapper>(handle, expected);
+    if (!w) return;   /* null or wrong type → reject */
+    delete w;         /* shared_ptr impl: deleter releases the underlying
+                       * object iff the handle is owning */
+}
+```
+
+This resolves the most common lifetime trap: the `Canvas*` returned by
+[`GPUSurface::LockCanvas()`](../../include/skity/gpu/gpu_surface.hpp) is owned by
+the surface. Its handle is built with a no-op deleter
+(`std::shared_ptr<void>(raw, [](void*){})`), so `skity_canvas_destroy` only
+reclaims the wrapper struct and never touches the surface's object. A C caller
+can call `*_destroy` uniformly without tracking which handles are owning.
+
+## 4. CreateInfo & Extensibility
+
+Two independent mechanisms are kept strictly separate:
+
+- **CreateInfo descriptors** (short-lived, on the stack) use `s_type` / `p_next`;
+- **handle objects** (long-lived, on the heap) use `header.type` / `header.flags`.
+
+Skity's C++ inheritance `GPUSurfaceDescriptor` → `GPUSurfaceDescriptorGL` maps
+naturally onto a base CreateInfo with a backend-specific struct hung off
+`p_next`. Adding a field or a backend later only adds a new structure type — it
+never breaks the existing ABI:
+
+```c
+typedef enum {
+    SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO,
+    SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL,
+    /* future fields/backends add new values here */
+} skity_structure_type;
+
+typedef struct skity_surface_create_info {
+    skity_structure_type s_type;
+    const void*          p_next;   /* → skity_surface_create_info_gl, … */
+    uint32_t width;
+    uint32_t height;
+    uint32_t sample_count;
+    float    content_scale;
+} skity_surface_create_info;
+
+typedef struct skity_surface_create_info_gl {
+    skity_structure_type  s_type;
+    const void*           p_next;
+    skity_gl_surface_type surface_type; /* TEXTURE or FRAMEBUFFER */
+    uint32_t              gl_id;        /* GL texture id or framebuffer id
+                                         * (0 = on-screen default FBO) */
+    uint32_t              has_stencil;  /* valid only for FRAMEBUFFER */
+} skity_surface_create_info_gl;
+```
+
+## 5. Type Mapping
+
+| C++ type | Category | C representation |
+|---|---|---|
+| [`GPUContext`](../../include/skity/gpu/gpu_context.hpp) | opaque, owning handle | `skity_context` |
+| [`GPUSurface`](../../include/skity/gpu/gpu_surface.hpp) | opaque, owning handle | `skity_surface` |
+| [`Canvas`](../../include/skity/render/canvas.hpp) | opaque, **non-owning** handle | `skity_canvas` |
+| [`Paint`](../../include/skity/graphic/paint.hpp) | opaque, owning handle | `skity_paint` |
+| [`Path`](../../include/skity/graphic/path.hpp) | opaque, owning handle | `skity_path` |
+| [`Shader`](../../include/skity/effect/shader.hpp) / [`ColorFilter`](../../include/skity/effect/color_filter.hpp) / [`ImageFilter`](../../include/skity/effect/image_filter.hpp) / [`MaskFilter`](../../include/skity/effect/mask_filter.hpp) / [`PathEffect`](../../include/skity/effect/path_effect.hpp) | opaque, owning handle | `skity_shader` / … |
+| [`Typeface`](../../include/skity/text/typeface.hpp) / [`FontManager`](../../include/skity/text/font_manager.hpp) | opaque, owning handle | `skity_typeface` / `skity_font_manager` |
+| [`Rect`](../../include/skity/geometry/rect.hpp) | POD | `skity_rect { float left, top, right, bottom; }` |
+| [`Vec4`](../../include/skity/geometry/vector.hpp) / `Point` / `Color4f` | POD (4 floats) | `skity_vec4 { float e[4]; }` |
+| [`Vec2`](../../include/skity/geometry/vector.hpp) | POD (2 floats) | `skity_vec2 { float e[2]; }` |
+| [`Matrix`](../../include/skity/geometry/matrix.hpp) | POD (16 floats, column-major) | `skity_matrix { float m[16]; }` |
+| `Color` / `PMColor` | `uint32_t` (ARGB) | `uint32_t` |
+| [`BlendMode`](../../include/skity/graphic/blend_mode.hpp) | `int32_t` enum | `skity_blend_mode` (values aligned) |
+| [`TileMode`](../../include/skity/graphic/tile_mode.hpp) | enum | `skity_tile_mode` |
+| `GlyphID` | `uint16_t` | `uint16_t` |
+
+All POD structs are standard-layout and binary-compatible with their C++
+counterparts — they may be passed by pointer across the boundary with no
+conversion.
+
+> `RRect` contains a `std::array` and is not pure POD, so it is not exposed as a
+> struct. APIs that need rounded-rectangle geometry take a `skity_rect` plus an
+> explicit radii parameter.
+
+## 6. Core API Surface
+
+All functions return [`skity_result`](./include/skity_c/skity_base.h)
+(`SKITY_SUCCESS = 0`, `SKITY_ERROR_INVALID_HANDLE`,
+`SKITY_ERROR_INITIALIZATION_FAILED`, …). Every `extern "C"` function is
+`noexcept`; the wrapper catches C++ exceptions and converts them to a result.
+
+```c
+/* context — GL entry */
+skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
+                                     skity_context* out_context);
+void         skity_context_destroy(skity_context context);
+
+/* surface — base CreateInfo + p_next extension */
+skity_result skity_surface_create(skity_context ctx,
+                                  const skity_surface_create_info* info,
+                                  skity_surface* out_surface);
+void         skity_surface_destroy(skity_surface surface);
+void         skity_surface_flush(skity_surface surface);
+
+/* canvas — non-owning, lifetime tied to the surface */
+skity_canvas skity_surface_lock_canvas(skity_surface surface, uint32_t clear);
+skity_result skity_canvas_flush(skity_canvas canvas);
+void         skity_canvas_draw_rect(skity_canvas c, const skity_rect* r,
+                                    skity_paint paint);
+void         skity_canvas_draw_path(skity_canvas c, skity_path path,
+                                    skity_paint paint);
+void         skity_canvas_concat(skity_canvas c, const skity_matrix* m);
+
+/* paint — owning */
+skity_paint  skity_paint_create();
+void         skity_paint_destroy(skity_paint paint);
+void         skity_paint_set_color(skity_paint p, uint32_t color);
+void         skity_paint_set_style(skity_paint p, skity_paint_style style);
+void         skity_paint_set_shader(skity_paint p, skity_shader shader);
+void         skity_paint_set_anti_alias(skity_paint p, uint32_t aa);
+
+/* shader factory — owning */
+skity_shader skity_shader_make_linear(const skity_vec4 pts[2],
+                                      const skity_vec4* colors,
+                                      const float* pos, int32_t count,
+                                      skity_tile_mode mode);
+```
+
+## 7. Backend Bindings
+
+### OpenGL / OpenGL ES
+
+The C++ [`GLContextCreate(void* proc_loader)`](../../include/skity/gpu/gpu_context_gl.hpp)
+does **not** take a C++ `GLProcLoader` object. Despite the documentation, the
+`void*` is in fact a glad `GLADloadfunc` — a plain C function pointer
+`void* (*)(const char*)` (see `third_party/glad/include/glad/gl.h`). Example
+[`example/common/gl/window_gl.cc`](../../example/common/gl/window_gl.cc) passes
+`glfwGetProcAddress` directly.
+
+The C API therefore takes a single function pointer:
+
+```c
+typedef void* (*skity_gl_get_proc)(const char* name);
+skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
+                                     skity_context* out_context);
+```
+
+### Vulkan
+
+Vulkan types (`PFN_vkGetInstanceProcAddr`, `VkInstance`, …) are already C and
+ABI-stable, so the C API reuses them directly rather than redefining wrappers.
+The two overloads mirror
+[`CreateGPUContextVK`](../../include/skity/gpu/gpu_context_vk.hpp):
+
+```c
+skity_result skity_context_create_vk(PFN_vkGetInstanceProcAddr get_proc,
+                                     skity_context* out_context);
+```
+
+### Metal (Stage 2)
+
+[`gpu_context_mtl.h`](../../include/skity/gpu/gpu_context_mtl.h) is an Objective-C++
+header. Its C wrapper will live in a `.mm` source and accept the native
+`id<MTLDevice>` / `id<MTLCommandQueue>` as opaque `void*`. Not in Stage 1.
+
+## 8. Header-only C++ Wrapper
+
+For C++ consumers, the eventual `skity.hpp` wraps the C handles in RAII types
+that are binary-identical in usage to today's classes. Because it is
+header-only, it is compiled with the consumer's own toolchain and may freely
+use `std::shared_ptr` / `std::vector` without introducing any ABI coupling —
+those types never enter `libskity.so`.
+
+```cpp
+/* skity.hpp — header-only, compiled in the consumer's TU */
+namespace skity {
+class Canvas {  /* non-owning view, destructor does not delete */
+ public:
+  void DrawRect(const Rect& r, const Paint& p) {
+    skity_canvas_draw_rect(h_, &r, p.get());
+  }
+  void Flush() { skity_canvas_flush(h_); }
+ private:
+  skity_canvas h_ = nullptr;
+  friend class Surface;
+};
+class Paint {  /* owning, destructor calls skity_paint_destroy */
+ public:
+  ~Paint() { skity_paint_destroy(h_); }
+  skity_paint get() const { return h_; }
+ private:
+  skity_paint h_;
+};
+}  // namespace skity
+```
+
+## 9. Gradual Migration
+
+| Stage | `libskity.so` | C API | header-only `skity.hpp` | old `include/skity/` C++ headers | Risk |
+|---|---|---|---|---|---|
+| 0 (current) | exports C++ | — | — | primary | — |
+| **1 (this work)** | **unchanged** | **`libskity-capi.so`, GL+VK core path** | — | kept | none — C consumers benefit first |
+| 2 | unchanged | feature parity with old C++ headers + MTL | new `skity.hpp` shipped | kept / deprecated | old + new C++ entry points coexist |
+| 3 (major bump) | C++ symbols hidden, only C exported | complete | primary | removed | requires all downstream migrated |
+
+Each stage is independently shippable and never breaks existing C++ consumers.
+Only Stage 3 — hiding the C++ symbols in `libskity.so` — is a breaking change,
+and it is gated on downstream migration completion.
+
+## 10. Build
+
+The wrapper is a standalone shared library that links `libskity.so`, mirroring
+[`module/codec`](../codec/CMakeLists.txt):
+
+```bash
+cmake -DSKITY_CAPI_MODULE=ON -DSKITY_GL_BACKEND=ON -DSKITY_VK_BACKEND=ON ...
+cmake --build .            # produces libskity-capi.so
+```
+
+Symbol check — only `skity_*` C symbols should be exported:
+
+```bash
+nm -D --defined-only libskity-capi.so | grep ' T '
+```
+
+With `-DSKITY_CAPI_MODULE=OFF` (the default is ON) the build is identical to
+today; `libskity.so` is never modified by this work.
+
+## 11. API Coverage & Known Gaps
+
+This section tracks how completely the C API mirrors the C++ public surface
+under [`include/skity/`](../../include/skity/skity.hpp), to guide follow-up
+work.
+
+### Fully covered
+
+These modules have complete (or near-complete) C coverage of their core:
+
+- Effects: `color_filter`, `mask_filter`, `path_effect`, `image_filter`
+  (all factories)
+- `FontManager` + `FontStyleSet`
+- `PictureRecorder` + `DisplayList` (core record / replay; introspection is
+  not — see below)
+- `PrecompileContext`
+- `Texture` (create / wrap-external / upload / deferred-upload)
+- `GPUContext` (create, `set_error_callback`, all `set_enable_*` tuning,
+  precompile, `create_texture`, `wrap_texture`, `set_resource_cache_limit`)
+- `Bitmap` / `Pixmap` (pixel access), `image_read_pixels`
+- 3D / misc: [`Camera`](./include/skity_c/skity_camera.h),
+  [`Quaternion`](./include/skity_c/skity_quaternion.h),
+  [`Stroke`](./include/skity_c/skity_stroke.h),
+  [`Data`](./include/skity_c/skity_data.h)
+- POD types: `color`, `blend_mode`, `tile_mode`, `sampling_options`,
+  `alpha_type`, `color_type`, `font_style`, `font_metrics`
+
+`Paint`, `Path`, `Shader`, `Font`, `Typeface`, `TextBlob`, `Image`,
+`GPUSurface`, `Canvas` all have working core coverage but carry functional
+gaps — they are listed in the next table.
+
+### Partially covered (gaps remain)
+
+Priority tags: **P0/P1/P2** are planned for the next pass; **P3** is deferred.
+
+| Module | Covered | Missing (priority) |
+|---|---|---|
+| `Paint` | all setters (style/stroke/color/alpha/blend/aa/text-size), attach shader/filter/effect/typeface | **P0**: fill/stroke split-color (`set/get_stroke_color`, `set/get_fill_color`); getters (`get_stroke_miter/cap/join`, `get_text_size`, `get_shader`/`get_color_filter`/…). **P3**: `get_color4f`, `get_alpha_f`, SDF / font-threshold |
+| `Shader` | gradient factories (linear/radial/sweep/conical) + image shader | **P0**: `set/get_local_matrix` (gradient transform). **P3**: `is_opaque`, `as_gradient` introspection |
+| `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters | **P0**: GL `surface_mode` + `can_blit_from_target_fbo` on `surface_create_info_gl`. **P3**: per-surface CoverageAAMode, `add_external_wait_semaphore` (needs semaphore) |
+| `Path` | construction, tangent `arc_to`, `add_*`, boolean ops, `PathMeasure`, `transform`, `count`/`get_point`/`is_rect` | **P1**: oval `arc_to(oval,start,sweep)` + SVG `arc_to(rx,ry,rot,ArcSize,sweep,x,y)` (+ `ArcSize` enum), per-corner `add_round_rect(radii[])`, `get/set_last_pt`, `AddMode` (extend), `copy_with_matrix/scale`. **P3**: convexity / segment-masks introspection |
+| `Image` | 5 factories + `read_pixels` + size getters | **P1**: `scale_pixels`; `make_from_pixels` variant taking a `GPUContext`. **P3**: alpha/type/backend introspection |
+| `Font` | create, set typeface/size, `get_metrics`, rendering-quality switches, `make_with_size`, `get_widths` | **P0**: rendering-switch getters (`is_subpixel`/…), `get_size`, `get_typeface`. **P1**: `scale_x/skew_x` (+ 4-arg ctor). **P3**: `get_widths` bounds overload, `LoadGlyph*` (needs GlyphData) |
+| `Typeface` | `make_from_file`, `get_default`, `unichars_to_glyphs`/`unichar_to_glyph` | **P1**: `make_from_data` (in-memory load, pairs with `skity_data`). **P3**: `get_font_style`/`is_bold`/`is_italic`, `contain_glyph`, `units_per_em`/`contains_color_table`, table / variation / descriptor |
+| `TextBlob` | build (UTF-8) + draw | **P2**: `get_bounds_rect`, `compute_bounds`. **P3**: `get_text_run`; multi-font fallback via `TypefaceDelegate` (large, separate increment) |
+| `Canvas` | full draw + state + clip + text/glyphs | **P3**: per-corner RRect draw/clip/drrect, `get_global_clip_bounds`, `draw_image` sampling overloads |
+| `DisplayList` | draw / bounds / op_count | **P3**: `search` (RTree) + property getters (`has_shader`, …) — needs `build_rtree` option + `RecordedOpOffset` as a set |
+| `GPUContext` | (see Fully covered) | **P3**: `create_texture_with_desc` (mipmap), `is_gpu_backend_supported`, `get_backend_type` |
+
+### Not yet covered (whole module missing)
+
+| Module | Purpose | Why deferred |
+|---|---|---|
+| `GPUPresenter` | Vulkan swapchain present (`acquire_next_surface` / `present` / `resize`) | `Present()` consumes a `unique_ptr<GPUSurface>`, incompatible with the shared_ptr handle model (same blocker as `MakeSnapshot`). Vulkan-only; revisit alongside a transfer-ownership path. |
+| `GPUSemaphore` | cross-GPU / cross-process texture sync | `ImportSemaphore` takes a backend-specific derived struct (`GPUSemaphoreImportInfoVK`); the import path is Vulkan-only and unverified on the GL build. Will land together with `GPUPresenter`. |
+| `GlyphData` | glyph bitmap / path query (used by `Font::LoadGlyph*`) | exposing it cleanly needs a richer query surface |
+| `gpu_context_mtl` / `gpu_context_web` | Metal / WebGPU context | platform backends (Stage 2) |
+| `utils` (settings / trace) | config / tracing | minor |
+
+> `GPUContext::create_render_target` / `make_snapshot` are intentionally
+> skipped — `MakeSnapshot` consumes a `unique_ptr`, incompatible with the
+> shared_ptr handle model.
+
+### Suggested priorities
+
+**P0** — high-value, low-cost (next pass):
+
+- ☐ `Paint` fill/stroke split-color setters + getters; remaining `Paint` getters
+- ☐ `Font` rendering-switch getters + `get_size` / `get_typeface`
+- ☐ `Shader::set/get_local_matrix` (gradient transforms)
+- ☐ GL `surface_mode` on `surface_create_info_gl` (only functional GL gap)
+
+**P1** — core capability:
+
+- ☐ `Path` arc family (oval arc, SVG arc + `ArcSize`) + per-corner round-rect
+- ☐ `Image::scale_pixels` + `make_from_pixels(context)`
+- ☐ `Typeface` / `FontManager::make_from_data` (in-memory font load)
+- ☐ `Font::scale_x/skew_x` (+ 4-arg ctor)
+
+**P2** — measurement:
+
+- ☐ `TextBlob::get_bounds_rect` / `compute_bounds`
+
+**P3** — deferred. Detailed backlog by module:
+
+- **Paint**: `get_color4f`, `get_alpha_f`; SDF / font-threshold
+  (`set/is_sdf_for_small_text`, `get/set_font_threshold`).
+- **Shader**: `is_opaque` (opacity hint); `as_gradient` (recover gradient
+  params, needs `GradientInfo` / `GradientType`).
+- **Path**: convexity (`get/is_convex`, +`ConvexityType`); `get_segment_masks`;
+  `get_verb` (+`Verb` enum); `get_last_move_pt`; type queries (`is_line`,
+  `is_simple_rrect`, `get_is_a_type`, +`IsAType`); `is_finite`; `reverse_path_to`;
+  `add_path` extend mode (+`AddMode`).
+- **Image**: property/type introspection (`get_alpha_type`, `is_texture_backend`,
+  `get_image_type`, `is_lazy`); backend handles (`get_texture`, `get_pixmap`,
+  `get_texture_by_context`).
+- **Font**: `get_widths` bounds overload; `LoadGlyph*` family
+  (`load_glyph_metrics` / `path` / `bitmap` / `bitmap_info`) — depends on
+  `GlyphData`.
+- **Typeface**: style (`get_font_style`, `is_bold`, `is_italic`);
+  `contain_glyph`; emoji/COLR (`get_units_per_em`, `contains_color_table`);
+  raw tables (`count_tables`, `get_table_tags` / `size` / `data`, `get_data`);
+  variable fonts (`get_variation_design_position` / `parameters`,
+  `make_variation`, +`FontArguments`); cache keys (`typeface_id`,
+  `get_font_descriptor`).
+- **TextBlob**: `get_text_run` (+`TextRun` projection); **`TypefaceDelegate`
+  multi-font fallback** — the largest text gap (CJK/emoji auto-fallback).
+- **Canvas**: per-corner RRect `draw_rrect` / `clip_rrect` / `draw_drrect`
+  (+RRect projection or 8-radii); `get_global_clip_bounds`; `draw_image`
+  sampling/paint overloads; `draw_color(color4f, blend)`.
+- **DisplayList**: `search` / `search_non_overlapping_drawn_rects` (RTree);
+  property getters (`has_save_layer` / `has_shader` / …); `get_op_paint_by_offset`
+  (+`RecordedOpOffset`); `draw(canvas, cull_rect)`; prerequisite
+  `begin_recording(rect, DisplayListBuildOptions)` (+`build_rtree` option).
+- **GPUContext**: `create_texture_with_desc` (mipmap, +`TextureDescriptor`
+  mirror); `is_gpu_backend_supported`; `get_backend_type`.
+
+> `GPUPresenter` / `GPUSemaphore` / `MakeSnapshot` remain blocked on the
+> `unique_ptr`-ownership / Vulkan-only constraints (see "Not yet covered").
+> The CPU raster backend (`Canvas::MakeSoftwareCanvas`) is intentionally
+> deferred — GPU paths are the current priority.

--- a/module/capi/README.md
+++ b/module/capi/README.md
@@ -1,0 +1,71 @@
+# skity-capi
+
+A Vulkan-style C ABI wrapper around the core `libskity` library. It links
+`libskity.so` and re-exports a stable C surface so that the rendering engine can
+be consumed from any language (Swift, Rust, Go, C#) or from C++ built with an
+incompatible libstdc++ / libc++, without depending on the unstable C++ ABI.
+
+See [C_API_DESIGN.md](C_API_DESIGN.md) for the full design.
+
+## Build
+
+```
+cmake -DSKITY_CAPI_MODULE=ON -DSKITY_GL_BACKEND=ON -DSKITY_VK_BACKEND=ON ...
+cmake --build .
+```
+
+This produces `libskity-capi.so`. With `-DSKITY_CAPI_MODULE=OFF` the wrapper is
+not built and the rest of the project is unaffected.
+
+## Example
+
+A complete, runnable GL example lives with the other skity examples in
+[`../../example/case/c_api/main.c`](../../example/case/c_api/main.c). It opens a
+GLFW window and drives the full loop through the C API — GL context, GL surface
+via the `p_next` extension, paint, gradient shader, path construction, and draw
+calls. Build it by enabling the examples:
+
+```
+cmake -DSKITY_EXAMPLE=ON -DSKITY_CAPI_MODULE=ON ...
+cmake --build . --target skity-c-api
+```
+
+## Usage
+
+```c
+#include <skity_c/skity.h>
+
+skity_context ctx;
+skity_context_create_gl(my_gl_get_proc, &ctx);
+
+skity_surface_create_info_gl gl_ext = {
+    .s_type = SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL,
+    .surface_type = SKITY_GL_SURFACE_TYPE_FRAMEBUFFER,
+    .gl_id = fbo,
+    .has_stencil = 1,
+};
+skity_surface_create_info info = {
+    .s_type = SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO,
+    .p_next = &gl_ext,
+    .width = 800,
+    .height = 600,
+};
+
+skity_surface surface;
+skity_surface_create(ctx, &info, &surface);
+
+skity_canvas canvas = skity_surface_lock_canvas(surface, 1);
+skity_paint paint = skity_paint_create();
+skity_paint_set_color(paint, 0xFF000000);
+
+skity_rect r = {10, 10, 200, 200};
+skity_canvas_draw_rect(canvas, &r, paint);
+
+skity_canvas_flush(canvas);
+skity_surface_flush(surface);
+
+skity_paint_destroy(paint);
+skity_canvas_destroy(canvas);
+skity_surface_destroy(surface);
+skity_context_destroy(ctx);
+```

--- a/module/capi/include/skity_c/skity.h
+++ b/module/capi/include/skity_c/skity.h
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_H
+
+/*
+ * Aggregate header for the Skity C API. Include this for the full surface.
+ * Vulkan context creation (skity_context_create_vk) is in skity_context_vk.h,
+ * which is intentionally separate so that non-Vulkan consumers are not forced
+ * to pull in <vulkan/vulkan.h>.
+ */
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_bitmap.h>
+#include <skity_c/skity_camera.h>
+#include <skity_c/skity_canvas.h>
+#include <skity_c/skity_color_filter.h>
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_data.h>
+#include <skity_c/skity_font.h>
+#include <skity_c/skity_image.h>
+#include <skity_c/skity_image_filter.h>
+#include <skity_c/skity_mask_filter.h>
+#include <skity_c/skity_paint.h>
+#include <skity_c/skity_path.h>
+#include <skity_c/skity_path_effect.h>
+#include <skity_c/skity_path_measure.h>
+#include <skity_c/skity_path_op.h>
+#include <skity_c/skity_precompile.h>
+#include <skity_c/skity_quaternion.h>
+#include <skity_c/skity_recorder.h>
+#include <skity_c/skity_shader.h>
+#include <skity_c/skity_stroke.h>
+#include <skity_c/skity_surface.h>
+#include <skity_c/skity_text.h>
+#include <skity_c/skity_texture.h>
+#include <skity_c/skity_types.h>
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_H

--- a/module/capi/include/skity_c/skity_base.h
+++ b/module/capi/include/skity_c/skity_base.h
@@ -1,0 +1,62 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BASE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BASE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Symbol visibility. The wrapper library (libskity-capi.so) is built with
+ * -fvisibility=hidden, so every exported function must carry this attribute.
+ * This mirrors the SKITY_API macro used by the C++ headers, but is defined here
+ * independently so that the C headers do not depend on any C++ header.
+ */
+#if defined(_WIN32) || defined(_WIN64)
+#define SKITY_C_API __declspec(dllexport)
+#elif defined(_MSC_VER)
+#define SKITY_C_API __declspec(dllexport)
+#else
+#define SKITY_C_API __attribute__((visibility("default")))
+#endif
+
+/**
+ * Defines an opaque handle type backed by a wrapper struct whose first member
+ * is skity_object_header. The struct definition itself lives inside the
+ * wrapper implementation and is never visible to C consumers.
+ *
+ *   SKITY_C_DEFINE_HANDLE(skity_paint);
+ *   // expands to: typedef struct skity_paint_s* skity_paint;
+ */
+#define SKITY_C_DEFINE_HANDLE(name) typedef struct name##_s* name
+
+/**
+ * NOTE: the handle header (type tag + ownership flags) and the object-type
+ * enum are implementation details of the wrapper (see src/handle.hpp) and are
+ * intentionally NOT part of the public C ABI. Handles are fully opaque to
+ * consumers — they only ever hold and pass the pointer around.
+ */
+
+/**
+ * @brief Result codes returned by all creating / querying entry points.
+ *        Negative values indicate failure.
+ */
+typedef enum {
+  SKITY_SUCCESS = 0,               /**< operation succeeded */
+  SKITY_ERROR_INVALID_HANDLE = -1, /**< the passed handle is NULL or invalid */
+  SKITY_ERROR_INVALID_ARGUMENT = -2, /**< one or more arguments are invalid */
+  SKITY_ERROR_INITIALIZATION_FAILED =
+      -3, /**< an internal object could not be initialized */
+  SKITY_ERROR_OUT_OF_HOST_MEMORY = -4, /**< host memory allocation failed */
+  SKITY_ERROR_NOT_SUPPORTED =
+      -5, /**< the operation is not supported on this build/backend */
+} skity_result;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BASE_H

--- a/module/capi/include/skity_c/skity_bitmap.h
+++ b/module/capi/include/skity_c/skity_bitmap.h
@@ -1,0 +1,95 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BITMAP_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BITMAP_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief CPU-side pixel buffer the caller owns and may read/write, mirroring
+ *        skity::Bitmap. Allocated with the requested color and alpha types and
+ *        backed by a Pixmap.
+ */
+SKITY_C_DEFINE_HANDLE(skity_bitmap);
+
+/**
+ * @brief Allocate a new bitmap of @p width x @p height pixels with the given
+ *        pixel formats.
+ * @param width       pixel width
+ * @param height      pixel height
+ * @param alpha_type  alpha interpretation of the pixels
+ * @param color_type  color packing of the pixels
+ * @return            a new handle, or NULL on failure
+ */
+SKITY_C_API skity_bitmap skity_bitmap_create(uint32_t width, uint32_t height,
+                                             skity_alpha_type alpha_type,
+                                             skity_color_type color_type);
+
+/** @brief Release the bitmap handle and its pixel storage. Safe on NULL. */
+SKITY_C_API void skity_bitmap_destroy(skity_bitmap bitmap);
+
+/** @brief Return the pixel width of the bitmap. */
+SKITY_C_API uint32_t skity_bitmap_get_width(skity_bitmap bitmap);
+
+/** @brief Return the pixel height of the bitmap. */
+SKITY_C_API uint32_t skity_bitmap_get_height(skity_bitmap bitmap);
+
+/** @brief Return the row stride in bytes (may be larger than width*bpp). */
+SKITY_C_API size_t skity_bitmap_get_row_bytes(skity_bitmap bitmap);
+
+/**
+ * @brief Return a writable pointer to the pixel data. The memory stays valid
+ *        for the life of the bitmap handle.
+ * @return pointer to the writable pixels
+ */
+SKITY_C_API void* skity_bitmap_get_pixels(skity_bitmap bitmap);
+
+/**
+ * @brief Read-only pixel view, mirroring skity::Pixmap. Typically obtained from
+ *        skity_image_read_pixels; the caller must not write through the pixel
+ *        pointer.
+ */
+SKITY_C_DEFINE_HANDLE(skity_pixmap);
+
+/** @brief Release the pixmap handle. Safe on NULL. */
+SKITY_C_API void skity_pixmap_destroy(skity_pixmap pixmap);
+
+/** @brief Return the pixel width of the pixmap. */
+SKITY_C_API uint32_t skity_pixmap_get_width(skity_pixmap pixmap);
+
+/** @brief Return the pixel height of the pixmap. */
+SKITY_C_API uint32_t skity_pixmap_get_height(skity_pixmap pixmap);
+
+/** @brief Return the row stride in bytes (may be larger than width*bpp). */
+SKITY_C_API size_t skity_pixmap_get_row_bytes(skity_pixmap pixmap);
+
+/**
+ * @brief Return a read-only pointer to the pixel data.
+ * @return pointer to the immutable pixels
+ */
+SKITY_C_API const void* skity_pixmap_get_pixels(skity_pixmap pixmap);
+
+/**
+ * @brief Borrow the writable pixel view of a bitmap. The returned pixmap
+ *        shares the bitmap's pixel memory (writes through it are visible to
+ *        the bitmap), so it can be used as a destination for e.g.
+ *        skity_image_scale_pixels. Destroy with skity_pixmap_destroy; the
+ *        bitmap keeps its pixels.
+ * @return a new pixmap handle, or NULL on failure
+ */
+SKITY_C_API skity_pixmap skity_bitmap_get_pixmap(skity_bitmap bitmap);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_BITMAP_H

--- a/module/capi/include/skity_c/skity_camera.h
+++ b/module/capi/include/skity_c/skity_camera.h
@@ -1,0 +1,81 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CAMERA_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CAMERA_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief 3D camera used to build a view / projection matrix for fake-3D
+ *        rendering, mirroring skity::Camera.
+ */
+SKITY_C_DEFINE_HANDLE(skity_camera);
+
+/**
+ * @brief Create a 3D camera for a viewport of @p viewport_width x
+ *        @p viewport_height.
+ * @param viewport_width   viewport width in pixels
+ * @param viewport_height  viewport height in pixels
+ * @return                 a new camera handle, or NULL on failure
+ */
+SKITY_C_API skity_camera skity_camera_create(float viewport_width,
+                                             float viewport_height);
+
+/** @brief Release the camera handle. Safe on NULL. */
+SKITY_C_API void skity_camera_destroy(skity_camera camera);
+
+/**
+ * @brief Set the camera position in 3D space.
+ * @param position  camera position interpreted as a Point / Vec4
+ */
+SKITY_C_API void skity_camera_set_position(skity_camera camera,
+                                           const skity_vec4* position);
+
+/**
+ * @brief Point the camera at @p target.
+ * @param target  look-at target interpreted as a Point / Vec4
+ */
+SKITY_C_API void skity_camera_look_at(skity_camera camera,
+                                      const skity_vec4* target);
+
+/**
+ * @brief Set the camera distance used when computing the perspective / view
+ *        matrix.
+ * @param dist  distance from the eye to the near plane
+ */
+SKITY_C_API void skity_camera_set_camera_dist(skity_camera camera, float dist);
+
+/**
+ * @brief Override the camera rotation.
+ * @param rotation  4x4 column-major rotation matrix
+ */
+SKITY_C_API void skity_camera_set_rotation(skity_camera camera,
+                                           const skity_matrix* rotation);
+
+/**
+ * @brief Write the fixed view-projection matrix into @p out.
+ * @param out  points to a skity_matrix; receives 16 column-major floats
+ */
+SKITY_C_API void skity_camera_get_fixed_camera(skity_camera camera,
+                                               skity_matrix* out);
+
+/**
+ * @brief Write the current view-projection matrix (reflecting position / look
+ *        target / rotation / distance) into @p out.
+ * @param out  points to a skity_matrix; receives 16 column-major floats
+ */
+SKITY_C_API void skity_camera_get_camera(skity_camera camera,
+                                         skity_matrix* out);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CAMERA_H

--- a/module/capi/include/skity_c/skity_canvas.h
+++ b/module/capi/include/skity_c/skity_canvas.h
@@ -1,0 +1,399 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CANVAS_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CANVAS_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_font.h>
+#include <skity_c/skity_image.h>
+#include <skity_c/skity_paint.h>
+#include <skity_c/skity_path.h>
+#include <skity_c/skity_surface.h>
+#include <skity_c/skity_text.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Clip operation. Values aligned with skity::Canvas::ClipOp. */
+typedef enum {
+  SKITY_CLIP_OP_DIFFERENCE = 0, /**< subtract the shape from the current clip */
+  SKITY_CLIP_OP_INTERSECT, /**< intersect the shape with the current clip */
+} skity_clip_op;
+
+/**
+ * @brief Save the current matrix and clip on an internal stack so later
+ *        changes can be rolled back with skity_canvas_restore. This is the
+ *        entry point of the save/restore and matrix/clip state group.
+ *
+ * @return the depth of the save stack after this save
+ */
+SKITY_C_API int32_t skity_canvas_save(skity_canvas canvas);
+
+/** @brief Roll back changes to the matrix and clip made since the most recent
+ *         skity_canvas_save. */
+SKITY_C_API void skity_canvas_restore(skity_canvas canvas);
+
+/**
+ * @brief Restore state to the matrix and clip captured when
+ *        skity_canvas_save returned @p save_count. Does nothing if
+ *        @p save_count is greater than the current stack depth.
+ * @param save_count  value previously returned by skity_canvas_save
+ */
+SKITY_C_API void skity_canvas_restore_to_count(skity_canvas canvas,
+                                               int32_t save_count);
+
+/** @brief Return the current depth of the save stack. */
+SKITY_C_API int32_t skity_canvas_get_save_count(skity_canvas canvas);
+
+/**
+ * @brief Translate the current matrix by @p dx along the x-axis and @p dy
+ *        along the y-axis.
+ * @param dx  distance to translate on the x-axis
+ * @param dy  distance to translate on the y-axis
+ */
+SKITY_C_API void skity_canvas_translate(skity_canvas canvas, float dx,
+                                        float dy);
+
+/**
+ * @brief Scale the current matrix by @p sx on the x-axis and @p sy on the
+ *        y-axis.
+ * @param sx  amount to scale on the x-axis
+ * @param sy  amount to scale on the y-axis
+ */
+SKITY_C_API void skity_canvas_scale(skity_canvas canvas, float sx, float sy);
+
+/**
+ * @brief Rotate the current matrix by @p degrees. Positive values rotate
+ *        clockwise.
+ * @param degrees  amount to rotate, in degrees
+ */
+SKITY_C_API void skity_canvas_rotate(skity_canvas canvas, float degrees);
+
+/**
+ * @brief Rotate the current matrix by @p degrees about the point (@p px, @p
+ * py).
+ * @param degrees  amount to rotate, in degrees
+ * @param px       x-axis value of the point to rotate about
+ * @param py       y-axis value of the point to rotate about
+ */
+SKITY_C_API void skity_canvas_rotate_deg(skity_canvas canvas, float degrees,
+                                         float px, float py);
+
+/**
+ * @brief Skew the current matrix by @p sx on the x-axis and @p sy on the
+ *        y-axis.
+ * @param sx  amount to skew on the x-axis
+ * @param sy  amount to skew on the y-axis
+ */
+SKITY_C_API void skity_canvas_skew(skity_canvas canvas, float sx, float sy);
+
+/**
+ * @brief Replace the current matrix with @p matrix premultiplied with the
+ *        existing matrix.
+ * @param matrix  matrix to premultiply with the existing matrix
+ */
+SKITY_C_API void skity_canvas_concat(skity_canvas canvas,
+                                     const skity_matrix* matrix);
+
+/**
+ * @brief Replace the current matrix with @p matrix.
+ * @param matrix  matrix to replace the existing matrix
+ */
+SKITY_C_API void skity_canvas_set_matrix(skity_canvas canvas,
+                                         const skity_matrix* matrix);
+
+/** @brief Reset the current matrix to the identity matrix. */
+SKITY_C_API void skity_canvas_reset_matrix(skity_canvas canvas);
+
+/**
+ * @brief Combine @p rect with the current clip using @p op, replacing the
+ *        clip with the result.
+ * @param rect  rectangle to combine with the clip
+ * @param op    clip operation to apply
+ */
+SKITY_C_API void skity_canvas_clip_rect(skity_canvas canvas,
+                                        const skity_rect* rect,
+                                        skity_clip_op op);
+
+/**
+ * @brief Combine @p path with the current clip using @p op, replacing the
+ *        clip with the result.
+ * @param path  path to combine with the clip
+ * @param op    clip operation to apply
+ */
+SKITY_C_API void skity_canvas_clip_path(skity_canvas canvas, skity_path path,
+                                        skity_clip_op op);
+
+/**
+ * @brief Fill the current clip with a solid @p color combined via @p mode.
+ *        This begins the drawing-primitive group; the draw_xxx functions
+ *        below render geometry, images, and text using the current matrix,
+ *        clip, and the supplied paint.
+ * @param color  unpremultiplied ARGB, packed as 0xAARRGGBB
+ * @param mode   blend mode used to combine the source color with the
+ * destination
+ */
+SKITY_C_API void skity_canvas_draw_color(skity_canvas canvas, skity_color color,
+                                         skity_blend_mode mode);
+
+/**
+ * @brief Fill the entire clip using @p paint. The paint's color, shader,
+ *        color filter, image filter, and blend mode all apply.
+ * @param paint  graphics state used to fill the canvas
+ */
+SKITY_C_API void skity_canvas_draw_paint(skity_canvas canvas,
+                                         skity_paint paint);
+
+/**
+ * @brief Draw a single point at (@p x, @p y) using @p paint. The paint's
+ *        stroke width determines the point size.
+ * @param x      point position on the x-axis
+ * @param y      point position on the y-axis
+ * @param paint  stroke width, color, blend, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_point(skity_canvas canvas, float x, float y,
+                                         skity_paint paint);
+
+/**
+ * @brief Draw a line segment from (@p x0, @p y0) to (@p x1, @p y1) using
+ *        @p paint. The stroke width sets the line thickness; the paint's cap
+ *        controls the end caps; the paint style is treated as stroke.
+ * @param x0     start of the line segment on the x-axis
+ * @param y0     start of the line segment on the y-axis
+ * @param x1     end of the line segment on the x-axis
+ * @param y1     end of the line segment on the y-axis
+ * @param paint  stroke width, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_line(skity_canvas canvas, float x0, float y0,
+                                        float x1, float y1, skity_paint paint);
+
+/**
+ * @brief Draw the rectangle @p rect using @p paint.
+ * @param rect   rectangle to draw
+ * @param paint  stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_rect(skity_canvas canvas,
+                                        const skity_rect* rect,
+                                        skity_paint paint);
+
+/**
+ * @brief Draw a circle centered at (@p cx, @p cy) with the given @p radius
+ *        using @p paint.
+ * @param cx      circle center on the x-axis
+ * @param cy      circle center on the y-axis
+ * @param radius  half the diameter of the circle
+ * @param paint   stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_circle(skity_canvas canvas, float cx,
+                                          float cy, float radius,
+                                          skity_paint paint);
+
+/**
+ * @brief Draw the oval bounded by @p oval using @p paint.
+ * @param oval   rectangle bounds of the oval
+ * @param paint  stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_oval(skity_canvas canvas,
+                                        const skity_rect* oval,
+                                        skity_paint paint);
+
+/**
+ * @brief Draw the rounded rectangle bounded by @p rect with corner radii
+ *        (@p rx, @p ry) using @p paint.
+ * @param rect   bounds of the rounded rectangle to draw
+ * @param rx     x-axis radius of the oval describing the rounded corners
+ * @param ry     y-axis radius of the oval describing the rounded corners
+ * @param paint  stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_round_rect(skity_canvas canvas,
+                                              const skity_rect* rect, float rx,
+                                              float ry, skity_paint paint);
+
+/**
+ * @brief Draw @p path using @p paint.
+ * @param path   path to draw
+ * @param paint  stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_path(skity_canvas canvas, skity_path path,
+                                        skity_paint paint);
+
+/**
+ * @brief Draw @p image with its top-left corner at (@p x, @p y), using the
+ *        default sampling and no paint.
+ * @param image  image to draw
+ * @param x      position of the image's top-left corner on the x-axis
+ * @param y      position of the image's top-left corner on the y-axis
+ */
+SKITY_C_API void skity_canvas_draw_image(skity_canvas canvas, skity_image image,
+                                         float x, float y);
+
+/**
+ * @brief Draw the sub-rectangle @p src of @p image into the destination
+ *        rectangle @p dst, filtered with @p sampling and modulated by @p paint.
+ * @param image     image to draw
+ * @param src       sub-rectangle of the image to draw
+ * @param dst       destination rectangle to draw into
+ * @param sampling  sampling options used to filter the image
+ * @param paint     paint applied to modulate the image; NULL to draw without a
+ * paint
+ */
+SKITY_C_API void skity_canvas_draw_image_rect(
+    skity_canvas canvas, skity_image image, const skity_rect* src,
+    const skity_rect* dst, const skity_sampling_options* sampling,
+    skity_paint paint);
+
+/**
+ * @brief Draw @p blob with its origin at (@p x, @p y) using @p paint. The
+ *        glyphs are taken from the blob; the paint supplies color, blend
+ *        mode, and related state.
+ * @param blob   text blob to draw
+ * @param x      origin of the text blob on the x-axis
+ * @param y      baseline of the text blob on the y-axis
+ * @param paint  color, blend, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_text_blob(skity_canvas canvas,
+                                             skity_text_blob blob, float x,
+                                             float y, skity_paint paint);
+
+/**
+ * @brief Combine the rounded rectangle defined by @p rect and corner radii
+ *        (@p rx, @p ry) with the current clip using @p op, replacing the
+ *        clip with the result.
+ * @param rect  bounds of the rounded rectangle to combine with the clip
+ * @param rx    x-axis radius of the oval describing the rounded corners
+ * @param ry    y-axis radius of the oval describing the rounded corners
+ * @param op    clip operation to apply
+ */
+SKITY_C_API void skity_canvas_clip_rrect(skity_canvas canvas,
+                                         const skity_rect* rect, float rx,
+                                         float ry, skity_clip_op op);
+
+/**
+ * @brief Save the current matrix and clip, and allocate a backend render
+ *        target for subsequent drawing. A matching skity_canvas_restore
+ *        discards the layer and composites it back into the current context,
+ *        applying @p paint's alpha, blend mode, and mask filter.
+ * @param bounds  location and size of the layer's backing store
+ * @param paint   alpha, blend mode, and mask filter applied when the layer
+ *                is composited back to the context
+ * @return the depth of the save stack after this save
+ */
+SKITY_C_API int32_t skity_canvas_save_layer(skity_canvas canvas,
+                                            const skity_rect* bounds,
+                                            skity_paint paint);
+
+/**
+ * @brief Draw an arc that is part of the oval bounded by @p oval, sweeping
+ *        from @p start_angle to @p start_angle plus @p sweep_angle (both in
+ *        degrees). A @p start_angle of zero starts at the right-middle edge of
+ *        the oval; positive @p sweep_angle sweeps clockwise, negative sweeps
+ *        counter-clockwise, and the sweep may exceed 360 degrees. When
+ *        @p use_center is non-zero the arc is drawn as a wedge that includes
+ *        lines from the oval's center to the arc end points; otherwise only
+ *        the arc between the end points is drawn. Nothing is drawn if @p oval
+ *        is empty or @p sweep_angle is zero.
+ * @param oval         bounds of the oval containing the arc
+ * @param start_angle  angle in degrees where the arc begins
+ * @param sweep_angle  sweep angle in degrees; positive is clockwise
+ * @param use_center   non-zero to include the oval's center, forming a wedge
+ * @param paint        stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_arc(skity_canvas canvas,
+                                       const skity_rect* oval,
+                                       float start_angle, float sweep_angle,
+                                       uint32_t use_center, skity_paint paint);
+
+/**
+ * @brief Draw the ring shape formed by the rounded rectangle @p outer minus
+ *        the rounded rectangle @p inner. Each rounded rectangle is described
+ *        by its bounds and corner radii.
+ * @param outer     bounds of the outer rounded rectangle
+ * @param outer_rx  x-axis radius of the outer corners
+ * @param outer_ry  y-axis radius of the outer corners
+ * @param inner     bounds of the inner rounded rectangle (the hole)
+ * @param inner_rx  x-axis radius of the inner corners
+ * @param inner_ry  y-axis radius of the inner corners
+ * @param paint     stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_drrect(skity_canvas canvas,
+                                          const skity_rect* outer,
+                                          float outer_rx, float outer_ry,
+                                          const skity_rect* inner,
+                                          float inner_rx, float inner_ry,
+                                          skity_paint paint);
+
+/**
+ * @brief Write the current total matrix (the accumulated transform applied
+ *        to the canvas) to @p out.
+ * @param out  receives the total matrix; must not be NULL
+ */
+SKITY_C_API void skity_canvas_get_total_matrix(skity_canvas canvas,
+                                               skity_matrix* out);
+
+/**
+ * @brief Write the current clip bounds, expressed in local (pre-transform)
+ *        coordinates, to @p out.
+ * @param out  receives the local clip bounds; must not be NULL
+ */
+SKITY_C_API void skity_canvas_get_local_clip_bounds(skity_canvas canvas,
+                                                    skity_rect* out);
+
+/**
+ * @brief Test whether @p rect is entirely outside the current clip.
+ * @param rect  rectangle to test
+ * @return 1 if @p rect is fully outside the clip and the draw can be skipped,
+ *         0 otherwise
+ */
+SKITY_C_API uint32_t skity_canvas_quick_reject(skity_canvas canvas,
+                                               const skity_rect* rect);
+
+/**
+ * @brief Draw a run of @p count glyphs at the given positions using @p font
+ *        and @p paint. @p glyphs, @p positions_x, and @p positions_y must
+ *        each contain at least @p count entries.
+ * @param count        number of glyphs to draw
+ * @param glyphs       array of glyph IDs, length @p count
+ * @param positions_x  x position of each glyph, length @p count
+ * @param positions_y  y position of each glyph, length @p count
+ * @param font         font used to render the glyphs
+ * @param paint        color, blend, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_glyphs(skity_canvas canvas, uint32_t count,
+                                          const uint16_t* glyphs,
+                                          const float* positions_x,
+                                          const float* positions_y,
+                                          skity_font font, skity_paint paint);
+
+/**
+ * @brief Submit accumulated draw commands to the GPU backend. Must be called
+ *        before skity_surface_flush. On OpenGL backends this may leave the
+ *        stencil buffer dirty and change stencil/color state; on Vulkan
+ *        backends it fills the current command buffer and changes the bound
+ *        pipeline.
+ */
+SKITY_C_API void skity_canvas_flush(skity_canvas canvas);
+
+/** @brief Return the canvas width in pixels. */
+SKITY_C_API uint32_t skity_canvas_get_width(skity_canvas canvas);
+
+/** @brief Return the canvas height in pixels. */
+SKITY_C_API uint32_t skity_canvas_get_height(skity_canvas canvas);
+
+/**
+ * @brief Release the non-owning canvas wrapper. The underlying Canvas object
+ *        is owned by the surface and is not deleted here. Calling this is
+ *        optional — the wrapper is small, but releasing it avoids leaking the
+ *        wrapper struct across many frames.
+ */
+SKITY_C_API void skity_canvas_destroy(skity_canvas canvas);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CANVAS_H

--- a/module/capi/include/skity_c/skity_color_filter.h
+++ b/module/capi/include/skity_c/skity_color_filter.h
@@ -1,0 +1,66 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_COLOR_FILTER_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_COLOR_FILTER_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ColorFilter: transforms the source color of each pixel during
+ *        drawing. Filters are composable and can be wrapped as an image
+ *        filter. Mirrors skity::ColorFilter.
+ */
+SKITY_C_DEFINE_HANDLE(skity_color_filter);
+
+/**
+ * @brief Create a color filter that blends each source pixel with a constant
+ *        color using @p mode.
+ * @param color  unpremultiplied ARGB, packed as 0xAARRGGBB
+ * @param mode   blend mode applied per pixel
+ * @return       filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_color_filter
+skity_color_filter_create_blend(skity_color color, skity_blend_mode mode);
+
+/**
+ * @brief Create a color filter that applies @p outer after @p inner:
+ *        result = outer(inner(src)).
+ * @param outer  filter applied last
+ * @param inner  filter applied first
+ * @return       composed filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_color_filter skity_color_filter_create_compose(
+    skity_color_filter outer, skity_color_filter inner);
+
+/**
+ * @brief Create a color filter that applies a 4x5 color matrix to each pixel.
+ * @param row_major  20 floats, 4 rows x 5 columns (RGBA + bias)
+ * @return           filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_color_filter
+skity_color_filter_create_matrix(const float* row_major);
+
+/** @brief Create a color filter that converts sRGB-encoded pixels to a linear
+ *         gamma. */
+SKITY_C_API skity_color_filter skity_color_filter_create_linear_to_srgb(void);
+
+/** @brief Create a color filter that converts linear-gamma pixels to sRGB
+ *         encoding. */
+SKITY_C_API skity_color_filter skity_color_filter_create_srgb_to_linear(void);
+
+/** @brief Release the color filter handle and its underlying object. Safe on
+ *         NULL. */
+SKITY_C_API void skity_color_filter_destroy(skity_color_filter filter);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_COLOR_FILTER_H

--- a/module/capi/include/skity_c/skity_context.h
+++ b/module/capi/include/skity_c/skity_context.h
@@ -1,0 +1,143 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_H
+
+#include <skity_c/skity_base.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque handle to a skity::GPUContext, the root of the GPU backend
+ *         that owns surfaces, textures, and the render-thread state. */
+SKITY_C_DEFINE_HANDLE(skity_context);
+
+/**
+ * @brief GL procedure address loader.
+ *
+ * A plain C function pointer `void* (*)(const char*)`, matching the glad
+ * GLADloadfunc contract that skity::GLContextCreate expects internally.
+ * Pass something like glfwGetProcAddress / eglGetProcAddress / the platform
+ * equivalent.
+ */
+typedef void* (*skity_gl_get_proc)(const char* name);
+
+/**
+ * @brief Create a GPUContext targeting the OpenGL / OpenGL ES backend.
+ *
+ * The created context owns its GL interface and is returned with the owning
+ * flag set; call skity_context_destroy to release it.
+ *
+ * @param get_proc    function used to load GL symbol addresses at runtime
+ * @param out_context receives the new context handle on success
+ * @return SKITY_SUCCESS on success, or a SKITY_ERROR_* code on failure
+ */
+SKITY_C_API skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
+                                                 skity_context* out_context);
+
+/** @brief Destroy a context previously created by skity_context_create_gl or
+ *         skity_context_create_vk. Safe to call with NULL or a wrong-type
+ *         handle (both are rejected silently). */
+SKITY_C_API void skity_context_destroy(skity_context context);
+
+/** @brief GPU error code reported through the error callback. Values aligned
+ *         with skity::GPUError. */
+typedef enum {
+  SKITY_GPU_ERROR_NO_ERROR = 0,   /**< no error, everything is fine */
+  SKITY_GPU_ERROR_GPU_ERROR,      /**< error during GPU context creation (e.g.
+                                     missing driver) */
+  SKITY_GPU_ERROR_PIPELINE_ERROR, /**< error during pipeline creation (shader
+                                     compile/link) */
+} skity_gpu_error;
+
+/**
+ * @brief Error callback invoked by the engine. skity_gpu_error is
+ *        ABI-compatible with skity::GPUError (both int-backed enums with
+ *        matching values), so the C callback is passed straight through.
+ *
+ * @param error    error code
+ * @param message  human-readable description (valid only for the duration of
+ *                 the call)
+ * @param userdata opaque pointer registered alongside the callback
+ */
+typedef void (*skity_gpu_error_callback)(skity_gpu_error error,
+                                         const char* message, void* userdata);
+
+/**
+ * @brief Register a callback to receive engine error reports.
+ * @param callback  function invoked on error (may be NULL to clear)
+ * @param userdata  opaque pointer passed back to the callback
+ */
+SKITY_C_API void skity_context_set_error_callback(
+    skity_context context, skity_gpu_error_callback callback, void* userdata);
+
+/** @brief Control whether draw calls that can be merged are merged internally
+ *         (on by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_enable_merging_draw_call(
+    skity_context context, uint32_t enable);
+
+/** @brief Control whether contour-based AA is used for anti-aliasing when MSAA
+ *         is disabled (off by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_enable_contour_aa(skity_context context,
+                                                     uint32_t enable);
+
+/** @brief Set the default Coverage AA state for surfaces whose render option is
+ *         kAuto (off by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_enable_coverage_aa(skity_context context,
+                                                      uint32_t enable);
+
+/** @brief Set the default sampling-based conflation correction heuristic for
+ *         surfaces whose render option is kAuto. Ignored when Coverage AA is
+ *         disabled (off by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_conflation_correction(skity_context context,
+                                                         uint32_t enable);
+
+/**
+ * @brief Use a larger atlas cache for better performance at the cost of memory
+ *        (4x per set bit).
+ * @param mask  bit 0 = A8 atlas (normal text), bit 1 = RGBA32 atlas (emoji)
+ */
+SKITY_C_API void skity_context_set_larger_atlas_mask(skity_context context,
+                                                     uint8_t mask);
+
+/**
+ * @brief Use linear filtering when sampling text. Skity does not currently
+ *        render rotated text, so linear filtering hides jagged edges.
+ * @warning This is a workaround and will be removed in the next major version.
+ * @param enable non-zero to enable
+ */
+SKITY_C_API void skity_context_set_enable_text_linear_filter(
+    skity_context context, uint32_t enable);
+
+/** @brief Control whether the GPU tessellation path is used (on by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_enable_gpu_tessellation(
+    skity_context context, uint32_t enable);
+
+/** @brief Control whether the simple-shape pipeline is used (off by default).
+ * @param enable non-zero to enable */
+SKITY_C_API void skity_context_set_enable_simple_shape_pipeline(
+    skity_context context, uint32_t enable);
+
+/**
+ * @brief Set the maximum GPU resource cache size in bytes. Pass 0 to disable
+ *        the cache. Mirrors GPUContext::SetResourceCacheLimit (experimental).
+ * @param max_bytes  maximum cache size in bytes, or 0 to disable caching
+ */
+SKITY_C_API void skity_context_set_resource_cache_limit(skity_context context,
+                                                        size_t max_bytes);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_H

--- a/module/capi/include/skity_c/skity_context_vk.h
+++ b/module/capi/include/skity_c/skity_context_vk.h
@@ -1,0 +1,40 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_VK_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_VK_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_context.h>
+#include <vulkan/vulkan.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create a GPUContext targeting the Vulkan backend.
+ *
+ * The engine creates and owns its own VkInstance / VkDevice, so the resulting
+ * context cannot be mixed with other Vulkan code. The instance and device are
+ * not available for outside use.
+ *
+ * Native Vulkan types (PFN_vkGetInstanceProcAddr) are reused directly because
+ * they are already C and ABI-stable.
+ *
+ * Only available when skity is built with SKITY_VK_BACKEND=ON.
+ *
+ * @param get_instance_proc_addr  instance procedure-address loader
+ * @param out_context             receives the new context handle on success
+ * @return SKITY_SUCCESS on success, or a SKITY_ERROR_* code on failure
+ */
+SKITY_C_API skity_result
+skity_context_create_vk(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                        skity_context* out_context);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_CONTEXT_VK_H

--- a/module/capi/include/skity_c/skity_data.h
+++ b/module/capi/include/skity_c/skity_data.h
@@ -1,0 +1,60 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_DATA_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_DATA_H
+
+#include <skity_c/skity_base.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Immutable byte buffer, mirroring skity::Data. The pointer returned
+ *        by skity_data_get_data stays valid for the life of the handle and is
+ *        always the same address.
+ */
+SKITY_C_DEFINE_HANDLE(skity_data);
+
+/**
+ * @brief Create a new buffer holding a copy of the first @p length bytes of
+ *        @p data.
+ * @param data   source bytes to copy (may be NULL when @p length is 0)
+ * @param length number of bytes to copy
+ * @return       a new handle, or NULL on allocation failure
+ */
+SKITY_C_API skity_data skity_data_make_with_copy(const void* data,
+                                                 size_t length);
+
+/**
+ * @brief Load a whole file into memory.
+ * @param path  filesystem path of the file to load
+ * @return      a new handle, or NULL if the file could not be opened or read
+ */
+SKITY_C_API skity_data skity_data_make_from_file(const char* path);
+
+/** @brief Return a shared, always-non-NULL empty buffer (size() == 0). */
+SKITY_C_API skity_data skity_data_make_empty(void);
+
+/** @brief Release the data handle and its underlying buffer. Safe on NULL. */
+SKITY_C_API void skity_data_destroy(skity_data data);
+
+/** @brief Return the number of bytes stored in the buffer. */
+SKITY_C_API size_t skity_data_get_size(skity_data data);
+
+/**
+ * @brief Return a read-only pointer to the bytes. The address is stable for
+ *        the life of the handle; returns NULL for an empty buffer.
+ * @return pointer to the immutable bytes
+ */
+SKITY_C_API const void* skity_data_get_data(skity_data data);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_DATA_H

--- a/module/capi/include/skity_c/skity_font.h
+++ b/module/capi/include/skity_c/skity_font.h
@@ -1,0 +1,202 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_FONT_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_FONT_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_text.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque font, the C handle for skity::Font. Pairs a typeface with a
+ *         size and a set of glyph-rendering options (hinting, edging, etc.). */
+SKITY_C_DEFINE_HANDLE(skity_font);
+
+/** @brief Glyph hinting level. Values aligned with skity::Font::FontHinting. */
+typedef enum {
+  SKITY_FONT_HINTING_NONE = 0, /**< glyph outlines left unchanged */
+  SKITY_FONT_HINTING_SLIGHT,   /**< minimal modification to improve contrast */
+  SKITY_FONT_HINTING_NORMAL, /**< glyph outlines modified to improve contrast */
+  SKITY_FONT_HINTING_FULL, /**< glyph outlines adjusted for maximum contrast */
+} skity_font_hinting;
+
+/** @brief Glyph edge rendering. Values aligned with skity::Font::Edging. */
+typedef enum {
+  SKITY_FONT_EDGING_ALIAS = 0,  /**< opaque edges, no transparency */
+  SKITY_FONT_EDGING_ANTI_ALIAS, /**< edges may use partial transparency */
+  SKITY_FONT_EDGING_SUBPIXEL_ANTI_ALIAS, /**< glyph positioned at subpixel
+                                            resolution */
+} skity_font_edging;
+
+/** @brief Create a font initialized to its default typeface and size. */
+SKITY_C_API skity_font skity_font_create(void);
+
+/**
+ * @brief Create a font from @p typeface at @p size.
+ * @param typeface  typeface to use (NULL selects the default)
+ * @param size      text size in pixels; values <= 0 are ignored
+ */
+SKITY_C_API skity_font skity_font_create_with_typeface(skity_typeface typeface,
+                                                       float size);
+
+/**
+ * @brief Create a font from @p typeface at @p size with horizontal axis
+ *        transforms.
+ * @param typeface  typeface to use (NULL selects the default)
+ * @param size      text size in pixels; values <= 0 are ignored
+ * @param scale_x   horizontal scale; 1.0 leaves glyphs unmodified
+ * @param skew_x    horizontal skew; 0.0 leaves glyphs unmodified
+ */
+SKITY_C_API skity_font skity_font_create_with_typeface_scale(
+    skity_typeface typeface, float size, float scale_x, float skew_x);
+
+/** @brief Release a font handle. Safe on NULL. */
+SKITY_C_API void skity_font_destroy(skity_font font);
+
+/**
+ * @brief Replace the typeface. Pass NULL to revert to the default typeface.
+ */
+SKITY_C_API void skity_font_set_typeface(skity_font font,
+                                         skity_typeface typeface);
+
+/**
+ * @brief Return the typeface currently bound to this font.
+ * @return a new owning handle to the typeface, or NULL if the font has no
+ *         typeface assigned (e.g. default-constructed and never set). The
+ *         caller must release the returned handle with
+ *         skity_typeface_destroy.
+ */
+SKITY_C_API skity_typeface skity_font_get_typeface(skity_font font);
+
+/** @brief Set the text size in pixels. Values <= 0 are ignored. */
+SKITY_C_API void skity_font_set_size(skity_font font, float size);
+
+/** @brief Return the current text size in pixels. */
+SKITY_C_API float skity_font_get_size(skity_font font);
+
+/** @brief Return the horizontal scale applied to glyphs (default 1.0). */
+SKITY_C_API float skity_font_get_scale_x(skity_font font);
+
+/** @brief Set the horizontal scale applied to glyphs (default 1.0). */
+SKITY_C_API void skity_font_set_scale_x(skity_font font, float scale_x);
+
+/** @brief Return the horizontal skew applied to glyphs (default 0.0). */
+SKITY_C_API float skity_font_get_skew_x(skity_font font);
+
+/** @brief Set the horizontal skew applied to glyphs (default 0.0). */
+SKITY_C_API void skity_font_set_skew_x(skity_font font, float skew_x);
+
+/**
+ * @brief Fetch the font metrics (ascent, descent, leading, ...).
+ * @param out  receives the metrics; must point to a valid skity_font_metrics
+ */
+SKITY_C_API void skity_font_get_metrics(skity_font font,
+                                        skity_font_metrics* out);
+
+/** @brief Rendering-quality switches (see skity::Font). */
+
+/** @brief Set how aggressively glyph outlines are snapped for contrast. */
+SKITY_C_API void skity_font_set_hinting(skity_font font,
+                                        skity_font_hinting hinting);
+
+/** @brief Return the current hinting level. */
+SKITY_C_API skity_font_hinting skity_font_get_hinting(skity_font font);
+
+/** @brief Set how the edge pixels of a glyph are rendered. */
+SKITY_C_API void skity_font_set_edging(skity_font font,
+                                       skity_font_edging edging);
+
+/** @brief Return the current edge rendering mode. */
+SKITY_C_API skity_font_edging skity_font_get_edging(skity_font font);
+
+/**
+ * @brief Toggle subpixel glyph positioning.
+ * @param enable  non-zero to enable subpixel positioning
+ */
+SKITY_C_API void skity_font_set_subpixel(skity_font font, uint32_t enable);
+
+/**
+ * @brief Force the auto-hinter even when the font ships its own hints.
+ * @param enable  non-zero to force auto-hinting
+ */
+SKITY_C_API void skity_font_set_force_auto_hinting(skity_font font,
+                                                   uint32_t enable);
+
+/**
+ * @brief Allow embedded bitmap (EBDT/sbix) strikes to be used when available.
+ * @param enable  non-zero to use embedded bitmaps
+ */
+SKITY_C_API void skity_font_set_embedded_bitmaps(skity_font font,
+                                                 uint32_t enable);
+
+/**
+ * @brief Use linear (non-rounded) metrics so advances are not snapped to
+ *        whole pixels.
+ * @param enable  non-zero to enable linear metrics
+ */
+SKITY_C_API void skity_font_set_linear_metrics(skity_font font,
+                                               uint32_t enable);
+
+/**
+ * @brief Synthesize a bolder appearance by widening glyph stems.
+ * @param enable  non-zero to embolden glyphs
+ */
+SKITY_C_API void skity_font_set_embolden(skity_font font, uint32_t enable);
+
+/**
+ * @brief Snap the baseline to an integer pixel boundary for crisper text.
+ * @param enable  non-zero to snap the baseline
+ */
+SKITY_C_API void skity_font_set_baseline_snap(skity_font font, uint32_t enable);
+
+/**
+ * @brief Rendering-quality switch getters (see skity::Font). Each returns 1 if
+ *        the corresponding switch is enabled, 0 otherwise.
+ */
+/** @brief Return 1 if the auto-hinter is forced on, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_force_auto_hinting(skity_font font);
+
+/** @brief Return 1 if embedded bitmap strikes are allowed, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_embedded_bitmaps(skity_font font);
+
+/** @brief Return 1 if subpixel glyph positioning is enabled, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_subpixel(skity_font font);
+
+/** @brief Return 1 if linear (non-rounded) metrics are used, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_linear_metrics(skity_font font);
+
+/** @brief Return 1 if glyphs are emboldened, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_embolden(skity_font font);
+
+/** @brief Return 1 if the baseline snaps to pixel boundaries, 0 otherwise. */
+SKITY_C_API uint32_t skity_font_is_baseline_snap(skity_font font);
+
+/**
+ * @brief Return a copy of this font configured with @p size.
+ * @param size  the new text size in pixels
+ * @return a new font handle
+ */
+SKITY_C_API skity_font skity_font_make_with_size(skity_font font, float size);
+
+/**
+ * @brief Measure the advance width of each glyph.
+ *
+ * The caller must ensure @p widths points to at least @p count entries.
+ *
+ * @param glyphs  array of @p count glyph ids
+ * @param count   number of glyphs in @p glyphs
+ * @param widths  output array receiving @p count advance widths
+ */
+SKITY_C_API void skity_font_get_widths(skity_font font, const uint16_t* glyphs,
+                                       int32_t count, float* widths);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_FONT_H

--- a/module/capi/include/skity_c/skity_image.h
+++ b/module/capi/include/skity_c/skity_image.h
@@ -1,0 +1,209 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_bitmap.h>
+#include <skity_c/skity_texture.h>
+#include <skity_c/skity_types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Image: a 2D raster of pixels that can be sampled by a shader or drawn
+ *        to a surface. Backed by CPU memory, a GPU texture, a deferred-upload
+ *        placeholder, or a promise texture. Mirrors skity::Image.
+ */
+SKITY_C_DEFINE_HANDLE(skity_image);
+
+/**
+ * @brief Create a raster image from raw pixel data. The pixels are copied, so
+ *        the caller's buffer may be released immediately after this returns.
+ * @param width       pixel width
+ * @param height      pixel height
+ * @param pixels      pointer to the pixel data
+ * @param row_bytes   bytes per row; 0 means width * bytes-per-pixel (tightly
+ *                    packed)
+ * @param alpha_type  how to interpret the alpha channel
+ * @param color_type  how pixel bits encode color (RGBA / BGRA / ...)
+ * @return            image handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image skity_image_create_from_pixels(
+    uint32_t width, uint32_t height, const void* pixels, size_t row_bytes,
+    skity_alpha_type alpha_type, skity_color_type color_type);
+
+/**
+ * @brief Create a raster image from raw pixel data, bound to a GPU @p context.
+ *        Variant of skity_image_create_from_pixels that associates the image
+ *        with a GPU context so it can be uploaded / used as a texture on that
+ *        device. The pixels are copied, so the caller's buffer may be released
+ *        immediately after this returns. Passing a NULL @p context degrades to
+ *        the pure-CPU path (equivalent to skity_image_create_from_pixels).
+ * @param width       pixel width
+ * @param height      pixel height
+ * @param pixels      pointer to the pixel data
+ * @param row_bytes   bytes per row; 0 means width * bytes-per-pixel (tightly
+ *                    packed)
+ * @param alpha_type  how to interpret the alpha channel
+ * @param color_type  how pixel bits encode color (RGBA / BGRA / ...)
+ * @param context     GPU context to bind the image to; may be NULL
+ * @return            image handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image skity_image_create_from_pixels_with_context(
+    uint32_t width, uint32_t height, const void* pixels, size_t row_bytes,
+    skity_alpha_type alpha_type, skity_color_type color_type,
+    skity_context context);
+
+/** @brief Release the image handle and its underlying object. Safe on NULL. */
+SKITY_C_API void skity_image_destroy(skity_image image);
+
+/** @brief Return the pixel width of the image. */
+SKITY_C_API uint32_t skity_image_get_width(skity_image image);
+
+/** @brief Return the pixel height of the image. */
+SKITY_C_API uint32_t skity_image_get_height(skity_image image);
+
+/**
+ * @brief Wrap an existing GPU texture as an image. The image references the
+ *        texture, which must outlive the image.
+ * @param texture  GPU texture to wrap
+ * @return         image handle, or NULL on failure
+ */
+SKITY_C_API skity_image skity_image_create_from_texture(skity_texture texture);
+
+/**
+ * @brief Create a deferred-upload image: a placeholder that knows its format
+ *        and size but has no GPU texture yet. Bind a texture later with
+ *        skity_image_deferred_set_texture. Useful when the texture is uploaded
+ *        lazily or produced on another thread.
+ * @param format      texture format to reserve
+ * @param width       pixel width
+ * @param height      pixel height
+ * @param alpha_type  alpha interpretation for the future texture
+ * @return            image handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image
+skity_image_create_deferred(skity_texture_format format, uint32_t width,
+                            uint32_t height, skity_alpha_type alpha_type);
+
+/**
+ * @brief Bind a texture to a deferred image created with
+ *        skity_image_create_deferred. Calling this on a non-deferred image is
+ *        undefined.
+ * @param image    deferred image handle
+ * @param texture  texture to bind; must outlive the image
+ */
+SKITY_C_API void skity_image_deferred_set_texture(skity_image image,
+                                                  skity_texture texture);
+
+/**
+ * @brief Promise-texture callback invoked when skity needs the GPU texture
+ *        backing a promise image. Return a shared (ref-counted) texture
+ *        handle; the caller keeps ownership of the texture lifecycle (video /
+ *        camera frames, cross-process textures, ...). The returned handle is
+ *        shared with skity, so it stays alive until both sides release it.
+ *
+ * @param userdata  caller-supplied pointer passed back unchanged
+ * @return          current GPU texture
+ */
+typedef skity_texture (*skity_promise_texture_callback)(void* userdata);
+
+/**
+ * @brief Variant of skity_promise_texture_callback that also receives the GPU
+ *        context the image is being used with, allowing context-specific
+ *        texture selection.
+ *
+ * @param userdata  caller-supplied pointer passed back unchanged
+ * @param context   GPU context the image is currently bound to
+ * @return          current GPU texture
+ */
+typedef skity_texture (*skity_promise_texture_callback2)(void* userdata,
+                                                         skity_context context);
+
+/**
+ * @brief Promise-texture callback invoked when a promise image is destroyed
+ *        and the caller no longer needs to keep its texture alive.
+ *
+ * @param userdata  caller-supplied pointer passed back unchanged
+ */
+typedef void (*skity_promise_release_callback)(void* userdata);
+
+/**
+ * @brief Create a promise-texture image (v1): @p get_texture receives only
+ *        @p userdata. skity invokes @p get_texture when it needs the GPU
+ *        texture, and @p release when the promise is no longer needed (image
+ *        destroyed).
+ * @param format       texture format
+ * @param width        pixel width
+ * @param height       pixel height
+ * @param alpha_type   alpha interpretation
+ * @param get_texture  callback returning the current texture
+ * @param release      callback invoked when the promise is no longer needed
+ * @param userdata     caller-supplied pointer passed back to the callbacks
+ * @return             image handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image skity_image_create_promise(
+    skity_texture_format format, uint32_t width, uint32_t height,
+    skity_alpha_type alpha_type, skity_promise_texture_callback get_texture,
+    skity_promise_release_callback release, void* userdata);
+
+/**
+ * @brief Create a promise-texture image (v2): identical to
+ *        skity_image_create_promise, but @p get_texture also receives the GPU
+ *        context the image is being used with.
+ * @param format       texture format
+ * @param width        pixel width
+ * @param height       pixel height
+ * @param alpha_type   alpha interpretation
+ * @param get_texture  callback returning the current texture for the given
+ *                     GPU context
+ * @param release      callback invoked when the promise is no longer needed
+ * @param userdata     caller-supplied pointer passed back to the callbacks
+ * @return             image handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image skity_image_create_promise2(
+    skity_texture_format format, uint32_t width, uint32_t height,
+    skity_alpha_type alpha_type, skity_promise_texture_callback2 get_texture,
+    skity_promise_release_callback release, void* userdata);
+
+/**
+ * @brief Read the image's pixels back to CPU memory.
+ * @param image    source image
+ * @param context  GPU context, required when the image is GPU-backed
+ * @return         read-only pixmap handle, or NULL on failure (e.g. the image
+ *                 has no readable backing)
+ */
+SKITY_C_API skity_pixmap skity_image_read_pixels(skity_image image,
+                                                 skity_context context);
+
+/**
+ * @brief Resample the image's pixels into @p dst, scaling to fill the entire
+ *        destination pixmap. @p dst describes the destination buffer (width,
+ *        height, row bytes, color / alpha info) and the caller owns its
+ *        writable storage. GPU-backed images require a non-NULL @p context to
+ *        perform the readback; CPU-backed images accept NULL.
+ * @param image    source image
+ * @param dst      destination pixmap (writable pixel buffer)
+ * @param context  GPU context, required when the image is GPU-backed; may be
+ *                 NULL for CPU-backed images
+ * @param sampling filter / mipmap / cubic resampling options; NULL uses the
+ *                 defaults (nearest-filter, no mipmap, no cubic)
+ * @return         1 on success, 0 on failure (NULL image / dst, or the
+ *                 backend failed to scale)
+ */
+SKITY_C_API uint32_t skity_image_scale_pixels(
+    skity_image image, skity_pixmap dst, skity_context context,
+    const skity_sampling_options* sampling);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_H

--- a/module/capi/include/skity_c/skity_image_filter.h
+++ b/module/capi/include/skity_c/skity_image_filter.h
@@ -1,0 +1,112 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_FILTER_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_FILTER_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_color_filter.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ImageFilter: filters the entire drawing before it is composited,
+ *        operating on the source image rather than per-pixel. Used for blur,
+ *        shadows, morphology, transforms, and chaining filters together.
+ *        Mirrors skity::ImageFilter.
+ */
+SKITY_C_DEFINE_HANDLE(skity_image_filter);
+
+/**
+ * @brief Create a Gaussian blur image filter.
+ * @param sigma_x  horizontal blur sigma, in pixels; must be >= 0
+ * @param sigma_y  vertical blur sigma, in pixels; must be >= 0
+ * @return         filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_blur(float sigma_x,
+                                                              float sigma_y);
+
+/**
+ * @brief Create a morphology dilate (max) image filter.
+ * @param radius_x  horizontal dilation radius, in pixels
+ * @param radius_y  vertical dilation radius, in pixels
+ * @return          filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_dilate(float radius_x,
+                                                                float radius_y);
+
+/**
+ * @brief Create a morphology erode (min) image filter.
+ * @param radius_x  horizontal erosion radius, in pixels
+ * @param radius_y  vertical erosion radius, in pixels
+ * @return          filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_erode(float radius_x,
+                                                               float radius_y);
+
+/**
+ * @brief Create an image filter that transforms its input by @p matrix.
+ * @param matrix  4x4 transform applied to the filtered result
+ * @return        filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter
+skity_image_filter_create_matrix_transform(const skity_matrix* matrix);
+
+/**
+ * @brief Wrap a color filter as an image filter so it can be chained or
+ *        attached where an image filter is expected.
+ * @param filter  color filter to wrap
+ * @return        image filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter
+skity_image_filter_create_from_color_filter(skity_color_filter filter);
+
+/**
+ * @brief Create a composed image filter: result = outer(inner(src)).
+ * @param outer  filter applied last
+ * @param inner  filter applied first
+ * @return       composed filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_compose(
+    skity_image_filter outer, skity_image_filter inner);
+
+/**
+ * @brief Create a drop-shadow image filter.
+ * @param dx       horizontal shadow offset, in pixels
+ * @param dy       vertical shadow offset, in pixels
+ * @param sigma_x  horizontal blur sigma of the shadow, in pixels
+ * @param sigma_y  vertical blur sigma of the shadow, in pixels
+ * @param color    shadow color, unpremultiplied ARGB packed as 0xAARRGGBB
+ * @param input    source image filter to shadow, or NULL to use the source
+ *                 primitive directly
+ * @param crop     optional crop rectangle applied to the output, or NULL for
+ *                 no crop
+ * @return         filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_drop_shadow(
+    float dx, float dy, float sigma_x, float sigma_y, skity_color color,
+    skity_image_filter input, const skity_rect* crop);
+
+/**
+ * @brief Wrap an image filter with a local matrix applied before the canvas
+ *        matrix.
+ * @param input   filter to wrap
+ * @param matrix  local transform applied to @p input's sampling
+ * @return        filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_image_filter skity_image_filter_create_local_matrix(
+    skity_image_filter input, const skity_matrix* matrix);
+
+/** @brief Release the image filter handle and its underlying object. Safe on
+ *         NULL. */
+SKITY_C_API void skity_image_filter_destroy(skity_image_filter filter);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_IMAGE_FILTER_H

--- a/module/capi/include/skity_c/skity_mask_filter.h
+++ b/module/capi/include/skity_c/skity_mask_filter.h
@@ -1,0 +1,48 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_MASK_FILTER_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_MASK_FILTER_H
+
+#include <skity_c/skity_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MaskFilter: modifies the alpha mask of a drawing primitive before it
+ *        is rasterized. Currently used to apply Gaussian blur to edges and
+ *        alpha. Mirrors skity::MaskFilter.
+ */
+SKITY_C_DEFINE_HANDLE(skity_mask_filter);
+
+/** @brief Blur style, controlling what is drawn inside vs. outside the
+ *         geometry's alpha mask. Values aligned with skity::BlurStyle
+ *         (starts at 1). */
+typedef enum {
+  SKITY_BLUR_STYLE_NORMAL = 1, /**< fuzzy inside and outside */
+  SKITY_BLUR_STYLE_SOLID = 2,  /**< solid inside, fuzzy outside */
+  SKITY_BLUR_STYLE_OUTER = 3,  /**< nothing inside, fuzzy outside */
+  SKITY_BLUR_STYLE_INNER = 4,  /**< fuzzy inside, nothing outside */
+} skity_blur_style;
+
+/**
+ * @brief Create a Gaussian blur mask filter.
+ * @param style   which side(s) of the mask are blurred
+ * @param radius  Gaussian blur radius, in pixels; must be > 0
+ * @return        mask filter handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_mask_filter
+skity_mask_filter_create_blur(skity_blur_style style, float radius);
+
+/** @brief Release the mask filter handle and its underlying object. Safe on
+ *         NULL. */
+SKITY_C_API void skity_mask_filter_destroy(skity_mask_filter filter);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_MASK_FILTER_H

--- a/module/capi/include/skity_c/skity_paint.h
+++ b/module/capi/include/skity_c/skity_paint.h
@@ -1,0 +1,223 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PAINT_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PAINT_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_color_filter.h>
+#include <skity_c/skity_image_filter.h>
+#include <skity_c/skity_mask_filter.h>
+#include <skity_c/skity_path_effect.h>
+#include <skity_c/skity_shader.h>
+#include <skity_c/skity_text.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Paint controls the options applied when drawing geometry and text:
+ *        style (fill / stroke), color, stroke parameters, anti-aliasing, blend
+ *        mode, and the attached shader / filters / typeface.
+ */
+SKITY_C_DEFINE_HANDLE(skity_paint);
+
+/** @brief Geometry draw style. Values aligned with skity::Paint::Style. */
+typedef enum {
+  SKITY_PAINT_STYLE_FILL = 0,         /**< fill the geometry */
+  SKITY_PAINT_STYLE_STROKE,           /**< outline the geometry */
+  SKITY_PAINT_STYLE_STROKE_AND_FILL,  /**< fill then stroke */
+  SKITY_PAINT_STYLE_STROKE_THEN_FILL, /**< stroke then fill */
+} skity_paint_style;
+
+/** @brief Decoration drawn at the ends of an open contour. Values aligned
+ *         with skity::Paint::Cap. */
+typedef enum {
+  SKITY_PAINT_CAP_BUTT = 0, /**< no extension */
+  SKITY_PAINT_CAP_ROUND,    /**< cap with a circle */
+  SKITY_PAINT_CAP_SQUARE,   /**< cap with a square */
+} skity_paint_cap;
+
+/** @brief Decoration drawn at the corners of a stroked shape. Values aligned
+ *         with skity::Paint::Join. */
+typedef enum {
+  SKITY_PAINT_JOIN_MITER = 0, /**< extend to the miter limit */
+  SKITY_PAINT_JOIN_ROUND,     /**< join with a circle */
+  SKITY_PAINT_JOIN_BEVEL,     /**< connect the outside edges */
+} skity_paint_join;
+
+/** @brief Create a paint initialized to its defaults (fill style, black,
+ *         no effects). */
+SKITY_C_API skity_paint skity_paint_create(void);
+
+/** @brief Release the paint handle and its underlying object. Safe on NULL. */
+SKITY_C_API void skity_paint_destroy(skity_paint paint);
+
+/** @brief Restore the paint to its default values. */
+SKITY_C_API void skity_paint_reset(skity_paint paint);
+
+/** @brief Set whether the geometry is filled, stroked, or both. */
+SKITY_C_API void skity_paint_set_style(skity_paint paint,
+                                       skity_paint_style style);
+
+/** @brief Set the pen thickness used to outline the shape. */
+SKITY_C_API void skity_paint_set_stroke_width(skity_paint paint, float width);
+
+/** @brief Set how the beginnings and ends of open contours are drawn. */
+SKITY_C_API void skity_paint_set_stroke_cap(skity_paint paint,
+                                            skity_paint_cap cap);
+
+/** @brief Set how corners are drawn when the shape is stroked. */
+SKITY_C_API void skity_paint_set_stroke_join(skity_paint paint,
+                                             skity_paint_join join);
+
+/** @brief Set the limit at which a sharp corner is drawn beveled. */
+SKITY_C_API void skity_paint_set_stroke_miter(skity_paint paint, float miter);
+
+/**
+ * @brief Set the alpha and RGB used for both stroking and filling.
+ * @param color  unpremultiplied ARGB, packed as 0xAARRGGBB
+ */
+SKITY_C_API void skity_paint_set_color(skity_paint paint, skity_color color);
+
+/**
+ * @brief Set the color used when stroking. skity stores stroke and fill colors
+ *        separately; this replaces only the stroke color and leaves the fill
+ *        color untouched.
+ * @param color  unpremultiplied ARGB, packed as 0xAARRGGBB
+ */
+SKITY_C_API void skity_paint_set_stroke_color(skity_paint paint,
+                                              skity_color color);
+
+/**
+ * @brief Set the color used when filling. skity stores stroke and fill colors
+ *        separately; this replaces only the fill color and leaves the stroke
+ *        color untouched.
+ * @param color  unpremultiplied ARGB, packed as 0xAARRGGBB
+ */
+SKITY_C_API void skity_paint_set_fill_color(skity_paint paint,
+                                            skity_color color);
+
+/** @brief Replace the alpha component of the color (0 = fully transparent,
+ *         255 = fully opaque). */
+SKITY_C_API void skity_paint_set_alpha(skity_paint paint, uint8_t alpha);
+
+/** @brief Replace the alpha component as a float in [0, 1]. */
+SKITY_C_API void skity_paint_set_alpha_f(skity_paint paint, float alpha);
+
+/** @brief Set the blend mode applied when this paint draws over the
+ *         destination. */
+SKITY_C_API void skity_paint_set_blend_mode(skity_paint paint,
+                                            skity_blend_mode mode);
+
+/**
+ * @brief Request anti-aliased edges. This is a hint and is not guaranteed.
+ * @param aa  non-zero to enable
+ */
+SKITY_C_API void skity_paint_set_anti_alias(skity_paint paint, uint32_t aa);
+
+/** @brief Set the text size. Values <= 0 are ignored. */
+SKITY_C_API void skity_paint_set_text_size(skity_paint paint, float size);
+
+/**
+ * @brief Attach an effect or typeface. The paint holds a shared reference to
+ *        the passed handle, so the handle may be destroyed immediately
+ *        afterwards.
+ */
+SKITY_C_API void skity_paint_set_shader(skity_paint paint, skity_shader shader);
+SKITY_C_API void skity_paint_set_color_filter(skity_paint paint,
+                                              skity_color_filter filter);
+SKITY_C_API void skity_paint_set_image_filter(skity_paint paint,
+                                              skity_image_filter filter);
+SKITY_C_API void skity_paint_set_mask_filter(skity_paint paint,
+                                             skity_mask_filter filter);
+SKITY_C_API void skity_paint_set_path_effect(skity_paint paint,
+                                             skity_path_effect effect);
+SKITY_C_API void skity_paint_set_typeface(skity_paint paint,
+                                          skity_typeface typeface);
+
+/** @brief Return the current color as an unpremultiplied ARGB value. */
+SKITY_C_API skity_color skity_paint_get_color(skity_paint paint);
+
+/**
+ * @brief Return the stroke color as floating-point RGBA components.
+ * @param out  receives the four components in RGBA order; may be NULL, in which
+ *             case nothing is written
+ */
+SKITY_C_API void skity_paint_get_stroke_color(skity_paint paint,
+                                              skity_vec4* out);
+
+/**
+ * @brief Return the fill color as floating-point RGBA components.
+ * @param out  receives the four components in RGBA order; may be NULL, in which
+ *             case nothing is written
+ */
+SKITY_C_API void skity_paint_get_fill_color(skity_paint paint, skity_vec4* out);
+
+/** @brief Return the current draw style. */
+SKITY_C_API skity_paint_style skity_paint_get_style(skity_paint paint);
+
+/** @brief Return the pen thickness. */
+SKITY_C_API float skity_paint_get_stroke_width(skity_paint paint);
+
+/** @brief Return the limit at which a sharp corner is drawn beveled. */
+SKITY_C_API float skity_paint_get_stroke_miter(skity_paint paint);
+
+/** @brief Return how the beginnings and ends of open contours are drawn. */
+SKITY_C_API skity_paint_cap skity_paint_get_stroke_cap(skity_paint paint);
+
+/** @brief Return how corners are drawn when the shape is stroked. */
+SKITY_C_API skity_paint_join skity_paint_get_stroke_join(skity_paint paint);
+
+/** @brief Return the text size. */
+SKITY_C_API float skity_paint_get_text_size(skity_paint paint);
+
+/** @brief Return the current blend mode. */
+SKITY_C_API skity_blend_mode skity_paint_get_blend_mode(skity_paint paint);
+
+/** @brief Return the alpha component of the color (0..255). */
+SKITY_C_API uint8_t skity_paint_get_alpha(skity_paint paint);
+
+/** @brief Return 1 if anti-aliasing is requested, 0 otherwise. */
+SKITY_C_API uint32_t skity_paint_is_anti_alias(skity_paint paint);
+
+/**
+ * @brief Return the attached shader, or NULL if none is set. The returned
+ *        handle is owning (a new reference to the same underlying shader);
+ *        release it with @ref skity_shader_destroy.
+ */
+SKITY_C_API skity_shader skity_paint_get_shader(skity_paint paint);
+
+/** @brief Return the attached color filter, or NULL if none is set. The
+ *         returned handle is owning; release it with @ref
+ *         skity_color_filter_destroy. */
+SKITY_C_API skity_color_filter skity_paint_get_color_filter(skity_paint paint);
+
+/** @brief Return the attached image filter, or NULL if none is set. The
+ *         returned handle is owning; release it with @ref
+ *         skity_image_filter_destroy. */
+SKITY_C_API skity_image_filter skity_paint_get_image_filter(skity_paint paint);
+
+/** @brief Return the attached mask filter, or NULL if none is set. The
+ *         returned handle is owning; release it with @ref
+ *         skity_mask_filter_destroy. */
+SKITY_C_API skity_mask_filter skity_paint_get_mask_filter(skity_paint paint);
+
+/** @brief Return the attached path effect, or NULL if none is set. The
+ *         returned handle is owning; release it with @ref
+ *         skity_path_effect_destroy. */
+SKITY_C_API skity_path_effect skity_paint_get_path_effect(skity_paint paint);
+
+/** @brief Return the attached typeface, or NULL if none is set. The returned
+ *         handle is owning; release it with @ref skity_typeface_destroy. */
+SKITY_C_API skity_typeface skity_paint_get_typeface(skity_paint paint);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PAINT_H

--- a/module/capi/include/skity_c/skity_path.h
+++ b/module/capi/include/skity_c/skity_path.h
@@ -1,0 +1,283 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Path describes a piece of vector geometry as a sequence of verbs
+ *        (move / line / quad / conic / cubic / close) and their control points.
+ *        It is the geometry source for drawing and clipping, and the operand
+ *        for boolean path operations.
+ */
+SKITY_C_DEFINE_HANDLE(skity_path);
+
+/** @brief Contour winding direction. Values aligned with
+ *         skity::Path::Direction. */
+typedef enum {
+  SKITY_PATH_DIRECTION_CW = 0, /**< clockwise winding */
+  SKITY_PATH_DIRECTION_CCW,    /**< counter-clockwise winding */
+} skity_path_direction;
+
+/** @brief Fill rule used to decide whether a point is inside the path.
+ *         Values aligned with skity::Path::PathFillType. */
+typedef enum {
+  /** non-zero sum of signed edge crossings counts as inside */
+  SKITY_PATH_FILL_TYPE_WINDING = 0,
+  SKITY_PATH_FILL_TYPE_EVEN_ODD, /**< odd number of edge crossings is inside */
+} skity_path_fill_type;
+
+/** @brief Choice of arc size for SVG-style elliptical arcs. Values aligned
+ *         with skity::Path::ArcSize (kSmall = 0, kLarge = 1). */
+typedef enum {
+  SKITY_ARC_SIZE_SMALL = 0, /**< sweep the smaller of the two candidate arcs */
+  SKITY_ARC_SIZE_LARGE = 1, /**< sweep the larger of the two candidate arcs */
+} skity_arc_size;
+
+/** @brief Create an empty path. */
+SKITY_C_API skity_path skity_path_create(void);
+
+/** @brief Release the path handle and its underlying object. Safe on NULL. */
+SKITY_C_API void skity_path_destroy(skity_path path);
+
+/** @brief Clear all verbs and points, leaving the path empty (fill type is
+ *         retained). */
+SKITY_C_API void skity_path_reset(skity_path path);
+
+/** @brief Set the rule used to test whether a point is inside the path. */
+SKITY_C_API void skity_path_set_fill_type(skity_path path,
+                                          skity_path_fill_type type);
+
+/**
+ * @brief Begin a new contour at (x, y). If a contour is already in progress it
+ *        is closed logically (no Close verb is emitted) and a new one starts.
+ */
+SKITY_C_API void skity_path_move_to(skity_path path, float x, float y);
+
+/** @brief Append a straight line from the last point to (x, y). */
+SKITY_C_API void skity_path_line_to(skity_path path, float x, float y);
+
+/**
+ * @brief Append a quadratic Bezier from the last point using one control point.
+ * @param x1, y1  the quadratic control point
+ * @param x2, y2  the end point of the curve
+ */
+SKITY_C_API void skity_path_quad_to(skity_path path, float x1, float y1,
+                                    float x2, float y2);
+
+/**
+ * @brief Append a rational quadratic (conic) from the last point.
+ * @param x1, y1  the control point
+ * @param x2, y2  the end point of the curve
+ * @param weight  conic weight; 1.0 yields a quadratic, < 1 flattens toward the
+ *                chord, > 1 bulges toward the control point
+ */
+SKITY_C_API void skity_path_conic_to(skity_path path, float x1, float y1,
+                                     float x2, float y2, float weight);
+
+/**
+ * @brief Append a cubic Bezier from the last point using two control points.
+ * @param x1, y1  the first control point
+ * @param x2, y2  the second control point
+ * @param x3, y3  the end point of the curve
+ */
+SKITY_C_API void skity_path_cubic_to(skity_path path, float x1, float y1,
+                                     float x2, float y2, float x3, float y3);
+
+/**
+ * @brief Append a circular arc tangent to the segment from the last point
+ *        towards (x1, y1) and ending tangent to the segment towards (x2, y2).
+ *        A connecting line is appended first so the contour stays continuous.
+ * @param x1, y1  intermediate point the incoming tangent points at
+ * @param x2, y2  point the outgoing tangent is taken from
+ * @param radius   radius of the appended arc
+ */
+SKITY_C_API void skity_path_arc_to(skity_path path, float x1, float y1,
+                                   float x2, float y2, float radius);
+
+/** @brief Close the current contour by appending a line back to its start. */
+SKITY_C_API void skity_path_close(skity_path path);
+
+/**
+ * @brief Append a circle centered at (x, y) with the given radius as a new
+ *        contour. Has no effect when radius <= 0.
+ * @param dir  winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_circle(skity_path path, float x, float y,
+                                       float radius, skity_path_direction dir);
+
+/**
+ * @brief Append an upright ellipse bounded by @p oval as a new contour.
+ * @param oval  bounding rect of the ellipse
+ * @param dir   winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_oval(skity_path path, const skity_rect* oval,
+                                     skity_path_direction dir);
+
+/**
+ * @brief Append @p rect as a closed contour (move + three lines + close).
+ * @param dir  winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_rect(skity_path path, const skity_rect* rect,
+                                     skity_path_direction dir);
+
+/**
+ * @brief Append @p rect with corner radii (rx, ry) as a new contour.
+ * @param rx, ry  x and y radii of every corner
+ * @param dir     winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_round_rect(skity_path path,
+                                           const skity_rect* rect, float rx,
+                                           float ry, skity_path_direction dir);
+
+/** @brief Apply @p matrix to every point of the path in place. */
+SKITY_C_API void skity_path_transform(skity_path path,
+                                      const skity_matrix* matrix);
+
+/** @brief Write the bounding box of all points into @p out_bounds. */
+SKITY_C_API void skity_path_get_bounds(skity_path path, skity_rect* out_bounds);
+
+/**
+ * @brief Append @p src to @p path, offset by (dx, dy).
+ */
+SKITY_C_API void skity_path_add_path(skity_path path, skity_path src, float dx,
+                                     float dy);
+
+/**
+ * @brief Append @p rect with uniform corner radii (rx, ry) as a new contour.
+ *        Same shape as skity_path_add_round_rect; kept for naming parity with
+ *        the C++ API.
+ * @param dir  winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_rrect(skity_path path, const skity_rect* rect,
+                                      float rx, float ry,
+                                      skity_path_direction dir);
+
+/** @brief Return 1 if the point (x, y) lies inside the path under the current
+ *         fill type, 0 otherwise. */
+SKITY_C_API uint32_t skity_path_contains(skity_path path, float x, float y);
+
+/** @brief Return the fill rule currently in effect. */
+SKITY_C_API skity_path_fill_type skity_path_get_fill_type(skity_path path);
+
+/** @brief Append @p src to @p path after transforming it by @p matrix
+ *         (append mode — no connecting line is inserted). */
+SKITY_C_API void skity_path_add_path_matrix(skity_path path, skity_path src,
+                                            const skity_matrix* matrix);
+
+/** @brief Append the contours of @p src in reverse order to @p path. */
+SKITY_C_API void skity_path_reverse_add_path(skity_path path, skity_path src);
+
+/** @brief Return the number of verbs stored in the path. */
+SKITY_C_API uint32_t skity_path_count_verbs(skity_path path);
+
+/** @brief Return the number of control points stored in the path. */
+SKITY_C_API uint32_t skity_path_count_points(skity_path path);
+
+/**
+ * @brief Write the point at @p index into @p out as a Vec4.
+ * @return 1 on success, 0 if @p index is out of range.
+ */
+SKITY_C_API uint32_t skity_path_get_point(skity_path path, int32_t index,
+                                          skity_vec4* out);
+
+/**
+ * @brief Test whether the path is equivalent to a single rect when filled.
+ * @param out_rect      if non-NULL and the test passes, receives the rect
+ * @param out_is_closed if non-NULL and the test passes, set to 1 when the
+ *                      contour is closed, 0 otherwise
+ * @return 1 if the path is a rect, 0 otherwise.
+ */
+SKITY_C_API uint32_t skity_path_is_rect(skity_path path, skity_rect* out_rect,
+                                        uint32_t* out_is_closed);
+
+/**
+ * @brief Append an elliptical arc that lies on the ellipse bounded by @p oval.
+ *        Angles are in degrees; zero degrees aligns with the positive x-axis
+ *        and a positive sweepAngle extends the arc clockwise.
+ * @param oval           bounds of the containing ellipse
+ * @param start_angle    starting angle in degrees
+ * @param sweep_angle    sweep in degrees; positive is clockwise, modulo 360
+ * @param force_move_to  non-zero to begin a new contour with this arc; zero to
+ *                       keep the contour continuous (a connecting line is
+ *                       appended when the last point differs from the arc
+ * start)
+ */
+SKITY_C_API void skity_path_arc_to_oval(skity_path path, const skity_rect* oval,
+                                        float start_angle, float sweep_angle,
+                                        uint32_t force_move_to);
+
+/**
+ * @brief Append an SVG-style elliptical arc from the last point to (x, y).
+ * @param rx, ry         radii of the ellipse
+ * @param x_axis_rotate  x-axis rotation of the ellipse in degrees
+ * @param large_arc      choose the larger (SKITY_ARC_SIZE_LARGE) or smaller
+ *                       candidate arc
+ * @param sweep          winding direction of the arc (CW or CCW)
+ * @param x, y           end point of the arc
+ */
+SKITY_C_API void skity_path_arc_to_svg(skity_path path, float rx, float ry,
+                                       float x_axis_rotate,
+                                       skity_arc_size large_arc,
+                                       skity_path_direction sweep, float x,
+                                       float y);
+
+/**
+ * @brief Append @p rect with per-corner radii as a new contour, allowing each
+ *        corner to use different x and y radii.
+ * @param rect   bounds of the rounded rectangle
+ * @param radii  8 floats, laid out as (x, y) pairs in corner order:
+ *               top-left, top-right, bottom-right, bottom-left (the same order
+ *               used by skity::RRect::Corner). May be NULL, in which case the
+ *               call is a no-op.
+ * @param dir    winding direction of the new contour
+ */
+SKITY_C_API void skity_path_add_round_rect_radii(skity_path path,
+                                                 const skity_rect* rect,
+                                                 const float* radii,
+                                                 skity_path_direction dir);
+
+/**
+ * @brief Write the last point of the path into @p out.
+ * @return 1 if the path had a last point (and @p out is non-NULL); 0 otherwise.
+ *         On failure @p out is left untouched.
+ */
+SKITY_C_API uint32_t skity_path_get_last_pt(skity_path path, skity_point* out);
+
+/**
+ * @brief Replace the last point of the path with (x, y). If the path is empty a
+ *        MoveTo is appended instead.
+ */
+SKITY_C_API void skity_path_set_last_pt(skity_path path, float x, float y);
+
+/**
+ * @brief Return a new owning handle holding a transformed copy of @p path; the
+ *        original path is not modified. Returns NULL on a null/wrong-type
+ *        handle or a NULL @p matrix. The caller owns the returned handle and
+ *        must release it with skity_path_destroy.
+ */
+SKITY_C_API skity_path skity_path_copy_with_matrix(skity_path path,
+                                                   const skity_matrix* matrix);
+
+/**
+ * @brief Return a new owning handle holding a uniformly scaled copy of @p path;
+ *        the original path is not modified. Returns NULL on a null handle. The
+ *        caller owns the returned handle and must release it with
+ *        skity_path_destroy.
+ */
+SKITY_C_API skity_path skity_path_copy_with_scale(skity_path path, float scale);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_H

--- a/module/capi/include/skity_c/skity_path_effect.h
+++ b/module/capi/include/skity_c/skity_path_effect.h
@@ -1,0 +1,54 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_EFFECT_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_EFFECT_H
+
+#include <skity_c/skity_base.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief PathEffect: transforms a path's geometry before rasterization
+ *        (e.g. dashing, jittering). Attached to a paint. Mirrors
+ *        skity::PathEffect.
+ */
+SKITY_C_DEFINE_HANDLE(skity_path_effect);
+
+/**
+ * @brief Create a discrete path effect that chops the path into segments of
+ *        length @p seg_length and randomly displaces each segment's vertices.
+ * @param seg_length   length of each segment; must be > 0
+ * @param dev          maximum displacement applied to each vertex; must be
+ *                     >= 0
+ * @param seed_assist  seed for the pseudo-random displacements; 0 makes the
+ *                     result deterministic
+ * @return             path effect handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_path_effect skity_path_effect_create_discrete(
+    float seg_length, float dev, uint32_t seed_assist);
+
+/**
+ * @brief Create a dash path effect that strokes a path as a series of dashes.
+ * @param intervals  array of on/off lengths; must have @p count entries
+ *                   (an even number)
+ * @param count      number of entries in @p intervals; must be even
+ * @param phase      offset into the dash pattern, in pixels
+ * @return           path effect handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_path_effect skity_path_effect_create_dash(
+    const float* intervals, int32_t count, float phase);
+
+/** @brief Release the path effect handle and its underlying object. Safe on
+ *         NULL. */
+SKITY_C_API void skity_path_effect_destroy(skity_path_effect effect);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_EFFECT_H

--- a/module/capi/include/skity_c/skity_path_measure.h
+++ b/module/capi/include/skity_c/skity_path_measure.h
@@ -1,0 +1,94 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_MEASURE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_MEASURE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_path.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief PathMeasure samples a path by arc length: total length, position and
+ *        tangent at a distance, and sub-paths between two distances. A path
+ *        with multiple contours is measured one contour at a time — advance
+ *        with skity_path_measure_next_contour.
+ */
+SKITY_C_DEFINE_HANDLE(skity_path_measure);
+
+/**
+ * @brief Create a measure over @p path.
+ * @param path          the path to measure; may be NULL to create an empty
+ *                      measure (bind a path later with set_path)
+ * @param force_closed  non-zero to synthesize a close when the contour is open
+ * @param res_scale     resolution scale; values > 1 increase measuring
+ *                      precision (1.0 is normal)
+ */
+SKITY_C_API skity_path_measure skity_path_measure_create(skity_path path,
+                                                         uint32_t force_closed,
+                                                         float res_scale);
+
+/** @brief Release the measure handle and its underlying object. Safe on NULL.
+ */
+SKITY_C_API void skity_path_measure_destroy(skity_path_measure measure);
+
+/**
+ * @brief Re-bind this measure to @p path, replacing any previously bound path.
+ * @param path          the new path to measure; NULL detaches
+ * @param force_closed  non-zero to synthesize a close when the contour is open
+ * @return 1 on success, 0 if @p measure is a wrong-type handle.
+ */
+SKITY_C_API uint32_t skity_path_measure_set_path(skity_path_measure measure,
+                                                 skity_path path,
+                                                 uint32_t force_closed);
+
+/** @brief Return the total length of the current contour, or 0 if no path is
+ *         bound. */
+SKITY_C_API float skity_path_measure_get_length(skity_path_measure measure);
+
+/**
+ * @brief Sample the position and unit tangent at @p distance along the current
+ *        contour.
+ *
+ * @p distance is clamped to [0, length]. Both outputs are skity_vec4
+ * (skity::Point / skity::Vector are Vec4) and either may be NULL.
+ *
+ * @return 1 on success, 0 if no path is bound or the contour is zero-length.
+ */
+SKITY_C_API uint32_t skity_path_measure_get_pos_tan(skity_path_measure measure,
+                                                    float distance,
+                                                    skity_vec4* out_position,
+                                                    skity_vec4* out_tangent);
+
+/**
+ * @brief Append the sub-path of the current contour between @p start_d and
+ *        @p stop_d to @p dst.
+ * @param start_d           start distance along the contour
+ * @param stop_d            stop distance along the contour
+ * @param dst               destination path that receives the segment
+ * @param start_with_move_to  non-zero to begin the segment with a MoveTo,
+ *                          0 to continue the current contour
+ * @return 1 on success, 0 if the segment is zero-length or @p start_d >
+ *         @p stop_d.
+ */
+SKITY_C_API uint32_t skity_path_measure_get_segment(
+    skity_path_measure measure, float start_d, float stop_d, skity_path dst,
+    uint32_t start_with_move_to);
+
+/** @brief Return 1 if the current contour is closed, 0 otherwise. */
+SKITY_C_API uint32_t skity_path_measure_is_closed(skity_path_measure measure);
+
+/** @brief Advance to the next contour. Return 1 if one exists, 0 at the end. */
+SKITY_C_API uint32_t
+skity_path_measure_next_contour(skity_path_measure measure);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_MEASURE_H

--- a/module/capi/include/skity_c/skity_path_op.h
+++ b/module/capi/include/skity_c/skity_path_op.h
@@ -1,0 +1,45 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_OP_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_OP_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_path.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Boolean operation kind applied between two paths. Values are
+ *         aligned with skity::PathOp::Op. */
+typedef enum {
+  SKITY_PATH_OP_DIFFERENCE = 0, /**< subtract @p two from @p one */
+  SKITY_PATH_OP_INTERSECT,      /**< keep only the overlap of the two paths */
+  SKITY_PATH_OP_UNION,          /**< combine the two paths into one */
+  SKITY_PATH_OP_XOR,            /**< keep the non-overlapping parts of both */
+} skity_path_op;
+
+/**
+ * @brief Compute the boolean combination of @p one and @p two, overwriting
+ *        @p result with the product. @p result must be an existing skity_path;
+ *        its previous contents are discarded. The result is constructed from
+ *        non-overlapping contours; curves may degenerate to lines and the
+ *        contour direction may change.
+ *
+ * @param one     the first operand
+ * @param two     the second operand
+ * @param op      the operation to apply
+ * @param result  destination path that receives the product
+ * @return 1 on success, 0 on failure or if any handle is null or wrong type.
+ */
+SKITY_C_API uint32_t skity_path_op_execute(skity_path one, skity_path two,
+                                           skity_path_op op, skity_path result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PATH_OP_H

--- a/module/capi/include/skity_c/skity_precompile.h
+++ b/module/capi/include/skity_c/skity_precompile.h
@@ -1,0 +1,81 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PRECOMPILE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PRECOMPILE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_paint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque handle to a skity::PrecompileContext, used to warm up GPU
+ *         pipeline variants before they are needed for drawing. The context
+ *         must be used on the same thread that owns its GPUContext. */
+SKITY_C_DEFINE_HANDLE(skity_precompile_context);
+
+/** @brief Target surface color type for precompilation. Values aligned with
+ *         skity::PrecompileColorType. */
+typedef enum {
+  SKITY_PRECOMPILE_COLOR_TYPE_RGBA = 0, /**< 8-bit RGBA channel order */
+  SKITY_PRECOMPILE_COLOR_TYPE_BGRA,     /**< 8-bit BGRA channel order */
+} skity_precompile_color_type;
+
+/** @brief Draw type for targeted precompilation. Values aligned with
+ *         skity::PrecompileDrawType. */
+typedef enum {
+  SKITY_PRECOMPILE_DRAW_TYPE_RECT = 0,    /**< axis-aligned rectangle */
+  SKITY_PRECOMPILE_DRAW_TYPE_RRECT,       /**< rounded rectangle */
+  SKITY_PRECOMPILE_DRAW_TYPE_PATH,        /**< arbitrary path */
+  SKITY_PRECOMPILE_DRAW_TYPE_TEXT,        /**< regular glyph text */
+  SKITY_PRECOMPILE_DRAW_TYPE_SDF_TEXT,    /**< SDF-rendered text */
+  SKITY_PRECOMPILE_DRAW_TYPE_EMOJI_TEXT,  /**< emoji / color-glyph text */
+  SKITY_PRECOMPILE_DRAW_TYPE_IMAGE,       /**< image draw */
+  SKITY_PRECOMPILE_DRAW_TYPE_IMAGE_RRECT, /**< image draw clipped to an rrect */
+  SKITY_PRECOMPILE_DRAW_TYPE_CLIP_PATH,   /**< path used as a clip */
+} skity_precompile_draw_type;
+
+/** @brief Warm up a common set of graphics / image / text pipelines. The exact
+ *         pipeline set is an implementation detail and may evolve over time. */
+SKITY_C_API void skity_precompile_context_precompile_default_shaders(
+    skity_precompile_context context);
+
+/**
+ * @brief Warm up the pipeline for a specific draw type + paint combination.
+ * @param draw_type  which draw operation to target
+ * @param paint      paint state whose pipeline variants should be precompiled
+ */
+SKITY_C_API void skity_precompile_context_precompile_draw(
+    skity_precompile_context context, skity_precompile_draw_type draw_type,
+    skity_paint paint);
+
+/**
+ * @brief Create a precompile context bound to @p context, used to warm up
+ *        pipeline variants before drawing.
+ *
+ * @p color_type / @p enable_msaa should match the surface that will later
+ * render with the precompiled shaders; when MSAA is enabled precompile uses a
+ * sample count of 4.
+ *
+ * @param context     owning GPU context
+ * @param color_type  color type of the target surface
+ * @param enable_msaa non-zero if the target surface uses MSAA
+ * @return new precompile context handle, or NULL on failure
+ */
+SKITY_C_API skity_precompile_context skity_context_create_precompile_context(
+    skity_context context, skity_precompile_color_type color_type,
+    uint32_t enable_msaa);
+
+/** @brief Release the precompile context. Safe on NULL. */
+SKITY_C_API void skity_precompile_context_destroy(
+    skity_precompile_context context);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_PRECOMPILE_H

--- a/module/capi/include/skity_c/skity_quaternion.h
+++ b/module/capi/include/skity_c/skity_quaternion.h
@@ -1,0 +1,43 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_QUATERNION_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_QUATERNION_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Build a rotation matrix from XYZ exterior Euler angles, mirroring
+ *        skity::Quaternion::EulerToMatrix.
+ * @param alpha   rotation angle around the X axis (radians)
+ * @param beta    rotation angle around the Y axis (radians)
+ * @param gamma   rotation angle around the Z axis (radians)
+ * @param out     points to a skity_matrix; receives 16 column-major floats.
+ *                Each input angle should be less than 2*PI for a stable result.
+ */
+SKITY_C_API void skity_quaternion_euler_to_matrix(float alpha, float beta,
+                                                  float gamma,
+                                                  skity_matrix* out);
+
+/**
+ * @brief Build a rotation matrix from a normalized axis and angle, mirroring
+ *        skity::Quaternion (FromAxisAngle + ToMatrix).
+ * @param axis   normalized rotation axis (3 floats, vec3)
+ * @param angle  rotation angle (radians)
+ * @param out    points to a skity_matrix; receives 16 column-major floats
+ */
+SKITY_C_API void skity_quaternion_axis_angle_to_matrix(const skity_vec3* axis,
+                                                       float angle,
+                                                       skity_matrix* out);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_QUATERNION_H

--- a/module/capi/include/skity_c/skity_recorder.h
+++ b/module/capi/include/skity_c/skity_recorder.h
@@ -1,0 +1,98 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_RECORDER_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_RECORDER_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_canvas.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Records canvas draw commands into a replayable display list,
+ *        mirroring skity::PictureRecorder.
+ */
+SKITY_C_DEFINE_HANDLE(skity_picture_recorder);
+
+/**
+ * @brief A recorded, replayable set of draw commands, mirroring
+ *        skity::DisplayList. Draw it onto any canvas with
+ *        skity_display_list_draw.
+ */
+SKITY_C_DEFINE_HANDLE(skity_display_list);
+
+// ----- picture recorder: records draw commands into a display list -----
+
+/** @brief Create a new picture recorder. */
+SKITY_C_API skity_picture_recorder skity_picture_recorder_create(void);
+
+/** @brief Release the picture recorder handle. Safe on NULL. */
+SKITY_C_API void skity_picture_recorder_destroy(
+    skity_picture_recorder recorder);
+
+/**
+ * @brief Begin recording. Subsequent draws on the recorder's canvas are
+ *        captured into a new display list.
+ * @param recorder  the recorder handle
+ * @param bounds    cull rect of the recorded content, or NULL for an unbounded
+ *                  recording
+ */
+SKITY_C_API void skity_picture_recorder_begin(skity_picture_recorder recorder,
+                                              const skity_rect* bounds);
+
+/**
+ * @brief Return the recording canvas. It is owned by the recorder (a
+ *        non-owning handle) and stays valid until
+ *        skity_picture_recorder_finish or skity_picture_recorder_destroy.
+ *        Draw on it with the regular skity_canvas_* API to record commands.
+ * @return the recording canvas handle, or NULL if recording has not begun
+ */
+SKITY_C_API skity_canvas
+skity_picture_recorder_get_canvas(skity_picture_recorder recorder);
+
+/**
+ * @brief Finish recording and produce a display list. The recording canvas
+ *        handle is invalidated after this call.
+ * @param recorder  the recorder handle
+ * @param out       receives the new display list handle
+ * @return          SKITY_SUCCESS, or SKITY_ERROR_INVALID_ARGUMENT if the
+ *                  recorder has not begun recording
+ */
+SKITY_C_API skity_result skity_picture_recorder_finish(
+    skity_picture_recorder recorder, skity_display_list* out);
+
+// ----- display list: a recorded, replayable set of draw commands -----
+
+/** @brief Release the display list handle. Safe on NULL. */
+SKITY_C_API void skity_display_list_destroy(skity_display_list list);
+
+/**
+ * @brief Playback the recorded commands onto @p canvas.
+ * @param list    the display list to replay
+ * @param canvas  destination canvas receiving the draws
+ */
+SKITY_C_API void skity_display_list_draw(skity_display_list list,
+                                         skity_canvas canvas);
+
+/**
+ * @brief Write the display list's cull bounds into @p out_bounds.
+ * @param list        the display list
+ * @param out_bounds  receives the bounds rectangle
+ */
+SKITY_C_API void skity_display_list_get_bounds(skity_display_list list,
+                                               skity_rect* out_bounds);
+
+/** @brief Return the number of recorded draw ops in the list. */
+SKITY_C_API uint32_t skity_display_list_get_op_count(skity_display_list list);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_RECORDER_H

--- a/module/capi/include/skity_c/skity_shader.h
+++ b/module/capi/include/skity_c/skity_shader.h
@@ -1,0 +1,146 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SHADER_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SHADER_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_image.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Shader: source color(s) for drawing. When a paint has a shader, its
+ *        output replaces the paint's solid color. Gradients and image-based
+ *        fills are shaders. Mirrors skity::Shader.
+ */
+SKITY_C_DEFINE_HANDLE(skity_shader);
+
+/**
+ * @brief Create a linear gradient shader between two points.
+ * @param pts        start and end points; each entry uses only the x/y of the
+ *                   Vec4
+ * @param colors     array of @p count color stops
+ * @param pos        array of @p count stop positions in [0, 1], or NULL to
+ *                   distribute colors evenly
+ * @param count      number of entries in @p colors (and @p pos when non-NULL);
+ *                   must be >= 2
+ * @param tile_mode  how colors are extrapolated outside the [0, 1] stop range
+ * @param flags      non-zero to premultiply colors before interpolating
+ * @return           shader handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_shader skity_shader_create_linear(
+    const skity_point pts[2], const skity_color4f* colors, const float* pos,
+    int32_t count, skity_tile_mode tile_mode, int32_t flags);
+
+/**
+ * @brief Create a radial gradient shader.
+ * @param center     center of the gradient circle; only x/y of the Vec4 are
+ *                   used
+ * @param radius     radius of the gradient circle, in pixels; must be > 0
+ * @param colors     array of @p count color stops
+ * @param pos        array of @p count stop positions in [0, 1], or NULL to
+ *                   distribute colors evenly
+ * @param count      number of entries in @p colors; must be >= 2
+ * @param tile_mode  how colors are extrapolated outside the [0, 1] stop range
+ * @param flags      non-zero to premultiply colors before interpolating
+ * @return           shader handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_shader skity_shader_create_radial(
+    skity_point center, float radius, const skity_color4f* colors,
+    const float* pos, int32_t count, skity_tile_mode tile_mode, int32_t flags);
+
+/**
+ * @brief Create a sweep (angular) gradient shader.
+ * @param cx          x coordinate of the sweep center
+ * @param cy          y coordinate of the sweep center
+ * @param start_angle start of the angular range, corresponding to pos == 0
+ * @param end_angle   end of the angular range, corresponding to pos == 1
+ * @param colors      array of @p count color stops
+ * @param pos         array of @p count stop positions in [0, 1], or NULL to
+ *                    distribute colors evenly
+ * @param count       number of entries in @p colors; must be >= 2
+ * @param tile_mode   how colors are extrapolated outside the [0, 1] stop range
+ * @param flags       non-zero to premultiply colors before interpolating
+ * @return            shader handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_shader skity_shader_create_sweep(
+    float cx, float cy, float start_angle, float end_angle,
+    const skity_color4f* colors, const float* pos, int32_t count,
+    skity_tile_mode tile_mode, int32_t flags);
+
+/**
+ * @brief Create a two-point conical gradient shader (a radial gradient between
+ *        two circles), following the HTML canvas createRadialGradient spec.
+ * @param start        center of the starting circle; only x/y of the Vec4 are
+ *                     used
+ * @param start_radius radius of the starting circle
+ * @param end          center of the ending circle; only x/y of the Vec4 are
+ *                     used
+ * @param end_radius   radius of the ending circle
+ * @param colors       array of @p count color stops
+ * @param pos          array of @p count stop positions in [0, 1], or NULL to
+ *                     distribute colors evenly
+ * @param count        number of entries in @p colors; must be >= 2
+ * @param tile_mode    how colors are extrapolated outside the [0, 1] stop range
+ * @param flags        non-zero to premultiply colors before interpolating
+ * @return             shader handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_shader skity_shader_create_two_point_conical(
+    skity_point start, float start_radius, skity_point end, float end_radius,
+    const skity_color4f* colors, const float* pos, int32_t count,
+    skity_tile_mode tile_mode, int32_t flags);
+
+/**
+ * @brief Create an image shader that fills geometry with @p image's pixels.
+ * @param image         source image
+ * @param sampling      sampling options, or NULL for the defaults
+ * @param x_tile_mode   tiling mode along the x axis
+ * @param y_tile_mode   tiling mode along the y axis
+ * @param local_matrix  optional local matrix applied before the canvas
+ *                       matrix, or NULL for identity
+ * @return              shader handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_shader skity_shader_create_image(
+    skity_image image, const skity_sampling_options* sampling,
+    skity_tile_mode x_tile_mode, skity_tile_mode y_tile_mode,
+    const skity_matrix* local_matrix);
+
+/**
+ * @brief Replace the shader's local matrix.
+ *
+ * The local matrix is applied before the canvas matrix, mapping from "local"
+ * shader coordinates into the geometry's coordinate space. Mirrors
+ * skity::Shader::SetLocalMatrix.
+ *
+ * @param shader  shader handle
+ * @param matrix  new local matrix, or NULL to reset to identity
+ */
+SKITY_C_API void skity_shader_set_local_matrix(skity_shader shader,
+                                               const skity_matrix* matrix);
+
+/**
+ * @brief Read the shader's current local matrix.
+ *
+ * Mirrors skity::Shader::GetLocalMatrix.
+ *
+ * @param shader  shader handle
+ * @param out     receives the 16 column-major floats; must point to a
+ *                skity_matrix with room for 16 elements
+ */
+SKITY_C_API void skity_shader_get_local_matrix(skity_shader shader,
+                                               skity_matrix* out);
+
+/** @brief Release the shader handle and its underlying object. Safe on NULL. */
+SKITY_C_API void skity_shader_destroy(skity_shader shader);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SHADER_H

--- a/module/capi/include/skity_c/skity_stroke.h
+++ b/module/capi/include/skity_c/skity_stroke.h
@@ -1,0 +1,43 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_STROKE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_STROKE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_paint.h>
+#include <skity_c/skity_path.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Stroke @p src using the stroke parameters carried by @p paint (width,
+ *        cap, join, miter) and append the resulting outline to @p dst. @p paint
+ *        must be set to a stroke style for a meaningful result.
+ * @param paint  source of stroke parameters (style, width, cap, join, miter)
+ * @param src    input path to outline
+ * @param dst    destination path the outline is appended to
+ */
+SKITY_C_API void skity_stroke_stroke_path(skity_paint paint, skity_path src,
+                                          skity_path dst);
+
+/**
+ * @brief Convert @p src into a quadratic / cubic outline per @p paint's stroke
+ *        settings and append it to @p dst.
+ * @param paint       source of stroke parameters
+ * @param src         input path to outline
+ * @param dst         destination path the outline is appended to
+ * @param keep_cubic  non-zero to preserve cubic segments, 0 to flatten them
+ */
+SKITY_C_API void skity_stroke_quad_path(skity_paint paint, skity_path src,
+                                        skity_path dst, uint32_t keep_cubic);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_STROKE_H

--- a/module/capi/include/skity_c/skity_surface.h
+++ b/module/capi/include/skity_c/skity_surface.h
@@ -1,0 +1,147 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_bitmap.h>
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque handle to a skity::GPUSurface, a GPU-backed render target
+ *         that owns a canvas and drives per-frame drawing. */
+SKITY_C_DEFINE_HANDLE(skity_surface);
+
+/** @brief Opaque handle to the skity::Canvas associated with a surface. The
+ *         surface owns the canvas; this handle is non-owning. */
+SKITY_C_DEFINE_HANDLE(skity_canvas);
+
+/** @brief Structure type values (skity_structure_type) and the backend
+ *         extension structs they tag are defined in skity_c/skity_types.h so
+ *         they can be shared across surface and texture. */
+
+/**
+ * @brief Base surface creation descriptor. Values mirror
+ *        skity::GPUSurfaceDescriptor. Set @p p_next to point at a
+ *        backend-specific extension (e.g. skity_surface_create_info_gl) to
+ *        select the render target.
+ */
+typedef struct skity_surface_create_info {
+  skity_structure_type s_type; /**< SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO */
+  const void* p_next;          /**< → backend-specific extension struct */
+  uint32_t width;              /**< surface width in pixels */
+  uint32_t height;             /**< surface height in pixels */
+  uint32_t sample_count;       /**< MSAA sample count (1 = no MSAA) */
+  float content_scale;         /**< logical-to-physical pixel scale */
+} skity_surface_create_info;
+
+/** @brief GL surface target kind. */
+typedef enum {
+  SKITY_GL_SURFACE_TYPE_INVALID = 0, /**< unused / sentinel */
+  SKITY_GL_SURFACE_TYPE_TEXTURE,     /**< render into a GL texture */
+  SKITY_GL_SURFACE_TYPE_FRAMEBUFFER, /**< render into a GL framebuffer object */
+} skity_gl_surface_type;
+
+/**
+ * @brief How a framebuffer-backed GL surface presents its final color contents
+ *        to the target framebuffer. Values align with skity::GLSurfaceMode.
+ *        Ignored when surface_type is not SKITY_GL_SURFACE_TYPE_FRAMEBUFFER.
+ */
+typedef enum {
+  SKITY_GL_SURFACE_MODE_AUTO = 0, /**< let the backend choose */
+  SKITY_GL_SURFACE_MODE_DIRECT,   /**< render directly into the target FBO */
+  SKITY_GL_SURFACE_MODE_BLIT,     /**< render offscreen, blit to target FBO */
+  SKITY_GL_SURFACE_MODE_DRAW_TEXTURE, /**< render offscreen, draw as texture */
+} skity_gl_surface_mode;
+
+/**
+ * @brief GL backend extension. Hang this off skity_surface_create_info::p_next
+ *        with s_type = SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL.
+ */
+typedef struct skity_surface_create_info_gl {
+  skity_structure_type
+      s_type;         /**< SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL */
+  const void* p_next; /**< reserved for future extensions */
+  skity_gl_surface_type
+      surface_type; /**< whether @p gl_id is a texture or FBO */
+  uint32_t
+      gl_id; /**< GL texture id or framebuffer id (0 = on-screen default FBO) */
+  uint32_t has_stencil; /**< non-zero if the target has a stencil attachment
+                           (FRAMEBUFFER only) */
+  skity_gl_surface_mode surface_mode; /**< how a FBO surface presents to the
+                                         target (FRAMEBUFFER only); defaults to
+                                         SKITY_GL_SURFACE_MODE_AUTO */
+  uint32_t can_blit_from_target_fbo;  /**< non-zero to blit from the target FBO
+                                         to the internal FBO before drawing
+                                         (FRAMEBUFFER only, no stencil,
+                                         sample_count == 1) */
+} skity_surface_create_info_gl;
+
+/**
+ * @brief Create a GPU surface bound to the given context. The backend is
+ *        chosen by the p_next extension of @p info.
+ * @param context     context that will own the surface
+ * @param info        creation descriptor (with backend extension chained via
+ *                    p_next)
+ * @param out_surface receives the new surface handle on success
+ * @return SKITY_SUCCESS on success, or a SKITY_ERROR_* code on failure
+ */
+SKITY_C_API skity_result skity_surface_create(
+    skity_context context, const skity_surface_create_info* info,
+    skity_surface* out_surface);
+
+/** @brief Release the surface and its underlying GPU resources. Safe on NULL.
+ */
+SKITY_C_API void skity_surface_destroy(skity_surface surface);
+
+/**
+ * @brief Lock the canvas for the current frame.
+ *
+ * The returned canvas is owned by the surface (non-owning handle) and stays
+ * valid until the next skity_surface_lock_canvas call or until the surface is
+ * destroyed.
+ *
+ * @param clear  non-zero to clear the previous frame's contents; skipping the
+ *               clear costs extra memory and may hurt performance
+ * @return Canvas handle for the current frame (NULL on failure)
+ */
+SKITY_C_API skity_canvas skity_surface_lock_canvas(skity_surface surface,
+                                                   uint32_t clear);
+
+/** @brief Present the rendering result. Canvas::Flush must be called first. */
+SKITY_C_API void skity_surface_flush(skity_surface surface);
+
+/**
+ * @brief Read a region of the rendered surface back into CPU memory.
+ *
+ * Mirrors GPUSurface::ReadPixels (experimental).
+ *
+ * @param rect region to read; NULL reads the full surface
+ * @return a read-only skity_pixmap handle (use skity_pixmap_get_pixels to
+ *         access the data and skity_pixmap_destroy to release it), or NULL on
+ *         failure
+ */
+SKITY_C_API skity_pixmap skity_surface_read_pixels(skity_surface surface,
+                                                   const skity_rect* rect);
+
+/** @brief Return the surface width in pixels. */
+SKITY_C_API uint32_t skity_surface_get_width(skity_surface surface);
+
+/** @brief Return the surface height in pixels. */
+SKITY_C_API uint32_t skity_surface_get_height(skity_surface surface);
+
+/** @brief Return the logical-to-physical pixel content scale. */
+SKITY_C_API float skity_surface_get_content_scale(skity_surface surface);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_H

--- a/module/capi/include/skity_c/skity_text.h
+++ b/module/capi/include/skity_c/skity_text.h
@@ -1,0 +1,280 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXT_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXT_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque typeface, the C handle for skity::Typeface. Describes a
+ *         single font face and provides Unicode-code-point-to-glyph mapping
+ *         and table access. */
+SKITY_C_DEFINE_HANDLE(skity_typeface);
+
+/** @brief Opaque font manager, the C handle for skity::FontManager. Enumerates
+ *         installed font families and instantiates typefaces from them or
+ *         from font files. */
+SKITY_C_DEFINE_HANDLE(skity_font_manager);
+
+/** @brief Forward declaration; skity_data is defined in skity_data.h. */
+SKITY_C_DEFINE_HANDLE(skity_data);
+
+/**
+ * @brief Return the default system font manager.
+ *
+ * The handle is reference-counted internally; call
+ * skity_font_manager_destroy when it is no longer needed.
+ */
+SKITY_C_API skity_font_manager skity_font_manager_ref_default(void);
+
+/** @brief Release a font manager handle returned by the manager constructors.
+ *         Safe on NULL. */
+SKITY_C_API void skity_font_manager_destroy(skity_font_manager manager);
+
+/**
+ * @brief Load a typeface from a font file.
+ * @param path  filesystem path to the font file
+ * @return the new typeface, or NULL on failure
+ */
+SKITY_C_API skity_typeface skity_typeface_make_from_file(const char* path);
+
+/**
+ * @brief Load a typeface from an in-memory font blob.
+ *
+ * The new typeface takes a reference to @p data; the caller may release the
+ * data handle afterwards.
+ *
+ * @param data  font file bytes loaded into memory (e.g. via skity_data_make_*)
+ * @return the new typeface, or NULL on failure
+ */
+SKITY_C_API skity_typeface skity_typeface_make_from_data(skity_data data);
+
+/** @brief Return the default normal typeface. Never returns NULL. */
+SKITY_C_API skity_typeface skity_typeface_get_default(void);
+
+/** @brief Release a typeface handle. Safe on NULL. */
+SKITY_C_API void skity_typeface_destroy(skity_typeface typeface);
+
+/**
+ * @brief Map an array of Unicode code points to glyph ids.
+ *
+ * Each code point without a matching glyph is written as 0. The caller must
+ * ensure @p glyphs points to at least @p count entries.
+ *
+ * @param typeface  the typeface to query
+ * @param uni       array of @p count Unicode code points
+ * @param count     number of code points in @p uni
+ * @param glyphs    output array receiving @p count glyph ids
+ */
+SKITY_C_API void skity_typeface_unichars_to_glyphs(skity_typeface typeface,
+                                                   const uint32_t* uni,
+                                                   int32_t count,
+                                                   uint16_t* glyphs);
+
+/**
+ * @brief Convenience wrapper mapping a single code point to a glyph id.
+ * @return the glyph id, or 0 if the code point is unmapped
+ */
+SKITY_C_API uint16_t skity_typeface_unichar_to_glyph(skity_typeface typeface,
+                                                     uint32_t unichar);
+
+/** @brief Text blob handles and constructors. */
+
+/** @brief Forward declaration; skity_paint is defined in skity_paint.h. */
+SKITY_C_DEFINE_HANDLE(skity_paint);
+
+/** @brief Forward declaration; skity_font is defined in skity_font.h. */
+SKITY_C_DEFINE_HANDLE(skity_font);
+
+/** @brief Opaque text blob, the C handle for skity::TextBlob. An immutable
+ *         container of pre-laid-out text runs built from a UTF-8 string. */
+SKITY_C_DEFINE_HANDLE(skity_text_blob);
+
+/**
+ * @brief Build an immutable text blob from a UTF-8 string.
+ *
+ * The text size and typeface are taken from @p paint; use
+ * skity_paint_set_text_size and skity_paint_set_typeface to control the font.
+ *
+ * @param text   NUL-terminated UTF-8 string to lay out
+ * @param paint  paint supplying the text size and typeface
+ * @return the new text blob
+ */
+SKITY_C_API skity_text_blob skity_text_blob_create(const char* text,
+                                                   skity_paint paint);
+
+/** @brief Release a text blob handle. Safe on NULL. */
+SKITY_C_API void skity_text_blob_destroy(skity_text_blob blob);
+
+/**
+ * @brief Compute the axis-aligned bounding box of a text blob.
+ *
+ * @param blob  the text blob to measure
+ * @param out   receives the bounding rectangle; left untouched on failure
+ */
+SKITY_C_API void skity_text_blob_get_bounds(skity_text_blob blob,
+                                            skity_rect* out);
+
+/**
+ * @brief Compute the bounding box of a raw glyph run without building a blob.
+ *
+ * @p glyphs, @p pos_x and @p pos_y are parallel arrays of length @p count:
+ * glyph id @p glyphs[i] is positioned at (pos_x[i], pos_y[i]).
+ *
+ * @param count   number of glyphs in the run
+ * @param glyphs  array of @p count glyph ids
+ * @param pos_x   array of @p count glyph origins, X channel
+ * @param pos_y   array of @p count glyph origins, Y channel
+ * @param font    font describing size, typeface and hinting of the run
+ * @param paint   paint supplying stroke / fill metrics
+ * @param out     receives the bounding rectangle; left untouched on failure
+ */
+SKITY_C_API void skity_text_blob_compute_bounds(
+    int32_t count, const uint16_t* glyphs, const float* pos_x,
+    const float* pos_y, skity_font font, skity_paint paint, skity_rect* out);
+
+/** @brief Font family enumeration and typeface lookup. */
+
+/** @brief Opaque font style set, the C handle for skity::FontStyleSet. Groups
+ *         the variants (weight / width / slant) of a single font family. */
+SKITY_C_DEFINE_HANDLE(skity_font_style_set);
+
+/** @brief Return the number of font families known to the manager. */
+SKITY_C_API int32_t
+skity_font_manager_count_families(skity_font_manager manager);
+
+/**
+ * @brief Copy the family name at @p index into @p buffer (two-pass idiom).
+ *
+ * Returns the name length in bytes including the NUL terminator. When @p
+ * buffer is NULL or @p buffer_size is too small, nothing is written but the
+ * required length is still returned, so the caller can size the buffer and
+ * call again.
+ *
+ * @param manager      the font manager
+ * @param index        family index in [0, skity_font_manager_count_families)
+ * @param buffer       destination byte buffer, or NULL to query the length
+ * @param buffer_size  capacity of @p buffer in bytes
+ * @return family-name length in bytes including the NUL terminator
+ */
+SKITY_C_API int32_t
+skity_font_manager_get_family_name(skity_font_manager manager, int32_t index,
+                                   char* buffer, int32_t buffer_size);
+
+/** @brief Return the style set for the family at @p index, or NULL on
+ *         failure. */
+SKITY_C_API skity_font_style_set
+skity_font_manager_create_style_set(skity_font_manager manager, int32_t index);
+
+/**
+ * @brief Find a font family by name.
+ * @param name  NUL-terminated family name
+ * @return the matching style set, or NULL if the family is not found
+ */
+SKITY_C_API skity_font_style_set
+skity_font_manager_match_family(skity_font_manager manager, const char* name);
+
+/**
+ * @brief Find the typeface within the named family closest to @p style.
+ * @param name   NUL-terminated family name
+ * @param style  requested font style
+ * @return the matching typeface, or NULL if the family is not found
+ */
+SKITY_C_API skity_typeface skity_font_manager_match_family_style(
+    skity_font_manager manager, const char* name, skity_font_style style);
+
+/**
+ * @brief Find a typeface in family @p name that matches @p style and provides
+ *        a glyph for @p character.
+ *
+ * @param name         NUL-terminated family name
+ * @param style        requested font style
+ * @param bcp47        array of BCP-47 language tags, may be NULL
+ * @param bcp47_count  number of entries in @p bcp47
+ * @param character    the Unicode code point that must be covered
+ * @return the matching typeface, or NULL if none is found
+ */
+SKITY_C_API skity_typeface skity_font_manager_match_family_style_character(
+    skity_font_manager manager, const char* name, skity_font_style style,
+    const char** bcp47, int32_t bcp47_count, uint32_t character);
+
+/**
+ * @brief Load a typeface from a TrueType / OpenType collection file.
+ * @param path       filesystem path to the font file
+ * @param ttc_index  0-based index of the face within the collection
+ * @return the new typeface, or NULL on failure
+ */
+SKITY_C_API skity_typeface skity_font_manager_make_from_file(
+    skity_font_manager manager, const char* path, int32_t ttc_index);
+
+/**
+ * @brief Load a typeface from an in-memory font blob.
+ *
+ * @param manager    the font manager
+ * @param data       font file bytes loaded into memory
+ * @param ttc_index  0-based index of the face within a TrueType / OpenType
+ *                   collection (pass 0 for a plain font)
+ * @return the new typeface, or NULL on failure
+ */
+SKITY_C_API skity_typeface skity_font_manager_make_from_data(
+    skity_font_manager manager, skity_data data, int32_t ttc_index);
+
+/**
+ * @brief Return the default typeface for @p style.
+ * @param style  requested font style
+ * @return the default typeface, or NULL if @p manager is invalid
+ */
+SKITY_C_API skity_typeface skity_font_manager_get_default_typeface(
+    skity_font_manager manager, skity_font_style style);
+
+/** @brief Font style set accessors. */
+
+/** @brief Return the number of variants in the set. */
+SKITY_C_API int32_t skity_font_style_set_count(skity_font_style_set set);
+
+/**
+ * @brief Fetch the style, and optionally its display name, at @p index.
+ *
+ * @p out_style and @p name_buffer are both optional and may be NULL. When @p
+ * name_buffer is non-NULL and @p name_size is positive, the style display
+ * name is copied into it and NUL-terminated, truncated to fit @p name_size
+ * bytes.
+ *
+ * @param set          the style set
+ * @param index        variant index in [0, skity_font_style_set_count)
+ * @param out_style    receives the style, or NULL to ignore
+ * @param name_buffer  destination for the style display name, or NULL to ignore
+ * @param name_size    capacity of @p name_buffer in bytes
+ */
+SKITY_C_API void skity_font_style_set_get_style(skity_font_style_set set,
+                                                int32_t index,
+                                                skity_font_style* out_style,
+                                                char* name_buffer,
+                                                int32_t name_size);
+
+/** @brief Create the typeface for the variant at @p index, or NULL on
+ *         failure. */
+SKITY_C_API skity_typeface
+skity_font_style_set_create_typeface(skity_font_style_set set, int32_t index);
+
+/**
+ * @brief Return the variant in the set closest to @p style.
+ * @return the matching typeface, or NULL if the set is empty
+ */
+SKITY_C_API skity_typeface skity_font_style_set_match_style(
+    skity_font_style_set set, skity_font_style style);
+
+/** @brief Release a font style set handle. Safe on NULL. */
+SKITY_C_API void skity_font_style_set_destroy(skity_font_style_set set);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXT_H

--- a/module/capi/include/skity_c/skity_texture.h
+++ b/module/capi/include/skity_c/skity_texture.h
@@ -1,0 +1,146 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Opaque handle to a skity::Texture, a GPU image resource owned by a
+ *         GPUContext that can be uploaded to or wrapped around an existing
+ *         backend texture. */
+SKITY_C_DEFINE_HANDLE(skity_texture);
+
+/** @brief Texture pixel format. Values aligned with skity::TextureFormat. */
+typedef enum {
+  SKITY_TEXTURE_FORMAT_R = 0,  /**< single-channel (alpha/luminance) 8-bit */
+  SKITY_TEXTURE_FORMAT_RGB,    /**< 3-channel, 8 bits per channel */
+  SKITY_TEXTURE_FORMAT_RGB565, /**< 16-bit packed RGB (5-6-5) */
+  SKITY_TEXTURE_FORMAT_RGBA,   /**< 4-channel, 8 bits per channel */
+  SKITY_TEXTURE_FORMAT_BGRA,   /**< 4-channel, 8 bits per channel, B-order */
+  SKITY_TEXTURE_FORMAT_S,      /**< single-channel special-purpose format */
+} skity_texture_format;
+
+/**
+ * @brief Create a GPU texture owned by @p context. The texture is allocated on
+ *        the context's backend; upload pixels with skity_texture_upload (or
+ *        skity_texture_deferred_upload to upload lazily).
+ *
+ * @param context     owning context
+ * @param format      pixel format of the allocation
+ * @param width       texture width in pixels
+ * @param height      texture height in pixels
+ * @param alpha_type  alpha representation of the texture contents
+ * @return new texture handle, or NULL on failure
+ */
+SKITY_C_API skity_texture skity_texture_create(skity_context context,
+                                               skity_texture_format format,
+                                               uint32_t width, uint32_t height,
+                                               skity_alpha_type alpha_type);
+
+/** @brief Release the texture handle and its GPU resource. Safe on NULL. */
+SKITY_C_API void skity_texture_destroy(skity_texture texture);
+
+/**
+ * @brief Upload pixel data to the texture immediately. @p pixels is copied
+ *        into an internal buffer before the upload, so the caller's buffer may
+ *        be released right away.
+ *
+ * @param pixels      source pixel data, laid out per @p row_bytes
+ * @param row_bytes   stride in bytes of each row in @p pixels
+ * @param color_type  color type of @p pixels
+ * @param alpha_type  alpha type of @p pixels
+ */
+SKITY_C_API void skity_texture_upload(skity_texture texture, const void* pixels,
+                                      size_t row_bytes,
+                                      skity_color_type color_type,
+                                      skity_alpha_type alpha_type);
+
+/**
+ * @brief Store pixel data for a deferred upload. The actual GPU upload happens
+ *        later, when the texture is first used by the rendering pipeline.
+ *
+ * @param pixels      source pixel data (copied), laid out per @p row_bytes
+ * @param row_bytes   stride in bytes of each row in @p pixels
+ * @param color_type  color type of @p pixels
+ * @param alpha_type  alpha type of @p pixels
+ */
+SKITY_C_API void skity_texture_deferred_upload(skity_texture texture,
+                                               const void* pixels,
+                                               size_t row_bytes,
+                                               skity_color_type color_type,
+                                               skity_alpha_type alpha_type);
+
+/** @brief Return the texture width in pixels. */
+SKITY_C_API uint32_t skity_texture_get_width(skity_texture texture);
+
+/** @brief Return the texture height in pixels. */
+SKITY_C_API uint32_t skity_texture_get_height(skity_texture texture);
+
+/**
+ * @brief Descriptor for wrapping an externally-created GPU texture. Values
+ *        mirror skity::GPUBackendTextureInfo. Set @p p_next to a
+ *        backend-specific extension (e.g. skity_backend_texture_info_gl) to
+ *        identify the texture.
+ */
+typedef struct skity_backend_texture_info {
+  skity_structure_type s_type; /**< SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO */
+  const void* p_next;          /**< → backend-specific extension (e.g. _gl) */
+  skity_gpu_backend_type backend; /**< which backend owns the wrapped texture */
+  uint32_t width;                 /**< texture width in pixels */
+  uint32_t height;                /**< texture height in pixels */
+  skity_texture_format format;    /**< pixel format of the wrapped texture */
+  skity_alpha_type alpha_type;    /**< alpha representation of the contents */
+} skity_backend_texture_info;
+
+/**
+ * @brief GL backend extension: wraps an existing GL texture id. Chain via
+ *        skity_backend_texture_info::p_next with s_type =
+ *        SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL.
+ */
+typedef struct skity_backend_texture_info_gl {
+  skity_structure_type
+      s_type;               /**< SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL */
+  const void* p_next;       /**< reserved for future extensions */
+  uint32_t texture_id;      /**< existing GL texture id to wrap */
+  uint32_t owned_by_engine; /**< non-zero if skity owns and must delete it */
+} skity_backend_texture_info_gl;
+
+/**
+ * @brief Release callback invoked when skity no longer references a wrapped
+ *        backend texture.
+ *
+ * @param userdata opaque pointer registered with the wrap call
+ */
+typedef void (*skity_texture_release_callback)(void* userdata);
+
+/**
+ * @brief Wrap an existing backend texture (e.g. a GL texture id created
+ *        elsewhere) as a skity texture.
+ *
+ * @param context  owning context
+ * @param info     backend texture descriptor (with extension chained via
+ *                 p_next)
+ * @param release  invoked (with @p userdata) when skity drops its reference;
+ *                 may be NULL
+ * @param userdata opaque pointer passed to @p release
+ * @return new texture handle, or NULL on failure
+ */
+SKITY_C_API skity_texture skity_texture_create_from_backend(
+    skity_context context, const skity_backend_texture_info* info,
+    skity_texture_release_callback release, void* userdata);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_H

--- a/module/capi/include/skity_c/skity_types.h
+++ b/module/capi/include/skity_c/skity_types.h
@@ -1,0 +1,242 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TYPES_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TYPES_H
+
+#include <skity_c/skity_base.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Plain-old-data geometry types. These mirror the memory layout of the
+ * corresponding C++ types (skity::Vec2/Vec3/Vec4, Rect, Matrix) exactly, so
+ * they can be passed across the ABI boundary by pointer with no conversion.
+ */
+
+/** @brief 2-component single-precision vector, matching skity::Vec2. */
+typedef struct skity_vec2 {
+  float e[2]; /**< vector components */
+} skity_vec2;
+
+/** @brief 3-component single-precision vector, matching skity::Vec3. */
+typedef struct skity_vec3 {
+  float e[3]; /**< vector components */
+} skity_vec3;
+
+/** @brief 4-component single-precision vector, matching skity::Vec4. */
+typedef struct skity_vec4 {
+  float e[4]; /**< vector components */
+} skity_vec4;
+
+/** @brief Alias of skity_vec4; skity::Point and skity::Color4f are both
+ *         aliases for Vec4. */
+typedef skity_vec4 skity_point;
+/** @brief Alias of skity_vec4 used for floating-point RGBA color. */
+typedef skity_vec4 skity_color4f;
+
+/** @brief Axis-aligned rectangle, matching skity::Rect. */
+typedef struct skity_rect {
+  float left;   /**< left edge X coordinate */
+  float top;    /**< top edge Y coordinate */
+  float right;  /**< right edge X coordinate */
+  float bottom; /**< bottom edge Y coordinate */
+} skity_rect;
+
+/**
+ * @brief 4x4 column-major matrix, matching skity::Matrix::m[16]. Indexed as
+ *        column-major: element (row, col) = m[col * 4 + row].
+ */
+typedef struct skity_matrix {
+  float m[16]; /**< column-major matrix elements */
+} skity_matrix;
+
+/** @brief 32-bit unpremultiplied ARGB color packed as 0xAARRGGBB, same as
+ *         skity::Color. */
+typedef uint32_t skity_color;
+
+/**
+ * @brief Blend modes applied when compositing a source color over a
+ *        destination. Values are aligned with skity::BlendMode. With s =
+ * source, d = destination, sa = source alpha, da = destination alpha, r =
+ * result.
+ */
+typedef enum {
+  SKITY_BLEND_MODE_CLEAR = 0, /**< r = 0 */
+  SKITY_BLEND_MODE_SRC,       /**< r = s */
+  SKITY_BLEND_MODE_DST,       /**< r = d */
+  SKITY_BLEND_MODE_SRC_OVER,  /**< r = s + (1-sa)*d */
+  SKITY_BLEND_MODE_DST_OVER,  /**< r = d + (1-da)*s */
+  SKITY_BLEND_MODE_SRC_IN,    /**< r = s * da */
+  SKITY_BLEND_MODE_DST_IN,    /**< r = d * sa */
+  SKITY_BLEND_MODE_SRC_OUT,   /**< r = s * (1-da) */
+  SKITY_BLEND_MODE_DST_OUT,   /**< r = d * (1-sa) */
+  SKITY_BLEND_MODE_SRC_A_TOP, /**< r = s*da + d*(1-sa) */
+  SKITY_BLEND_MODE_DST_A_TOP, /**< r = d*sa + s*(1-da) */
+  SKITY_BLEND_MODE_XOR,       /**< r = s*(1-da) + d*(1-sa) */
+  SKITY_BLEND_MODE_PLUS,      /**< r = min(s + d, 1) */
+  SKITY_BLEND_MODE_MODULATE,  /**< r = s*d */
+  SKITY_BLEND_MODE_SCREEN,    /**< r = s + d - s*d */
+  SKITY_BLEND_MODE_OVERLAY, /**< multiply or screen, depending on destination */
+  SKITY_BLEND_MODE_DARKEN,  /**< rc = s + d - max(s*da, d*sa), ra = SRC_OVER */
+  SKITY_BLEND_MODE_LIGHTEN, /**< rc = s + d - min(s*da, d*sa), ra = SRC_OVER */
+  SKITY_BLEND_MODE_COLOR_DODGE, /**< brighten destination to reflect source */
+  SKITY_BLEND_MODE_COLOR_BURN,  /**< darken destination to reflect source */
+  SKITY_BLEND_MODE_HARD_LIGHT,  /**< multiply or screen, depending on source */
+  SKITY_BLEND_MODE_SOFT_LIGHT,  /**< lighten or darken, depending on source */
+  SKITY_BLEND_MODE_DIFFERENCE,  /**< rc = s + d - 2*(min(s*da, d*sa)), ra =
+                                   SRC_OVER */
+  SKITY_BLEND_MODE_EXCLUSION,   /**< rc = s + d - 2*(s*d), ra = SRC_OVER */
+  SKITY_BLEND_MODE_MULTIPLY,    /**< r = s*(1-da) + d*(1-sa) + s*d */
+  SKITY_BLEND_MODE_HUE, /**< hue of source with saturation and luminosity of
+                           destination */
+  SKITY_BLEND_MODE_SATURATION, /**< saturation of source with hue and luminosity
+                                  of destination */
+  SKITY_BLEND_MODE_COLOR, /**< hue and saturation of source with luminosity of
+                             destination */
+  SKITY_BLEND_MODE_LUMINOSITY, /**< luminosity of source with hue and saturation
+                                  of destination */
+} skity_blend_mode;
+
+/**
+ * @brief How a shader behaves outside its defined bounds. Values are aligned
+ *        with skity::TileMode.
+ */
+typedef enum {
+  SKITY_TILE_MODE_CLAMP = 0, /**< replicate the edge color outside the bounds */
+  SKITY_TILE_MODE_REPEAT, /**< repeat the shader image horizontally/vertically
+                           */
+  SKITY_TILE_MODE_MIRROR, /**< repeat the shader image, alternating mirrored
+                             copies */
+  SKITY_TILE_MODE_DECAL,  /**< draw only within the bounds; transparent black
+                             outside */
+} skity_tile_mode;
+
+/**
+ * @brief How to interpret the alpha component of a pixel. Values aligned with
+ *        skity::AlphaType.
+ */
+typedef enum {
+  SKITY_ALPHA_TYPE_UNKNOWN = 0, /**< uninitialized / unknown alpha treatment */
+  SKITY_ALPHA_TYPE_OPAQUE,      /**< pixels are fully opaque (alpha ignored) */
+  SKITY_ALPHA_TYPE_PREMUL,   /**< color components are premultiplied by alpha */
+  SKITY_ALPHA_TYPE_UNPREMUL, /**< color components are independent of alpha */
+} skity_alpha_type;
+
+/**
+ * @brief How pixel bits encode color. Values aligned with skity::ColorType.
+ *        Currently only RGBA / BGRA are fully supported.
+ */
+typedef enum {
+  SKITY_COLOR_TYPE_UNKNOWN = 0, /**< uninitialized */
+  SKITY_COLOR_TYPE_RGBA,   /**< 8 bits each for red, green, blue, alpha (32-bit
+                              word) */
+  SKITY_COLOR_TYPE_BGRA,   /**< 8 bits each for blue, green, red, alpha (32-bit
+                              word) */
+  SKITY_COLOR_TYPE_RGB565, /**< 5/6/5-bit red/green/blue (16-bit word) */
+  SKITY_COLOR_TYPE_A8,     /**< 8-bit alpha only (internal use) */
+} skity_color_type;
+
+/**
+ * @brief Filter mode for image sampling. Values aligned with skity::FilterMode.
+ */
+typedef enum {
+  SKITY_FILTER_MODE_NEAREST = 0, /**< sample the nearest single pixel */
+  SKITY_FILTER_MODE_LINEAR,      /**< interpolate linearly between pixels */
+} skity_filter_mode;
+
+/**
+ * @brief Mipmap mode for image sampling. Values aligned with skity::MipmapMode.
+ */
+typedef enum {
+  SKITY_MIPMAP_MODE_NONE = 0, /**< ignore mipmaps */
+  SKITY_MIPMAP_MODE_NEAREST,  /**< sample the nearest mip level */
+  SKITY_MIPMAP_MODE_LINEAR,   /**< blend between the two nearest mip levels */
+} skity_mipmap_mode;
+
+/**
+ * @brief Sampling options for image filtering, combining filter / mipmap modes
+ *        with optional cubic coefficients.
+ */
+typedef struct skity_sampling_options {
+  skity_filter_mode filter; /**< min/mag filter mode */
+  skity_mipmap_mode mipmap; /**< mipmap sampling mode */
+  float cubic_b;            /**< cubic B-spline coefficient (Mitchell b) */
+  float cubic_c;            /**< cubic C-spline coefficient (Mitchell c) */
+} skity_sampling_options;
+
+/** @brief GPU backend type. Values aligned with skity::GPUBackendType. */
+typedef enum {
+  SKITY_GPU_BACKEND_TYPE_NONE = 0, /**< no / software backend */
+  SKITY_GPU_BACKEND_TYPE_OPENGL,   /**< desktop or embedded OpenGL */
+  SKITY_GPU_BACKEND_TYPE_VULKAN,   /**< Vulkan */
+  SKITY_GPU_BACKEND_TYPE_WEBGL2,   /**< WebGL 2 */
+  SKITY_GPU_BACKEND_TYPE_WEBGPU,   /**< WebGPU */
+  SKITY_GPU_BACKEND_TYPE_METAL,    /**< Metal */
+} skity_gpu_backend_type;
+
+/**
+ * @brief Structure types used in s_type / p_next chains across CreateInfo /
+ *        backend info structs (shared by surface and texture).
+ */
+typedef enum {
+  SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO =
+      0, /**< base surface creation info */
+  SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL, /**< OpenGL-specific surface
+                                                  creation info */
+  SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO,   /**< base backend texture info */
+  SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL, /**< OpenGL-specific backend
+                                                   texture info */
+} skity_structure_type;
+
+/**
+ * @brief Font slant. Values aligned with skity::FontStyle::Slant.
+ */
+typedef enum {
+  SKITY_FONT_SLANT_UPRIGHT = 0, /**< upright / roman glyphs */
+  SKITY_FONT_SLANT_ITALIC,      /**< italic glyphs */
+  SKITY_FONT_SLANT_OBLIQUE,     /**< oblique glyphs */
+} skity_font_slant;
+
+/**
+ * @brief Font style (weight / width / slant), matching skity::FontStyle.
+ */
+typedef struct skity_font_style {
+  int32_t weight;         /**< 0..1000 (400 = normal, 700 = bold) */
+  int32_t width;          /**< 1..9 (5 = normal) */
+  skity_font_slant slant; /**< glyph slant */
+} skity_font_style;
+
+/**
+ * @brief Font metrics, in pixels. Values follow the standard baseline layout
+ *        used by skity::FontMetrics.
+ */
+typedef struct skity_font_metrics {
+  float top;     /**< top extent of the tallest glyph above the baseline */
+  float ascent;  /**< recommended distance above the baseline */
+  float descent; /**< recommended distance below the baseline (positive) */
+  float bottom; /**< bottom extent of the lowest descender below the baseline */
+  float leading;             /**< recommended extra line spacing */
+  float avg_char_width;      /**< average character advance */
+  float max_char_width;      /**< maximum character advance */
+  float x_min;               /**< minimum x extent over all glyphs */
+  float x_max;               /**< maximum x extent over all glyphs */
+  float x_height;            /**< height of the lowercase 'x' */
+  float cap_height;          /**< height of an uppercase glyph */
+  float underline_thickness; /**< thickness of the underline */
+  float underline_position;  /**< position of the underline relative to the
+                                baseline */
+  float strikeout_thickness; /**< thickness of the strikeout */
+  float strikeout_position;  /**< position of the strikeout relative to the
+                                baseline */
+} skity_font_metrics;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TYPES_H

--- a/module/capi/src/bitmap_c.cpp
+++ b/module/capi/src/bitmap_c.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_bitmap.h>
+
+#include <skity/graphic/bitmap.hpp>
+#include <skity/io/pixmap.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Bitmap* bitmap_of(skity_bitmap handle) {
+  auto* w =
+      skity::capi::resolve<skity_bitmap_s>(handle, SKITY_OBJECT_TYPE_BITMAP);
+  return w ? static_cast<skity::Bitmap*>(w->impl.get()) : nullptr;
+}
+
+skity::Pixmap* pixmap_of(skity_pixmap handle) {
+  auto* w =
+      skity::capi::resolve<skity_pixmap_s>(handle, SKITY_OBJECT_TYPE_PIXMAP);
+  return w ? static_cast<skity::Pixmap*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_bitmap skity_bitmap_create(uint32_t width, uint32_t height,
+                                 skity_alpha_type alpha_type,
+                                 skity_color_type color_type) {
+  if (width == 0 || height == 0) {
+    return nullptr;
+  }
+  auto bp = std::make_shared<skity::Bitmap>(
+      width, height, static_cast<skity::AlphaType>(alpha_type),
+      static_cast<skity::ColorType>(color_type));
+  return skity::capi::alloc_handle<skity_bitmap_s>(
+      SKITY_OBJECT_TYPE_BITMAP, SKITY_HANDLE_OWNING, std::move(bp));
+}
+
+void skity_bitmap_destroy(skity_bitmap bitmap) {
+  skity::capi::destroy_handle<skity_bitmap_s>(bitmap, SKITY_OBJECT_TYPE_BITMAP);
+}
+
+uint32_t skity_bitmap_get_width(skity_bitmap bitmap) {
+  auto* b = bitmap_of(bitmap);
+  return b ? b->Width() : 0;
+}
+
+uint32_t skity_bitmap_get_height(skity_bitmap bitmap) {
+  auto* b = bitmap_of(bitmap);
+  return b ? b->Height() : 0;
+}
+
+size_t skity_bitmap_get_row_bytes(skity_bitmap bitmap) {
+  auto* b = bitmap_of(bitmap);
+  return b ? b->RowBytes() : 0;
+}
+
+void* skity_bitmap_get_pixels(skity_bitmap bitmap) {
+  auto* b = bitmap_of(bitmap);
+  return b ? b->GetPixelAddr() : nullptr;
+}
+
+void skity_pixmap_destroy(skity_pixmap pixmap) {
+  skity::capi::destroy_handle<skity_pixmap_s>(pixmap, SKITY_OBJECT_TYPE_PIXMAP);
+}
+
+uint32_t skity_pixmap_get_width(skity_pixmap pixmap) {
+  auto* p = pixmap_of(pixmap);
+  return p ? p->Width() : 0;
+}
+
+uint32_t skity_pixmap_get_height(skity_pixmap pixmap) {
+  auto* p = pixmap_of(pixmap);
+  return p ? p->Height() : 0;
+}
+
+size_t skity_pixmap_get_row_bytes(skity_pixmap pixmap) {
+  auto* p = pixmap_of(pixmap);
+  return p ? p->RowBytes() : 0;
+}
+
+const void* skity_pixmap_get_pixels(skity_pixmap pixmap) {
+  auto* p = pixmap_of(pixmap);
+  return p ? p->Addr() : nullptr;
+}
+
+skity_pixmap skity_bitmap_get_pixmap(skity_bitmap bitmap) {
+  auto* b = bitmap_of(bitmap);
+  if (b == nullptr) return nullptr;
+  auto pm = b->GetPixmap();
+  if (pm == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_pixmap_s>(SKITY_OBJECT_TYPE_PIXMAP,
+                                                   SKITY_HANDLE_OWNING, pm);
+}
+
+}  // extern "C"

--- a/module/capi/src/camera_c.cpp
+++ b/module/capi/src/camera_c.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_camera.h>
+
+#include <skity/geometry/camera.hpp>
+#include <skity/geometry/matrix.hpp>
+#include <skity/geometry/vector.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Camera* camera_of(skity_camera handle) {
+  auto* w =
+      skity::capi::resolve<skity_camera_s>(handle, SKITY_OBJECT_TYPE_CAMERA);
+  return w ? static_cast<skity::Camera*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_camera skity_camera_create(float viewport_width, float viewport_height) {
+  auto cam = std::make_shared<skity::Camera>(viewport_width, viewport_height);
+  return skity::capi::alloc_handle<skity_camera_s>(
+      SKITY_OBJECT_TYPE_CAMERA, SKITY_HANDLE_OWNING, std::move(cam));
+}
+
+void skity_camera_destroy(skity_camera camera) {
+  skity::capi::destroy_handle<skity_camera_s>(camera, SKITY_OBJECT_TYPE_CAMERA);
+}
+
+void skity_camera_set_position(skity_camera camera,
+                               const skity_vec4* position) {
+  auto* c = camera_of(camera);
+  if (c != nullptr && position != nullptr) {
+    c->SetPosition(*reinterpret_cast<const skity::Point*>(position));
+  }
+}
+
+void skity_camera_look_at(skity_camera camera, const skity_vec4* target) {
+  auto* c = camera_of(camera);
+  if (c != nullptr && target != nullptr) {
+    c->LookAt(*reinterpret_cast<const skity::Point*>(target));
+  }
+}
+
+void skity_camera_set_camera_dist(skity_camera camera, float dist) {
+  if (auto* c = camera_of(camera)) c->SetCameraDist(dist);
+}
+
+void skity_camera_set_rotation(skity_camera camera,
+                               const skity_matrix* rotation) {
+  auto* c = camera_of(camera);
+  if (c != nullptr && rotation != nullptr) {
+    c->SetRotation(*reinterpret_cast<const skity::Matrix*>(rotation));
+  }
+}
+
+void skity_camera_get_fixed_camera(skity_camera camera, skity_matrix* out) {
+  auto* c = camera_of(camera);
+  if (c == nullptr || out == nullptr) return;
+  *reinterpret_cast<skity::Matrix*>(out) = c->GetFixedCamera();
+}
+
+void skity_camera_get_camera(skity_camera camera, skity_matrix* out) {
+  auto* c = camera_of(camera);
+  if (c == nullptr || out == nullptr) return;
+  *reinterpret_cast<skity::Matrix*>(out) = c->GetCamera();
+}
+
+}  // extern "C"

--- a/module/capi/src/canvas_c.cpp
+++ b/module/capi/src/canvas_c.cpp
@@ -1,0 +1,355 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_canvas.h>
+
+#include <skity/geometry/matrix.hpp>
+#include <skity/geometry/rect.hpp>
+#include <skity/geometry/rrect.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/graphic/path.hpp>
+#include <skity/graphic/sampling_options.hpp>
+#include <skity/render/canvas.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/text_blob.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Canvas* canvas_of(skity_canvas handle) {
+  auto* w =
+      skity::capi::resolve<skity_canvas_s>(handle, SKITY_OBJECT_TYPE_CANVAS);
+  return w ? static_cast<skity::Canvas*>(w->impl.get()) : nullptr;
+}
+
+skity::Paint* paint_of(skity_paint handle) {
+  auto* w =
+      skity::capi::resolve<skity_paint_s>(handle, SKITY_OBJECT_TYPE_PAINT);
+  return w ? static_cast<skity::Paint*>(w->impl.get()) : nullptr;
+}
+
+skity::Path* path_of(skity_path handle) {
+  auto* w = skity::capi::resolve<skity_path_s>(handle, SKITY_OBJECT_TYPE_PATH);
+  return w ? static_cast<skity::Path*>(w->impl.get()) : nullptr;
+}
+
+skity::Canvas::ClipOp to_clip_op(skity_clip_op op) {
+  return op == SKITY_CLIP_OP_DIFFERENCE ? skity::Canvas::ClipOp::kDifference
+                                        : skity::Canvas::ClipOp::kIntersect;
+}
+
+skity::TextBlob* text_blob_of(skity_text_blob handle) {
+  auto* w = skity::capi::resolve<skity_text_blob_s>(
+      handle, SKITY_OBJECT_TYPE_TEXT_BLOB);
+  return w ? static_cast<skity::TextBlob*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+int32_t skity_canvas_save(skity_canvas canvas) {
+  auto* c = canvas_of(canvas);
+  return c ? c->Save() : 0;
+}
+
+void skity_canvas_restore(skity_canvas canvas) {
+  if (auto* c = canvas_of(canvas)) c->Restore();
+}
+
+void skity_canvas_restore_to_count(skity_canvas canvas, int32_t save_count) {
+  if (auto* c = canvas_of(canvas)) c->RestoreToCount(save_count);
+}
+
+int32_t skity_canvas_get_save_count(skity_canvas canvas) {
+  auto* c = canvas_of(canvas);
+  return c ? c->GetSaveCount() : 0;
+}
+
+void skity_canvas_translate(skity_canvas canvas, float dx, float dy) {
+  if (auto* c = canvas_of(canvas)) c->Translate(dx, dy);
+}
+
+void skity_canvas_scale(skity_canvas canvas, float sx, float sy) {
+  if (auto* c = canvas_of(canvas)) c->Scale(sx, sy);
+}
+
+void skity_canvas_rotate(skity_canvas canvas, float degrees) {
+  if (auto* c = canvas_of(canvas)) c->Rotate(degrees);
+}
+
+void skity_canvas_rotate_deg(skity_canvas canvas, float degrees, float px,
+                             float py) {
+  if (auto* c = canvas_of(canvas)) c->Rotate(degrees, px, py);
+}
+
+void skity_canvas_skew(skity_canvas canvas, float sx, float sy) {
+  if (auto* c = canvas_of(canvas)) c->Skew(sx, sy);
+}
+
+void skity_canvas_concat(skity_canvas canvas, const skity_matrix* matrix) {
+  auto* c = canvas_of(canvas);
+  if (c != nullptr && matrix != nullptr) {
+    c->Concat(*reinterpret_cast<const skity::Matrix*>(matrix));
+  }
+}
+
+void skity_canvas_set_matrix(skity_canvas canvas, const skity_matrix* matrix) {
+  auto* c = canvas_of(canvas);
+  if (c != nullptr && matrix != nullptr) {
+    c->SetMatrix(*reinterpret_cast<const skity::Matrix*>(matrix));
+  }
+}
+
+void skity_canvas_reset_matrix(skity_canvas canvas) {
+  if (auto* c = canvas_of(canvas)) c->ResetMatrix();
+}
+
+void skity_canvas_clip_rect(skity_canvas canvas, const skity_rect* rect,
+                            skity_clip_op op) {
+  auto* c = canvas_of(canvas);
+  if (c != nullptr && rect != nullptr) {
+    c->ClipRect(*reinterpret_cast<const skity::Rect*>(rect), to_clip_op(op));
+  }
+}
+
+void skity_canvas_clip_path(skity_canvas canvas, skity_path path,
+                            skity_clip_op op) {
+  auto* c = canvas_of(canvas);
+  auto* p = path_of(path);
+  if (c != nullptr && p != nullptr) {
+    c->ClipPath(*p, to_clip_op(op));
+  }
+}
+
+void skity_canvas_draw_color(skity_canvas canvas, skity_color color,
+                             skity_blend_mode mode) {
+  if (auto* c = canvas_of(canvas)) {
+    c->DrawColor(static_cast<skity::Color>(color),
+                 static_cast<skity::BlendMode>(mode));
+  }
+}
+
+void skity_canvas_draw_paint(skity_canvas canvas, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && p != nullptr) c->DrawPaint(*p);
+}
+
+void skity_canvas_draw_point(skity_canvas canvas, float x, float y,
+                             skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && p != nullptr) c->DrawCircle(x, y, 0, *p);
+}
+
+void skity_canvas_draw_line(skity_canvas canvas, float x0, float y0, float x1,
+                            float y1, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && p != nullptr) c->DrawLine(x0, y0, x1, y1, *p);
+}
+
+void skity_canvas_draw_rect(skity_canvas canvas, const skity_rect* rect,
+                            skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && rect != nullptr && p != nullptr) {
+    c->DrawRect(*reinterpret_cast<const skity::Rect*>(rect), *p);
+  }
+}
+
+void skity_canvas_draw_circle(skity_canvas canvas, float cx, float cy,
+                              float radius, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && p != nullptr) c->DrawCircle(cx, cy, radius, *p);
+}
+
+void skity_canvas_draw_oval(skity_canvas canvas, const skity_rect* oval,
+                            skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && oval != nullptr && p != nullptr) {
+    c->DrawOval(*reinterpret_cast<const skity::Rect*>(oval), *p);
+  }
+}
+
+void skity_canvas_draw_round_rect(skity_canvas canvas, const skity_rect* rect,
+                                  float rx, float ry, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && rect != nullptr && p != nullptr) {
+    c->DrawRoundRect(*reinterpret_cast<const skity::Rect*>(rect), rx, ry, *p);
+  }
+}
+
+void skity_canvas_draw_path(skity_canvas canvas, skity_path path,
+                            skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = path_of(path);
+  auto* pt = paint_of(paint);
+  if (c != nullptr && p != nullptr && pt != nullptr) {
+    c->DrawPath(*p, *pt);
+  }
+}
+
+void skity_canvas_draw_image(skity_canvas canvas, skity_image image, float x,
+                             float y) {
+  auto* c = canvas_of(canvas);
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  if (c != nullptr && img != nullptr) {
+    c->DrawImage(img, x, y);
+  }
+}
+
+void skity_canvas_draw_image_rect(skity_canvas canvas, skity_image image,
+                                  const skity_rect* src, const skity_rect* dst,
+                                  const skity_sampling_options* sampling,
+                                  skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  auto* p = paint_of(paint);
+  if (c == nullptr || img == nullptr || src == nullptr || dst == nullptr) {
+    return;
+  }
+  skity::SamplingOptions so{};
+  if (sampling != nullptr) {
+    so.filter = static_cast<skity::FilterMode>(sampling->filter);
+    so.mipmap = static_cast<skity::MipmapMode>(sampling->mipmap);
+    so.cubic.B = sampling->cubic_b;
+    so.cubic.C = sampling->cubic_c;
+  }
+  c->DrawImageRect(img, *reinterpret_cast<const skity::Rect*>(src),
+                   *reinterpret_cast<const skity::Rect*>(dst), so, p);
+}
+
+void skity_canvas_draw_text_blob(skity_canvas canvas, skity_text_blob blob,
+                                 float x, float y, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* b = text_blob_of(blob);
+  auto* p = paint_of(paint);
+  if (c != nullptr && b != nullptr && p != nullptr) {
+    c->DrawTextBlob(b, x, y, *p);
+  }
+}
+
+void skity_canvas_clip_rrect(skity_canvas canvas, const skity_rect* rect,
+                             float rx, float ry, skity_clip_op op) {
+  auto* c = canvas_of(canvas);
+  if (c == nullptr || rect == nullptr) {
+    return;
+  }
+  auto rr = skity::RRect::MakeRectXY(
+      *reinterpret_cast<const skity::Rect*>(rect), rx, ry);
+  c->ClipRRect(rr, to_clip_op(op));
+}
+
+int32_t skity_canvas_save_layer(skity_canvas canvas, const skity_rect* bounds,
+                                skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c == nullptr || p == nullptr) {
+    return 0;
+  }
+  skity::Rect b = bounds != nullptr
+                      ? *reinterpret_cast<const skity::Rect*>(bounds)
+                      : skity::Rect{};
+  return c->SaveLayer(b, *p);
+}
+
+void skity_canvas_draw_arc(skity_canvas canvas, const skity_rect* oval,
+                           float start_angle, float sweep_angle,
+                           uint32_t use_center, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c != nullptr && oval != nullptr && p != nullptr) {
+    c->DrawArc(*reinterpret_cast<const skity::Rect*>(oval), start_angle,
+               sweep_angle, use_center != 0, *p);
+  }
+}
+
+void skity_canvas_draw_drrect(skity_canvas canvas, const skity_rect* outer,
+                              float outer_rx, float outer_ry,
+                              const skity_rect* inner, float inner_rx,
+                              float inner_ry, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c == nullptr || outer == nullptr || inner == nullptr || p == nullptr) {
+    return;
+  }
+  auto o = skity::RRect::MakeRectXY(
+      *reinterpret_cast<const skity::Rect*>(outer), outer_rx, outer_ry);
+  auto i = skity::RRect::MakeRectXY(
+      *reinterpret_cast<const skity::Rect*>(inner), inner_rx, inner_ry);
+  c->DrawDRRect(o, i, *p);
+}
+
+void skity_canvas_get_total_matrix(skity_canvas canvas, skity_matrix* out) {
+  auto* c = canvas_of(canvas);
+  if (c == nullptr || out == nullptr) {
+    return;
+  }
+  *reinterpret_cast<skity::Matrix*>(out) = c->GetTotalMatrix();
+}
+
+void skity_canvas_get_local_clip_bounds(skity_canvas canvas, skity_rect* out) {
+  auto* c = canvas_of(canvas);
+  if (c == nullptr || out == nullptr) {
+    return;
+  }
+  skity::Rect b = c->GetLocalClipBounds();
+  out->left = b.Left();
+  out->top = b.Top();
+  out->right = b.Right();
+  out->bottom = b.Bottom();
+}
+
+uint32_t skity_canvas_quick_reject(skity_canvas canvas,
+                                   const skity_rect* rect) {
+  auto* c = canvas_of(canvas);
+  if (c == nullptr || rect == nullptr) {
+    return 1;
+  }
+  return c->QuickReject(*reinterpret_cast<const skity::Rect*>(rect)) ? 1 : 0;
+}
+
+void skity_canvas_draw_glyphs(skity_canvas canvas, uint32_t count,
+                              const uint16_t* glyphs, const float* positions_x,
+                              const float* positions_y, skity_font font,
+                              skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto f = skity::capi::get_impl<skity_font_s, skity::Font>(
+      font, SKITY_OBJECT_TYPE_FONT);
+  auto* p = paint_of(paint);
+  if (c == nullptr || f == nullptr || p == nullptr || glyphs == nullptr ||
+      positions_x == nullptr || positions_y == nullptr) {
+    return;
+  }
+  c->DrawGlyphs((int)count, glyphs, positions_x, positions_y, *f, *p);
+}
+
+void skity_canvas_flush(skity_canvas canvas) {
+  if (auto* c = canvas_of(canvas)) c->Flush();
+}
+
+uint32_t skity_canvas_get_width(skity_canvas canvas) {
+  auto* c = canvas_of(canvas);
+  return c ? c->Width() : 0;
+}
+
+uint32_t skity_canvas_get_height(skity_canvas canvas) {
+  auto* c = canvas_of(canvas);
+  return c ? c->Height() : 0;
+}
+
+void skity_canvas_destroy(skity_canvas canvas) {
+  skity::capi::destroy_handle<skity_canvas_s>(canvas, SKITY_OBJECT_TYPE_CANVAS);
+}
+
+}  // extern "C"

--- a/module/capi/src/context_c.cpp
+++ b/module/capi/src/context_c.cpp
@@ -1,0 +1,163 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_precompile.h>
+
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/render/precompile_context.hpp>
+#include <utility>
+
+#include "handle.hpp"
+
+#if defined(SKITY_OPENGL)
+#include <skity/gpu/gpu_context_gl.hpp>
+#endif
+
+#if defined(SKITY_VULKAN)
+#include <skity_c/skity_context_vk.h>
+#include <vulkan/vulkan.h>
+
+#include <skity/gpu/gpu_context_vk.hpp>
+#endif
+
+namespace {
+
+skity::GPUContext* context_of(skity_context handle) {
+  auto* w =
+      skity::capi::resolve<skity_context_s>(handle, SKITY_OBJECT_TYPE_CONTEXT);
+  return w ? static_cast<skity::GPUContext*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
+                                     skity_context* out_context) {
+  if (get_proc == nullptr || out_context == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+#if defined(SKITY_OPENGL)
+  std::unique_ptr<skity::GPUContext> ctx =
+      skity::GLContextCreate(reinterpret_cast<void*>(get_proc));
+  if (ctx == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+  std::shared_ptr<void> impl(ctx.release());
+  skity_context_s* w = skity::capi::alloc_handle<skity_context_s>(
+      SKITY_OBJECT_TYPE_CONTEXT, SKITY_HANDLE_OWNING, std::move(impl));
+  if (w == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out_context = w;
+  return SKITY_SUCCESS;
+#else
+  return SKITY_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+void skity_context_destroy(skity_context context) {
+  skity::capi::destroy_handle<skity_context_s>(context,
+                                               SKITY_OBJECT_TYPE_CONTEXT);
+}
+
+void skity_context_set_error_callback(skity_context context,
+                                      skity_gpu_error_callback callback,
+                                      void* userdata) {
+  auto* c = context_of(context);
+  if (c == nullptr) {
+    return;
+  }
+  c->SetErrorCallback(reinterpret_cast<skity::GPUErrorCallback>(callback),
+                      userdata);
+}
+
+void skity_context_set_enable_merging_draw_call(skity_context context,
+                                                uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetEnableMergingDrawCall(enable != 0);
+}
+
+void skity_context_set_enable_contour_aa(skity_context context,
+                                         uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetEnableContourAA(enable != 0);
+}
+
+void skity_context_set_enable_coverage_aa(skity_context context,
+                                          uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetEnableCoverageAA(enable != 0);
+}
+
+void skity_context_set_conflation_correction(skity_context context,
+                                             uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetConflationCorrection(enable != 0);
+}
+
+void skity_context_set_larger_atlas_mask(skity_context context, uint8_t mask) {
+  if (auto* c = context_of(context)) c->SetLargerAtlasMask(mask);
+}
+
+void skity_context_set_enable_text_linear_filter(skity_context context,
+                                                 uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetEnableTextLinearFilter(enable != 0);
+}
+
+void skity_context_set_enable_gpu_tessellation(skity_context context,
+                                               uint32_t enable) {
+  if (auto* c = context_of(context)) c->SetEnableGPUTessellation(enable != 0);
+}
+
+void skity_context_set_enable_simple_shape_pipeline(skity_context context,
+                                                    uint32_t enable) {
+  if (auto* c = context_of(context))
+    c->SetEnableSimpleShapePipeline(enable != 0);
+}
+
+void skity_context_set_resource_cache_limit(skity_context context,
+                                            size_t max_bytes) {
+  if (auto* c = context_of(context)) c->SetResourceCacheLimit(max_bytes);
+}
+
+skity_precompile_context skity_context_create_precompile_context(
+    skity_context context, skity_precompile_color_type color_type,
+    uint32_t enable_msaa) {
+  auto* c = context_of(context);
+  if (c == nullptr) {
+    return nullptr;
+  }
+  auto pc = c->CreatePrecompileContext(
+      static_cast<skity::PrecompileColorType>(color_type), enable_msaa != 0);
+  if (pc == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<void> impl(pc.release());
+  return skity::capi::alloc_handle<skity_precompile_context_s>(
+      SKITY_OBJECT_TYPE_PRECOMPILE_CONTEXT, SKITY_HANDLE_OWNING,
+      std::move(impl));
+}
+
+#if defined(SKITY_VULKAN)
+skity_result skity_context_create_vk(
+    PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+    skity_context* out_context) {
+  if (get_instance_proc_addr == nullptr || out_context == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  std::unique_ptr<skity::GPUContext> ctx =
+      skity::CreateGPUContextVK(get_instance_proc_addr);
+  if (ctx == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+  std::shared_ptr<void> impl(ctx.release());
+  skity_context_s* w = skity::capi::alloc_handle<skity_context_s>(
+      SKITY_OBJECT_TYPE_CONTEXT, SKITY_HANDLE_OWNING, std::move(impl));
+  if (w == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out_context = w;
+  return SKITY_SUCCESS;
+}
+#endif  // defined(SKITY_VULKAN)
+
+}  // extern "C"

--- a/module/capi/src/data_c.cpp
+++ b/module/capi/src/data_c.cpp
@@ -1,0 +1,58 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_data.h>
+
+#include <skity/io/data.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Data* data_of(skity_data handle) {
+  auto* w = skity::capi::resolve<skity_data_s>(handle, SKITY_OBJECT_TYPE_DATA);
+  return w ? static_cast<skity::Data*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_data skity_data_make_with_copy(const void* data, size_t length) {
+  auto d = skity::Data::MakeWithCopy(data, length);
+  if (d == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_data_s>(
+      SKITY_OBJECT_TYPE_DATA, SKITY_HANDLE_OWNING, std::move(d));
+}
+
+skity_data skity_data_make_from_file(const char* path) {
+  if (path == nullptr) return nullptr;
+  auto d = skity::Data::MakeFromFileName(path);
+  if (d == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_data_s>(
+      SKITY_OBJECT_TYPE_DATA, SKITY_HANDLE_OWNING, std::move(d));
+}
+
+skity_data skity_data_make_empty(void) {
+  auto d = skity::Data::MakeEmpty();
+  if (d == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_data_s>(
+      SKITY_OBJECT_TYPE_DATA, SKITY_HANDLE_OWNING, std::move(d));
+}
+
+void skity_data_destroy(skity_data data) {
+  skity::capi::destroy_handle<skity_data_s>(data, SKITY_OBJECT_TYPE_DATA);
+}
+
+size_t skity_data_get_size(skity_data data) {
+  auto* d = data_of(data);
+  return d ? d->Size() : 0u;
+}
+
+const void* skity_data_get_data(skity_data data) {
+  auto* d = data_of(data);
+  return d ? d->RawData() : nullptr;
+}
+
+}  // extern "C"

--- a/module/capi/src/filters_c.cpp
+++ b/module/capi/src/filters_c.cpp
@@ -1,0 +1,204 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_color_filter.h>
+#include <skity_c/skity_image_filter.h>
+#include <skity_c/skity_mask_filter.h>
+#include <skity_c/skity_path_effect.h>
+
+#include <skity/effect/color_filter.hpp>
+#include <skity/effect/image_filter.hpp>
+#include <skity/effect/mask_filter.hpp>
+#include <skity/effect/path_effect.hpp>
+#include <skity/geometry/matrix.hpp>
+
+#include "handle.hpp"
+
+extern "C" {
+
+/* ----- color filter ----- */
+
+skity_color_filter skity_color_filter_create_blend(skity_color color,
+                                                   skity_blend_mode mode) {
+  auto sp = skity::ColorFilters::Blend(static_cast<skity::Color>(color),
+                                       static_cast<skity::BlendMode>(mode));
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_color_filter skity_color_filter_create_compose(skity_color_filter outer,
+                                                     skity_color_filter inner) {
+  auto o = skity::capi::get_impl<skity_color_filter_s, skity::ColorFilter>(
+      outer, SKITY_OBJECT_TYPE_COLOR_FILTER);
+  auto i = skity::capi::get_impl<skity_color_filter_s, skity::ColorFilter>(
+      inner, SKITY_OBJECT_TYPE_COLOR_FILTER);
+  auto sp = skity::ColorFilters::Compose(o, i);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_color_filter skity_color_filter_create_matrix(const float* row_major) {
+  if (row_major == nullptr) return nullptr;
+  auto sp = skity::ColorFilters::Matrix(row_major);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_color_filter skity_color_filter_create_linear_to_srgb(void) {
+  auto sp = skity::ColorFilters::LinearToSRGBGamma();
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_color_filter skity_color_filter_create_srgb_to_linear(void) {
+  auto sp = skity::ColorFilters::SRGBToLinearGamma();
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_color_filter_destroy(skity_color_filter filter) {
+  skity::capi::destroy_handle<skity_color_filter_s>(
+      filter, SKITY_OBJECT_TYPE_COLOR_FILTER);
+}
+
+/* ----- image filter ----- */
+
+skity_image_filter skity_image_filter_create_blur(float sigma_x,
+                                                  float sigma_y) {
+  auto sp = skity::ImageFilters::Blur(sigma_x, sigma_y);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_dilate(float radius_x,
+                                                    float radius_y) {
+  auto sp = skity::ImageFilters::Dilate(radius_x, radius_y);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_erode(float radius_x,
+                                                   float radius_y) {
+  auto sp = skity::ImageFilters::Erode(radius_x, radius_y);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_matrix_transform(
+    const skity_matrix* matrix) {
+  if (matrix == nullptr) return nullptr;
+  auto sp = skity::ImageFilters::MatrixTransform(
+      *reinterpret_cast<const skity::Matrix*>(matrix));
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_from_color_filter(
+    skity_color_filter filter) {
+  auto cf = skity::capi::get_impl<skity_color_filter_s, skity::ColorFilter>(
+      filter, SKITY_OBJECT_TYPE_COLOR_FILTER);
+  auto sp = skity::ImageFilters::ColorFilter(cf);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_compose(skity_image_filter outer,
+                                                     skity_image_filter inner) {
+  auto o = skity::capi::get_impl<skity_image_filter_s, skity::ImageFilter>(
+      outer, SKITY_OBJECT_TYPE_IMAGE_FILTER);
+  auto i = skity::capi::get_impl<skity_image_filter_s, skity::ImageFilter>(
+      inner, SKITY_OBJECT_TYPE_IMAGE_FILTER);
+  auto sp = skity::ImageFilters::Compose(o, i);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_drop_shadow(
+    float dx, float dy, float sigma_x, float sigma_y, skity_color color,
+    skity_image_filter input, const skity_rect* crop) {
+  auto in = skity::capi::get_impl<skity_image_filter_s, skity::ImageFilter>(
+      input, SKITY_OBJECT_TYPE_IMAGE_FILTER);
+  skity::Rect c = crop != nullptr ? *reinterpret_cast<const skity::Rect*>(crop)
+                                  : skity::Rect{};
+  auto sp = skity::ImageFilters::DropShadow(
+      dx, dy, sigma_x, sigma_y, static_cast<skity::Color>(color), in, c);
+  if (sp == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_image_filter_create_local_matrix(
+    skity_image_filter input, const skity_matrix* matrix) {
+  auto in = skity::capi::get_impl<skity_image_filter_s, skity::ImageFilter>(
+      input, SKITY_OBJECT_TYPE_IMAGE_FILTER);
+  if (in == nullptr || matrix == nullptr) {
+    return nullptr;
+  }
+  auto sp = skity::ImageFilters::LocalMatrix(
+      in, *reinterpret_cast<const skity::Matrix*>(matrix));
+  if (sp == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_image_filter_destroy(skity_image_filter filter) {
+  skity::capi::destroy_handle<skity_image_filter_s>(
+      filter, SKITY_OBJECT_TYPE_IMAGE_FILTER);
+}
+
+/* ----- mask filter ----- */
+
+skity_mask_filter skity_mask_filter_create_blur(skity_blur_style style,
+                                                float radius) {
+  auto sp =
+      skity::MaskFilter::MakeBlur(static_cast<skity::BlurStyle>(style), radius);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_mask_filter_s>(
+      SKITY_OBJECT_TYPE_MASK_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_mask_filter_destroy(skity_mask_filter filter) {
+  skity::capi::destroy_handle<skity_mask_filter_s>(
+      filter, SKITY_OBJECT_TYPE_MASK_FILTER);
+}
+
+/* ----- path effect ----- */
+
+skity_path_effect skity_path_effect_create_discrete(float seg_length, float dev,
+                                                    uint32_t seed_assist) {
+  auto sp =
+      skity::PathEffect::MakeDiscretePathEffect(seg_length, dev, seed_assist);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_path_effect_s>(
+      SKITY_OBJECT_TYPE_PATH_EFFECT, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_path_effect skity_path_effect_create_dash(const float* intervals,
+                                                int32_t count, float phase) {
+  if (intervals == nullptr || count <= 0) return nullptr;
+  auto sp = skity::PathEffect::MakeDashPathEffect(intervals, count, phase);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_path_effect_s>(
+      SKITY_OBJECT_TYPE_PATH_EFFECT, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_path_effect_destroy(skity_path_effect effect) {
+  skity::capi::destroy_handle<skity_path_effect_s>(
+      effect, SKITY_OBJECT_TYPE_PATH_EFFECT);
+}
+
+}  // extern "C"

--- a/module/capi/src/font_c.cpp
+++ b/module/capi/src/font_c.cpp
@@ -1,0 +1,221 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_font.h>
+
+#include <skity/text/font.hpp>
+#include <skity/text/font_metrics.hpp>
+#include <skity/text/typeface.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Font* font_of(skity_font handle) {
+  auto* w = skity::capi::resolve<skity_font_s>(handle, SKITY_OBJECT_TYPE_FONT);
+  return w ? static_cast<skity::Font*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_font skity_font_create(void) {
+  return skity::capi::alloc_handle<skity_font_s>(
+      SKITY_OBJECT_TYPE_FONT, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Font>());
+}
+
+skity_font skity_font_create_with_typeface(skity_typeface typeface,
+                                           float size) {
+  auto tf = skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+      typeface, SKITY_OBJECT_TYPE_TYPEFACE);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_font_s>(
+      SKITY_OBJECT_TYPE_FONT, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Font>(tf, size));
+}
+
+skity_font skity_font_create_with_typeface_scale(skity_typeface typeface,
+                                                 float size, float scale_x,
+                                                 float skew_x) {
+  auto tf = skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+      typeface, SKITY_OBJECT_TYPE_TYPEFACE);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_font_s>(
+      SKITY_OBJECT_TYPE_FONT, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Font>(tf, size, scale_x, skew_x));
+}
+
+void skity_font_destroy(skity_font font) {
+  skity::capi::destroy_handle<skity_font_s>(font, SKITY_OBJECT_TYPE_FONT);
+}
+
+void skity_font_set_typeface(skity_font font, skity_typeface typeface) {
+  auto* f = font_of(font);
+  auto tf = skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+      typeface, SKITY_OBJECT_TYPE_TYPEFACE);
+  if (f != nullptr && tf != nullptr) {
+    f->SetTypeface(tf);
+  }
+}
+
+skity_typeface skity_font_get_typeface(skity_font font) {
+  auto* f = font_of(font);
+  if (f == nullptr) return nullptr;
+  auto sp = f->GetTypeface();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_font_set_size(skity_font font, float size) {
+  if (auto* f = font_of(font)) f->SetSize(size);
+}
+
+float skity_font_get_size(skity_font font) {
+  auto* f = font_of(font);
+  return f ? f->GetSize() : 0.0f;
+}
+
+float skity_font_get_scale_x(skity_font font) {
+  auto* f = font_of(font);
+  return f ? f->GetScaleX() : 1.0f;
+}
+
+void skity_font_set_scale_x(skity_font font, float scale_x) {
+  if (auto* f = font_of(font)) f->SetScaleX(scale_x);
+}
+
+float skity_font_get_skew_x(skity_font font) {
+  auto* f = font_of(font);
+  return f ? f->GetSkewX() : 0.0f;
+}
+
+void skity_font_set_skew_x(skity_font font, float skew_x) {
+  if (auto* f = font_of(font)) f->SetSkewX(skew_x);
+}
+
+void skity_font_get_metrics(skity_font font, skity_font_metrics* out) {
+  auto* f = font_of(font);
+  if (f == nullptr || out == nullptr) {
+    return;
+  }
+  skity::FontMetrics m;
+  f->GetMetrics(&m);
+  out->top = m.top_;
+  out->ascent = m.ascent_;
+  out->descent = m.descent_;
+  out->bottom = m.bottom_;
+  out->leading = m.leading_;
+  out->avg_char_width = m.avg_char_width_;
+  out->max_char_width = m.max_char_width_;
+  out->x_min = m.x_min_;
+  out->x_max = m.x_max_;
+  out->x_height = m.x_height_;
+  out->cap_height = m.cap_height_;
+  out->underline_thickness = m.underline_thickness_;
+  out->underline_position = m.underline_position_;
+  out->strikeout_thickness = m.strikeout_thickness_;
+  out->strikeout_position = m.strikeout_position_;
+}
+
+void skity_font_set_hinting(skity_font font, skity_font_hinting hinting) {
+  if (auto* f = font_of(font))
+    f->SetHinting(static_cast<skity::Font::FontHinting>(hinting));
+}
+
+skity_font_hinting skity_font_get_hinting(skity_font font) {
+  auto* f = font_of(font);
+  return f ? static_cast<skity_font_hinting>(f->GetHinting())
+           : SKITY_FONT_HINTING_NORMAL;
+}
+
+void skity_font_set_edging(skity_font font, skity_font_edging edging) {
+  if (auto* f = font_of(font))
+    f->SetEdging(static_cast<skity::Font::Edging>(edging));
+}
+
+skity_font_edging skity_font_get_edging(skity_font font) {
+  auto* f = font_of(font);
+  return f ? static_cast<skity_font_edging>(f->GetEdging())
+           : SKITY_FONT_EDGING_ALIAS;
+}
+
+void skity_font_set_subpixel(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetSubpixel(enable != 0);
+}
+
+void skity_font_set_force_auto_hinting(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetForceAutoHinting(enable != 0);
+}
+
+void skity_font_set_embedded_bitmaps(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetEmbeddedBitmaps(enable != 0);
+}
+
+void skity_font_set_linear_metrics(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetLinearMetrics(enable != 0);
+}
+
+void skity_font_set_embolden(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetEmbolden(enable != 0);
+}
+
+void skity_font_set_baseline_snap(skity_font font, uint32_t enable) {
+  if (auto* f = font_of(font)) f->SetBaselineSnap(enable != 0);
+}
+
+uint32_t skity_font_is_force_auto_hinting(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsForceAutoHinting() ? 1u : 0u;
+}
+
+uint32_t skity_font_is_embedded_bitmaps(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsEmbeddedBitmaps() ? 1u : 0u;
+}
+
+uint32_t skity_font_is_subpixel(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsSubpixel() ? 1u : 0u;
+}
+
+uint32_t skity_font_is_linear_metrics(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsLinearMetrics() ? 1u : 0u;
+}
+
+uint32_t skity_font_is_embolden(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsEmbolden() ? 1u : 0u;
+}
+
+uint32_t skity_font_is_baseline_snap(skity_font font) {
+  auto* f = font_of(font);
+  return f && f->IsBaselineSnap() ? 1u : 0u;
+}
+
+skity_font skity_font_make_with_size(skity_font font, float size) {
+  auto* f = font_of(font);
+  if (f == nullptr) return nullptr;
+  auto nf = std::make_shared<skity::Font>(f->MakeWithSize(size));
+  return skity::capi::alloc_handle<skity_font_s>(
+      SKITY_OBJECT_TYPE_FONT, SKITY_HANDLE_OWNING, std::move(nf));
+}
+
+void skity_font_get_widths(skity_font font, const uint16_t* glyphs,
+                           int32_t count, float* widths) {
+  auto* f = font_of(font);
+  if (f == nullptr || glyphs == nullptr || widths == nullptr || count <= 0) {
+    return;
+  }
+  f->GetWidths(reinterpret_cast<const skity::GlyphID*>(glyphs), count, widths);
+}
+
+}  // extern "C"

--- a/module/capi/src/handle.hpp
+++ b/module/capi/src/handle.hpp
@@ -1,0 +1,228 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_SRC_HANDLE_HPP
+#define MODULE_CAPI_SRC_HANDLE_HPP
+
+#include <cstdint>
+#include <memory>
+#include <new>
+
+/*
+ * Object type tag + handle header. These are implementation details of the
+ * wrapper and are intentionally NOT exposed in the public C headers — handles
+ * are fully opaque to consumers. The header is the first member of every
+ * wrapper struct so that resolve() can validate the type tag before use.
+ */
+typedef enum {
+  SKITY_OBJECT_TYPE_UNKNOWN = 0,
+  SKITY_OBJECT_TYPE_CONTEXT = 1,
+  SKITY_OBJECT_TYPE_SURFACE,
+  SKITY_OBJECT_TYPE_CANVAS,
+  SKITY_OBJECT_TYPE_PAINT,
+  SKITY_OBJECT_TYPE_PATH,
+  SKITY_OBJECT_TYPE_SHADER,
+  SKITY_OBJECT_TYPE_COLOR_FILTER,
+  SKITY_OBJECT_TYPE_IMAGE_FILTER,
+  SKITY_OBJECT_TYPE_MASK_FILTER,
+  SKITY_OBJECT_TYPE_PATH_EFFECT,
+  SKITY_OBJECT_TYPE_TYPEFACE,
+  SKITY_OBJECT_TYPE_FONT_MANAGER,
+  SKITY_OBJECT_TYPE_PICTURE_RECORDER,
+  SKITY_OBJECT_TYPE_DISPLAY_LIST,
+  SKITY_OBJECT_TYPE_IMAGE,
+  SKITY_OBJECT_TYPE_TEXT_BLOB,
+  SKITY_OBJECT_TYPE_TEXTURE,
+  SKITY_OBJECT_TYPE_FONT_STYLE_SET,
+  SKITY_OBJECT_TYPE_PRECOMPILE_CONTEXT,
+  SKITY_OBJECT_TYPE_FONT,
+  SKITY_OBJECT_TYPE_BITMAP,
+  SKITY_OBJECT_TYPE_PIXMAP,
+  SKITY_OBJECT_TYPE_PATH_MEASURE,
+  SKITY_OBJECT_TYPE_CAMERA,
+  SKITY_OBJECT_TYPE_DATA,
+} skity_object_type;
+
+/* When set, the wrapper owns the underlying object and releases it on destroy.
+ * When clear (e.g. the Canvas from skity_surface_lock_canvas, owned by the
+ * surface), destroy only reclaims the wrapper struct. */
+#define SKITY_HANDLE_OWNING 0x1u
+
+typedef struct skity_object_header {
+  uint32_t type;  /* skity_object_type */
+  uint32_t flags; /* SKITY_HANDLE_OWNING | reserved */
+} skity_object_header;
+
+/*
+ * Wrapper-internal struct definitions. Each is `header + impl` where impl is a
+ * type-erased shared_ptr:
+ *   - owning handles store a shared_ptr with the default deleter (or the
+ *     factory's original shared_ptr), so destroying the wrapper releases the
+ *     object;
+ *   - non-owning handles (e.g. Canvas returned by lock_canvas) store the raw
+ *     pointer with an empty deleter, so destroying the wrapper is a no-op on
+ *     the underlying object.
+ *
+ * These structs live at global scope so they match the C-side typedefs
+ * produced by SKITY_C_DEFINE_HANDLE.
+ */
+struct skity_context_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_surface_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_canvas_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_paint_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_path_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_shader_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_color_filter_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_image_filter_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_mask_filter_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_path_effect_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_typeface_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_font_manager_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_picture_recorder_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_display_list_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_image_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_text_blob_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_texture_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_font_style_set_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_precompile_context_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_font_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_bitmap_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_pixmap_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_path_measure_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_camera_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_data_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+
+namespace skity {
+namespace capi {
+
+/*
+ * Allocate a wrapper struct with its header filled in. Uses nothrow new so a
+ * failed allocation returns nullptr (the wrapper is built with -fno-exceptions,
+ * matching the core skity library).
+ */
+template <typename Wrapper>
+inline Wrapper* alloc_handle(skity_object_type type, uint32_t flags,
+                             std::shared_ptr<void> impl) {
+  Wrapper* w = new (std::nothrow) Wrapper{};
+  if (w == nullptr) return nullptr;
+  w->header.type = type;
+  w->header.flags = flags;
+  w->impl = std::move(impl);
+  return w;
+}
+
+/*
+ * Validate the handle's type tag and return it as its concrete wrapper struct,
+ * or nullptr if the handle is null / wrong type. The first-member header
+ * invariant lets every wrapper be read as skity_object_header*.
+ */
+template <typename Wrapper>
+inline Wrapper* resolve(void* handle, skity_object_type expected) {
+  if (handle == nullptr) return nullptr;
+  auto* hdr = static_cast<skity_object_header*>(handle);
+  return hdr->type == expected ? static_cast<Wrapper*>(handle) : nullptr;
+}
+
+/*
+ * Reclaim a wrapper. The shared_ptr impl field's deleter decides whether the
+ * underlying object is released (owning) or left untouched (non-owning), so
+ * this is uniformly safe regardless of the owning flag.
+ */
+template <typename Wrapper>
+inline void destroy_handle(void* handle, skity_object_type expected) {
+  Wrapper* w = resolve<Wrapper>(handle, expected);
+  if (w == nullptr) return;
+  delete w;
+}
+
+/*
+ * Resolve a handle and return its impl re-typed to T. Returns an empty
+ * shared_ptr on null / wrong type.
+ */
+template <typename Wrapper, typename T>
+inline std::shared_ptr<T> get_impl(void* handle, skity_object_type expected) {
+  Wrapper* w = resolve<Wrapper>(handle, expected);
+  if (w == nullptr) return nullptr;
+  return std::static_pointer_cast<T>(w->impl);
+}
+
+}  // namespace capi
+}  // namespace skity
+
+#endif  // MODULE_CAPI_SRC_HANDLE_HPP

--- a/module/capi/src/image_c.cpp
+++ b/module/capi/src/image_c.cpp
@@ -1,0 +1,342 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_image.h>
+
+#include <cstring>
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/texture.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/io/data.hpp>
+#include <skity/io/pixmap.hpp>
+#include <vector>
+
+#include "handle.hpp"
+
+namespace {
+
+size_t bytes_per_pixel(skity_color_type ct) {
+  switch (ct) {
+    case SKITY_COLOR_TYPE_A8:
+      return 1;
+    case SKITY_COLOR_TYPE_RGB565:
+      return 2;
+    default:
+      return 4;
+  }
+}
+
+// Build a tightly-packed Pixmap from a (possibly strided) pixel source. The
+// GPU upload path (GPUTexture::UploadData) takes a base pointer with no row
+// stride, so strided rows are repacked to avoid misaligned / out-of-bounds
+// uploads. Returns nullptr on invalid arguments (unknown color type, or a
+// row_bytes too small to hold a full row of pixels).
+std::shared_ptr<skity::Pixmap> pixmap_from_pixels(
+    const void* pixels, size_t row_bytes, uint32_t width, uint32_t height,
+    skity_color_type color_type, skity_alpha_type alpha_type) {
+  if (color_type == SKITY_COLOR_TYPE_UNKNOWN) {
+    return nullptr;
+  }
+  size_t bpp = bytes_per_pixel(color_type);
+  size_t min_row_bytes = static_cast<size_t>(width) * bpp;
+  if (row_bytes == 0) {
+    row_bytes = min_row_bytes;
+  }
+  if (row_bytes < min_row_bytes) {
+    return nullptr;
+  }
+  std::shared_ptr<skity::Data> data;
+  if (row_bytes == min_row_bytes) {
+    data = skity::Data::MakeWithCopy(pixels, min_row_bytes * height);
+  } else {
+    std::vector<uint8_t> packed(min_row_bytes * height);
+    const auto* src = static_cast<const uint8_t*>(pixels);
+    for (uint32_t y = 0; y < height; y++) {
+      std::memcpy(packed.data() + y * min_row_bytes, src + y * row_bytes,
+                  min_row_bytes);
+    }
+    data = skity::Data::MakeWithCopy(packed.data(), packed.size());
+  }
+  if (data == nullptr) {
+    return nullptr;
+  }
+  return std::make_shared<skity::Pixmap>(
+      data, min_row_bytes, width, height,
+      static_cast<skity::AlphaType>(alpha_type),
+      static_cast<skity::ColorType>(color_type));
+}
+
+// Adapts the C callback pair (get_texture / release + userdata) to the C++
+// GetPromiseTexture / ReleaseCallback signatures skity expects. The C callback
+// returns a skity_texture handle; the thunk turns it into a shared_ptr<Texture>
+// (sharing the refcount with the caller's handle).
+
+struct PromiseCtx1 {
+  skity_promise_texture_callback c_get;
+  skity_promise_release_callback c_release;
+  void* c_userdata;
+};
+
+struct PromiseCtx2 {
+  skity_promise_texture_callback2 c_get;
+  skity_promise_release_callback c_release;
+  void* c_userdata;
+};
+
+std::shared_ptr<skity::Texture> texture_from_handle(skity_texture handle) {
+  auto* w =
+      skity::capi::resolve<skity_texture_s>(handle, SKITY_OBJECT_TYPE_TEXTURE);
+  return w ? std::static_pointer_cast<skity::Texture>(w->impl) : nullptr;
+}
+
+std::shared_ptr<skity::Texture> promise_get_thunk1(
+    skity::PromiseTextureContext pctx) {
+  auto* pc = static_cast<PromiseCtx1*>(pctx);
+  if (pc->c_get == nullptr) {
+    return nullptr;
+  }
+  return texture_from_handle(pc->c_get(pc->c_userdata));
+}
+
+void promise_release_thunk1(skity::PromiseTextureContext pctx) {
+  auto* pc = static_cast<PromiseCtx1*>(pctx);
+  if (pc->c_release != nullptr) {
+    pc->c_release(pc->c_userdata);
+  }
+  delete pc;
+}
+
+std::shared_ptr<skity::Texture> promise_get_thunk2(
+    skity::PromiseTextureContext pctx, skity::GPUContext* gpu_ctx) {
+  auto* pc = static_cast<PromiseCtx2*>(pctx);
+  if (pc->c_get == nullptr) {
+    return nullptr;
+  }
+  // Wrap the GPUContext as a non-owning handle for the duration of the call.
+  skity_context ch = nullptr;
+  if (gpu_ctx != nullptr) {
+    std::shared_ptr<void> non_owning(gpu_ctx, [](void*) {});
+    ch = skity::capi::alloc_handle<skity_context_s>(SKITY_OBJECT_TYPE_CONTEXT,
+                                                    0, std::move(non_owning));
+  }
+  skity_texture th = pc->c_get(pc->c_userdata, ch);
+  if (ch != nullptr) {
+    skity::capi::destroy_handle<skity_context_s>(ch, SKITY_OBJECT_TYPE_CONTEXT);
+  }
+  return texture_from_handle(th);
+}
+
+void promise_release_thunk2(skity::PromiseTextureContext pctx) {
+  auto* pc = static_cast<PromiseCtx2*>(pctx);
+  if (pc->c_release != nullptr) {
+    pc->c_release(pc->c_userdata);
+  }
+  delete pc;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_image skity_image_create_from_pixels(uint32_t width, uint32_t height,
+                                           const void* pixels, size_t row_bytes,
+                                           skity_alpha_type alpha_type,
+                                           skity_color_type color_type) {
+  if (width == 0 || height == 0 || pixels == nullptr) {
+    return nullptr;
+  }
+  auto pixmap = pixmap_from_pixels(pixels, row_bytes, width, height, color_type,
+                                   alpha_type);
+  if (pixmap == nullptr) {
+    return nullptr;
+  }
+  auto image = skity::Image::MakeImage(pixmap, nullptr);
+  if (image == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(image));
+}
+
+skity_image skity_image_create_from_pixels_with_context(
+    uint32_t width, uint32_t height, const void* pixels, size_t row_bytes,
+    skity_alpha_type alpha_type, skity_color_type color_type,
+    skity_context context) {
+  if (width == 0 || height == 0 || pixels == nullptr) {
+    return nullptr;
+  }
+  auto pixmap = pixmap_from_pixels(pixels, row_bytes, width, height, color_type,
+                                   alpha_type);
+  if (pixmap == nullptr) {
+    return nullptr;
+  }
+  // NULL context handle resolves to a null GPUContext*, matching the CPU-only
+  // skity_image_create_from_pixels path.
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  auto image = skity::Image::MakeImage(pixmap, ctx.get());
+  if (image == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(image));
+}
+
+void skity_image_destroy(skity_image image) {
+  skity::capi::destroy_handle<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
+}
+
+uint32_t skity_image_get_width(skity_image image) {
+  auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
+  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Width() : 0u;
+}
+
+uint32_t skity_image_get_height(skity_image image) {
+  auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
+  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Height()
+           : 0u;
+}
+
+skity_image skity_image_create_from_texture(skity_texture texture) {
+  auto tex = skity::capi::get_impl<skity_texture_s, skity::Texture>(
+      texture, SKITY_OBJECT_TYPE_TEXTURE);
+  if (tex == nullptr) {
+    return nullptr;
+  }
+  auto image = skity::Image::MakeHWImage(tex);
+  if (image == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(image));
+}
+
+skity_image skity_image_create_deferred(skity_texture_format format,
+                                        uint32_t width, uint32_t height,
+                                        skity_alpha_type alpha_type) {
+  if (width == 0 || height == 0) {
+    return nullptr;
+  }
+  auto di = skity::Image::MakeDeferredTextureImage(
+      static_cast<skity::TextureFormat>(format), width, height,
+      static_cast<skity::AlphaType>(alpha_type));
+  if (di == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(di));
+}
+
+void skity_image_deferred_set_texture(skity_image image,
+                                      skity_texture texture) {
+  auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
+  auto tex = skity::capi::get_impl<skity_texture_s, skity::Texture>(
+      texture, SKITY_OBJECT_TYPE_TEXTURE);
+  if (w == nullptr || tex == nullptr) {
+    return;
+  }
+  // Only valid on a deferred image; see skity_image_create_deferred.
+  auto di = std::static_pointer_cast<skity::DeferredTextureImage>(w->impl);
+  di->SetTexture(tex);
+}
+
+skity_image skity_image_create_promise(
+    skity_texture_format format, uint32_t width, uint32_t height,
+    skity_alpha_type alpha_type, skity_promise_texture_callback get_texture,
+    skity_promise_release_callback release, void* userdata) {
+  if (width == 0 || height == 0 || get_texture == nullptr) {
+    return nullptr;
+  }
+  auto* pc = new (std::nothrow) PromiseCtx1{get_texture, release, userdata};
+  if (pc == nullptr) {
+    return nullptr;
+  }
+  auto img = skity::Image::MakePromiseTextureImage(
+      static_cast<skity::TextureFormat>(format), width, height,
+      static_cast<skity::AlphaType>(alpha_type), &promise_get_thunk1,
+      &promise_release_thunk1, pc);
+  if (img == nullptr) {
+    delete pc;
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(img));
+}
+
+skity_image skity_image_create_promise2(
+    skity_texture_format format, uint32_t width, uint32_t height,
+    skity_alpha_type alpha_type, skity_promise_texture_callback2 get_texture,
+    skity_promise_release_callback release, void* userdata) {
+  if (width == 0 || height == 0 || get_texture == nullptr) {
+    return nullptr;
+  }
+  auto* pc = new (std::nothrow) PromiseCtx2{get_texture, release, userdata};
+  if (pc == nullptr) {
+    return nullptr;
+  }
+  auto img = skity::Image::MakePromiseTextureImage2(
+      static_cast<skity::TextureFormat>(format), width, height,
+      static_cast<skity::AlphaType>(alpha_type), &promise_get_thunk2,
+      &promise_release_thunk2, pc);
+  if (img == nullptr) {
+    delete pc;
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_image_s>(
+      SKITY_OBJECT_TYPE_IMAGE, SKITY_HANDLE_OWNING, std::move(img));
+}
+
+skity_pixmap skity_image_read_pixels(skity_image image, skity_context context) {
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  if (img == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<skity::Pixmap> pm;
+  // CPU-backed images (PixmapImage) own their pixels directly and can be read
+  // back without a GPUContext; only GPU-backed images require one. This matches
+  // the header note that a context is only needed for GPU-backed images.
+  auto* pixmap_slot = img->GetPixmap();
+  if (pixmap_slot != nullptr && *pixmap_slot) {
+    pm = *pixmap_slot;
+  } else {
+    auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+        context, SKITY_OBJECT_TYPE_CONTEXT);
+    if (ctx == nullptr) {
+      return nullptr;
+    }
+    pm = img->ReadPixels(ctx.get());
+  }
+  if (pm == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_pixmap_s>(
+      SKITY_OBJECT_TYPE_PIXMAP, SKITY_HANDLE_OWNING, std::move(pm));
+}
+
+uint32_t skity_image_scale_pixels(skity_image image, skity_pixmap dst,
+                                  skity_context context,
+                                  const skity_sampling_options* sampling) {
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  auto pm = skity::capi::get_impl<skity_pixmap_s, skity::Pixmap>(
+      dst, SKITY_OBJECT_TYPE_PIXMAP);
+  if (img == nullptr || pm == nullptr) {
+    return 0;
+  }
+  // NULL context handle yields a null GPUContext*; GPU-backed images will then
+  // fail to scale (CPU-backed images scale on the CPU).
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  skity::SamplingOptions so{};
+  if (sampling != nullptr) {
+    so.filter = static_cast<skity::FilterMode>(sampling->filter);
+    so.mipmap = static_cast<skity::MipmapMode>(sampling->mipmap);
+    so.cubic.B = sampling->cubic_b;
+    so.cubic.C = sampling->cubic_c;
+  }
+  return img->ScalePixels(pm, ctx.get(), so) ? 1u : 0u;
+}
+
+}  // extern "C"

--- a/module/capi/src/paint_c.cpp
+++ b/module/capi/src/paint_c.cpp
@@ -1,0 +1,301 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_paint.h>
+
+#include <skity/effect/color_filter.hpp>
+#include <skity/effect/image_filter.hpp>
+#include <skity/effect/mask_filter.hpp>
+#include <skity/effect/path_effect.hpp>
+#include <skity/effect/shader.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/text/typeface.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Paint* paint_of(skity_paint handle) {
+  auto* w =
+      skity::capi::resolve<skity_paint_s>(handle, SKITY_OBJECT_TYPE_PAINT);
+  return w ? static_cast<skity::Paint*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_paint skity_paint_create(void) {
+  auto impl = std::make_shared<skity::Paint>();
+  return skity::capi::alloc_handle<skity_paint_s>(
+      SKITY_OBJECT_TYPE_PAINT, SKITY_HANDLE_OWNING, std::move(impl));
+}
+
+void skity_paint_destroy(skity_paint paint) {
+  skity::capi::destroy_handle<skity_paint_s>(paint, SKITY_OBJECT_TYPE_PAINT);
+}
+
+void skity_paint_reset(skity_paint paint) {
+  if (auto* p = paint_of(paint)) p->Reset();
+}
+
+void skity_paint_set_style(skity_paint paint, skity_paint_style style) {
+  if (auto* p = paint_of(paint))
+    p->SetStyle(static_cast<skity::Paint::Style>(style));
+}
+
+void skity_paint_set_stroke_width(skity_paint paint, float width) {
+  if (auto* p = paint_of(paint)) p->SetStrokeWidth(width);
+}
+
+void skity_paint_set_stroke_cap(skity_paint paint, skity_paint_cap cap) {
+  if (auto* p = paint_of(paint))
+    p->SetStrokeCap(static_cast<skity::Paint::Cap>(cap));
+}
+
+void skity_paint_set_stroke_join(skity_paint paint, skity_paint_join join) {
+  if (auto* p = paint_of(paint))
+    p->SetStrokeJoin(static_cast<skity::Paint::Join>(join));
+}
+
+void skity_paint_set_stroke_miter(skity_paint paint, float miter) {
+  if (auto* p = paint_of(paint)) p->SetStrokeMiter(miter);
+}
+
+void skity_paint_set_color(skity_paint paint, skity_color color) {
+  if (auto* p = paint_of(paint)) p->SetColor(static_cast<skity::Color>(color));
+}
+
+void skity_paint_set_stroke_color(skity_paint paint, skity_color color) {
+  if (auto* p = paint_of(paint))
+    p->SetStrokeColor(static_cast<skity::Color>(color));
+}
+
+void skity_paint_set_fill_color(skity_paint paint, skity_color color) {
+  if (auto* p = paint_of(paint))
+    p->SetFillColor(static_cast<skity::Color>(color));
+}
+
+void skity_paint_set_alpha(skity_paint paint, uint8_t alpha) {
+  if (auto* p = paint_of(paint)) p->SetAlpha(alpha);
+}
+
+void skity_paint_set_alpha_f(skity_paint paint, float alpha) {
+  if (auto* p = paint_of(paint)) p->SetAlphaF(alpha);
+}
+
+void skity_paint_set_blend_mode(skity_paint paint, skity_blend_mode mode) {
+  if (auto* p = paint_of(paint))
+    p->SetBlendMode(static_cast<skity::BlendMode>(mode));
+}
+
+void skity_paint_set_anti_alias(skity_paint paint, uint32_t aa) {
+  if (auto* p = paint_of(paint)) p->SetAntiAlias(aa != 0);
+}
+
+void skity_paint_set_text_size(skity_paint paint, float size) {
+  if (auto* p = paint_of(paint)) p->SetTextSize(size);
+}
+
+void skity_paint_set_shader(skity_paint paint, skity_shader shader) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (shader != nullptr) {
+    p->SetShader(skity::capi::get_impl<skity_shader_s, skity::Shader>(
+        shader, SKITY_OBJECT_TYPE_SHADER));
+  } else {
+    p->SetShader(nullptr);
+  }
+}
+
+void skity_paint_set_color_filter(skity_paint paint,
+                                  skity_color_filter filter) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (filter != nullptr) {
+    p->SetColorFilter(
+        skity::capi::get_impl<skity_color_filter_s, skity::ColorFilter>(
+            filter, SKITY_OBJECT_TYPE_COLOR_FILTER));
+  } else {
+    p->SetColorFilter(nullptr);
+  }
+}
+
+void skity_paint_set_image_filter(skity_paint paint,
+                                  skity_image_filter filter) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (filter != nullptr) {
+    p->SetImageFilter(
+        skity::capi::get_impl<skity_image_filter_s, skity::ImageFilter>(
+            filter, SKITY_OBJECT_TYPE_IMAGE_FILTER));
+  } else {
+    p->SetImageFilter(nullptr);
+  }
+}
+
+void skity_paint_set_mask_filter(skity_paint paint, skity_mask_filter filter) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (filter != nullptr) {
+    p->SetMaskFilter(
+        skity::capi::get_impl<skity_mask_filter_s, skity::MaskFilter>(
+            filter, SKITY_OBJECT_TYPE_MASK_FILTER));
+  } else {
+    p->SetMaskFilter(nullptr);
+  }
+}
+
+void skity_paint_set_path_effect(skity_paint paint, skity_path_effect effect) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (effect != nullptr) {
+    p->SetPathEffect(
+        skity::capi::get_impl<skity_path_effect_s, skity::PathEffect>(
+            effect, SKITY_OBJECT_TYPE_PATH_EFFECT));
+  } else {
+    p->SetPathEffect(nullptr);
+  }
+}
+
+void skity_paint_set_typeface(skity_paint paint, skity_typeface typeface) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return;
+  if (typeface != nullptr) {
+    p->SetTypeface(skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+        typeface, SKITY_OBJECT_TYPE_TYPEFACE));
+  } else {
+    p->SetTypeface(nullptr);
+  }
+}
+
+skity_color skity_paint_get_color(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? static_cast<skity_color>(p->GetColor()) : 0;
+}
+
+void skity_paint_get_stroke_color(skity_paint paint, skity_vec4* out) {
+  auto* p = paint_of(paint);
+  if (p == nullptr || out == nullptr) return;
+  skity::Vector c = p->GetStrokeColor();
+  out->e[0] = c.e[0];
+  out->e[1] = c.e[1];
+  out->e[2] = c.e[2];
+  out->e[3] = c.e[3];
+}
+
+void skity_paint_get_fill_color(skity_paint paint, skity_vec4* out) {
+  auto* p = paint_of(paint);
+  if (p == nullptr || out == nullptr) return;
+  skity::Vector c = p->GetFillColor();
+  out->e[0] = c.e[0];
+  out->e[1] = c.e[1];
+  out->e[2] = c.e[2];
+  out->e[3] = c.e[3];
+}
+
+skity_paint_style skity_paint_get_style(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? static_cast<skity_paint_style>(p->GetStyle())
+           : SKITY_PAINT_STYLE_FILL;
+}
+
+float skity_paint_get_stroke_width(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? p->GetStrokeWidth() : 0.f;
+}
+
+float skity_paint_get_stroke_miter(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? p->GetStrokeMiter() : 0.f;
+}
+
+skity_paint_cap skity_paint_get_stroke_cap(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? static_cast<skity_paint_cap>(p->GetStrokeCap())
+           : SKITY_PAINT_CAP_BUTT;
+}
+
+skity_paint_join skity_paint_get_stroke_join(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? static_cast<skity_paint_join>(p->GetStrokeJoin())
+           : SKITY_PAINT_JOIN_MITER;
+}
+
+float skity_paint_get_text_size(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? p->GetTextSize() : 0.f;
+}
+
+skity_blend_mode skity_paint_get_blend_mode(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? static_cast<skity_blend_mode>(p->GetBlendMode())
+           : SKITY_BLEND_MODE_SRC_OVER;
+}
+
+uint8_t skity_paint_get_alpha(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return p ? p->GetAlpha() : 0;
+}
+
+uint32_t skity_paint_is_anti_alias(skity_paint paint) {
+  auto* p = paint_of(paint);
+  return (p != nullptr && p->IsAntiAlias()) ? 1u : 0u;
+}
+
+skity_shader skity_paint_get_shader(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetShader();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_color_filter skity_paint_get_color_filter(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetColorFilter();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_color_filter_s>(
+      SKITY_OBJECT_TYPE_COLOR_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_image_filter skity_paint_get_image_filter(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetImageFilter();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_image_filter_s>(
+      SKITY_OBJECT_TYPE_IMAGE_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_mask_filter skity_paint_get_mask_filter(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetMaskFilter();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_mask_filter_s>(
+      SKITY_OBJECT_TYPE_MASK_FILTER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_path_effect skity_paint_get_path_effect(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetPathEffect();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_path_effect_s>(
+      SKITY_OBJECT_TYPE_PATH_EFFECT, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_typeface skity_paint_get_typeface(skity_paint paint) {
+  auto* p = paint_of(paint);
+  if (p == nullptr) return nullptr;
+  auto sp = p->GetTypeface();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+}  // extern "C"

--- a/module/capi/src/path_c.cpp
+++ b/module/capi/src/path_c.cpp
@@ -1,0 +1,269 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_path.h>
+
+#include <skity/geometry/matrix.hpp>
+#include <skity/geometry/rect.hpp>
+#include <skity/graphic/path.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Path* path_of(skity_path handle) {
+  auto* w = skity::capi::resolve<skity_path_s>(handle, SKITY_OBJECT_TYPE_PATH);
+  return w ? static_cast<skity::Path*>(w->impl.get()) : nullptr;
+}
+
+skity::Path::Direction to_dir(skity_path_direction d) {
+  return static_cast<skity::Path::Direction>(d);
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_path skity_path_create(void) {
+  return skity::capi::alloc_handle<skity_path_s>(
+      SKITY_OBJECT_TYPE_PATH, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Path>());
+}
+
+void skity_path_destroy(skity_path path) {
+  skity::capi::destroy_handle<skity_path_s>(path, SKITY_OBJECT_TYPE_PATH);
+}
+
+void skity_path_reset(skity_path path) {
+  if (auto* p = path_of(path)) p->Reset();
+}
+
+void skity_path_set_fill_type(skity_path path, skity_path_fill_type type) {
+  if (auto* p = path_of(path))
+    p->SetFillType(static_cast<skity::Path::PathFillType>(type));
+}
+
+void skity_path_move_to(skity_path path, float x, float y) {
+  if (auto* p = path_of(path)) p->MoveTo(x, y);
+}
+
+void skity_path_line_to(skity_path path, float x, float y) {
+  if (auto* p = path_of(path)) p->LineTo(x, y);
+}
+
+void skity_path_quad_to(skity_path path, float x1, float y1, float x2,
+                        float y2) {
+  if (auto* p = path_of(path)) p->QuadTo(x1, y1, x2, y2);
+}
+
+void skity_path_conic_to(skity_path path, float x1, float y1, float x2,
+                         float y2, float weight) {
+  if (auto* p = path_of(path)) p->ConicTo(x1, y1, x2, y2, weight);
+}
+
+void skity_path_cubic_to(skity_path path, float x1, float y1, float x2,
+                         float y2, float x3, float y3) {
+  if (auto* p = path_of(path)) p->CubicTo(x1, y1, x2, y2, x3, y3);
+}
+
+void skity_path_arc_to(skity_path path, float x1, float y1, float x2, float y2,
+                       float radius) {
+  if (auto* p = path_of(path)) p->ArcTo(x1, y1, x2, y2, radius);
+}
+
+void skity_path_close(skity_path path) {
+  if (auto* p = path_of(path)) p->Close();
+}
+
+void skity_path_add_circle(skity_path path, float x, float y, float radius,
+                           skity_path_direction dir) {
+  if (auto* p = path_of(path)) p->AddCircle(x, y, radius, to_dir(dir));
+}
+
+void skity_path_add_oval(skity_path path, const skity_rect* oval,
+                         skity_path_direction dir) {
+  auto* p = path_of(path);
+  if (p != nullptr && oval != nullptr) {
+    p->AddOval(*reinterpret_cast<const skity::Rect*>(oval), to_dir(dir));
+  }
+}
+
+void skity_path_add_rect(skity_path path, const skity_rect* rect,
+                         skity_path_direction dir) {
+  auto* p = path_of(path);
+  if (p != nullptr && rect != nullptr) {
+    p->AddRect(*reinterpret_cast<const skity::Rect*>(rect), to_dir(dir));
+  }
+}
+
+void skity_path_add_round_rect(skity_path path, const skity_rect* rect,
+                               float rx, float ry, skity_path_direction dir) {
+  auto* p = path_of(path);
+  if (p != nullptr && rect != nullptr) {
+    p->AddRoundRect(*reinterpret_cast<const skity::Rect*>(rect), rx, ry,
+                    to_dir(dir));
+  }
+}
+
+void skity_path_transform(skity_path path, const skity_matrix* matrix) {
+  auto* p = path_of(path);
+  if (p != nullptr && matrix != nullptr) {
+    *p = p->CopyWithMatrix(*reinterpret_cast<const skity::Matrix*>(matrix));
+  }
+}
+
+void skity_path_get_bounds(skity_path path, skity_rect* out_bounds) {
+  auto* p = path_of(path);
+  if (p == nullptr || out_bounds == nullptr) return;
+  skity::Rect b = p->GetBounds();
+  out_bounds->left = b.Left();
+  out_bounds->top = b.Top();
+  out_bounds->right = b.Right();
+  out_bounds->bottom = b.Bottom();
+}
+
+void skity_path_add_path(skity_path path, skity_path src, float dx, float dy) {
+  auto* p = path_of(path);
+  auto* s = path_of(src);
+  if (p != nullptr && s != nullptr) {
+    p->AddPath(*s, dx, dy);
+  }
+}
+
+void skity_path_add_rrect(skity_path path, const skity_rect* rect, float rx,
+                          float ry, skity_path_direction dir) {
+  auto* p = path_of(path);
+  if (p != nullptr && rect != nullptr) {
+    p->AddRoundRect(*reinterpret_cast<const skity::Rect*>(rect), rx, ry,
+                    to_dir(dir));
+  }
+}
+
+uint32_t skity_path_contains(skity_path path, float x, float y) {
+  auto* p = path_of(path);
+  return (p != nullptr && p->Contains(x, y)) ? 1u : 0u;
+}
+
+skity_path_fill_type skity_path_get_fill_type(skity_path path) {
+  auto* p = path_of(path);
+  return p ? static_cast<skity_path_fill_type>(p->GetFillType())
+           : SKITY_PATH_FILL_TYPE_WINDING;
+}
+
+void skity_path_add_path_matrix(skity_path path, skity_path src,
+                                const skity_matrix* matrix) {
+  auto* p = path_of(path);
+  auto* s = path_of(src);
+  if (p != nullptr && s != nullptr && matrix != nullptr) {
+    p->AddPath(*s, *reinterpret_cast<const skity::Matrix*>(matrix));
+  }
+}
+
+void skity_path_reverse_add_path(skity_path path, skity_path src) {
+  auto* p = path_of(path);
+  auto* s = path_of(src);
+  if (p != nullptr && s != nullptr) {
+    p->ReverseAddPath(*s);
+  }
+}
+
+uint32_t skity_path_count_verbs(skity_path path) {
+  auto* p = path_of(path);
+  return p ? (uint32_t)p->CountVerbs() : 0u;
+}
+
+uint32_t skity_path_count_points(skity_path path) {
+  auto* p = path_of(path);
+  return p ? (uint32_t)p->CountPoints() : 0u;
+}
+
+uint32_t skity_path_get_point(skity_path path, int32_t index, skity_vec4* out) {
+  auto* p = path_of(path);
+  if (p == nullptr || out == nullptr || index < 0) return 0u;
+  skity::Point pt = p->GetPoint(index);
+  *reinterpret_cast<skity::Vec4*>(out) = pt;
+  return 1u;
+}
+
+uint32_t skity_path_is_rect(skity_path path, skity_rect* out_rect,
+                            uint32_t* out_is_closed) {
+  auto* p = path_of(path);
+  if (p == nullptr) return 0u;
+  skity::Rect r;
+  bool is_closed = false;
+  bool ok = p->IsRect(&r, &is_closed);
+  if (!ok) return 0u;
+  if (out_rect != nullptr) {
+    out_rect->left = r.Left();
+    out_rect->top = r.Top();
+    out_rect->right = r.Right();
+    out_rect->bottom = r.Bottom();
+  }
+  if (out_is_closed != nullptr) *out_is_closed = is_closed ? 1u : 0u;
+  return 1u;
+}
+
+void skity_path_arc_to_oval(skity_path path, const skity_rect* oval,
+                            float start_angle, float sweep_angle,
+                            uint32_t force_move_to) {
+  auto* p = path_of(path);
+  if (p != nullptr && oval != nullptr) {
+    p->ArcTo(*reinterpret_cast<const skity::Rect*>(oval), start_angle,
+             sweep_angle, force_move_to != 0u);
+  }
+}
+
+void skity_path_arc_to_svg(skity_path path, float rx, float ry,
+                           float x_axis_rotate, skity_arc_size large_arc,
+                           skity_path_direction sweep, float x, float y) {
+  auto* p = path_of(path);
+  if (p == nullptr) return;
+  p->ArcTo(rx, ry, x_axis_rotate, static_cast<skity::Path::ArcSize>(large_arc),
+           to_dir(sweep), x, y);
+}
+
+void skity_path_add_round_rect_radii(skity_path path, const skity_rect* rect,
+                                     const float* radii,
+                                     skity_path_direction dir) {
+  auto* p = path_of(path);
+  if (p != nullptr && rect != nullptr && radii != nullptr) {
+    p->AddRoundRect(*reinterpret_cast<const skity::Rect*>(rect), radii,
+                    to_dir(dir));
+  }
+}
+
+uint32_t skity_path_get_last_pt(skity_path path, skity_point* out) {
+  auto* p = path_of(path);
+  if (p == nullptr || out == nullptr) return 0u;
+  skity::Point pt;
+  if (!p->GetLastPt(&pt)) return 0u;
+  *reinterpret_cast<skity::Vec4*>(out) = pt;
+  return 1u;
+}
+
+void skity_path_set_last_pt(skity_path path, float x, float y) {
+  if (auto* p = path_of(path)) p->SetLastPt(x, y);
+}
+
+skity_path skity_path_copy_with_matrix(skity_path path,
+                                       const skity_matrix* matrix) {
+  auto* p = path_of(path);
+  if (p == nullptr || matrix == nullptr) return nullptr;
+  skity::Path copy =
+      p->CopyWithMatrix(*reinterpret_cast<const skity::Matrix*>(matrix));
+  return skity::capi::alloc_handle<skity_path_s>(
+      SKITY_OBJECT_TYPE_PATH, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Path>(std::move(copy)));
+}
+
+skity_path skity_path_copy_with_scale(skity_path path, float scale) {
+  auto* p = path_of(path);
+  if (p == nullptr) return nullptr;
+  skity::Path copy = p->CopyWithScale(scale);
+  return skity::capi::alloc_handle<skity_path_s>(
+      SKITY_OBJECT_TYPE_PATH, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Path>(std::move(copy)));
+}
+
+}  // extern "C"

--- a/module/capi/src/path_measure_c.cpp
+++ b/module/capi/src/path_measure_c.cpp
@@ -1,0 +1,111 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_path_measure.h>
+
+#include <skity/geometry/vector.hpp>
+#include <skity/graphic/path.hpp>
+#include <skity/graphic/path_measure.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::PathMeasure* measure_of(skity_path_measure handle) {
+  auto* w = skity::capi::resolve<skity_path_measure_s>(
+      handle, SKITY_OBJECT_TYPE_PATH_MEASURE);
+  return w ? static_cast<skity::PathMeasure*>(w->impl.get()) : nullptr;
+}
+
+std::shared_ptr<skity::Path> path_shared(skity_path handle) {
+  return skity::capi::get_impl<skity_path_s, skity::Path>(
+      handle, SKITY_OBJECT_TYPE_PATH);
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_path_measure skity_path_measure_create(skity_path path,
+                                             uint32_t force_closed,
+                                             float res_scale) {
+  auto p = path_shared(path);
+  std::shared_ptr<void> impl;
+  if (p != nullptr) {
+    impl =
+        std::make_shared<skity::PathMeasure>(*p, force_closed != 0, res_scale);
+  } else {
+    impl = std::make_shared<skity::PathMeasure>();
+  }
+  return skity::capi::alloc_handle<skity_path_measure_s>(
+      SKITY_OBJECT_TYPE_PATH_MEASURE, SKITY_HANDLE_OWNING, std::move(impl));
+}
+
+void skity_path_measure_destroy(skity_path_measure measure) {
+  skity::capi::destroy_handle<skity_path_measure_s>(
+      measure, SKITY_OBJECT_TYPE_PATH_MEASURE);
+}
+
+uint32_t skity_path_measure_set_path(skity_path_measure measure,
+                                     skity_path path, uint32_t force_closed) {
+  auto* m = measure_of(measure);
+  if (m == nullptr) {
+    return 0u;
+  }
+  auto p = path_shared(path);
+  m->SetPath(p.get(), force_closed != 0);
+  return 1u;
+}
+
+float skity_path_measure_get_length(skity_path_measure measure) {
+  auto* m = measure_of(measure);
+  return m ? m->GetLength() : 0.f;
+}
+
+uint32_t skity_path_measure_get_pos_tan(skity_path_measure measure,
+                                        float distance,
+                                        skity_vec4* out_position,
+                                        skity_vec4* out_tangent) {
+  auto* m = measure_of(measure);
+  if (m == nullptr) {
+    return 0u;
+  }
+  skity::Point pos;
+  skity::Vector tan;
+  if (!m->GetPosTan(distance, &pos, &tan)) {
+    return 0u;
+  }
+  if (out_position != nullptr) {
+    *reinterpret_cast<skity::Vec4*>(out_position) = pos;
+  }
+  if (out_tangent != nullptr) {
+    *reinterpret_cast<skity::Vec4*>(out_tangent) = tan;
+  }
+  return 1u;
+}
+
+uint32_t skity_path_measure_get_segment(skity_path_measure measure,
+                                        float start_d, float stop_d,
+                                        skity_path dst,
+                                        uint32_t start_with_move_to) {
+  auto* m = measure_of(measure);
+  auto d = path_shared(dst);
+  if (m == nullptr || d == nullptr) {
+    return 0u;
+  }
+  return m->GetSegment(start_d, stop_d, d.get(), start_with_move_to != 0) ? 1u
+                                                                          : 0u;
+}
+
+uint32_t skity_path_measure_is_closed(skity_path_measure measure) {
+  auto* m = measure_of(measure);
+  return (m != nullptr && m->IsClosed()) ? 1u : 0u;
+}
+
+uint32_t skity_path_measure_next_contour(skity_path_measure measure) {
+  auto* m = measure_of(measure);
+  return (m != nullptr && m->NextContour()) ? 1u : 0u;
+}
+
+}  // extern "C"

--- a/module/capi/src/path_op_c.cpp
+++ b/module/capi/src/path_op_c.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_path_op.h>
+
+#include <skity/graphic/path.hpp>
+#include <skity/graphic/path_op.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Path* path_of(skity_path handle) {
+  auto* w = skity::capi::resolve<skity_path_s>(handle, SKITY_OBJECT_TYPE_PATH);
+  return w ? static_cast<skity::Path*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+uint32_t skity_path_op_execute(skity_path one, skity_path two, skity_path_op op,
+                               skity_path result) {
+  auto* a = path_of(one);
+  auto* b = path_of(two);
+  auto* r = path_of(result);
+  if (a == nullptr || b == nullptr || r == nullptr) {
+    return 0u;
+  }
+  return skity::PathOp::Execute(*a, *b, static_cast<skity::PathOp::Op>(op), r)
+             ? 1u
+             : 0u;
+}
+
+}  // extern "C"

--- a/module/capi/src/precompile_c.cpp
+++ b/module/capi/src/precompile_c.cpp
@@ -1,0 +1,53 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_precompile.h>
+
+#include <skity/graphic/paint.hpp>
+#include <skity/render/precompile_context.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::PrecompileContext* precompile_of(skity_precompile_context handle) {
+  auto* w = skity::capi::resolve<skity_precompile_context_s>(
+      handle, SKITY_OBJECT_TYPE_PRECOMPILE_CONTEXT);
+  return w ? static_cast<skity::PrecompileContext*>(w->impl.get()) : nullptr;
+}
+
+skity::Paint* paint_of(skity_paint handle) {
+  auto* w =
+      skity::capi::resolve<skity_paint_s>(handle, SKITY_OBJECT_TYPE_PAINT);
+  return w ? static_cast<skity::Paint*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+void skity_precompile_context_precompile_default_shaders(
+    skity_precompile_context context) {
+  auto* pc = precompile_of(context);
+  if (pc != nullptr) {
+    pc->PrecompileDefaultShaders();
+  }
+}
+
+void skity_precompile_context_precompile_draw(
+    skity_precompile_context context, skity_precompile_draw_type draw_type,
+    skity_paint paint) {
+  auto* pc = precompile_of(context);
+  auto* p = paint_of(paint);
+  if (pc != nullptr && p != nullptr) {
+    pc->PrecompileDraw(static_cast<skity::PrecompileDrawType>(draw_type), *p);
+  }
+}
+
+void skity_precompile_context_destroy(skity_precompile_context context) {
+  skity::capi::destroy_handle<skity_precompile_context_s>(
+      context, SKITY_OBJECT_TYPE_PRECOMPILE_CONTEXT);
+}
+
+}  // extern "C"

--- a/module/capi/src/quaternion_c.cpp
+++ b/module/capi/src/quaternion_c.cpp
@@ -1,0 +1,30 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_quaternion.h>
+
+#include <skity/geometry/matrix.hpp>
+#include <skity/geometry/quaternion.hpp>
+#include <skity/geometry/vector.hpp>
+
+#include "handle.hpp"
+
+extern "C" {
+
+void skity_quaternion_euler_to_matrix(float alpha, float beta, float gamma,
+                                      skity_matrix* out) {
+  if (out == nullptr) return;
+  skity::Matrix m = skity::Quaternion::EulerToMatrix(alpha, beta, gamma);
+  *reinterpret_cast<skity::Matrix*>(out) = m;
+}
+
+void skity_quaternion_axis_angle_to_matrix(const skity_vec3* axis, float angle,
+                                           skity_matrix* out) {
+  if (out == nullptr || axis == nullptr) return;
+  skity::Vec3 v(axis->e[0], axis->e[1], axis->e[2]);
+  skity::Matrix m = skity::Quaternion::FromAxisAngle(v, angle).ToMatrix();
+  *reinterpret_cast<skity::Matrix*>(out) = m;
+}
+
+}  // extern "C"

--- a/module/capi/src/recorder_c.cpp
+++ b/module/capi/src/recorder_c.cpp
@@ -1,0 +1,121 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_recorder.h>
+
+#include <skity/recorder/display_list.hpp>
+#include <skity/recorder/picture_recorder.hpp>
+#include <skity/render/canvas.hpp>
+#include <utility>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::PictureRecorder* recorder_of(skity_picture_recorder handle) {
+  auto* w = skity::capi::resolve<skity_picture_recorder_s>(
+      handle, SKITY_OBJECT_TYPE_PICTURE_RECORDER);
+  return w ? static_cast<skity::PictureRecorder*>(w->impl.get()) : nullptr;
+}
+
+skity::DisplayList* display_list_of(skity_display_list handle) {
+  auto* w = skity::capi::resolve<skity_display_list_s>(
+      handle, SKITY_OBJECT_TYPE_DISPLAY_LIST);
+  return w ? static_cast<skity::DisplayList*>(w->impl.get()) : nullptr;
+}
+
+skity::Canvas* canvas_of(skity_canvas handle) {
+  auto* w =
+      skity::capi::resolve<skity_canvas_s>(handle, SKITY_OBJECT_TYPE_CANVAS);
+  return w ? static_cast<skity::Canvas*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_picture_recorder skity_picture_recorder_create(void) {
+  return skity::capi::alloc_handle<skity_picture_recorder_s>(
+      SKITY_OBJECT_TYPE_PICTURE_RECORDER, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::PictureRecorder>());
+}
+
+void skity_picture_recorder_destroy(skity_picture_recorder recorder) {
+  skity::capi::destroy_handle<skity_picture_recorder_s>(
+      recorder, SKITY_OBJECT_TYPE_PICTURE_RECORDER);
+}
+
+void skity_picture_recorder_begin(skity_picture_recorder recorder,
+                                  const skity_rect* bounds) {
+  auto* r = recorder_of(recorder);
+  if (r == nullptr) return;
+  if (bounds != nullptr) {
+    r->BeginRecording(*reinterpret_cast<const skity::Rect*>(bounds));
+  } else {
+    r->BeginRecording();
+  }
+}
+
+skity_canvas skity_picture_recorder_get_canvas(
+    skity_picture_recorder recorder) {
+  auto* r = recorder_of(recorder);
+  if (r == nullptr) return nullptr;
+  // The RecordingCanvas is owned by the recorder; wrap it non-owning.
+  skity::Canvas* raw = r->GetRecordingCanvas();
+  if (raw == nullptr) return nullptr;
+  std::shared_ptr<void> impl(raw, [](void*) {});
+  return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0,
+                                                   std::move(impl));
+}
+
+skity_result skity_picture_recorder_finish(skity_picture_recorder recorder,
+                                           skity_display_list* out) {
+  auto* r = recorder_of(recorder);
+  if (r == nullptr || out == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  std::unique_ptr<skity::DisplayList> dl = r->FinishRecording();
+  if (dl == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  std::shared_ptr<void> impl(dl.release());
+  skity_display_list_s* w = skity::capi::alloc_handle<skity_display_list_s>(
+      SKITY_OBJECT_TYPE_DISPLAY_LIST, SKITY_HANDLE_OWNING, std::move(impl));
+  if (w == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out = w;
+  return SKITY_SUCCESS;
+}
+
+void skity_display_list_destroy(skity_display_list list) {
+  skity::capi::destroy_handle<skity_display_list_s>(
+      list, SKITY_OBJECT_TYPE_DISPLAY_LIST);
+}
+
+void skity_display_list_draw(skity_display_list list, skity_canvas canvas) {
+  auto* dl = display_list_of(list);
+  auto* c = canvas_of(canvas);
+  if (dl != nullptr && c != nullptr) {
+    dl->Draw(c);
+  }
+}
+
+void skity_display_list_get_bounds(skity_display_list list,
+                                   skity_rect* out_bounds) {
+  auto* dl = display_list_of(list);
+  if (dl == nullptr || out_bounds == nullptr) return;
+  skity::Rect b = dl->GetBounds();
+  out_bounds->left = b.Left();
+  out_bounds->top = b.Top();
+  out_bounds->right = b.Right();
+  out_bounds->bottom = b.Bottom();
+}
+
+uint32_t skity_display_list_get_op_count(skity_display_list list) {
+  auto* dl = display_list_of(list);
+  return dl != nullptr ? dl->OpCount() : 0u;
+}
+
+}  // extern "C"

--- a/module/capi/src/shader_c.cpp
+++ b/module/capi/src/shader_c.cpp
@@ -1,0 +1,137 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_shader.h>
+
+#include <skity/effect/shader.hpp>
+#include <skity/geometry/matrix.hpp>
+#include <skity/geometry/point.hpp>
+#include <skity/graphic/image.hpp>
+#include <skity/graphic/sampling_options.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Shader* shader_of(skity_shader handle) {
+  auto* w =
+      skity::capi::resolve<skity_shader_s>(handle, SKITY_OBJECT_TYPE_SHADER);
+  return w ? static_cast<skity::Shader*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_shader skity_shader_create_linear(const skity_point pts[2],
+                                        const skity_color4f* colors,
+                                        const float* pos, int32_t count,
+                                        skity_tile_mode tile_mode,
+                                        int32_t flags) {
+  auto sp = skity::Shader::MakeLinear(
+      reinterpret_cast<const skity::Point*>(pts),
+      reinterpret_cast<const skity::Vec4*>(colors), pos, count,
+      static_cast<skity::TileMode>(tile_mode), flags);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_shader skity_shader_create_radial(skity_point center, float radius,
+                                        const skity_color4f* colors,
+                                        const float* pos, int32_t count,
+                                        skity_tile_mode tile_mode,
+                                        int32_t flags) {
+  auto sp = skity::Shader::MakeRadial(
+      *reinterpret_cast<const skity::Point*>(&center), radius,
+      reinterpret_cast<const skity::Vec4*>(colors), pos, count,
+      static_cast<skity::TileMode>(tile_mode), flags);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_shader skity_shader_create_sweep(float cx, float cy, float start_angle,
+                                       float end_angle,
+                                       const skity_color4f* colors,
+                                       const float* pos, int32_t count,
+                                       skity_tile_mode tile_mode,
+                                       int32_t flags) {
+  auto sp = skity::Shader::MakeSweep(
+      cx, cy, start_angle, end_angle,
+      reinterpret_cast<const skity::Vec4*>(colors), pos, count,
+      static_cast<skity::TileMode>(tile_mode), flags);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_shader skity_shader_create_two_point_conical(
+    skity_point start, float start_radius, skity_point end, float end_radius,
+    const skity_color4f* colors, const float* pos, int32_t count,
+    skity_tile_mode tile_mode, int32_t flags) {
+  auto sp = skity::Shader::MakeTwoPointConical(
+      *reinterpret_cast<const skity::Point*>(&start), start_radius,
+      *reinterpret_cast<const skity::Point*>(&end), end_radius,
+      reinterpret_cast<const skity::Vec4*>(colors), pos, count,
+      static_cast<skity::TileMode>(tile_mode), flags);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_shader skity_shader_create_image(skity_image image,
+                                       const skity_sampling_options* sampling,
+                                       skity_tile_mode x_tile_mode,
+                                       skity_tile_mode y_tile_mode,
+                                       const skity_matrix* local_matrix) {
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  if (img == nullptr) {
+    return nullptr;
+  }
+  skity::SamplingOptions so{};
+  if (sampling != nullptr) {
+    so.filter = static_cast<skity::FilterMode>(sampling->filter);
+    so.mipmap = static_cast<skity::MipmapMode>(sampling->mipmap);
+    so.cubic.B = sampling->cubic_b;
+    so.cubic.C = sampling->cubic_c;
+  }
+  skity::Matrix lm = local_matrix != nullptr
+                         ? *reinterpret_cast<const skity::Matrix*>(local_matrix)
+                         : skity::Matrix{};
+  auto sp = skity::Shader::MakeShader(
+      img, so, static_cast<skity::TileMode>(x_tile_mode),
+      static_cast<skity::TileMode>(y_tile_mode), lm);
+  if (sp == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_shader_s>(
+      SKITY_OBJECT_TYPE_SHADER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_shader_set_local_matrix(skity_shader shader,
+                                   const skity_matrix* matrix) {
+  auto* s = shader_of(shader);
+  if (s == nullptr) return;
+  // A NULL matrix resets the local matrix to identity, matching the header
+  // documentation. SetLocalMatrix replaces (rather than composes with) the
+  // stored matrix, so passing an identity matrix fully clears it.
+  skity::Matrix m = matrix != nullptr
+                        ? *reinterpret_cast<const skity::Matrix*>(matrix)
+                        : skity::Matrix{};
+  s->SetLocalMatrix(m);
+}
+
+void skity_shader_get_local_matrix(skity_shader shader, skity_matrix* out) {
+  auto* s = shader_of(shader);
+  if (s == nullptr || out == nullptr) return;
+  *reinterpret_cast<skity::Matrix*>(out) = s->GetLocalMatrix();
+}
+
+void skity_shader_destroy(skity_shader shader) {
+  skity::capi::destroy_handle<skity_shader_s>(shader, SKITY_OBJECT_TYPE_SHADER);
+}
+
+}  // extern "C"

--- a/module/capi/src/stroke_c.cpp
+++ b/module/capi/src/stroke_c.cpp
@@ -1,0 +1,50 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_stroke.h>
+
+#include <skity/geometry/stroke.hpp>
+#include <skity/graphic/paint.hpp>
+#include <skity/graphic/path.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::Paint* paint_of(skity_paint handle) {
+  auto* w =
+      skity::capi::resolve<skity_paint_s>(handle, SKITY_OBJECT_TYPE_PAINT);
+  return w ? static_cast<skity::Paint*>(w->impl.get()) : nullptr;
+}
+
+skity::Path* path_of(skity_path handle) {
+  auto* w = skity::capi::resolve<skity_path_s>(handle, SKITY_OBJECT_TYPE_PATH);
+  return w ? static_cast<skity::Path*>(w->impl.get()) : nullptr;
+}
+
+}  // namespace
+
+extern "C" {
+
+void skity_stroke_stroke_path(skity_paint paint, skity_path src,
+                              skity_path dst) {
+  auto* p = paint_of(paint);
+  auto* s = path_of(src);
+  auto* d = path_of(dst);
+  if (p == nullptr || s == nullptr || d == nullptr) return;
+  skity::Stroke stroke(*p);
+  stroke.StrokePath(*s, d);
+}
+
+void skity_stroke_quad_path(skity_paint paint, skity_path src, skity_path dst,
+                            uint32_t keep_cubic) {
+  auto* p = paint_of(paint);
+  auto* s = path_of(src);
+  auto* d = path_of(dst);
+  if (p == nullptr || s == nullptr || d == nullptr) return;
+  skity::Stroke stroke(*p);
+  stroke.QuadPath(*s, d, keep_cubic != 0);
+}
+
+}  // extern "C"

--- a/module/capi/src/surface_c.cpp
+++ b/module/capi/src/surface_c.cpp
@@ -1,0 +1,146 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_surface.h>
+
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/gpu_surface.hpp>
+#include <skity/render/canvas.hpp>
+#include <utility>
+
+#include "handle.hpp"
+
+#if defined(SKITY_OPENGL)
+#include <skity/gpu/gpu_context_gl.hpp>
+#endif
+
+extern "C" {
+
+skity_result skity_surface_create(skity_context context,
+                                  const skity_surface_create_info* info,
+                                  skity_surface* out_surface) {
+  if (info == nullptr || out_surface == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  if (ctx == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+
+#if defined(SKITY_OPENGL)
+  // Locate the GL backend extension in the p_next chain.
+  const skity_surface_create_info_gl* gl_ext = nullptr;
+  if (info->p_next != nullptr) {
+    auto s_type = *static_cast<const skity_structure_type*>(info->p_next);
+    if (s_type == SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL) {
+      gl_ext = static_cast<const skity_surface_create_info_gl*>(info->p_next);
+    }
+  }
+  if (gl_ext == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+
+  skity::GPUSurfaceDescriptorGL desc{};
+  desc.backend = skity::GPUBackendType::kOpenGL;
+  desc.width = info->width;
+  desc.height = info->height;
+  desc.sample_count = info->sample_count ? info->sample_count : 1;
+  desc.content_scale = info->content_scale != 0.f ? info->content_scale : 1.f;
+  desc.surface_type = (gl_ext->surface_type == SKITY_GL_SURFACE_TYPE_TEXTURE)
+                          ? skity::GLSurfaceType::kTexture
+                          : skity::GLSurfaceType::kFramebuffer;
+  desc.gl_id = gl_ext->gl_id;
+  desc.has_stencil_attachment = gl_ext->has_stencil != 0;
+  desc.surface_mode = static_cast<skity::GLSurfaceMode>(gl_ext->surface_mode);
+  desc.can_blit_from_target_fbo = gl_ext->can_blit_from_target_fbo != 0;
+
+  std::unique_ptr<skity::GPUSurface> surf = ctx->CreateSurface(&desc);
+  if (surf == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+  std::shared_ptr<void> impl(surf.release());
+  skity_surface_s* w = skity::capi::alloc_handle<skity_surface_s>(
+      SKITY_OBJECT_TYPE_SURFACE, SKITY_HANDLE_OWNING, std::move(impl));
+  if (w == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out_surface = w;
+  return SKITY_SUCCESS;
+#else
+  return SKITY_ERROR_NOT_SUPPORTED;
+#endif
+}
+
+void skity_surface_destroy(skity_surface surface) {
+  skity::capi::destroy_handle<skity_surface_s>(surface,
+                                               SKITY_OBJECT_TYPE_SURFACE);
+}
+
+skity_canvas skity_surface_lock_canvas(skity_surface surface, uint32_t clear) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  if (surf == nullptr) {
+    return nullptr;
+  }
+  // The Canvas is owned by the surface; wrap it with a no-op deleter.
+  skity::Canvas* raw = surf->LockCanvas(clear != 0);
+  if (raw == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<void> impl(raw, [](void*) {});
+  return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0,
+                                                   std::move(impl));
+}
+
+void skity_surface_flush(skity_surface surface) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  if (surf != nullptr) {
+    surf->Flush();
+  }
+}
+
+skity_pixmap skity_surface_read_pixels(skity_surface surface,
+                                       const skity_rect* rect) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  if (surf == nullptr) {
+    return nullptr;
+  }
+  skity::Rect region;
+  if (rect != nullptr) {
+    region = *reinterpret_cast<const skity::Rect*>(rect);
+  } else {
+    region = skity::Rect::MakeXYWH(0.f, 0.f, (float)surf->GetWidth(),
+                                   (float)surf->GetHeight());
+  }
+  auto pm = surf->ReadPixels(region);
+  if (pm == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<void> impl(std::move(pm));
+  return skity::capi::alloc_handle<skity_pixmap_s>(
+      SKITY_OBJECT_TYPE_PIXMAP, SKITY_HANDLE_OWNING, std::move(impl));
+}
+
+uint32_t skity_surface_get_width(skity_surface surface) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  return surf ? surf->GetWidth() : 0u;
+}
+
+uint32_t skity_surface_get_height(skity_surface surface) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  return surf ? surf->GetHeight() : 0u;
+}
+
+float skity_surface_get_content_scale(skity_surface surface) {
+  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  return surf ? surf->ContentScale() : 1.f;
+}
+
+}  // extern "C"

--- a/module/capi/src/text_c.cpp
+++ b/module/capi/src/text_c.cpp
@@ -1,0 +1,357 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_text.h>
+
+#include <cstring>
+#include <skity/graphic/paint.hpp>
+#include <skity/io/data.hpp>
+#include <skity/text/font.hpp>
+#include <skity/text/font_manager.hpp>
+#include <skity/text/font_style.hpp>
+#include <skity/text/text_blob.hpp>
+#include <skity/text/typeface.hpp>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::FontManager* font_manager_of(skity_font_manager handle) {
+  auto* w = skity::capi::resolve<skity_font_manager_s>(
+      handle, SKITY_OBJECT_TYPE_FONT_MANAGER);
+  return w ? static_cast<skity::FontManager*>(w->impl.get()) : nullptr;
+}
+
+skity::FontStyleSet* font_style_set_of(skity_font_style_set handle) {
+  auto* w = skity::capi::resolve<skity_font_style_set_s>(
+      handle, SKITY_OBJECT_TYPE_FONT_STYLE_SET);
+  return w ? static_cast<skity::FontStyleSet*>(w->impl.get()) : nullptr;
+}
+
+skity::Typeface* typeface_of(skity_typeface handle) {
+  auto* w = skity::capi::resolve<skity_typeface_s>(handle,
+                                                   SKITY_OBJECT_TYPE_TYPEFACE);
+  return w ? static_cast<skity::Typeface*>(w->impl.get()) : nullptr;
+}
+
+skity::TextBlob* text_blob_of(skity_text_blob handle) {
+  auto* w = skity::capi::resolve<skity_text_blob_s>(
+      handle, SKITY_OBJECT_TYPE_TEXT_BLOB);
+  return w ? static_cast<skity::TextBlob*>(w->impl.get()) : nullptr;
+}
+
+skity::Font* font_of(skity_font handle) {
+  auto* w = skity::capi::resolve<skity_font_s>(handle, SKITY_OBJECT_TYPE_FONT);
+  return w ? static_cast<skity::Font*>(w->impl.get()) : nullptr;
+}
+
+skity::FontStyle to_font_style(skity_font_style s) {
+  return skity::FontStyle(s.weight, s.width,
+                          static_cast<skity::FontStyle::Slant>(s.slant));
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_font_manager skity_font_manager_ref_default(void) {
+  auto sp = skity::FontManager::RefDefault();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_font_manager_s>(
+      SKITY_OBJECT_TYPE_FONT_MANAGER, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_font_manager_destroy(skity_font_manager manager) {
+  skity::capi::destroy_handle<skity_font_manager_s>(
+      manager, SKITY_OBJECT_TYPE_FONT_MANAGER);
+}
+
+skity_typeface skity_typeface_make_from_file(const char* path) {
+  if (path == nullptr) return nullptr;
+  auto sp = skity::Typeface::MakeFromFile(path);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_typeface skity_typeface_make_from_data(skity_data data) {
+  auto bytes = skity::capi::get_impl<skity_data_s, skity::Data>(
+      data, SKITY_OBJECT_TYPE_DATA);
+  if (bytes == nullptr) return nullptr;
+  auto sp = skity::Typeface::MakeFromData(bytes);
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+skity_typeface skity_typeface_get_default(void) {
+  auto sp = skity::Typeface::GetDefaultTypeface();
+  if (sp == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(sp));
+}
+
+void skity_typeface_destroy(skity_typeface typeface) {
+  skity::capi::destroy_handle<skity_typeface_s>(typeface,
+                                                SKITY_OBJECT_TYPE_TYPEFACE);
+}
+
+void skity_typeface_unichars_to_glyphs(skity_typeface typeface,
+                                       const uint32_t* uni, int32_t count,
+                                       uint16_t* glyphs) {
+  auto* tf = typeface_of(typeface);
+  if (tf == nullptr || uni == nullptr || glyphs == nullptr || count <= 0) {
+    return;
+  }
+  tf->UnicharsToGlyphs(uni, count, reinterpret_cast<skity::GlyphID*>(glyphs));
+}
+
+uint16_t skity_typeface_unichar_to_glyph(skity_typeface typeface,
+                                         uint32_t unichar) {
+  auto* tf = typeface_of(typeface);
+  return tf ? tf->UnicharToGlyph(unichar) : 0;
+}
+
+skity_text_blob skity_text_blob_create(const char* text, skity_paint paint) {
+  if (text == nullptr) {
+    return nullptr;
+  }
+  auto* pw =
+      skity::capi::resolve<skity_paint_s>(paint, SKITY_OBJECT_TYPE_PAINT);
+  if (pw == nullptr) {
+    return nullptr;
+  }
+  auto* p = static_cast<skity::Paint*>(pw->impl.get());
+  skity::TextBlobBuilder builder;
+  auto blob = builder.BuildTextBlob(text, *p);
+  if (blob == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_text_blob_s>(
+      SKITY_OBJECT_TYPE_TEXT_BLOB, SKITY_HANDLE_OWNING, std::move(blob));
+}
+
+void skity_text_blob_destroy(skity_text_blob blob) {
+  skity::capi::destroy_handle<skity_text_blob_s>(blob,
+                                                 SKITY_OBJECT_TYPE_TEXT_BLOB);
+}
+
+void skity_text_blob_get_bounds(skity_text_blob blob, skity_rect* out) {
+  if (out == nullptr) return;
+  auto* b = text_blob_of(blob);
+  if (b == nullptr) return;
+  skity::Rect r = b->GetBoundsRect();
+  out->left = r.Left();
+  out->top = r.Top();
+  out->right = r.Right();
+  out->bottom = r.Bottom();
+}
+
+void skity_text_blob_compute_bounds(int32_t count, const uint16_t* glyphs,
+                                    const float* pos_x, const float* pos_y,
+                                    skity_font font, skity_paint paint,
+                                    skity_rect* out) {
+  if (out == nullptr) return;
+  auto* f = font_of(font);
+  auto* pw =
+      skity::capi::resolve<skity_paint_s>(paint, SKITY_OBJECT_TYPE_PAINT);
+  if (f == nullptr || pw == nullptr || glyphs == nullptr || pos_x == nullptr ||
+      pos_y == nullptr || count <= 0) {
+    return;
+  }
+  auto* p = static_cast<skity::Paint*>(pw->impl.get());
+  skity::Rect r = skity::TextBlob::ComputeBounds(
+      (uint32_t)count, reinterpret_cast<const skity::GlyphID*>(glyphs), pos_x,
+      pos_y, *f, *p);
+  out->left = r.Left();
+  out->top = r.Top();
+  out->right = r.Right();
+  out->bottom = r.Bottom();
+}
+
+int32_t skity_font_manager_count_families(skity_font_manager manager) {
+  auto* m = font_manager_of(manager);
+  return m ? m->CountFamilies() : 0;
+}
+
+int32_t skity_font_manager_get_family_name(skity_font_manager manager,
+                                           int32_t index, char* buffer,
+                                           int32_t buffer_size) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr || index < 0) {
+    return 0;
+  }
+  std::string name = m->GetFamilyName(index);
+  int32_t len = (int32_t)name.size() + 1;
+  if (buffer != nullptr && buffer_size >= len) {
+    std::memcpy(buffer, name.c_str(), (size_t)len);
+  }
+  return len;
+}
+
+skity_font_style_set skity_font_manager_create_style_set(
+    skity_font_manager manager, int32_t index) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr) {
+    return nullptr;
+  }
+  auto set = m->CreateStyleSet(index);
+  if (set == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_font_style_set_s>(
+      SKITY_OBJECT_TYPE_FONT_STYLE_SET, SKITY_HANDLE_OWNING, std::move(set));
+}
+
+skity_font_style_set skity_font_manager_match_family(skity_font_manager manager,
+                                                     const char* name) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr || name == nullptr) {
+    return nullptr;
+  }
+  auto set = m->MatchFamily(name);
+  if (set == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_font_style_set_s>(
+      SKITY_OBJECT_TYPE_FONT_STYLE_SET, SKITY_HANDLE_OWNING, std::move(set));
+}
+
+skity_typeface skity_font_manager_match_family_style(skity_font_manager manager,
+                                                     const char* name,
+                                                     skity_font_style style) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr || name == nullptr) {
+    return nullptr;
+  }
+  auto tf = m->MatchFamilyStyle(name, to_font_style(style));
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+skity_typeface skity_font_manager_match_family_style_character(
+    skity_font_manager manager, const char* name, skity_font_style style,
+    const char** bcp47, int32_t bcp47_count, uint32_t character) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr || name == nullptr) {
+    return nullptr;
+  }
+  auto tf = m->MatchFamilyStyleCharacter(name, to_font_style(style), bcp47,
+                                         bcp47_count, character);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+skity_typeface skity_font_manager_make_from_file(skity_font_manager manager,
+                                                 const char* path,
+                                                 int32_t ttc_index) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr || path == nullptr) {
+    return nullptr;
+  }
+  auto tf = m->MakeFromFile(path, ttc_index);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+skity_typeface skity_font_manager_make_from_data(skity_font_manager manager,
+                                                 skity_data data,
+                                                 int32_t ttc_index) {
+  auto* m = font_manager_of(manager);
+  auto bytes = skity::capi::get_impl<skity_data_s, skity::Data>(
+      data, SKITY_OBJECT_TYPE_DATA);
+  if (m == nullptr || bytes == nullptr) {
+    return nullptr;
+  }
+  auto tf = m->MakeFromData(bytes, ttc_index);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+skity_typeface skity_font_manager_get_default_typeface(
+    skity_font_manager manager, skity_font_style style) {
+  auto* m = font_manager_of(manager);
+  if (m == nullptr) {
+    return nullptr;
+  }
+  auto tf = m->GetDefaultTypeface(to_font_style(style));
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+int32_t skity_font_style_set_count(skity_font_style_set set) {
+  auto* s = font_style_set_of(set);
+  return s ? s->Count() : 0;
+}
+
+void skity_font_style_set_get_style(skity_font_style_set set, int32_t index,
+                                    skity_font_style* out_style,
+                                    char* name_buffer, int32_t name_size) {
+  auto* s = font_style_set_of(set);
+  if (s == nullptr || index < 0) {
+    return;
+  }
+  skity::FontStyle fs;
+  std::string name;
+  s->GetStyle(index, &fs, name_buffer != nullptr ? &name : nullptr);
+  if (out_style != nullptr) {
+    out_style->weight = fs.weight();
+    out_style->width = fs.width();
+    out_style->slant = static_cast<skity_font_slant>(fs.slant());
+  }
+  if (name_buffer != nullptr && name_size > 0) {
+    std::strncpy(name_buffer, name.c_str(), (size_t)name_size);
+    name_buffer[name_size - 1] = '\0';
+  }
+}
+
+skity_typeface skity_font_style_set_create_typeface(skity_font_style_set set,
+                                                    int32_t index) {
+  auto* s = font_style_set_of(set);
+  if (s == nullptr) {
+    return nullptr;
+  }
+  auto tf = s->CreateTypeface(index);
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+skity_typeface skity_font_style_set_match_style(skity_font_style_set set,
+                                                skity_font_style style) {
+  auto* s = font_style_set_of(set);
+  if (s == nullptr) {
+    return nullptr;
+  }
+  auto tf = s->MatchStyle(to_font_style(style));
+  if (tf == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE, SKITY_HANDLE_OWNING, std::move(tf));
+}
+
+void skity_font_style_set_destroy(skity_font_style_set set) {
+  skity::capi::destroy_handle<skity_font_style_set_s>(
+      set, SKITY_OBJECT_TYPE_FONT_STYLE_SET);
+}
+
+}  // extern "C"

--- a/module/capi/src/texture_c.cpp
+++ b/module/capi/src/texture_c.cpp
@@ -1,0 +1,193 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_texture.h>
+
+#include <cstring>
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/texture.hpp>
+#include <skity/io/data.hpp>
+#include <skity/io/pixmap.hpp>
+#include <vector>
+
+#if defined(SKITY_OPENGL)
+#include <skity/gpu/gpu_context_gl.hpp>
+#endif
+
+#include "handle.hpp"
+
+namespace {
+
+size_t bytes_per_pixel(skity_color_type ct) {
+  switch (ct) {
+    case SKITY_COLOR_TYPE_A8:
+      return 1;
+    case SKITY_COLOR_TYPE_RGB565:
+      return 2;
+    default:
+      return 4;
+  }
+}
+
+skity::Texture* texture_of(skity_texture handle) {
+  auto* w =
+      skity::capi::resolve<skity_texture_s>(handle, SKITY_OBJECT_TYPE_TEXTURE);
+  return w ? static_cast<skity::Texture*>(w->impl.get()) : nullptr;
+}
+
+std::shared_ptr<skity::Pixmap> pixmap_from_pixels(
+    const void* pixels, size_t row_bytes, uint32_t width, uint32_t height,
+    skity_color_type color_type, skity_alpha_type alpha_type) {
+  if (color_type == SKITY_COLOR_TYPE_UNKNOWN) {
+    return nullptr;
+  }
+  size_t bpp = bytes_per_pixel(color_type);
+  size_t min_row_bytes = static_cast<size_t>(width) * bpp;
+  if (row_bytes == 0) {
+    row_bytes = min_row_bytes;
+  }
+  // A row must hold at least one full row of pixels. The GPU upload path
+  // (GPUTexture::UploadData) takes a base pointer with no row stride, so a
+  // smaller row_bytes would read out of bounds on upload.
+  if (row_bytes < min_row_bytes) {
+    return nullptr;
+  }
+  // Repack strided rows into a contiguous buffer: GPU uploads assume
+  // tightly-packed rows, so non-tightly-packed sources must be densified to
+  // avoid uploading padding bytes as pixel data.
+  std::shared_ptr<skity::Data> data;
+  if (row_bytes == min_row_bytes) {
+    data = skity::Data::MakeWithCopy(pixels, min_row_bytes * height);
+  } else {
+    std::vector<uint8_t> packed(min_row_bytes * height);
+    const auto* src = static_cast<const uint8_t*>(pixels);
+    for (uint32_t y = 0; y < height; y++) {
+      std::memcpy(packed.data() + y * min_row_bytes, src + y * row_bytes,
+                  min_row_bytes);
+    }
+    data = skity::Data::MakeWithCopy(packed.data(), packed.size());
+  }
+  if (data == nullptr) {
+    return nullptr;
+  }
+  return std::make_shared<skity::Pixmap>(
+      data, min_row_bytes, width, height,
+      static_cast<skity::AlphaType>(alpha_type),
+      static_cast<skity::ColorType>(color_type));
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_texture skity_texture_create(skity_context context,
+                                   skity_texture_format format, uint32_t width,
+                                   uint32_t height,
+                                   skity_alpha_type alpha_type) {
+  if (width == 0 || height == 0) {
+    return nullptr;
+  }
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  auto tex =
+      ctx->CreateTexture(static_cast<skity::TextureFormat>(format), width,
+                         height, static_cast<skity::AlphaType>(alpha_type));
+  if (tex == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_texture_s>(
+      SKITY_OBJECT_TYPE_TEXTURE, SKITY_HANDLE_OWNING, std::move(tex));
+}
+
+void skity_texture_destroy(skity_texture texture) {
+  skity::capi::destroy_handle<skity_texture_s>(texture,
+                                               SKITY_OBJECT_TYPE_TEXTURE);
+}
+
+void skity_texture_upload(skity_texture texture, const void* pixels,
+                          size_t row_bytes, skity_color_type color_type,
+                          skity_alpha_type alpha_type) {
+  auto* t = texture_of(texture);
+  if (t == nullptr || pixels == nullptr) {
+    return;
+  }
+  auto pm = pixmap_from_pixels(pixels, row_bytes, (uint32_t)t->Width(),
+                               (uint32_t)t->Height(), color_type, alpha_type);
+  if (!pm) {
+    return;
+  }
+  t->UploadImage(pm);
+}
+
+void skity_texture_deferred_upload(skity_texture texture, const void* pixels,
+                                   size_t row_bytes,
+                                   skity_color_type color_type,
+                                   skity_alpha_type alpha_type) {
+  auto* t = texture_of(texture);
+  if (t == nullptr || pixels == nullptr) {
+    return;
+  }
+  auto pm = pixmap_from_pixels(pixels, row_bytes, (uint32_t)t->Width(),
+                               (uint32_t)t->Height(), color_type, alpha_type);
+  if (!pm) {
+    return;
+  }
+  t->DeferredUploadImage(pm);
+}
+
+uint32_t skity_texture_get_width(skity_texture texture) {
+  auto* t = texture_of(texture);
+  return t ? (uint32_t)t->Width() : 0u;
+}
+
+uint32_t skity_texture_get_height(skity_texture texture) {
+  auto* t = texture_of(texture);
+  return t ? (uint32_t)t->Height() : 0u;
+}
+
+skity_texture skity_texture_create_from_backend(
+    skity_context context, const skity_backend_texture_info* info,
+    skity_texture_release_callback release, void* userdata) {
+  if (info == nullptr) {
+    return nullptr;
+  }
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+#if defined(SKITY_OPENGL)
+  const skity_backend_texture_info_gl* gl = nullptr;
+  if (info->p_next != nullptr) {
+    auto st = *static_cast<const skity_structure_type*>(info->p_next);
+    if (st == SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL) {
+      gl = static_cast<const skity_backend_texture_info_gl*>(info->p_next);
+    }
+  }
+  if (gl == nullptr) {
+    return nullptr;
+  }
+  skity::GPUBackendTextureInfoGL bi{};
+  bi.backend = skity::GPUBackendType::kOpenGL;
+  bi.width = info->width;
+  bi.height = info->height;
+  bi.format = static_cast<skity::TextureFormat>(info->format);
+  bi.alpha_type = static_cast<skity::AlphaType>(info->alpha_type);
+  bi.tex_id = gl->texture_id;
+  bi.owned_by_engine = gl->owned_by_engine != 0;
+  auto tex = ctx->WrapTexture(&bi, release, userdata);
+  if (tex == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_texture_s>(
+      SKITY_OBJECT_TYPE_TEXTURE, SKITY_HANDLE_OWNING, std::move(tex));
+#else
+  return nullptr;
+#endif
+}
+
+}  // extern "C"

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -31,6 +31,7 @@ android {
                             "-DSKITY_VK_BACKEND=ON",
                             "-DSKITY_CODEC_MODULE=ON",
                             "-DSKITY_IO_MODULE=ON",
+                            "-DSKITY_CAPI_MODULE=ON",
                             "-DWGX_GLSL_BACKEND=ON",
                             "-DWGX_MSL_BACKEND=OFF",
                             "-DSKITY_BUILD_INSTALL=OFF"
@@ -71,6 +72,11 @@ android {
         io {
             headers "../../module/io/include/"
             name "skity-io"
+        }
+
+        capi {
+            headers "../../module/capi/include/"
+            name "skity-capi"
         }
     }
 

--- a/platform/darwin/CMakeLists.txt
+++ b/platform/darwin/CMakeLists.txt
@@ -160,6 +160,34 @@ if(${SKITY_IO_MODULE})
   )
 endif()
 
+# C API wrapper sources are compiled into the framework when the capi module is
+# enabled, mirroring `add_subdirectory(module/capi)` in the root CMakeLists.txt
+# so the C ABI surface ships inside the static framework. The skity-capi target
+# is always defined before this directory is added (module/capi at root line
+# 182, platform/darwin at line 252), so its properties are available here.
+if(${SKITY_CAPI_MODULE})
+  get_target_property(capi_sources skity-capi SOURCES)
+  if (capi_sources STREQUAL "capi_sources-NOTFOUND")
+    message(FATAL_ERROR "capi_sources is not found")
+  endif()
+  target_sources(skity_framework PRIVATE ${capi_sources})
+
+  get_target_property(capi_include_dirs skity-capi INCLUDE_DIRECTORIES)
+  if (NOT capi_include_dirs STREQUAL "capi_include_dirs-NOTFOUND")
+    target_include_directories(skity_framework PRIVATE ${capi_include_dirs})
+  endif()
+
+  get_target_property(capi_compile_options skity-capi COMPILE_OPTIONS)
+  if (NOT capi_compile_options STREQUAL "capi_compile_options-NOTFOUND")
+    target_compile_options(skity_framework PRIVATE ${capi_compile_options})
+  endif()
+
+  get_target_property(capi_compile_definitions skity-capi COMPILE_DEFINITIONS)
+  if (NOT capi_compile_definitions STREQUAL "capi_compile_definitions-NOTFOUND")
+    target_compile_definitions(skity_framework PRIVATE ${capi_compile_definitions})
+  endif()
+endif()
+
 # set cxx standard
 set_target_properties(skity_framework PROPERTIES
   CXX_STANDARD 17
@@ -265,6 +293,15 @@ endif()
 if(${SKITY_IO_MODULE})
   install(
       DIRECTORY "${CMAKE_SOURCE_DIR}/module/io/include/skity/io"
+      DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
+      COMPONENT Runtime
+  )
+endif()
+
+# capi headers (pure-C ABI surface; consumers #include <skity_c/skity.h>)
+if(${SKITY_CAPI_MODULE})
+  install(
+      DIRECTORY "${CMAKE_SOURCE_DIR}/module/capi/include/skity_c"
       DESTINATION "${CMAKE_INSTALL_PREFIX}/skity.framework/Headers"
       COMPONENT Runtime
   )


### PR DESCRIPTION
Add a stable, Vulkan-style C ABI surface (libskity-capi) that mirrors the skity C++ API, so the engine can be consumed from any language (Swift, Rust, Go, C#) or an incompatible C++ ABI without coupling to libstdc++/libc++.

The wrapper is a thin forwarding layer over libskity: opaque handles with a typed header (rejects wrong-type casts), shared_ptr-backed ownership, and s_type/p_next-chained CreateInfo for forward compatibility. The existing C++ API under include/skity/ is untouched.

Coverage: context/surface/canvas/texture (GL + Vulkan), paint, path (+PathOp/PathMeasure), font/typeface/font_manager, text_blob, recorder, precompile, effects (shader/color_filter/image_filter/mask_filter/path_effect), image, bitmap/pixmap, camera/quaternion, stroke, data. Full Doxygen docs across all headers.

Packaging: Android prefab entry for skity-capi in the AAR; iOS/macOS capi sources compiled into the static skity_framework with headers in Headers/skity_c/.