### PR TITLE
feat(wgx): support discard statements

### DIFF
--- a/module/wgx/ir/ir_module.h
+++ b/module/wgx/ir/ir_module.h
@@ -146,6 +146,7 @@ struct InputVariable {
 enum class InstKind {
   kReturn,
   kUnreachable,
+  kDiscard,
   kVariable,
   kLoad,
   kStore,
@@ -275,7 +276,8 @@ struct Instruction {
 
   bool IsTerminator() const {
     return kind == InstKind::kReturn || kind == InstKind::kUnreachable ||
-           kind == InstKind::kBranch || kind == InstKind::kCondBranch;
+           kind == InstKind::kDiscard || kind == InstKind::kBranch ||
+           kind == InstKind::kCondBranch;
   }
 };
 

--- a/module/wgx/ir/verifier.cpp
+++ b/module/wgx/ir/verifier.cpp
@@ -94,6 +94,14 @@ VerificationResult Verifier::VerifyInstruction(const Instruction& inst,
       return VerifyReturn(inst, index);
     case InstKind::kUnreachable:
       return VerificationResult::Success();
+    case InstKind::kDiscard:
+      if (function.stage != PipelineStage::kFragment ||
+          !inst.operands.empty() || inst.result_id != 0) {
+        return VerificationResult::Failure(
+            "Discard must be a result-less fragment terminator", index,
+            inst.kind, block_index);
+      }
+      return VerificationResult::Success();
     case InstKind::kVariable:
       return VerifyVariable(inst, index);
     case InstKind::kLoad:

--- a/module/wgx/lower/lower_core.cpp
+++ b/module/wgx/lower/lower_core.cpp
@@ -260,8 +260,11 @@ bool Lowerer::LowerFunction(const ast::Function* function,
   ir_function_->entry_block_id = entry_block.id;
   ir_function_->blocks.push_back(std::move(entry_block));
   current_block_id_ = ir_function_->entry_block_id;
-  ir_function_->stage =
-      is_entry_point ? ir_module_->stage : ir::PipelineStage::kUnknown;
+  // Lowering currently builds an IR module for one entry point, so every
+  // reachable helper executes in the same shader stage. If an IR module ever
+  // contains multiple entry points, revisit this because a shared helper may
+  // be reachable from different stages.
+  ir_function_->stage = ir_module_->stage;
   ir_function_->return_type = ResolveType(function->return_type);
 
   bool ok = RegisterFunctionParameters();

--- a/module/wgx/lower/lower_internal.h
+++ b/module/wgx/lower/lower_internal.h
@@ -85,6 +85,7 @@ class Lowerer {
   bool LowerStatement(const ast::Statement* statement, ir::Block* block);
   ir::Value EnsureValue(const ir::ExprResult& expr, ir::Block* block);
   bool LowerReturnStatement(const ast::ReturnStatement* ret, ir::Block* block);
+  bool LowerDiscardStatement(ir::Block* block);
   ir::Block* CurrentBlock();
   ir::BlockId CreateBlock(const std::string& name);
   ir::BlockId CreateBlockWithId(const std::string& name, ir::BlockId id);

--- a/module/wgx/lower/lower_stmt.cpp
+++ b/module/wgx/lower/lower_stmt.cpp
@@ -45,6 +45,8 @@ bool Lowerer::LowerStatement(const ast::Statement* statement,
     case ast::StatementType::kReturn:
       return LowerReturnStatement(
           static_cast<const ast::ReturnStatement*>(statement), block);
+    case ast::StatementType::kDiscard:
+      return LowerDiscardStatement(block);
     case ast::StatementType::kBlock:
       return LowerBlockStatement(
           static_cast<const ast::BlockStatement*>(statement), block);
@@ -108,6 +110,13 @@ bool Lowerer::LowerReturnStatement(const ast::ReturnStatement* ret,
   }
   inst.operands.push_back(return_value);
 
+  block->instructions.emplace_back(inst);
+  return true;
+}
+
+bool Lowerer::LowerDiscardStatement(ir::Block* block) {
+  ir::Instruction inst;
+  inst.kind = ir::InstKind::kDiscard;
   block->instructions.emplace_back(inst);
   return true;
 }

--- a/module/wgx/msl/msl_ast_printer.cpp
+++ b/module/wgx/msl/msl_ast_printer.cpp
@@ -518,7 +518,7 @@ void AstPrinter::Visit(ast::Statement* statement) {
       break;
 
     case ast::StatementType::kDiscard:
-      ss_ << "discard;" << std::endl;
+      ss_ << "discard_fragment();" << std::endl;
       break;
 
     case ast::StatementType::kIf: {

--- a/module/wgx/spirv/module_builder.cpp
+++ b/module/wgx/spirv/module_builder.cpp
@@ -1114,6 +1114,9 @@ bool ModuleBuilder::EmitInstruction(const ir::Instruction& inst) {
     case ir::InstKind::kUnreachable:
       AppendInstruction(&sections_->functions, SpvOpUnreachable, {});
       return true;
+    case ir::InstKind::kDiscard:
+      AppendInstruction(&sections_->functions, SpvOpKill, {});
+      return true;
     default:
       return false;
   }

--- a/module/wgx/wgsl/wgsl_function.cpp
+++ b/module/wgx/wgsl/wgsl_function.cpp
@@ -80,7 +80,8 @@ class FunctionCreator : public ast::AstVisitor {
       this->Visit(param);
     }
 
-    if (!function->return_type.IsBuiltin()) {
+    if (function->return_type.expr != nullptr &&
+        !function->return_type.IsBuiltin()) {
       this->Visit(function->return_type.expr);
     }
 

--- a/test/ut/wgx/wgx_backend_name_resolution_test.cc
+++ b/test/ut/wgx/wgx_backend_name_resolution_test.cc
@@ -267,6 +267,71 @@ fn fs_main() -> @location(0) vec4<f32> {
 #endif
 }
 
+void ExpectDiscardLowers(const char* source) {
+  auto program = wgx::Program::Parse(source);
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_options;
+  auto glsl_result = program->WriteToGlsl("fs_main", glsl_options);
+  ASSERT_TRUE(glsl_result.success);
+  EXPECT_NE(glsl_result.content.find("discard;"), std::string::npos);
+
+  wgx::MslOptions msl_options;
+  auto msl_result = program->WriteToMsl("fs_main", msl_options);
+  ASSERT_TRUE(msl_result.success);
+  EXPECT_NE(msl_result.content.find("discard_fragment();"), std::string::npos);
+
+#if defined(WGX_SPIRV)
+  wgx::SpirvOptions spirv_options;
+  auto spirv_result = program->WriteToSpirv("fs_main", spirv_options);
+  ASSERT_TRUE(spirv_result.success);
+
+  bool emits_kill = false;
+  for (size_t offset = 5u; offset < spirv_result.spirv.size();) {
+    const uint32_t instruction = spirv_result.spirv[offset];
+    const uint32_t word_count = instruction >> SpvWordCountShift;
+    ASSERT_NE(word_count, 0u);
+    if (static_cast<SpvOp>(instruction & SpvOpCodeMask) == SpvOpKill) {
+      emits_kill = true;
+      break;
+    }
+    offset += word_count;
+  }
+  EXPECT_TRUE(emits_kill);
+#endif
+}
+
+TEST(WgxBackendNameResolutionTest, LowersDiscardInEntryPoint) {
+  ExpectDiscardLowers(R"(
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>)
+    -> @location(0) vec4<f32> {
+  if position.x < 0.0 {
+    discard;
+  }
+  return vec4<f32>(1.0);
+}
+)");
+}
+
+TEST(WgxBackendNameResolutionTest, LowersDiscardInHelper) {
+  ExpectDiscardLowers(R"(
+fn discard_if_negative(value: f32) {
+  if value < 0.0 {
+    discard;
+  }
+}
+
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>)
+    -> @location(0) vec4<f32> {
+  discard_if_negative(position.x);
+  return vec4<f32>(1.0);
+}
+)");
+}
+
 TEST(WgxBackendNameResolutionTest, RejectsBooleanVectorComparison) {
   auto program = wgx::Program::Parse(R"(
 @fragment


### PR DESCRIPTION
Lower WGSL discard statements into the shared IR as fragment-only terminators. Emit discard_fragment() for MSL and OpKill for SPIR-V, and cover the generated GLSL, MSL, and SPIR-V output.