### PR TITLE
feat(text): prepare deterministic cache keys for subpixel glyphs

### DIFF
--- a/src/render/text/atlas/atlas_glyph.hpp
+++ b/src/render/text/atlas/atlas_glyph.hpp
@@ -5,6 +5,7 @@
 #ifndef SRC_RENDER_TEXT_ATLAS_ATLAS_GLYPH_HPP
 #define SRC_RENDER_TEXT_ATLAS_ATLAS_GLYPH_HPP
 
+#include <cstring>
 #include <glm/glm.hpp>
 #include <memory>
 #include <skity/text/glyph.hpp>
@@ -74,8 +75,7 @@ struct GlyphKey {
 
   struct Equal {
     bool operator()(const GlyphKey& lhs, const GlyphKey& rhs) const {
-      return lhs.glyph_id == rhs.glyph_id &&
-             lhs.scaler_context_desc == rhs.scaler_context_desc;
+      return std::memcmp(&lhs, &rhs, sizeof(GlyphKey)) == 0;
     }
   };
 };

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -12,6 +12,8 @@
 #include "src/render/text/atlas/atlas_texture.hpp"
 #include "src/render/text/sdf_gen.hpp"
 #include "src/render/text/text_render_control.hpp"
+#include "src/text/scaler_context_cache.hpp"
+#include "src/text/scaler_context_container.hpp"
 #include "src/tracing.hpp"
 
 namespace skity {
@@ -20,6 +22,15 @@ namespace {
 
 bool valid_positive_float(float f) {
   return !(FloatIsNan(f) || !FloatIsFinite(f) || f < 0.f);
+}
+
+void LoadGlyphBitmap(const Font& font, GlyphID glyph_id,
+                     const GlyphData** glyph_data, const Paint& paint,
+                     const ScalerContextDesc& desc) {
+  auto scaler_context =
+      ScalerContextCache::GlobalScalerContextCache()->FindOrCreateScalerContext(
+          desc, font.GetTypeface());
+  scaler_context->PrepareImages(&glyph_id, 1, glyph_data, paint);
 }
 
 }  // namespace
@@ -67,7 +78,6 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
                                   const Paint& paint, bool load_sdf,
                                   float context_scale,
                                   const Matrix& transform) {
-  auto typeface = font.GetTypeface();
   float font_size = font.GetSize();
   float sdf_scale = 1.0f;
   // TODO(jingle) consider transform for sdf text
@@ -85,41 +95,21 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font, GlyphID glyph_id,
     }
   }
 
-  ScalerContextDesc scaler_context_desc;
-  scaler_context_desc.typeface_id = typeface->TypefaceId();
-  scaler_context_desc.text_size = load_sdf ? text_size : font_size;
-  scaler_context_desc.scale_x = font.GetScaleX();
-  scaler_context_desc.skew_x = font.GetSkewX();
-  if (load_sdf) {
-    Matrix22 transform22{1.f, 0.f, 0.f, 1.f};
-    scaler_context_desc.transform = transform22;
-  } else {
-    Matrix22 transform22{transform.GetScaleX(), transform.GetSkewX(),
-                         transform.GetSkewY(), transform.GetScaleY()};
-    scaler_context_desc.transform = transform22;
-  }
-  scaler_context_desc.context_scale = load_sdf ? 1.f : context_scale;
+  Font raster_font(font);
+  raster_font.SetSize(load_sdf ? text_size : font_size);
 
-  Paint glyph_image_paint = paint;
+  Paint raster_paint = paint;
   if (load_sdf) {
-    glyph_image_paint.SetStyle(Paint::kFill_Style);
+    raster_paint.SetStyle(Paint::kFill_Style);
   }
-  scaler_context_desc.foreground_color =
-      ScalerContextDesc::GetGlyphImageForegroundColor(font, glyph_image_paint);
 
