### PR TITLE
chore(ci): decouple WGX SPIR-V tests from Vulkan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
             run: |
                 $WindowsSdkVersion = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\Include" -Directory | Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1 -ExpandProperty Name
                 Write-Host "Using Windows SDK version: $WindowsSdkVersion"
-                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON  -DCMAKE_POLICY_VERSION_MINIMUM='3.5'
+                ./buildtools/cmake/bin/cmake -B out/cmake_host_build -DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion -DSKITY_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Debug -DSKITY_CODEC_MODULE=ON -DSKITY_TEST=ON -DWGX_SPIRV_BACKEND=ON -DCMAKE_POLICY_VERSION_MINIMUM='3.5'
                 Select-String -Path out/cmake_host_build/skity.vcxproj -Pattern "WindowsTargetPlatformVersion"
                 ./buildtools/cmake/bin/cmake --build out/cmake_host_build --target skity_unit_test
                 cd out/cmake_host_build/Debug

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -18,6 +18,13 @@ cmake_dependent_option(
 )
 
 option(SKITY_VK_BACKEND "option for vulkan backend" OFF)
+option(WGX_SPIRV_BACKEND "option for WGX SPIR-V generation"
+       ${SKITY_VK_BACKEND})
+
+if(SKITY_VK_BACKEND AND NOT WGX_SPIRV_BACKEND)
+  message(FATAL_ERROR "SKITY_VK_BACKEND requires WGX_SPIRV_BACKEND")
+endif()
+
 option(SKITY_CODEC_MODULE "option for build codec module" ON)
 cmake_dependent_option(
   SKITY_IO_MODULE "option for build io module"

--- a/cmake/ThirdPartyDep.cmake
+++ b/cmake/ThirdPartyDep.cmake
@@ -35,7 +35,6 @@ if(${SKITY_VK_BACKEND})
   target_include_directories(skity PRIVATE third_party/Vulkan-Headers/include)
   # set vulkan headers
   target_include_directories(skity PRIVATE third_party/VulkanMemoryAllocator/include)
-  add_subdirectory(third_party/SPIRV-Headers)
 
   # Detect Linux display server headers for Vulkan platform extensions
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -56,6 +55,10 @@ if(${SKITY_VK_BACKEND})
 elseif(${SKITY_HW_RENDERER})
   # Only Vulkan headers are needed for stub compilation when VK backend is off
   target_include_directories(skity PRIVATE third_party/Vulkan-Headers/include)
+endif()
+
+if(${WGX_SPIRV_BACKEND})
+  add_subdirectory(third_party/SPIRV-Headers)
 endif()
 
 # json parser

--- a/docs/BUILD_AND_RUN.md
+++ b/docs/BUILD_AND_RUN.md
@@ -76,6 +76,7 @@ There are several options you can use to configure the build:
     * `SKITY_GL_BACKEND` - Option for OpenGL backend. Default is ON. Pass `-DSKITY_GL_BACKEND=OFF` in command line to disable it. (OpenGL/GLES is almost supported by all platforms, so it is recommended not to turn this option off.)
     * `SKITY_MTL_BACKEND` - Option for Metal backend. Not available on Windows and Linux but open by default on Apple platform.
     * `SKITY_VK_BACKEND` - Option for Vulkan backend (experimental). Default is OFF. Pass `-DSKITY_VK_BACKEND=ON` in command line to enable it. Requires Vulkan at least version 1.1. Skity will attempt to create the highest available Vulkan version and leverage extensions such as dynamic rendering when supported.
+    * `WGX_SPIRV_BACKEND` - Option for WGX SPIR-V generation. Defaults to the value of `SKITY_VK_BACKEND`, but can be enabled independently without a Vulkan runtime by passing `-DWGX_SPIRV_BACKEND=ON`.
     * `SKITY_LOG` - Option for logging. Default is OFF since print log may slow down the performance. Pass `-DSKITY_LOG=ON` in command line to enable it.
 
 * Options for build optional modules:

--- a/module/wgx/CMakeLists.txt
+++ b/module/wgx/CMakeLists.txt
@@ -5,12 +5,6 @@
 option(WGX_GLSL_BACKEND "Generate GLSL shader" ON)
 option(WGX_MSL_BACKEND "Generate MSL shader" ON)
 
-if (${SKITY_VK_BACKEND})
-    set(WGX_VULKAN_BACKEND ON)
-else()
-    set(WGX_VULKAN_BACKEND OFF)
-endif()
-
 add_library(wgsl-cross STATIC
     ${CMAKE_CURRENT_LIST_DIR}/include/wgsl_cross.h
     ${CMAKE_CURRENT_LIST_DIR}/wgsl/ast/ast_attribute.cpp
@@ -74,8 +68,8 @@ if (WGX_MSL_BACKEND)
     )
 endif()
 
-if (WGX_VULKAN_BACKEND)
-    target_compile_definitions(wgsl-cross PRIVATE -DWGX_VULKAN=1)
+if (WGX_SPIRV_BACKEND)
+    target_compile_definitions(wgsl-cross PRIVATE -DWGX_SPIRV=1)
     target_sources(wgsl-cross PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/ir/ir_module.h
         ${CMAKE_CURRENT_LIST_DIR}/ir/ir_type.h

--- a/module/wgx/wgsl/program.cpp
+++ b/module/wgx/wgsl/program.cpp
@@ -13,7 +13,7 @@
 #include "wgsl/scanner.h"
 #include "wgsl/wgsl_function.h"
 
-#ifdef WGX_VULKAN
+#ifdef WGX_SPIRV
 #include "lower/lower_to_ir.h"
 #include "spirv/emitter.h"
 #endif
@@ -120,7 +120,7 @@ Result Program::WriteToSpirv(const char* entry_point,
                              std::optional<CompilerContext> ctx) const {
   (void)options;
   (void)ctx;
-#ifdef WGX_VULKAN
+#ifdef WGX_SPIRV
   auto func = module_->GetFunction(entry_point);
 
   if (func == nullptr || !func->IsEntryPoint()) {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -148,6 +148,20 @@ endif()
 target_link_libraries(skity_unit_test PRIVATE glm::glm-header-only)
 target_link_libraries(skity_unit_test PRIVATE wgsl-cross)
 
+if (${WGX_SPIRV_BACKEND})
+    target_sources(skity_unit_test PRIVATE
+        wgx/wgx_spirv_smoke_test.cc
+        wgx/wgx_value_test.cc
+    )
+    target_compile_definitions(skity_unit_test PRIVATE
+        -DWGX_SPIRV=1
+        -DWGX_SPIRV_DUMP_DEFAULT_DIR="${CMAKE_BINARY_DIR}"
+    )
+    target_link_libraries(skity_unit_test PRIVATE
+        SPIRV-Headers::SPIRV-Headers
+    )
+endif()
+
 if(SKITY_ENABLE_FONT_HARNESS AND TARGET skity_font_harness)
     target_sources(skity_unit_test PRIVATE
         ${CMAKE_SOURCE_DIR}/harness/font/tests/unit/font_harness_self_test.cc
@@ -175,9 +189,7 @@ if (${SKITY_VK_BACKEND})
 
     add_executable(skity_vulkan_unit_test
         gpu/vk/gpu_context_vk_test.cc
-        wgx/wgx_spirv_smoke_test.cc
         wgx/wgx_vulkan_pipeline_test.cc
-        wgx/wgx_value_test.cc
     )
 
     target_include_directories(skity_vulkan_unit_test
@@ -185,11 +197,9 @@ if (${SKITY_VK_BACKEND})
         ${CMAKE_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/module/wgx
     )
-    target_compile_definitions(skity_vulkan_unit_test PRIVATE -DWGX_VULKAN=1)
     if (${SKITY_VK_TEST_USE_SYSTEM_LOADER})
         target_compile_definitions(skity_vulkan_unit_test PRIVATE -DSKITY_VK_TEST_USE_SYSTEM_LOADER=1)
     endif()
-    target_compile_definitions(skity_vulkan_unit_test PRIVATE -DWGX_SPIRV_DUMP_DEFAULT_DIR="${CMAKE_BINARY_DIR}")
     target_include_directories(skity_vulkan_unit_test PRIVATE
         ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
         ${CMAKE_SOURCE_DIR}/third_party/VulkanMemoryAllocator/include
@@ -199,7 +209,6 @@ if (${SKITY_VK_BACKEND})
         gmock_main
         glm::glm-header-only
         wgsl-cross
-        SPIRV-Headers::SPIRV-Headers
         ${SKITY_VK_TEST_LOADER_LIBRARIES}
     )
     if (NOT USE_THIRD_PARTY_ZLIB)

--- a/test/ut/wgx/wgx_backend_name_resolution_test.cc
+++ b/test/ut/wgx/wgx_backend_name_resolution_test.cc
@@ -7,6 +7,10 @@
 
 #include <algorithm>
 
+#if defined(WGX_SPIRV)
+#include "spirv/unified1/spirv.h"
+#endif
+
 namespace {
 
 TEST(WgxBackendNameResolutionTest, RewritesGlslConflictingVariableNames) {
@@ -242,6 +246,25 @@ fn fs_main() -> @location(0) vec4<f32> {
   auto msl_result = program->WriteToMsl("fs_main", msl_options);
   ASSERT_TRUE(msl_result.success);
   EXPECT_NE(msl_result.content.find("any("), std::string::npos);
+
+#if defined(WGX_SPIRV)
+  wgx::SpirvOptions spirv_options;
+  auto spirv_result = program->WriteToSpirv("fs_main", spirv_options);
+  ASSERT_TRUE(spirv_result.success);
+
+  bool emits_any = false;
+  for (size_t offset = 5u; offset < spirv_result.spirv.size();) {
+    const uint32_t instruction = spirv_result.spirv[offset];
+    const uint32_t word_count = instruction >> SpvWordCountShift;
+    ASSERT_NE(word_count, 0u);
+    if (static_cast<SpvOp>(instruction & SpvOpCodeMask) == SpvOpAny) {
+      emits_any = true;
+      break;
+    }
+    offset += word_count;
+  }
+  EXPECT_TRUE(emits_any);
+#endif
 }
 
 TEST(WgxBackendNameResolutionTest, RejectsBooleanVectorComparison) {

--- a/test/ut/wgx/wgx_spirv_smoke_test.cc
+++ b/test/ut/wgx/wgx_spirv_smoke_test.cc
@@ -24,7 +24,7 @@
 
 namespace {
 
-#if defined(WGX_VULKAN)
+#if defined(WGX_SPIRV)
 bool ContainsInstruction(const std::vector<uint32_t>& words, SpvOp opcode) {
   size_t offset = 5u;
   while (offset < words.size()) {
@@ -318,26 +318,6 @@ fn fs_main() {
   ASSERT_GE(words.size(), 5u);
   EXPECT_TRUE(ContainsInstruction(words, SpvOpEntryPoint));
   EXPECT_TRUE(ContainsExecutionMode(words, SpvExecutionModeOriginUpperLeft));
-}
-
-TEST(WgxSpirvSmokeTest, EmitsAny) {
-  auto program = wgx::Program::Parse(R"(
-@fragment
-fn fs_main() -> @location(0) vec4<f32> {
-  let flags: vec4<bool> = vec4<bool>(false, true, false, false);
-  let value: f32 = select(0.0, 1.0, any(flags));
-  return vec4<f32>(value);
-}
-)");
-
-  ASSERT_NE(program, nullptr);
-  ASSERT_FALSE(program->GetDiagnosis().has_value());
-
-  wgx::SpirvOptions options;
-  auto result = program->WriteToSpirv("fs_main", options);
-
-  ASSERT_TRUE(result.success);
-  EXPECT_TRUE(ContainsInstruction(result.spirv, SpvOpAny));
 }
 
 TEST(WgxSpirvSmokeTest, EmitsCoverageAAConflationCorrectionShader) {


### PR DESCRIPTION
Add an independent WGX_SPIRV_BACKEND option that defaults to the Vulkan backend setting, and enable it for Windows CI. Move SPIR-V-only coverage into the regular unit-test target so Windows can validate shader generation without a SwiftShader Vulkan runtime.