### PR TITLE
fix(capi): drop common-page-size=16384 to keep PT_GNU_RELRO within its RW PT_LOAD

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -75,7 +75,14 @@ elseif(ANDROID)
 
   # arm64
   if (CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a" OR CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64")
-    target_link_options(skity PUBLIC "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
+    # 16 KiB device compatibility only requires max-page-size (p_align).
+    # Do NOT add common-page-size=16384 here: LLD 9 (NDK r21) pads
+    # PT_GNU_RELRO.memsz up to common-page-size but does not extend the
+    # covering RW PT_LOAD, so on targets whose RW segment is mostly RELRO
+    # data (e.g. the skity-capi shim) the RELRO range can stick past the RW
+    # PT_LOAD mapping and dlopen on 4 KiB-page devices fails with a
+    # misleading "can't enable GNU RELRO protection ... Out of memory".
+    target_link_options(skity PUBLIC "-Wl,-z,max-page-size=16384")
   endif()
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   message("build for macos")

--- a/module/capi/CMakeLists.txt
+++ b/module/capi/CMakeLists.txt
@@ -66,12 +66,14 @@ endif()
 
 # Android 16 KiB page-size alignment (arm64 / x86_64), required for the .so to
 # load on Android 15+ devices with 16 KiB pages. Mirrors the option applied to
-# the core skity target in cmake/Platform.cmake.
+# the core skity target in cmake/Platform.cmake. Note that only max-page-size
+# is used (see the comment there): LLD 9 pads PT_GNU_RELRO.memsz up to
+# common-page-size but does not extend the covering RW PT_LOAD, which made
+# dlopen on 4 KiB-page devices fail for this thin RELRO-heavy shim.
 if (ANDROID)
   if (CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a" OR CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64")
     target_link_options(skity-capi PRIVATE
       "-Wl,-z,max-page-size=16384"
-      "-Wl,-z,common-page-size=16384"
     )
   endif()
 endif()


### PR DESCRIPTION
libskity-capi.so failed to load on 4 KiB-page devices with "dlopen failed: can't enable GNU RELRO protection ... Out of memory". LLD 9 (NDK r21) pads PT_GNU_RELRO.memsz up to common-page-size but does not extend the covering RW PT_LOAD. skity-capi is a thin C-ABI shim whose RW segment is almost entirely RELRO data, so the padded RELRO range stuck ~13 KiB past the RW PT_LOAD mapping and the linker's mprotect hit unmapped pages.

Stop passing -z,common-page-size=16384 for both skity and skity-capi (it was also propagated PUBLICly from the skity target, so overriding it on the capi target alone could not win link-option ordering). RELRO now pads to 4 KiB and always stays within the RW PT_LOAD's page-rounded mapping. 16 KiB device compatibility is unaffected since it only depends on max-page-size / p_align, which is unchanged.

Verified with an NDK r21 arm64-v8a Release+LTO build: llvm-readelf shows the PT_GNU_RELRO range fully covered by the RW PT_LOAD mapping under both 4 KiB and 16 KiB page semantics for libskity.so and libskity-capi.so.