-  scaler_context_desc.stroke_width =
-      paint.GetStyle() == Paint::kStroke_Style ? paint.GetStrokeWidth() : 0.f;
-  scaler_context_desc.miter_limit = paint.GetStyle() == Paint::kStroke_Style
-                                        ? paint.GetStrokeMiter()
-                                        : Paint::kDefaultMiterLimit;
-  scaler_context_desc.cap = paint.GetStyle() == Paint::kStroke_Style
-                                ? paint.GetStrokeCap()
-                                : Paint::kDefault_Cap;
-  scaler_context_desc.join = paint.GetStyle() == Paint::kStroke_Style
-                                 ? paint.GetStrokeJoin()
-                                 : Paint::kDefault_Join;
-  scaler_context_desc.fake_bold = font.IsEmbolden() ? 1 : 0;
-  scaler_context_desc.hinting = static_cast<uint8_t>(font.GetHinting());
+  Matrix22 raster_transform =
+      load_sdf ? Matrix22{}
+               : Matrix22{transform.GetScaleX(), transform.GetSkewX(),
+                          transform.GetSkewY(), transform.GetScaleY()};
+  ScalerContextDesc scaler_context_desc = ScalerContextDesc::MakeTransformed(
+      raster_font, raster_paint, load_sdf ? 1.f : context_scale,
+      raster_transform);
   GlyphKey key(glyph_id, scaler_context_desc);
 
   for (uint32_t index = 0; index < atlas_bitmap_.size(); index++) {
@@ -150,19 +140,19 @@ GlyphRegion Atlas::GenerateGlyphRegion(const Font& font, GlyphKey const& key,
     fill_paint.SetStyle(Paint::kFill_Style);
   }
 
-  resized_font.LoadGlyphBitmap(&(key.glyph_id), 1, &glyph_data, fill_paint,
-                               key.scaler_context_desc.context_scale,
-                               key.scaler_context_desc.transform.ToMatrix());
+  LoadGlyphBitmap(resized_font, key.glyph_id, &glyph_data, fill_paint,
+                  key.scaler_context_desc);
   const auto& bitmap_info = glyph_data->Image();
 
   if (fill_paint.GetStyle() == Paint::kStroke_Style &&
       fill_paint.IsAdjustStroke()) {
     const GlyphData* glyph_data_fill;
     fill_paint.SetStyle(Paint::kFill_Style);
-    resized_font.LoadGlyphBitmap(&(key.glyph_id), 1, &glyph_data_fill,
-                                 fill_paint,
-                                 key.scaler_context_desc.context_scale,
-                                 key.scaler_context_desc.transform.ToMatrix());
+    ScalerContextDesc fill_desc = ScalerContextDesc::MakeTransformed(
+        resized_font, fill_paint, key.scaler_context_desc.context_scale,
+        key.scaler_context_desc.transform);
+    LoadGlyphBitmap(resized_font, key.glyph_id, &glyph_data_fill, fill_paint,
+                    fill_desc);
     fill_paint.SetStyle(Paint::kStroke_Style);
 
     if (valid_positive_float(bitmap_info.width) &&

--- a/src/text/scaler_context_desc.cc
+++ b/src/text/scaler_context_desc.cc
@@ -41,7 +41,7 @@ Color ScalerContextDesc::GetGlyphImageForegroundColor(const Font& font,
 
 ScalerContextDesc ScalerContextDesc::MakeCanonicalized(const Font& font,
                                                        const Paint& paint) {
-  ScalerContextDesc desc;
+  ScalerContextDesc desc{};
   desc.typeface_id = font.GetTypeface()->TypefaceId();
   desc.text_size = font.GetSize();
   desc.scale_x = font.GetScaleX();
@@ -63,7 +63,7 @@ ScalerContextDesc ScalerContextDesc::MakeCanonicalized(const Font& font,
 ScalerContextDesc ScalerContextDesc::MakeTransformed(
     const Font& font, const Paint& paint, float context_scale,
     const Matrix22& transform) {
-  ScalerContextDesc desc;
+  ScalerContextDesc desc{};
   desc.typeface_id = font.GetTypeface()->TypefaceId();
   desc.text_size = font.GetSize();
   desc.scale_x = font.GetScaleX();

--- a/src/text/scaler_context_desc.hpp
+++ b/src/text/scaler_context_desc.hpp
@@ -6,9 +6,11 @@
 #define SRC_TEXT_SCALER_CONTEXT_DESC_HPP
 
 #include <cstdint>
+#include <cstring>
 #include <skity/graphic/paint.hpp>
 #include <skity/text/font.hpp>
 #include <skity/text/typeface.hpp>
+#include <type_traits>
 
 #include "src/render/text/text_transform.hpp"
 
@@ -17,40 +19,31 @@ namespace skity {
 // The underlying port accepts what kind of scale ratio.
 enum class PortScaleType { kFull, kVertical };
 
-// Make sure the objects has no padding.
 struct ScalerContextDesc {
-  // hash start
-  uint32_t typeface_id;
-  float text_size;
-  float scale_x;
-  float skew_x;
-  Matrix22 transform;
+  // The complete object representation is the cache identity. Keep every
+  // member initialized and preserve the dense-layout assertions below.
+  uint32_t typeface_id{};
+  float text_size{};
+  float scale_x{};
+  float skew_x{};
+  Matrix22 transform{};
 
   // scale ratio applied to surface
   float context_scale = 1.0f;
 
-  Color foreground_color;
+  Color foreground_color{};
 
-  float stroke_width;
-  float miter_limit;
-  Paint::Cap cap;
-  Paint::Join join;
+  float stroke_width{};
+  float miter_limit{};
+  Paint::Cap cap{};
+  Paint::Join join{};
 
-  uint8_t fake_bold;
-  uint8_t hinting;
-  // hash end
+  uint8_t fake_bold{};
+  uint8_t hinting{};
 
   friend inline bool operator==(const ScalerContextDesc& lhs,
                                 const ScalerContextDesc& rhs) {
-    return lhs.typeface_id == rhs.typeface_id &&
-           lhs.text_size == rhs.text_size && lhs.scale_x == rhs.scale_x &&
-           lhs.skew_x == rhs.skew_x && lhs.transform == rhs.transform &&
-           lhs.stroke_width == rhs.stroke_width &&
-           lhs.miter_limit == rhs.miter_limit &&
-           lhs.context_scale == rhs.context_scale && lhs.cap == rhs.cap &&
-           lhs.join == rhs.join && lhs.fake_bold == rhs.fake_bold &&
-           lhs.foreground_color == rhs.foreground_color &&
-           lhs.hinting == rhs.hinting;
+    return std::memcmp(&lhs, &rhs, sizeof(ScalerContextDesc)) == 0;
   }
 
   friend inline bool operator!=(const ScalerContextDesc& lhs,
@@ -80,6 +73,11 @@ struct ScalerContextDesc {
   }
 };
 
+static_assert(sizeof(Matrix22) == sizeof(float) * 4,
+              "Matrix22 must have no padding");
+static_assert(std::is_trivially_copyable_v<Matrix22>,
+              "Matrix22 must be trivially copyable");
+
 static_assert(sizeof(ScalerContextDesc) ==
                   sizeof(ScalerContextDesc::typeface_id) +
                       sizeof(ScalerContextDesc::text_size) +
@@ -95,6 +93,8 @@ static_assert(sizeof(ScalerContextDesc) ==
                       sizeof(ScalerContextDesc::fake_bold) +
                       sizeof(ScalerContextDesc::hinting),
               "ScalerContextDesc must have no padding");
+static_assert(std::is_trivially_copyable_v<ScalerContextDesc>,
+              "ScalerContextDesc must be trivially copyable");
 
 }  // namespace skity
 

--- a/test/ut/text/atlas_glyph_test.cc
+++ b/test/ut/text/atlas_glyph_test.cc
@@ -15,7 +15,7 @@
 
 namespace skity {
 
-TEST(AtlasGlyphTest, GlyphKeyHashIgnoresPadding) {
+TEST(AtlasGlyphTest, GlyphKeyUsesDenseObjectRepresentation) {
   // Allocate two buffers with different "garbage" bytes, ensuring proper
   // alignment.
   alignas(GlyphKey) char buffer1[sizeof(GlyphKey)];
@@ -39,19 +39,31 @@ TEST(AtlasGlyphTest, GlyphKeyHashIgnoresPadding) {
   desc.fake_bold = 0;
   desc.hinting = 0;
 
-  // Use placement new to construct GlyphKey in the dirty buffers.
-  // The padding bytes will retain the garbage values (0xAA and 0xBB).
+  // Construct in prefilled storage to verify that initialization overwrites
+  // the complete dense key representation.
   GlyphKey* key1 = new (buffer1) GlyphKey(id, desc);
   GlyphKey* key2 = new (buffer2) GlyphKey(id, desc);
 
   GlyphKey::Hash hasher;
 
-  // If the hash function hashes the entire struct including padding,
-  // this EXPECT_EQ will fail.
+  EXPECT_EQ(std::memcmp(key1, key2, sizeof(GlyphKey)), 0);
+  EXPECT_TRUE(GlyphKey::Equal{}(*key1, *key2));
   EXPECT_EQ(hasher(*key1), hasher(*key2));
 
   key1->~GlyphKey();
   key2->~GlyphKey();
+}
+
+TEST(ScalerContextDescTest, SignedZeroHasDistinctBitwiseIdentity) {
+  ScalerContextDesc positive_zero{};
+  ScalerContextDesc negative_zero{};
+  positive_zero.skew_x = 0.f;
+  negative_zero.skew_x = -0.f;
+
+  EXPECT_NE(
+      std::memcmp(&positive_zero, &negative_zero, sizeof(ScalerContextDesc)),
+      0);
+  EXPECT_NE(positive_zero, negative_zero);
 }
 
 TEST(GlyphBitmapDataTest, ResolvesTightAndExplicitRowBytes) {
@@ -66,6 +78,27 @@ TEST(GlyphBitmapDataTest, ResolvesTightAndExplicitRowBytes) {
 
   bitmap.row_bytes = 16;
   EXPECT_EQ(bitmap.RowBytes(), 16u);
+}
+
+TEST(AtlasBitmapTest, KeepsBitwiseDistinctGlyphKeysSeparate) {
+  uint8_t source = 0xFF;
+  GlyphBitmapData bitmap;
+  bitmap.width = 1;
+  bitmap.height = 1;
+  bitmap.buffer = &source;
+  bitmap.format = BitmapFormat::kGray8;
+
+  ScalerContextDesc positive_zero{};
+  ScalerContextDesc negative_zero{};
+  positive_zero.skew_x = 0.f;
+  negative_zero.skew_x = -0.f;
+
+  AtlasBitmap atlas(16, 16, 1);
+  const glm::ivec4 inserted =
+      atlas.GenerateGlyphRegion(GlyphKey(7, positive_zero), bitmap);
+  ASSERT_NE(inserted, INVALID_LOC);
+  EXPECT_EQ(atlas.GetGlyphRegion(GlyphKey(7, positive_zero)), inserted);
+  EXPECT_EQ(atlas.GetGlyphRegion(GlyphKey(7, negative_zero)), INVALID_LOC);
 }
 
 TEST(AtlasBitmapTest, CopiesGlyphWithPaddedRows) {


### PR DESCRIPTION
Make glyph cache keys independent of object padding, laying the foundation for phase-aware glyph variants.

This is the first of four commits adding subpixel glyph positioning support.