### PR TITLE
feat(capi): add C++ bridge header for Canvas* to skity_canvas

### DIFF
--- a/module/capi/CMakeLists.txt
+++ b/module/capi/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(
     ${CMAKE_CURRENT_LIST_DIR}/src/quaternion_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/data_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/stroke_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/bridge_c.cpp
 )
 
 if (${SKITY_BUILD_INSTALL})
@@ -91,6 +92,13 @@ if (${SKITY_BUILD_INSTALL})
     "${CMAKE_CURRENT_LIST_DIR}/include/skity_c"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h"
+  )
+
+  install(
+    DIRECTORY
+    "${CMAKE_CURRENT_LIST_DIR}/include/skity_hpp"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
   )
 
   install(

--- a/module/capi/include/skity_hpp/skity_bridge.hpp
+++ b/module/capi/include/skity_hpp/skity_bridge.hpp
@@ -1,0 +1,68 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_HPP_SKITY_BRIDGE_HPP
+#define MODULE_CAPI_INCLUDE_SKITY_HPP_SKITY_BRIDGE_HPP
+
+/*
+ * C++ <-> C ABI bridge for skity-capi.
+ *
+ * This header declares entry points for C++ consumers that already hold
+ * native skity C++ objects (e.g. a skity::Canvas* obtained through the C++ GPU
+ * surface API) and want to drive them through the C API. It is the reverse
+ * direction of the eventual Stage 2 RAII wrapper (skity.hpp): here, C++
+ * objects are bridged INTO C handles.
+ *
+ * The handles produced are non-owning (borrowed): they wrap the object with a
+ * no-op deleter, exactly like the skity_canvas returned by
+ * skity_surface_lock_canvas. The caller must keep the underlying object alive
+ * for the handle's lifetime; skity_canvas_destroy only reclaims the small
+ * wrapper struct and never deletes the object.
+ *
+ * These entry points are declared here (and not in the public skity_c/
+ * headers) because they are meaningful only to C++ callers: they take a
+ * type-erased pointer to a native object.
+ */
+
+#include <skity_c/skity_canvas.h>  // skity_canvas, SKITY_C_API
+
+extern "C" {
+
+/**
+ * @brief Wrap an existing native (C++) Canvas pointer as a non-owning
+ *        skity_canvas handle.
+ *
+ * @warning This is a TEMPORARY bridge API. It exists only to ease the
+ *          current C++/capi mixed-usage transition and may be reworked or
+ *          removed in a future release. Do not build long-term abstractions on
+ *          top of it.
+ *
+ * @p native MUST be the raw pointer value of a @c skity::Canvas* (for example
+ * one obtained from @c GPUSurface::LockCanvas). Because the parameter is a
+ * type-erased @c void*, passing a pointer to any other type is undefined
+ * behaviour — the capi layer cannot validate the type and will happily
+ * reinterpret it.
+ *
+ * The capi layer does NOT take ownership of @p native; it only borrows it. The
+ * caller is solely responsible for keeping the Canvas alive for the entire
+ * lifetime of the returned handle (and any handle derived from it).
+ *
+ * Non-owning does NOT mean the handle is free to drop: the returned
+ * @c skity_canvas is still a capi-allocated wrapper and MUST be released with
+ * @c skity_canvas_destroy once it is no longer needed, otherwise the wrapper
+ * struct leaks (notably so when bridging every frame). That call only reclaims
+ * the wrapper — it never deletes the borrowed Canvas (same non-owning
+ * semantics as the canvas returned by @c skity_surface_lock_canvas), so it is
+ * always safe to call.
+ *
+ * @param native  raw pointer value of a skity::Canvas*, passed as @c void*;
+ *                NULL returns NULL
+ * @return a non-owning skity_canvas handle borrowing @p native, or NULL if
+ *         @p native is NULL
+ */
+SKITY_C_API skity_canvas skity_canvas_from_native(void* native);
+
+}  // extern "C"
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_HPP_SKITY_BRIDGE_HPP

--- a/module/capi/src/bridge_c.cpp
+++ b/module/capi/src/bridge_c.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_canvas.h>
+
+#include <memory>
+#include <utility>
+
+#include "handle.hpp"
+
+/*
+ * Bridge entry points (declared in include/skity_hpp/skity_bridge.hpp). They
+ * wrap existing native C++ objects as non-owning C handles, mirroring the
+ * borrow semantics of skity_surface_lock_canvas (no-op deleter). Declared in
+ * the bridge header rather than the public skity_c/ headers because they are
+ * meaningful only to C++ callers.
+ */
+
+extern "C" {
+
+// SKITY_C_API (visibility default) is applied at the definition because this
+// function has no public skity_c/ header declaration — without it the
+// -fvisibility=hidden build would hide the symbol.
+SKITY_C_API skity_canvas skity_canvas_from_native(void* native) {
+  if (native == nullptr) {
+    return nullptr;
+  }
+  // Non-owning: the no-op deleter means skity_canvas_destroy only reclaims the
+  // wrapper struct and never touches the caller's Canvas.
+  std::shared_ptr<void> impl(native, [](void*) {});
+  return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0u,
+                                                   std::move(impl));
+}
+
+}  // extern "C"


### PR DESCRIPTION
Add a header-only C++ <-> C ABI bridge under include/skity_hpp/ for consumers that already hold a native skity::Canvas* and want to drive it through the C API.

Bridge: skity_canvas_from_native() wraps a skity::Canvas* as a non-owning skity_canvas handle, borrowing the pointer the same way skity_surface_lock_canvas does. The entry point is declared only in the bridge header, keeping the public skity_c/ C surface free of C++-specific symbols.

Ownership: the returned handle is a capi-allocated wrapper and must still be released with skity_canvas_destroy; that call only reclaims the wrapper struct and never deletes the borrowed Canvas.

This is a temporary bridge API to ease the C++/capi mixed-usage transition.