### PR TITLE
feat(gpu): support dual-source blending

### DIFF
--- a/include/skity/gpu/gpu_context_vk.hpp
+++ b/include/skity/gpu/gpu_context_vk.hpp
@@ -118,6 +118,16 @@ struct GPUContextInfoVK {
   bool enabled_device_extensions_known = false;
 
   /**
+   * Whether the user-provided logical device was created with the core
+   * `dualSrcBlend` feature enabled.
+   *
+   * Vulkan cannot query enabled core features from an existing logical
+   * device, so this must be declared explicitly. It is ignored when Skity
+   * creates the logical device.
+   */
+  bool dual_source_blending_enabled = false;
+
+  /**
    * User provided Vulkan graphics queue.
    *
    * If nullptr, the engine will use the first graphics queue if available.

--- a/module/wgx/glsl/glsl_ast_printer.cpp
+++ b/module/wgx/glsl/glsl_ast_printer.cpp
@@ -1141,8 +1141,14 @@ void AstPrinter::WriteAttribute(ast::StructMember* member, bool input) {
   auto pipeline_stage = func_->GetFunction()->GetPipelineStage();
 
   auto attr = member->GetAttribute(ast::AttributeType::kLocation);
+  auto blend_src = member->GetAttribute(ast::AttributeType::kBlendSrc);
 
-  if (attr) {
+  if (attr && blend_src && !input &&
+      pipeline_stage == ast::PipelineStage::kFragment) {
+    ss_ << "layout(location = "
+        << static_cast<ast::LocationAttribute*>(attr)->index << ", index = "
+        << static_cast<ast::BlendSrcAttribute*>(blend_src)->index << ") ";
+  } else if (attr) {
     WriteLocation(attr, pipeline_stage, input);
   }
 

--- a/module/wgx/ir/ir_module.h
+++ b/module/wgx/ir/ir_module.h
@@ -71,6 +71,10 @@ struct OutputVariable {
   // - For kLocation: location index (0, 1, 2, ...)
   uint32_t decoration_value = 0;
 
+  // Dual-source fragment outputs share one color location and use this index
+  // to distinguish the primary (0) and secondary (1) blend sources.
+  std::optional<uint32_t> blend_src_index;
+
   // Helper to set builtin decoration
   void SetBuiltin(BuiltinType builtin) {
     decoration_kind = InterfaceDecorationKind::kBuiltin;

--- a/module/wgx/lower/lower_core.cpp
+++ b/module/wgx/lower/lower_core.cpp
@@ -496,6 +496,8 @@ std::vector<ir::OutputVariable> Lowerer::ResolveOutputVars(
     return outputs;
   }
 
+  const bool is_fragment_output =
+      function->GetPipelineStage() == ast::PipelineStage::kFragment;
   const ast::StructDecl* struct_decl = ResolveStructDecl(function->return_type);
   if (struct_decl != nullptr) {
     for (uint32_t i = 0; i < struct_decl->members.size(); ++i) {
@@ -508,9 +510,10 @@ std::vector<ir::OutputVariable> Lowerer::ResolveOutputVars(
       output.name = std::string{member->name->name};
       output.type = const_cast<Lowerer*>(this)->ResolveType(member->type);
       output.member_index = i;
-      ResolveInterfaceDecorations(member->attributes, &output.decoration_kind,
-                                  &output.decoration_value,
-                                  &output.interpolation);
+      ResolveInterfaceDecorations(
+          member->attributes, &output.decoration_kind, &output.decoration_value,
+          &output.interpolation,
+          is_fragment_output ? &output.blend_src_index : nullptr);
       if (output.type == ir::kInvalidTypeId ||
           output.decoration_kind == ir::InterfaceDecorationKind::kNone) {
         continue;
@@ -522,9 +525,10 @@ std::vector<ir::OutputVariable> Lowerer::ResolveOutputVars(
 
   ir::OutputVariable output;
   output.type = const_cast<Lowerer*>(this)->ResolveType(function->return_type);
-  ResolveInterfaceDecorations(function->return_type_attrs,
-                              &output.decoration_kind, &output.decoration_value,
-                              &output.interpolation);
+  ResolveInterfaceDecorations(
+      function->return_type_attrs, &output.decoration_kind,
+      &output.decoration_value, &output.interpolation,
+      is_fragment_output ? &output.blend_src_index : nullptr);
   if (output.decoration_kind == ir::InterfaceDecorationKind::kBuiltin &&
       output.GetBuiltin() == ir::BuiltinType::kPosition) {
     output.name = "position_output";
@@ -777,7 +781,8 @@ const ast::StructDecl* Lowerer::ResolveStructDeclByName(
 void Lowerer::ResolveInterfaceDecorations(
     const std::vector<ast::Attribute*>& attributes,
     ir::InterfaceDecorationKind* decoration_kind, uint32_t* decoration_value,
-    ir::InterpolationType* interpolation) const {
+    ir::InterpolationType* interpolation,
+    std::optional<uint32_t>* blend_src_index) const {
   if (decoration_kind == nullptr || decoration_value == nullptr) {
     return;
   }
@@ -786,6 +791,9 @@ void Lowerer::ResolveInterfaceDecorations(
   *decoration_value = 0;
   if (interpolation != nullptr) {
     *interpolation = ir::InterpolationType::kNone;
+  }
+  if (blend_src_index != nullptr) {
+    *blend_src_index = std::nullopt;
   }
 
   for (auto* attr : attributes) {
@@ -825,6 +833,10 @@ void Lowerer::ResolveInterfaceDecorations(
           *interpolation = ir::InterpolationType::kPerspective;
         }
       }
+    } else if (attr->GetType() == ast::AttributeType::kBlendSrc &&
+               blend_src_index != nullptr) {
+      auto* blend_src = static_cast<const ast::BlendSrcAttribute*>(attr);
+      *blend_src_index = static_cast<uint32_t>(blend_src->index);
     }
   }
 }

--- a/module/wgx/lower/lower_internal.h
+++ b/module/wgx/lower/lower_internal.h
@@ -157,7 +157,8 @@ class Lowerer {
   void ResolveInterfaceDecorations(
       const std::vector<ast::Attribute*>& attributes,
       ir::InterfaceDecorationKind* decoration_kind, uint32_t* decoration_value,
-      ir::InterpolationType* interpolation) const;
+      ir::InterpolationType* interpolation,
+      std::optional<uint32_t>* blend_src_index = nullptr) const;
   const ir::StructMember* FindStructMember(ir::TypeId struct_type,
                                            std::string_view member_name,
                                            uint32_t* member_index) const;

--- a/module/wgx/msl/msl_ast_printer.cpp
+++ b/module/wgx/msl/msl_ast_printer.cpp
@@ -999,6 +999,26 @@ std::vector<Attribute> AstPrinter::GetAttributes(
         attrs.emplace_back(
             Attribute{"color", static_cast<uint32_t>(color_attr->index)});
       }
+    } else if (attr->GetType() == ast::AttributeType::kBlendSrc) {
+      if (entry_point_output && func_->GetFunction()->GetPipelineStage() ==
+                                    ast::PipelineStage::kFragment) {
+        bool has_location = false;
+        for (auto* output_attr : attributes) {
+          if (output_attr->GetType() == ast::AttributeType::kLocation) {
+            has_location = true;
+            break;
+          }
+        }
+        if (!has_location) {
+          continue;
+        }
+
+        // @location(0) @blend_src(n) becomes
+        // [[color(0), index(n)]] on an MSL fragment output.
+        auto blend_src_attr = static_cast<ast::BlendSrcAttribute*>(attr);
+        attrs.emplace_back(
+            Attribute{"index", static_cast<uint32_t>(blend_src_attr->index)});
+      }
     } else if (attr->GetType() == ast::AttributeType::kVertex ||
                attr->GetType() == ast::AttributeType::kFragment) {
       if (target == AttrTarget::kFunction) {

--- a/module/wgx/spirv/emitter_internal.h
+++ b/module/wgx/spirv/emitter_internal.h
@@ -172,6 +172,7 @@ class ModuleBuilder {
     ir::InterfaceDecorationKind decoration_kind =
         ir::InterfaceDecorationKind::kNone;
     uint32_t decoration_value = 0;
+    std::optional<uint32_t> blend_src_index;
     uint32_t spirv_var_id = 0;
     ir::InterpolationType interpolation = ir::InterpolationType::kNone;
 

--- a/module/wgx/spirv/module_builder.cpp
+++ b/module/wgx/spirv/module_builder.cpp
@@ -504,6 +504,7 @@ bool ModuleBuilder::Build(SectionBuffers* sections,
     info.member_index = ir_output.member_index;
     info.decoration_kind = ir_output.decoration_kind;
     info.decoration_value = ir_output.decoration_value;
+    info.blend_src_index = ir_output.blend_src_index;
     info.interpolation = ir_output.interpolation;
     output_vars_.push_back(std::move(info));
   }
@@ -865,6 +866,13 @@ void ModuleBuilder::WriteAnnotationSection() {
           &sections_->annotations, SpvOpDecorate,
           {output.spirv_var_id, static_cast<uint32_t>(SpvDecorationLocation),
            output.decoration_value});
+    }
+    if (output.decoration_kind == ir::InterfaceDecorationKind::kLocation &&
+        output.blend_src_index.has_value()) {
+      AppendInstruction(
+          &sections_->annotations, SpvOpDecorate,
+          {output.spirv_var_id, static_cast<uint32_t>(SpvDecorationIndex),
+           output.blend_src_index.value()});
     }
     if (output.interpolation == ir::InterpolationType::kFlat) {
       AppendInstruction(

--- a/module/wgx/wgsl/ast/ast_attribute.cpp
+++ b/module/wgx/wgsl/ast/ast_attribute.cpp
@@ -61,6 +61,14 @@ AttributeType BindingAttribute::GetType() const {
   return AttributeType::kBinding;
 }
 
+BlendSrcAttribute::BlendSrcAttribute(int64_t index) : index(index) {}
+
+std::string BlendSrcAttribute::GetName() const { return "blend_src"; }
+
+AttributeType BlendSrcAttribute::GetType() const {
+  return AttributeType::kBlendSrc;
+}
+
 BuiltinAttribute::BuiltinAttribute(std::string_view name) : name(name) {}
 
 std::string BuiltinAttribute::GetName() const { return "builtin"; }

--- a/module/wgx/wgsl/ast/ast_attribute.h
+++ b/module/wgx/wgsl/ast/ast_attribute.h
@@ -124,6 +124,17 @@ struct BindingAttribute : public Attribute {
   int64_t index;
 };
 
+struct BlendSrcAttribute : public Attribute {
+  explicit BlendSrcAttribute(int64_t index);
+  ~BlendSrcAttribute() override = default;
+
+  std::string GetName() const override;
+
+  AttributeType GetType() const override;
+
+  int64_t index;
+};
+
 struct BuiltinAttribute : public Attribute {
   explicit BuiltinAttribute(std::string_view name);
   ~BuiltinAttribute() override = default;

--- a/module/wgx/wgsl/parser.cpp
+++ b/module/wgx/wgsl/parser.cpp
@@ -1998,6 +1998,45 @@ Parser::Result<ast::Attribute*> Parser::Attribute() {
     return ReturnType{allocator_->Allocate<ast::BindingAttribute>(index)};
   }
 
+  if (Consume(TokenType::kIdentifier, "blend_src")) {
+    if (!Consume(TokenType::kParenLeft)) {
+      diagnosis_.message = "Expected '(' after blend_src attribute";
+      diagnosis_.line = Peek().line;
+      diagnosis_.column = Peek().column;
+      return ReturnType{State::kError};
+    }
+
+    auto exp = ConstLiteral();
+    if (exp.state != State::kSuccess) {
+      return ReturnType{State::kError};
+    }
+
+    if (!Consume(TokenType::kParenRight)) {
+      diagnosis_.message = "Expected ')' after blend_src attribute";
+      diagnosis_.line = Peek().line;
+      diagnosis_.column = Peek().column;
+      return ReturnType{State::kError};
+    }
+
+    auto const_exp = exp.GetValue();
+    if (const_exp->GetType() != ast::ExpressionType::kIntLiteral) {
+      diagnosis_.message = "Expected integer literal after blend_src attribute";
+      diagnosis_.line = Peek().line;
+      diagnosis_.column = Peek().column;
+      return ReturnType{State::kError};
+    }
+
+    auto index = static_cast<ast::IntLiteralExp*>(const_exp)->value;
+    if (index < 0 || index > 1) {
+      diagnosis_.message = "blend_src index must be 0 or 1";
+      diagnosis_.line = Peek().line;
+      diagnosis_.column = Peek().column;
+      return ReturnType{State::kError};
+    }
+
+    return ReturnType{allocator_->Allocate<ast::BlendSrcAttribute>(index)};
+  }
+
   if (Consume(TokenType::kIdentifier, "builtin")) {
     if (!Consume(TokenType::kParenLeft)) {
       diagnosis_.message = "Expected '(' after builtin attribute";

--- a/src/gpu/gl/formats_gl.h
+++ b/src/gpu/gl/formats_gl.h
@@ -132,6 +132,14 @@ constexpr GLenum ToBlendFactor(GPUBlendFactor factor) {
       return GL_ONE_MINUS_DST_ALPHA;
     case GPUBlendFactor::kSrcAlphaSaturated:
       return GL_SRC_ALPHA_SATURATE;
+    case GPUBlendFactor::kSrc1:
+      return GL_SRC1_COLOR;
+    case GPUBlendFactor::kOneMinusSrc1:
+      return GL_ONE_MINUS_SRC1_COLOR;
+    case GPUBlendFactor::kSrc1Alpha:
+      return GL_SRC1_ALPHA;
+    case GPUBlendFactor::kOneMinusSrc1Alpha:
+      return GL_ONE_MINUS_SRC1_ALPHA;
   }
 }
 

--- a/src/gpu/gl/gl_interface.cc
+++ b/src/gpu/gl/gl_interface.cc
@@ -236,6 +236,9 @@ bool GLInterface::LoadExtensions(GLADloadfunc loader) {
   ext_shader_framebuffer_fetch =
       extensions.Contains("GL_EXT_shader_framebuffer_fetch");
 
+  // GL_EXT_blend_func_extended
+  ext_blend_func_extended = extensions.Contains("GL_EXT_blend_func_extended");
+
   // GL_KHR_blend_equation_advanced
   ext_khr_blend_equation_advanced =
       extensions.Contains("GL_KHR_blend_equation_advanced");

--- a/src/gpu/gl/gl_interface.hpp
+++ b/src/gpu/gl/gl_interface.hpp
@@ -175,6 +175,7 @@ struct GLInterface {
   bool ext_multisampled_render_to_texture = false;
   bool oes_egl_image_external = false;
   bool ext_shader_framebuffer_fetch = false;
+  bool ext_blend_func_extended = false;
   bool ext_khr_blend_equation_advanced = false;
   bool ext_khr_blend_equation_advanced_coherent = false;
 

--- a/src/gpu/gl/gpu_device_gl.cc
+++ b/src/gpu/gl/gpu_device_gl.cc
@@ -20,6 +20,7 @@ namespace skity {
 GPUDeviceGL::GPUDeviceGL() {
   auto gpu_caps = std::make_unique<GPUCaps>();
   auto* gl_interface = GLInterface::GlobalInterface();
+  InitGLVersion();
   gpu_caps->supports_framebuffer_fetch =
       gl_interface->ext_shader_framebuffer_fetch;
   gpu_caps->supports_native_advanced_blend =
@@ -28,6 +29,8 @@ GPUDeviceGL::GPUDeviceGL() {
       gl_interface->ext_khr_blend_equation_advanced_coherent;
   gpu_caps->native_blend_shader_variant =
       gl_interface->ext_khr_blend_equation_advanced;
+  gpu_caps->supports_dual_source_blending =
+      !is_gles_ || gl_interface->ext_blend_func_extended;
   InitCaps(std::move(gpu_caps));
 }
 
@@ -40,10 +43,6 @@ std::unique_ptr<GPUBuffer> GPUDeviceGL::CreateBuffer(
 
 std::shared_ptr<GPUShaderFunction> GPUDeviceGL::CreateShaderFunction(
     const GPUShaderFunctionDescriptor& desc) {
-  if (gl_version_major_ == 0 && gl_version_minor_ == 0) {
-    InitGLVersion();
-  }
-
   if (desc.source_type == GPUShaderSourceType::kWGX) {
     return CreateShaderFunctionFromModule(desc);
   }
@@ -191,6 +190,9 @@ std::shared_ptr<GPUShaderFunction> GPUDeviceGL::CreateShaderFunctionFromModule(
   }
   if (desc.features.framebuffer_fetch) {
     options.extensions.push_back("GL_EXT_shader_framebuffer_fetch");
+  }
+  if (is_gles_ && desc.features.dual_source_blending) {
+    options.extensions.push_back("GL_EXT_blend_func_extended");
   }
 
   auto wgx_result = source->module->GetProgram()->WriteToGlsl(

--- a/src/gpu/gpu_caps.hpp
+++ b/src/gpu/gpu_caps.hpp
@@ -15,6 +15,7 @@ struct GPUCaps {
   bool supports_native_advanced_blend = false;
   // true => advanced blend is coherent, no per-draw barrier required.
   bool supports_native_advanced_blend_coherent = false;
+  bool supports_dual_source_blending = false;
   // Native advanced blend needs a distinct shader variant only on GL (it must
   // inject #extension GL_KHR_blend_equation_advanced). Vulkan/Metal express it
   // purely through pipeline blend state, so their native-blend fragment shader
@@ -34,6 +35,10 @@ struct GPUShaderFeature {
   // Mirrors GPUCaps::supports_native_advanced_blend — the fragment shader
   // uses the device's native advanced blend equations.
   bool native_advanced_blend = false;
+  // Mirrors GPUCaps::supports_dual_source_blending. GL ES uses this request
+  // to emit GL_EXT_blend_func_extended; other backends express the feature in
+  // their native shader output and pipeline state.
+  bool dual_source_blending = false;
 };
 
 }  // namespace skity

--- a/src/gpu/gpu_render_pipeline.hpp
+++ b/src/gpu/gpu_render_pipeline.hpp
@@ -138,6 +138,10 @@ enum class GPUBlendFactor {
   kDstAlpha,
   kOneMinusDstAlpha,
   kSrcAlphaSaturated,
+  kSrc1,
+  kOneMinusSrc1,
+  kSrc1Alpha,
+  kOneMinusSrc1Alpha,
 };
 
 // Fixed-function blend equation. kAdd is the default and covers every

--- a/src/gpu/mtl/formats_mtl.h
+++ b/src/gpu/mtl/formats_mtl.h
@@ -119,6 +119,14 @@ constexpr MTLBlendFactor ToMTLBlendFactor(GPUBlendFactor type) {
       return MTLBlendFactorOneMinusDestinationAlpha;
     case GPUBlendFactor::kSrcAlphaSaturated:
       return MTLBlendFactorSourceAlphaSaturated;
+    case GPUBlendFactor::kSrc1:
+      return MTLBlendFactorSource1Color;
+    case GPUBlendFactor::kOneMinusSrc1:
+      return MTLBlendFactorOneMinusSource1Color;
+    case GPUBlendFactor::kSrc1Alpha:
+      return MTLBlendFactorSource1Alpha;
+    case GPUBlendFactor::kOneMinusSrc1Alpha:
+      return MTLBlendFactorOneMinusSource1Alpha;
   }
   return MTLBlendFactorZero;
 }

--- a/src/gpu/mtl/gpu_device_mtl.mm
+++ b/src/gpu/mtl/gpu_device_mtl.mm
@@ -62,6 +62,13 @@ static bool SupportsFramebufferFetch(id<MTLDevice> device) {
 #endif
 }
 
+static bool SupportsDualSourceBlending() {
+  if (@available(macOS 10.12, iOS 11.0, tvOS 11.0, *)) {
+    return true;
+  }
+  return false;
+}
+
 GPUDeviceMTL::GPUDeviceMTL(id<MTLDevice> device, id<MTLCommandQueue> queue)
     : GPUDevice(),
       mtl_device_(device),
@@ -71,6 +78,7 @@ GPUDeviceMTL::GPUDeviceMTL(id<MTLDevice> device, id<MTLCommandQueue> queue)
   auto gpu_caps = std::make_unique<GPUCaps>();
   gpu_caps->supports_framebuffer_fetch = SupportsFramebufferFetch(device);
   gpu_caps->supports_host_visible_buffer = true;
+  gpu_caps->supports_dual_source_blending = SupportsDualSourceBlending();
   InitCaps(std::move(gpu_caps));
 }
 

--- a/src/gpu/vk/gpu_device_vk.cc
+++ b/src/gpu/vk/gpu_device_vk.cc
@@ -82,6 +82,14 @@ VkBlendFactor ToVkBlendFactor(GPUBlendFactor factor) {
       return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
     case GPUBlendFactor::kSrcAlphaSaturated:
       return VK_BLEND_FACTOR_SRC_ALPHA_SATURATE;
+    case GPUBlendFactor::kSrc1:
+      return VK_BLEND_FACTOR_SRC1_COLOR;
+    case GPUBlendFactor::kOneMinusSrc1:
+      return VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR;
+    case GPUBlendFactor::kSrc1Alpha:
+      return VK_BLEND_FACTOR_SRC1_ALPHA;
+    case GPUBlendFactor::kOneMinusSrc1Alpha:
+      return VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA;
   }
 
   return VK_BLEND_FACTOR_ONE;
@@ -523,6 +531,8 @@ GPUDeviceVK::GPUDeviceVK(std::shared_ptr<const VulkanContextState> state)
       state_ && state_->IsAdvancedBlendEnabled();
   gpu_caps->supports_native_advanced_blend_coherent =
       state_ && state_->IsAdvancedBlendCoherent();
+  gpu_caps->supports_dual_source_blending =
+      state_ && state_->IsDualSourceBlendingEnabled();
   InitCaps(std::move(gpu_caps));
 
   if (state_ == nullptr || state_->GetPhysicalDevice() == VK_NULL_HANDLE ||

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -1098,6 +1098,7 @@ bool VulkanContextState::InitializeDevice(const GPUContextInfoVK& info) {
   dynamic_rendering_enabled_ = false;
   advanced_blend_enabled_ = false;
   advanced_blend_coherent_ = false;
+  dual_source_blending_enabled_ = false;
   pipeline_cache_ = VK_NULL_HANDLE;
 
   if (!LoadAvailableDeviceExtensions()) {
@@ -1105,6 +1106,7 @@ bool VulkanContextState::InitializeDevice(const GPUContextInfoVK& info) {
   }
 
   if (info.logical_device != VK_NULL_HANDLE) {
+    dual_source_blending_enabled_ = info.dual_source_blending_enabled;
     logical_device_ = info.logical_device;
     functions_.get_device_proc_addr =
         info.get_device_proc_addr != nullptr
@@ -1264,10 +1266,10 @@ bool VulkanContextState::InitializeOwnedDevice() {
     feature_query_next = &adv_blend_features.pNext;
   }
 
-  if (physical_device_features.pNext != nullptr) {
-    functions_.instance.vkGetPhysicalDeviceFeatures2(physical_device_,
-                                                     &physical_device_features);
-  }
+  functions_.instance.vkGetPhysicalDeviceFeatures2(physical_device_,
+                                                   &physical_device_features);
+  dual_source_blending_enabled_ =
+      physical_device_features.features.dualSrcBlend == VK_TRUE;
 
   if (has_dynamic_rendering_extension) {
     if (dynamic_rendering_features.dynamicRendering == VK_TRUE) {
@@ -1345,6 +1347,10 @@ bool VulkanContextState::InitializeOwnedDevice() {
   device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   device_info.queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size());
   device_info.pQueueCreateInfos = queue_infos.data();
+  VkPhysicalDeviceFeatures enabled_core_features = {};
+  enabled_core_features.dualSrcBlend =
+      dual_source_blending_enabled_ ? VK_TRUE : VK_FALSE;
+  device_info.pEnabledFeatures = &enabled_core_features;
 
   void* enabled_feature_chain = nullptr;
   void** enabled_feature_next = &enabled_feature_chain;
@@ -1360,6 +1366,9 @@ bool VulkanContextState::InitializeOwnedDevice() {
     *enabled_feature_next = &adv_blend_features;
     enabled_feature_next = &adv_blend_features.pNext;
   }
+  // These structs were previously linked for feature queries. Terminate the
+  // rebuilt chain so skipped features cannot remain reachable.
+  *enabled_feature_next = nullptr;
   if (enabled_feature_chain != nullptr) {
     device_info.pNext = enabled_feature_chain;
   }
@@ -1569,6 +1578,7 @@ void VulkanContextState::Reset() {
   enabled_device_extensions_known_ = false;
   synchronization2_enabled_ = false;
   dynamic_rendering_enabled_ = false;
+  dual_source_blending_enabled_ = false;
   debug_runtime_ = {};
   functions_ = {};
   instance_ = VK_NULL_HANDLE;

--- a/src/gpu/vk/vulkan_context_state.hpp
+++ b/src/gpu/vk/vulkan_context_state.hpp
@@ -87,6 +87,10 @@ class VulkanContextState {
 
   bool IsAdvancedBlendEnabled() const { return advanced_blend_enabled_; }
 
+  bool IsDualSourceBlendingEnabled() const {
+    return dual_source_blending_enabled_;
+  }
+
   // Whether advanced blend operations are coherent (no per-draw barrier
   // needed).
   bool IsAdvancedBlendCoherent() const { return advanced_blend_coherent_; }
@@ -177,6 +181,7 @@ class VulkanContextState {
   bool dynamic_rendering_enabled_ = false;
   bool advanced_blend_enabled_ = false;
   bool advanced_blend_coherent_ = false;
+  bool dual_source_blending_enabled_ = false;
   VulkanDebugRuntimeState debug_runtime_ = {};
 #if defined(SKITY_ANDROID)
   Fn_AHardwareBuffer_describe fn_ahb_describe_ = nullptr;

--- a/test/ut/gpu/vk/gpu_context_vk_test.cc
+++ b/test/ut/gpu/vk/gpu_context_vk_test.cc
@@ -39,6 +39,21 @@ fn fs_main() -> @location(0) vec4<f32> {
 }
 )";
 
+constexpr char kDualSourceFragmentWGSL[] = R"(
+struct FSOutput {
+  @location(0) @blend_src(0) primary: vec4<f32>,
+  @location(0) @blend_src(1) secondary: vec4<f32>,
+}
+
+@fragment
+fn fs_main() -> FSOutput {
+  var output: FSOutput;
+  output.primary = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+  output.secondary = vec4<f32>(1.0);
+  return output;
+}
+)";
+
 constexpr char kUniformFragmentWGSL[] = R"(
 struct FSUniforms {
   color : vec4<f32>,
@@ -810,6 +825,38 @@ TEST_F(VulkanSharedContextTest, CreateRenderPipelineFromWGXFunctions) {
   }
 }
 
+TEST_F(VulkanSharedContextTest, CreatesDualSourcePipelineWhenEnabled) {
+  ASSERT_NE(GetContext(), nullptr);
+  auto* device = GetDevice();
+  ASSERT_NE(device, nullptr);
+  ASSERT_EQ(device->GetCaps().supports_dual_source_blending,
+            GetState()->IsDualSourceBlendingEnabled());
+  if (!device->GetCaps().supports_dual_source_blending) {
+    GTEST_SKIP() << "Vulkan device does not support dualSrcBlend";
+  }
+
+  auto vertex_function =
+      CreateWGXShaderFunction(device, kSimpleVertexWGSL, "vk_dual_source_vs",
+                              "vs_main", skity::GPUShaderStage::kVertex);
+  auto fragment_function = CreateWGXShaderFunction(
+      device, kDualSourceFragmentWGSL, "vk_dual_source_fs", "fs_main",
+      skity::GPUShaderStage::kFragment);
+  ASSERT_NE(vertex_function, nullptr);
+  ASSERT_NE(fragment_function, nullptr);
+
+  skity::GPURenderPipelineDescriptor desc = {};
+  desc.vertex_function = vertex_function;
+  desc.fragment_function = fragment_function;
+  desc.target.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.target.src_blend_factor = skity::GPUBlendFactor::kOne;
+  desc.target.dst_blend_factor = skity::GPUBlendFactor::kOneMinusSrc1Alpha;
+  desc.label = skity::GPULabel("vk_dual_source_pipeline");
+
+  auto pipeline = device->CreateRenderPipeline(desc);
+  ASSERT_NE(pipeline, nullptr);
+  EXPECT_TRUE(pipeline->IsValid());
+}
+
 TEST_F(VulkanSharedContextTest,
        CreateRenderPipelineWithDepthStencilFormatFallback) {
   ASSERT_NE(GetContext(), nullptr);
@@ -1011,6 +1058,20 @@ TEST_F(VulkanSharedContextTest, EncodeDrawCommandWithUniformBinding) {
 
   EXPECT_TRUE(command_buffer->Submit());
   GetState()->CollectPendingSubmissions(true);
+}
+
+TEST(VulkanProcLoaderTest, ExternalDeviceDefaultsDualSourceDisabled) {
+  auto bundle = CreateLegacyGPUContextForTest();
+  ASSERT_NE(bundle.context, nullptr);
+
+  auto* vk_context = static_cast<skity::GPUContextVK*>(bundle.context.get());
+  ASSERT_NE(vk_context, nullptr);
+  EXPECT_FALSE(vk_context->GetState()->IsDualSourceBlendingEnabled());
+
+  auto* context_impl = static_cast<skity::GPUContextImpl*>(vk_context);
+  auto* device = context_impl->GetGPUDevice();
+  ASSERT_NE(device, nullptr);
+  EXPECT_FALSE(device->GetCaps().supports_dual_source_blending);
 }
 
 TEST(VulkanProcLoaderTest, EncodeLegacyDrawCommandWithUniformBinding) {

--- a/test/ut/wgx/wgx_backend_name_resolution_test.cc
+++ b/test/ut/wgx/wgx_backend_name_resolution_test.cc
@@ -13,6 +13,63 @@
 
 namespace {
 
+TEST(WgxBackendNameResolutionTest, LowersDualSourceFragmentOutputs) {
+  auto program = wgx::Program::Parse(R"(
+struct FSOutput {
+  @location(0) @blend_src(0) primary: vec4<f32>,
+  @location(0) @blend_src(1) secondary: vec4<f32>,
+}
+
+@fragment
+fn fs_main() -> FSOutput {
+  return FSOutput(vec4<f32>(1.0), vec4<f32>(0.5));
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::GlslOptions glsl_options;
+  glsl_options.standard = wgx::GlslOptions::Standard::kDesktop;
+  glsl_options.major_version = 3;
+  glsl_options.minor_version = 3;
+  auto glsl_result = program->WriteToGlsl("fs_main", glsl_options);
+  ASSERT_TRUE(glsl_result.success);
+  EXPECT_NE(glsl_result.content.find("layout(location = 0, index = 0)"),
+            std::string::npos);
+  EXPECT_NE(glsl_result.content.find("layout(location = 0, index = 1)"),
+            std::string::npos);
+
+  wgx::MslOptions msl_options;
+  auto msl_result = program->WriteToMsl("fs_main", msl_options);
+  ASSERT_TRUE(msl_result.success);
+  EXPECT_NE(msl_result.content.find("[[color(0),index(0)]]"),
+            std::string::npos);
+  EXPECT_NE(msl_result.content.find("[[color(0),index(1)]]"),
+            std::string::npos);
+}
+
+TEST(WgxBackendNameResolutionTest, IgnoresDualSourceIndexWithoutLocation) {
+  auto program = wgx::Program::Parse(R"(
+struct FSOutput {
+  @builtin(position) @blend_src(1) position: vec4<f32>,
+}
+
+@fragment
+fn fs_main() -> FSOutput {
+  return FSOutput(vec4<f32>(1.0));
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::MslOptions options;
+  auto result = program->WriteToMsl("fs_main", options);
+  ASSERT_TRUE(result.success);
+  EXPECT_EQ(result.content.find("index(1)"), std::string::npos);
+}
+
 TEST(WgxBackendNameResolutionTest, RewritesGlslConflictingVariableNames) {
   auto program = wgx::Program::Parse(R"(
 @vertex

--- a/test/ut/wgx/wgx_parser_test.cc
+++ b/test/ut/wgx/wgx_parser_test.cc
@@ -9,11 +9,13 @@
 #include <string_view>
 #include <vector>
 
+#include "module/wgx/wgsl/ast/ast_attribute.h"
 #include "module/wgx/wgsl/ast/ast_function.h"
 #include "module/wgx/wgsl/ast/ast_module.h"
 #include "module/wgx/wgsl/ast/expression.h"
 #include "module/wgx/wgsl/ast/identifier.h"
 #include "module/wgx/wgsl/ast/statement.h"
+#include "module/wgx/wgsl/ast/type_decl.h"
 #include "module/wgx/wgsl/parser.h"
 #include "module/wgx/wgsl/scanner.h"
 
@@ -220,6 +222,47 @@ fn two(a: bool) -> i32 {
   auto* ret = static_cast<ReturnStatement*>(else_block->statements[0]);
   ASSERT_EQ(ret->value->GetType(), ExpressionType::kIntLiteral);
   EXPECT_EQ(static_cast<IntLiteralExp*>(ret->value)->value, 2);
+}
+
+TEST_F(WgxParserTest, ParsesBlendSourceAttribute) {
+  Parse(R"(
+struct FSOutput {
+  @location(0) @blend_src(0) primary: vec4<f32>,
+  @location(0) @blend_src(1) secondary: vec4<f32>,
+}
+
+@fragment
+fn fs_main() -> FSOutput {
+  return FSOutput(vec4<f32>(1.0), vec4<f32>(1.0));
+}
+)");
+  ASSERT_NE(module_, nullptr) << parser_->GetDiagnosis().message;
+
+  auto* type_decl = module_->GetGlobalTypeDecl("FSOutput");
+  ASSERT_NE(type_decl, nullptr);
+  ASSERT_EQ(type_decl->GetType(), wgx::ast::TypeDeclType::kStruct);
+  auto* output = static_cast<wgx::ast::StructDecl*>(type_decl);
+  ASSERT_EQ(output->members.size(), 2u);
+
+  auto* primary =
+      output->members[0]->GetAttribute(wgx::ast::AttributeType::kBlendSrc);
+  auto* secondary =
+      output->members[1]->GetAttribute(wgx::ast::AttributeType::kBlendSrc);
+  ASSERT_NE(primary, nullptr);
+  ASSERT_NE(secondary, nullptr);
+  EXPECT_EQ(static_cast<wgx::ast::BlendSrcAttribute*>(primary)->index, 0);
+  EXPECT_EQ(static_cast<wgx::ast::BlendSrcAttribute*>(secondary)->index, 1);
+}
+
+TEST_F(WgxParserTest, RejectsInvalidBlendSourceIndex) {
+  Parse(R"(
+struct FSOutput {
+  @location(0) @blend_src(2) color: vec4<f32>,
+}
+)");
+  EXPECT_EQ(module_, nullptr);
+  EXPECT_NE(parser_->GetDiagnosis().message.find("must be 0 or 1"),
+            std::string::npos);
 }
 
 }  // namespace

--- a/test/ut/wgx/wgx_spirv_smoke_test.cc
+++ b/test/ut/wgx/wgx_spirv_smoke_test.cc
@@ -120,6 +120,31 @@ bool ContainsDecoration(const std::vector<uint32_t>& words,
   return false;
 }
 
+bool ContainsDecorationValue(const std::vector<uint32_t>& words,
+                             SpvDecoration decoration, uint32_t value) {
+  size_t offset = 5u;
+  while (offset < words.size()) {
+    const uint32_t inst = words[offset];
+    const uint16_t word_count =
+        static_cast<uint16_t>(inst >> SpvWordCountShift);
+    const auto opcode = static_cast<SpvOp>(inst & SpvOpCodeMask);
+
+    if (word_count == 0u) {
+      return false;
+    }
+
+    if (opcode == SpvOpDecorate && word_count >= 4u &&
+        words[offset + 2u] == static_cast<uint32_t>(decoration) &&
+        words[offset + 3u] == value) {
+      return true;
+    }
+
+    offset += word_count;
+  }
+
+  return false;
+}
+
 bool ContainsMemberDecoration(const std::vector<uint32_t>& words,
                               SpvDecoration decoration) {
   size_t offset = 5u;
@@ -1151,6 +1176,64 @@ fn fs_main() -> @location(0) vec4<f32> {
   EXPECT_TRUE(ContainsDecoration(words, SpvDecorationDescriptorSet));
   EXPECT_TRUE(ContainsDecoration(words, SpvDecorationBinding));
   EXPECT_TRUE(ContainsDecoration(words, SpvDecorationLocation));
+}
+
+TEST(WgxSpirvSmokeTest, EmitsDualSourceOutputIndexDecorations) {
+  auto program = wgx::Program::Parse(R"(
+struct FSOutput {
+  @location(0) @blend_src(0) primary: vec4<f32>,
+  @location(0) @blend_src(1) secondary: vec4<f32>,
+}
+
+@fragment
+fn fs_main() -> FSOutput {
+  var output: FSOutput;
+  output.primary = vec4<f32>(1.0);
+  output.secondary = vec4<f32>(0.5);
+  return output;
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  wgx::SpirvOptions options;
+  auto result = program->WriteToSpirv("fs_main", options);
+
+  ASSERT_TRUE(result.success);
+  EXPECT_TRUE(ContainsDecorationValue(result.spirv, SpvDecorationIndex, 0u));
+  EXPECT_TRUE(ContainsDecorationValue(result.spirv, SpvDecorationIndex, 1u));
+}
+
+TEST(WgxSpirvSmokeTest, IgnoresDualSourceIndexOnVertexOutputs) {
+  auto program = wgx::Program::Parse(R"(
+struct VSOutput {
+  @builtin(position) @blend_src(1) position: vec4<f32>,
+}
+
+@vertex
+fn struct_vs_main() -> VSOutput {
+  var output: VSOutput;
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  return output;
+}
+
+@vertex
+fn direct_vs_main() -> @builtin(position) @blend_src(1) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+)");
+
+  ASSERT_NE(program, nullptr);
+  ASSERT_FALSE(program->GetDiagnosis().has_value());
+
+  for (const char* entry_point : {"struct_vs_main", "direct_vs_main"}) {
+    wgx::SpirvOptions options;
+    auto result = program->WriteToSpirv(entry_point, options);
+
+    ASSERT_TRUE(result.success);
+    EXPECT_FALSE(ContainsDecoration(result.spirv, SpvDecorationIndex));
+  }
 }
 
 TEST(WgxSpirvSmokeTest, EmitsDFdxBuiltinForFragmentShader) {


### PR DESCRIPTION
Add @blend_src fragment outputs to WGX and lower them to GLSL output indices, MSL color indices, and SPIR-V Index decorations.

Expose dual-source blend factors and capability detection across OpenGL/GLES, Metal, Vulkan, and WebGPU. This commit only provides the generic backend capability; renderer routing is added separately.