### PR TITLE
feat(text): align FreeType scaler policy and glyph rasterization with Skia

### DIFF
--- a/src/text/ports/color_freetype.cc
+++ b/src/text/ports/color_freetype.cc
@@ -775,16 +775,72 @@ Path clip_box_path(ColorContext context, GlyphID glyph_id, bool untransformed) {
 
 }  // namespace
 
-bool ColorFreeType::DrawColorV1Glyph(FT_Face face, const GlyphData& glyph) {
+bool ColorFreeType::DrawColorV0Glyph(FT_Face face, const GlyphData& glyph,
+                                     uint32_t load_glyph_flags,
+                                     const Rect& raster_bounds,
+                                     const Vec2& subpixel_offset) {
   PreparePalette(face);
-  if (!PrepareCanvas(glyph)) {
+  if (!PrepareCanvas(raster_bounds)) {
+    return false;
+  }
+
+  // Skia rasterizes COLRv0 as its component outlines rather than asking
+  // FreeType to pre-compose a BGRA bitmap. This makes the packed glyph phase
+  // part of the color mask itself and keeps the result in Skity's RGBA atlas
+  // convention.
+  canvas_->Translate(-raster_bounds.Left() + subpixel_offset.x,
+                     -raster_bounds.Top() + subpixel_offset.y);
+  FT_LayerIterator iterator{0, 0, nullptr};
+  FT_UInt layer_glyph = 0;
+  FT_UInt layer_color = 0;
+  bool have_layers = false;
+  uint32_t flags = load_glyph_flags;
+  flags |= FT_LOAD_BITMAP_METRICS_ONLY;
+  flags |= FT_LOAD_NO_BITMAP;
+  flags &= ~FT_LOAD_RENDER;
+  flags &= ~FT_LOAD_COLOR;
+
+  while (FT_Get_Color_Glyph_Layer(face, glyph.Id(), &layer_glyph, &layer_color,
+                                  &iterator)) {
+    have_layers = true;
+    if (FT_Load_Glyph(face, layer_glyph, flags) != 0 ||
+        face->glyph->format != FT_GLYPH_FORMAT_OUTLINE) {
+      return false;
+    }
+
+    Path path;
+    if (!path_unitls_->GenerateGlyphPath(face, &path)) {
+      return false;
+    }
+
+    Paint paint;
+    paint.SetAntiAlias(true);
+    if (layer_color == kForegroundColorPaletteIndex) {
+      paint.SetColor(foreground_color_);
+    } else if (layer_color < palette_.size()) {
+      paint.SetColor(palette_[layer_color]);
+    } else {
+      return false;
+    }
+    canvas_->DrawPath(path, paint);
+  }
+
+  return have_layers;
+}
+
+bool ColorFreeType::DrawColorV1Glyph(FT_Face face, const GlyphData& glyph,
+                                     const Rect& raster_bounds,
+                                     const Vec2& subpixel_offset) {
+  PreparePalette(face);
+  if (!PrepareCanvas(raster_bounds)) {
     return false;
   }
 
   VisitedSet visited_set;
   ColorContext context{this,      path_unitls_,      canvas_.get(), face,
                        &palette_, foreground_color_, &visited_set};
-  context.canvas->Translate(-glyph.GetHoriBearingX(), glyph.GetHoriBearingY());
+  context.canvas->Translate(-raster_bounds.Left() + subpixel_offset.x,
+                            -raster_bounds.Top() + subpixel_offset.y);
   return start_glyph(context, glyph.Id(), FT_COLOR_INCLUDE_ROOT_TRANSFORM);
 }
 
@@ -818,12 +874,12 @@ void ColorFreeType::PreparePalette(FT_Face face) {
   }
 }
 
-bool ColorFreeType::PrepareCanvas(const GlyphData& glyph) {
+bool ColorFreeType::PrepareCanvas(const Rect& raster_bounds) {
   canvas_.reset();
   bitmap_.reset();
 
-  float width = glyph.GetWidth();
-  float height = glyph.GetHeight();
+  float width = raster_bounds.Width();
+  float height = raster_bounds.Height();
   constexpr float kMaxBitmapSize =
       static_cast<float>(std::numeric_limits<uint32_t>::max());
 

--- a/src/text/ports/color_freetype.hpp
+++ b/src/text/ports/color_freetype.hpp
@@ -23,15 +23,22 @@ class ColorFreeType {
   explicit ColorFreeType(PathFreeType* path_unitls)
       : path_unitls_(path_unitls) {}
 
-  bool DrawColorV1Glyph(FT_Face face, const GlyphData& glyph);
+  bool DrawColorV0Glyph(FT_Face face, const GlyphData& glyph,
+                        uint32_t load_glyph_flags, const Rect& raster_bounds,
+                        const Vec2& subpixel_offset);
+
+  bool DrawColorV1Glyph(FT_Face face, const GlyphData& glyph,
+                        const Rect& raster_bounds, const Vec2& subpixel_offset);
 
   bool ComputeColorV1Glyph(FT_Face face, const GlyphData& glyph, Rect* bounds);
 
   Bitmap* GetBitmap() { return bitmap_.get(); }
 
+  void SetForegroundColor(Color color) { foreground_color_ = color; }
+
  private:
   void PreparePalette(FT_Face face);
-  bool PrepareCanvas(const GlyphData& glyph);
+  bool PrepareCanvas(const Rect& raster_bounds);
 
   [[maybe_unused]] PathFreeType* path_unitls_ = nullptr;
 

--- a/src/text/ports/scaler_context_freetype.cc
+++ b/src/text/ports/scaler_context_freetype.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <limits>
 #include <skity/geometry/stroke.hpp>
+#include <vector>
 
 #include "src/base/fixed_types.hpp"
 #include "src/render/sw/sw_a8_drawable.hpp"
@@ -69,6 +70,220 @@ void SetGlyphBitmapOrigin(GlyphBitmapData* image, FT_Pos bitmap_left,
   // physical-pixel grid instead of applying the phase twice.
   image->origin_x = (bitmap_left - offset.x) / context_scale;
   image->origin_y = (bitmap_top + offset.y) / context_scale;
+}
+
+bool RasterizeOutline(FT_GlyphSlot slot, const GlyphSubpixelOffset& offset,
+                      float context_scale, GlyphBitmapData* image) {
+  if (slot == nullptr || image == nullptr || context_scale <= 0.f ||
+      slot->format != FT_GLYPH_FORMAT_OUTLINE) {
+    return false;
+  }
+
+  FT_BBox bbox;
+  FT_Outline_Get_CBox(&slot->outline, &bbox);
+  const FT_Pos x_min = bbox.xMin + offset.ft_x;
+  const FT_Pos x_max = bbox.xMax + offset.ft_x;
+  const FT_Pos y_min = bbox.yMin + offset.ft_y;
+  const FT_Pos y_max = bbox.yMax + offset.ft_y;
+  const FT_Pos left = FDot6Floor(x_min);
+  const FT_Pos right = FDot6Ceil(x_max);
+  const FT_Pos bottom = FDot6Floor(y_min);
+  const FT_Pos top = FDot6Ceil(y_max);
+  if (right <= left || top <= bottom ||
+      static_cast<uint64_t>(right - left) >
+          std::numeric_limits<unsigned int>::max() ||
+      static_cast<uint64_t>(top - bottom) >
+          std::numeric_limits<unsigned int>::max()) {
+    return false;
+  }
+
+  // Skia's A8 FreeType path applies the packed phase and aligns the
+  // phase-shifted outline bounds to the destination bitmap in one translate.
+  // This keeps negative coordinates on floor semantics and prevents
+  // FT_Render_Glyph from choosing a different implicit mask extent.
+  const FT_Pos x_shift = offset.ft_x - left * 64;
+  const FT_Pos y_shift = offset.ft_y - bottom * 64;
+  FT_Outline_Translate(&slot->outline, x_shift, y_shift);
+
+  FT_Bitmap target{};
+  target.width = static_cast<unsigned int>(right - left);
+  target.rows = static_cast<unsigned int>(top - bottom);
+  target.pitch = static_cast<int>(target.width);
+  target.pixel_mode = FT_PIXEL_MODE_GRAY;
+  target.num_grays = 256;
+
+  const size_t row_bytes = static_cast<size_t>(target.pitch);
+  if (target.rows > 0u &&
+      row_bytes > std::numeric_limits<size_t>::max() / target.rows) {
+    return false;
+  }
+  std::vector<uint8_t> pixels(row_bytes * target.rows, 0u);
+  target.buffer = pixels.data();
+  if (FT_Outline_Get_Bitmap(slot->library, &slot->outline, &target) != 0 ||
+      !internal::CopyFreetypeBitmap(target, image)) {
+    return false;
+  }
+
+  SetGlyphBitmapOrigin(image, left, top, offset, context_scale);
+  return true;
+}
+
+Rect GetColorRasterBounds(const GlyphData& glyph,
+                          const GlyphSubpixelOffset& offset) {
+  const float left = glyph.GetHoriBearingX() + offset.x;
+  const float top = -glyph.GetHoriBearingY() + offset.y;
+  return Rect::MakeLTRB(std::floor(left), std::floor(top),
+                        std::ceil(left + glyph.GetWidth()),
+                        std::ceil(top + glyph.GetHeight()));
+}
+
+bool ShouldSubpixelBitmap(FT_Face face, const ScalerContextDesc& desc,
+                          FT_GlyphSlot slot, const Matrix22& transform,
+                          const GlyphSubpixelOffset& offset) {
+  const bool mechanism =
+      slot != nullptr && slot->format == FT_GLYPH_FORMAT_BITMAP &&
+      desc.subpixel_positioning && (offset.ft_x != 0 || offset.ft_y != 0);
+  // Match Skia's policy: bitmap-only faces always resample for phase, while a
+  // scalable face's embedded strike is only phase-resampled when another
+  // transform already requires filtering.
+  const bool policy =
+      face != nullptr && (!FT_IS_SCALABLE(face) || !transform.IsIdentity());
+  return mechanism && policy;
+}
+
+bool IsAxisAlignedForHinting(const ScalerContextDesc& desc) {
+  const Matrix22 transform = desc.GetTransformMatrix();
+  const bool keeps_device_axes =
+      transform.GetSkewX() == 0.f && transform.GetSkewY() == 0.f;
+  const bool swaps_device_axes =
+      transform.GetScaleX() == 0.f && transform.GetScaleY() == 0.f;
+  // This is Skia's FreeType isAxisAligned(rec) predicate. Font skew is part of
+  // the pre-transform and therefore also makes grid-aligned hinting unsafe.
+  return desc.skew_x == 0.f && (keeps_device_axes || swaps_device_axes);
+}
+
+bool RasterizeBitmap(FT_GlyphSlot slot, Matrix bitmap_transform,
+                     const GlyphSubpixelOffset& offset,
+                     bool apply_subpixel_offset, float context_scale,
+                     GlyphBitmapData* image) {
+  if (slot == nullptr || image == nullptr || context_scale <= 0.f ||
+      slot->format != FT_GLYPH_FORMAT_BITMAP) {
+    return false;
+  }
+
+  if (apply_subpixel_offset) {
+    bitmap_transform.PostTranslate(offset.x, offset.y);
+  }
+
+  if (bitmap_transform.IsIdentity()) {
+    if (!internal::CopyFreetypeBitmap(slot->bitmap, image)) {
+      return false;
+    }
+    // Skia leaves a scalable strike un-resampled when its adjusted bitmap
+    // transform is identity, so the packed phase does not enter the mask
+    // bounds. Skity's run position already contains that phase; cancel it in
+    // the bitmap origin just as the phase-aware branches do, otherwise phase
+    // 3 crosses the nearest-sampled pixel boundary and shifts the whole glyph.
+    SetGlyphBitmapOrigin(image, slot->bitmap_left, slot->bitmap_top, offset,
+                         context_scale);
+    return true;
+  }
+
+  GlyphBitmapData source;
+  if (!internal::CopyFreetypeBitmap(slot->bitmap, &source)) {
+    return false;
+  }
+
+  // The atlas contract keeps native color glyph bytes in FreeType BGRA order
+  // and applies the R/B swizzle in the emoji fragment. Use an RGBA software
+  // surface here as a byte-preserving four-channel resampler; declaring the
+  // intermediate BGRA would make the software canvas convert channels before
+  // the atlas shader performs its existing swizzle.
+  const ColorType color_type =
+      source.format == BitmapFormat::kGray8 ? ColorType::kA8 : ColorType::kRGBA;
+  auto source_pixmap = std::make_shared<Pixmap>(
+      static_cast<uint32_t>(source.width), static_cast<uint32_t>(source.height),
+      AlphaType::kPremul_AlphaType, color_type);
+  if (source_pixmap->WritableAddr() == nullptr ||
+      source_pixmap->RowBytes() < source.RowBytes()) {
+    if (source.need_free) {
+      std::free(source.buffer);
+    }
+    return false;
+  }
+  for (uint32_t row = 0; row < static_cast<uint32_t>(source.height); ++row) {
+    std::memcpy(source_pixmap->WritableAddr8(0, row),
+                source.buffer + row * source.RowBytes(), source.RowBytes());
+  }
+  if (source.need_free) {
+    std::free(source.buffer);
+  }
+
+  const Rect source_bounds =
+      Rect::MakeXYWH(static_cast<float>(slot->bitmap_left),
+                     -static_cast<float>(slot->bitmap_top),
+                     static_cast<float>(slot->bitmap.width),
+                     static_cast<float>(slot->bitmap.rows));
+  const Rect mapped_bounds = bitmap_transform.MapRect(source_bounds);
+  if (!mapped_bounds.IsFinite() || mapped_bounds.IsEmpty()) {
+    return false;
+  }
+
+  const float left = std::floor(mapped_bounds.Left());
+  const float top = std::floor(mapped_bounds.Top());
+  const float right = std::ceil(mapped_bounds.Right());
+  const float bottom = std::ceil(mapped_bounds.Bottom());
+  const double width = static_cast<double>(right) - left;
+  const double height = static_cast<double>(bottom) - top;
+  if (!(width > 0.0 && height > 0.0) ||
+      width > std::numeric_limits<uint32_t>::max() ||
+      height > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  Bitmap destination(static_cast<uint32_t>(width),
+                     static_cast<uint32_t>(height),
+                     AlphaType::kPremul_AlphaType, color_type);
+  auto canvas = Canvas::MakeSoftwareCanvas(&destination);
+  auto source_image = Image::MakeImage(source_pixmap, nullptr);
+  if (!canvas || !source_image) {
+    return false;
+  }
+
+  // This is Skia's native-bitmap path: round out the transformed mask bounds,
+  // translate them to the destination origin, then linearly resample the
+  // strike. A packed phase is a post-translation on the bitmap transform.
+  canvas->Translate(-left, -top);
+  canvas->Concat(bitmap_transform);
+  canvas->Translate(slot->bitmap_left, -slot->bitmap_top);
+  SamplingOptions options;
+  options.filter = FilterMode::kLinear;
+  options.mipmap = MipmapMode::kNearest;
+  canvas->DrawImage(source_image, 0, 0, options);
+
+  const size_t row_bytes = destination.RowBytes();
+  if (destination.Height() > 0u &&
+      row_bytes > std::numeric_limits<size_t>::max() / destination.Height()) {
+    return false;
+  }
+  const size_t byte_count = row_bytes * destination.Height();
+  auto* pixels = static_cast<uint8_t*>(std::malloc(byte_count));
+  if (pixels == nullptr) {
+    return false;
+  }
+  std::memcpy(pixels, destination.GetPixelAddr(), byte_count);
+
+  image->buffer = pixels;
+  image->need_free = true;
+  image->width = destination.Width();
+  image->height = destination.Height();
+  image->row_bytes = row_bytes;
+  image->format = source.format;
+  const float phase_x = apply_subpixel_offset ? offset.x : 0.f;
+  const float phase_y = apply_subpixel_offset ? offset.y : 0.f;
+  image->origin_x = (left - phase_x) / context_scale;
+  image->origin_y = (-top + phase_y) / context_scale;
+  return true;
 }
 
 }  // namespace
@@ -224,15 +439,25 @@ ScalerContextFreetype::ScalerContextFreetype(
     return;
   }
   FT_Int32 load_flags = FT_LOAD_DEFAULT;
+  bool linear_metrics = desc->IsLinearMetrics();
+  Font::FontHinting hinting = desc->GetHinting();
+  if (!IsAxisAlignedForHinting(*desc)) {
+    // Skia's FreeType typeface filters non-axis-aligned strikes to unhinted
+    // outlines before constructing the scaler. Hinting against the original
+    // pixel grid would otherwise distort rotated or skewed glyphs.
+    hinting = Font::FontHinting::kNone;
+  }
 
-  switch (desc->GetHinting()) {
+  // Keep the A8 load-flag mapping synchronized with Skia's
+  // SkScalerContext_FreeType constructor.
+  switch (hinting) {
     case Font::FontHinting::kNone:
       load_flags = FT_LOAD_NO_HINTING;
-      linear_metrics_ = true;
+      linear_metrics = true;
       break;
     case Font::FontHinting::kSlight:
       load_flags = FT_LOAD_TARGET_LIGHT;
-      linear_metrics_ = true;
+      linear_metrics = true;
       break;
     case Font::FontHinting::kNormal:
     case Font::FontHinting::kFull:
@@ -243,8 +468,14 @@ ScalerContextFreetype::ScalerContextFreetype(
       break;
   }
 
+  if (desc->IsForceAutoHinting()) {
+    load_flags |= FT_LOAD_FORCE_AUTOHINT;
+  }
+  if (!desc->IsEmbeddedBitmaps()) {
+    load_flags |= FT_LOAD_NO_BITMAP;
+  }
+
   load_flags |= FT_LOAD_IGNORE_GLOBAL_ADVANCE_WIDTH;
-  load_flags |= FT_LOAD_COLOR;
 
   load_glyph_flags_ = load_flags;
   using DoneFTSize = FunctionWrapper<decltype(FT_Done_Size), FT_Done_Size>;
@@ -305,8 +536,9 @@ ScalerContextFreetype::ScalerContextFreetype(
         Matrix22(text_scale_.x / ft_face_->Face()->size->metrics.x_ppem, 0, 0,
                  text_scale_.y / ft_face_->Face()->size->metrics.y_ppem);
     load_glyph_flags_ &= ~FT_LOAD_NO_BITMAP;
+    load_glyph_flags_ |= FT_LOAD_COLOR;
     // FreeType does not provide linear metrics for bitmap fonts.
-    linear_metrics_ = false;
+    linear_metrics = false;
   } else {
     return;
   }
@@ -323,6 +555,7 @@ ScalerContextFreetype::ScalerContextFreetype(
 
   ft_size_ = ftSize.release();
   face_ = ft_face_->Face();
+  linear_metrics_ = linear_metrics;
 }
 
 ScalerContextFreetype::~ScalerContextFreetype() {
@@ -582,46 +815,56 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID id, GlyphData* glyph,
     return;
   }
 
-  if (FT_IS_SCALABLE(face_) && glyph->color_type_ == GlyphColorType::kColorV1) {
-    FT_OpaquePaint opaqueLayerPaint{nullptr, 1};
-    if (FT_Get_Color_Glyph_Paint(face_, glyph->Id(),
-                                 FT_COLOR_INCLUDE_ROOT_TRANSFORM,
-                                 &opaqueLayerPaint)) {
-      if (!color_utils_->DrawColorV1Glyph(face_, *glyph)) {
-        glyph->image_ = {};
-        return;
-      }
+  const GlyphSubpixelOffset subpixel_offset = GetGlyphSubpixelOffset(desc_, id);
 
-      GlyphBitmapData& info = glyph->image_;
-      Bitmap* bitmap = color_utils_->GetBitmap();
-      if (bitmap == nullptr || bitmap->Width() == 0 || bitmap->Height() == 0) {
-        info = {};
-        return;
-      }
-
-      info.buffer = bitmap->GetPixelAddr();
-      info.width = bitmap->Width();
-      info.height = bitmap->Height();
-      info.origin_x = glyph->GetHoriBearingX() / desc_.context_scale;
-      info.origin_y = glyph->GetHoriBearingY() / desc_.context_scale;
-      info.format = BitmapFormat::kRGBA8;
-
+  if (FT_IS_SCALABLE(face_) &&
+      (glyph->color_type_ == GlyphColorType::kColorV0 ||
+       glyph->color_type_ == GlyphColorType::kColorV1)) {
+    const Rect raster_bounds = GetColorRasterBounds(*glyph, subpixel_offset);
+    color_utils_->SetForegroundColor(desc_.foreground_color);
+    const bool drew_glyph =
+        glyph->color_type_ == GlyphColorType::kColorV0
+            ? color_utils_->DrawColorV0Glyph(
+                  face_, *glyph, load_glyph_flags_, raster_bounds,
+                  {subpixel_offset.x, subpixel_offset.y})
+            : color_utils_->DrawColorV1Glyph(
+                  face_, *glyph, raster_bounds,
+                  {subpixel_offset.x, subpixel_offset.y});
+    if (!drew_glyph) {
+      glyph->image_ = {};
       return;
     }
+
+    GlyphBitmapData& info = glyph->image_;
+    Bitmap* bitmap = color_utils_->GetBitmap();
+    if (bitmap == nullptr || bitmap->Width() == 0 || bitmap->Height() == 0) {
+      info = {};
+      return;
+    }
+
+    info.buffer = bitmap->GetPixelAddr();
+    info.width = bitmap->Width();
+    info.height = bitmap->Height();
+    info.origin_x =
+        (raster_bounds.Left() - subpixel_offset.x) / desc_.context_scale;
+    info.origin_y =
+        (-raster_bounds.Top() + subpixel_offset.y) / desc_.context_scale;
+    info.format = BitmapFormat::kRGBA8;
+
+    return;
   }
 
   if (FT_Load_Glyph(face_, glyph->Id(), load_glyph_flags_)) {
     return;
   }
   EmboldenIfNeeded(glyph->Id());
-  const GlyphSubpixelOffset subpixel_offset = GetGlyphSubpixelOffset(desc_, id);
-  ApplyGlyphSubpixelOffset(face_->glyph, subpixel_offset);
 
   FT_Bitmap bitmap;
   GlyphBitmapData& info = glyph->image_;
 
   if (face_->glyph->format != FT_GLYPH_FORMAT_BITMAP) {
     if (stroke_desc.is_stroke) {
+      ApplyGlyphSubpixelOffset(face_->glyph, subpixel_offset);
       FT_Stroker stroker;
 
       int radius = static_cast<FT_Fixed>(
@@ -649,75 +892,18 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID id, GlyphData* glyph,
                            subpixel_offset, desc_.context_scale);
       FT_Done_Glyph(ft_glyph);
     } else {
-      if (FT_Render_Glyph(face_->glyph, FT_RENDER_MODE_NORMAL)) {
+      if (!RasterizeOutline(face_->glyph, subpixel_offset, desc_.context_scale,
+                            &info)) {
         return;
       }
-      bitmap = face_->glyph->bitmap;
-      if (!internal::CopyFreetypeBitmap(bitmap, &info)) {
-        return;
-      }
-      SetGlyphBitmapOrigin(&info, face_->glyph->bitmap_left,
-                           face_->glyph->bitmap_top, subpixel_offset,
-                           desc_.context_scale);
     }
   } else {
-    if (transform_matrix_.IsIdentity()) {
-      bitmap = face_->glyph->bitmap;
-      // Not use slot memory directly as slot in ft is temporary before next
-      // loading.
-      if (!internal::CopyFreetypeBitmap(bitmap, &info)) {
-        return;
-      }
-      info.origin_x = glyph->GetHoriBearingX() / desc_.context_scale;
-      info.origin_y = glyph->GetHoriBearingY() / desc_.context_scale;
-    } else {
-      // transform bitmap
-      bitmap = face_->glyph->bitmap;
-      auto pixmap = std::make_shared<Pixmap>(bitmap.width, bitmap.rows,
-                                             AlphaType::kPremul_AlphaType,
-                                             ColorType::kRGBA);
-      std::memcpy(pixmap->WritableAddr(), bitmap.buffer,
-                  bitmap.rows * bitmap.pitch);
-      auto origin_image = Image::MakeImage(pixmap, nullptr);
-
-      uint32_t dst_width = std::floor(glyph->GetWidth());
-      uint32_t dst_height = std::floor(glyph->GetHeight());
-      Bitmap dst_bitmap(dst_width, dst_height, AlphaType::kPremul_AlphaType);
-      auto canvas = skity::Canvas::MakeSoftwareCanvas(&dst_bitmap);
-
-      if (canvas) {
-        canvas->Translate(-glyph->hori_bearing_x_, glyph->hori_bearing_y_);
-        canvas->Concat(transform_matrix_.ToMatrix());
-        canvas->Translate(face_->glyph->bitmap_left, -face_->glyph->bitmap_top);
-
-        SamplingOptions options;
-        options.filter = FilterMode::kLinear;
-        options.mipmap = MipmapMode::kNearest;
-        canvas->DrawImage(origin_image, 0, 0, options);
-
-        // copy dst
-        uint32_t bytes_count = dst_width * dst_height * sizeof(uint32_t);
-        uint8_t* copy_data =
-            reinterpret_cast<uint8_t*>(std::malloc(bytes_count));
-        std::memcpy(copy_data, dst_bitmap.GetPixelAddr(), bytes_count);
-        info.buffer = copy_data;
-        info.need_free = true;
-
-        info.width = dst_width;
-        info.height = dst_height;
-        info.origin_x = glyph->GetHoriBearingX() / desc_.context_scale;
-        info.origin_y = glyph->GetHoriBearingY() / desc_.context_scale;
-        info.row_bytes = static_cast<size_t>(dst_width) * sizeof(uint32_t);
-        info.format = BitmapFormat::kRGBA8;
-      } else {
-        // transformed bitmap is invisible
-        info.buffer = nullptr;
-        info.width = 0;
-        info.height = 0;
-        info.origin_x = 0;
-        info.origin_y = 0;
-        info.format = BitmapFormat::kGray8;
-      }
+    const bool subpixel_bitmap = ShouldSubpixelBitmap(
+        face_, desc_, face_->glyph, transform_matrix_, subpixel_offset);
+    if (!RasterizeBitmap(face_->glyph, transform_matrix_.ToMatrix(),
+                         subpixel_offset, subpixel_bitmap, desc_.context_scale,
+                         &info)) {
+      info = {};
     }
   }
 }

--- a/src/text/ports/scaler_context_freetype.cc
+++ b/src/text/ports/scaler_context_freetype.cc
@@ -20,24 +20,148 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <skity/geometry/stroke.hpp>
 
 #include "src/base/fixed_types.hpp"
 #include "src/render/sw/sw_a8_drawable.hpp"
+#include "src/render/text/glyph_position.hpp"
 #include "src/tracing.hpp"
 
 namespace skity {
-static BitmapFormat ft_pixel_mode_to_fmt(FT_Pixel_Mode mode) {
-  switch (mode) {
-    case FT_PIXEL_MODE_GRAY:
-      return BitmapFormat::kGray8;
-    case FT_PIXEL_MODE_BGRA:
-      return BitmapFormat::kBGRA8;
-    default:
-      DEBUG_CHECK(false);
-      return BitmapFormat::kUnknown;
+namespace {
+
+struct GlyphSubpixelOffset {
+  float x = 0.f;
+  float y = 0.f;
+  FT_Pos ft_x = 0;
+  FT_Pos ft_y = 0;
+};
+
+GlyphSubpixelOffset GetGlyphSubpixelOffset(const ScalerContextDesc& desc,
+                                           PackedGlyphID id) {
+  if (!desc.subpixel_positioning) {
+    return {};
+  }
+
+  const uint8_t x_phase = id.GetSubpixelXPhase();
+  const uint8_t y_phase = id.GetSubpixelYPhase();
+  return {GlyphSubpixelPhase(x_phase), GlyphSubpixelPhase(y_phase),
+          static_cast<FT_Pos>(x_phase) << 4,
+          -(static_cast<FT_Pos>(y_phase) << 4)};
+}
+
+void ApplyGlyphSubpixelOffset(FT_GlyphSlot slot,
+                              const GlyphSubpixelOffset& offset) {
+  if (slot->format == FT_GLYPH_FORMAT_OUTLINE &&
+      (offset.ft_x != 0 || offset.ft_y != 0)) {
+    // Skia applies the packed device-space phase after FT_Load_Glyph. FreeType
+    // uses an upward Y axis, hence the negated Y offset above.
+    FT_Outline_Translate(&slot->outline, offset.ft_x, offset.ft_y);
   }
 }
+
+void SetGlyphBitmapOrigin(GlyphBitmapData* image, FT_Pos bitmap_left,
+                          FT_Pos bitmap_top, const GlyphSubpixelOffset& offset,
+                          float context_scale) {
+  // The run position already contains the packed phase. Cancel it from the
+  // bitmap origin so that a phase-specific mask is placed on the integer
+  // physical-pixel grid instead of applying the phase twice.
+  image->origin_x = (bitmap_left - offset.x) / context_scale;
+  image->origin_y = (bitmap_top + offset.y) / context_scale;
+}
+
+}  // namespace
+
+namespace internal {
+
+bool CopyFreetypeBitmap(const FT_Bitmap& source, GlyphBitmapData* target) {
+  if (target == nullptr) {
+    return false;
+  }
+
+  BitmapFormat format = BitmapFormat::kGray8;
+  size_t bytes_per_pixel = 1u;
+  size_t packed_source_row_bytes = 0u;
+  switch (source.pixel_mode) {
+    case FT_PIXEL_MODE_MONO:
+      packed_source_row_bytes = (source.width + 7u) / 8u;
+      break;
+    case FT_PIXEL_MODE_GRAY:
+      packed_source_row_bytes = source.width;
+      break;
+    case FT_PIXEL_MODE_BGRA:
+      format = BitmapFormat::kBGRA8;
+      bytes_per_pixel = 4u;
+      packed_source_row_bytes = static_cast<size_t>(source.width) * 4u;
+      break;
+    default:
+      return false;
+  }
+
+  const size_t source_pitch = source.pitch < 0
+                                  ? static_cast<size_t>(-int64_t{source.pitch})
+                                  : static_cast<size_t>(source.pitch);
+  const size_t target_row_bytes =
+      static_cast<size_t>(source.width) * bytes_per_pixel;
+  if ((source.width > 0u && source.rows > 0u && source.buffer == nullptr) ||
+      source_pitch < packed_source_row_bytes ||
+      (source.rows > 0u &&
+       target_row_bytes > std::numeric_limits<size_t>::max() / source.rows)) {
+    return false;
+  }
+
+  const size_t byte_count = target_row_bytes * source.rows;
+  uint8_t* pixels = byte_count == 0u
+                        ? nullptr
+                        : static_cast<uint8_t*>(std::malloc(byte_count));
+  if (byte_count != 0u && pixels == nullptr) {
+    return false;
+  }
+
+  if (byte_count == 0u) {
+    target->width = source.width;
+    target->height = source.rows;
+    target->buffer = nullptr;
+    target->row_bytes = target_row_bytes;
+    target->format = format;
+    target->need_free = false;
+    return true;
+  }
+
+  // FreeType defines `buffer` as the first logical row and `pitch` as the
+  // signed offset to the following row. This also covers upward-flow bitmaps.
+  const uint8_t* source_row = source.buffer;
+  for (size_t y = 0; y < source.rows; ++y) {
+    uint8_t* target_row = pixels + y * target_row_bytes;
+    switch (source.pixel_mode) {
+      case FT_PIXEL_MODE_MONO:
+        for (size_t x = 0; x < source.width; ++x) {
+          target_row[x] =
+              (source_row[x >> 3u] & (0x80u >> (x & 7u))) ? 0xFFu : 0u;
+        }
+        break;
+      case FT_PIXEL_MODE_GRAY:
+      case FT_PIXEL_MODE_BGRA:
+        std::memcpy(target_row, source_row, target_row_bytes);
+        break;
+      default:
+        std::free(pixels);
+        return false;
+    }
+    source_row += source.pitch;
+  }
+
+  target->width = source.width;
+  target->height = source.rows;
+  target->buffer = pixels;
+  target->row_bytes = target_row_bytes;
+  target->format = format;
+  target->need_free = pixels != nullptr;
+  return true;
+}
+
+}  // namespace internal
 /** Returns the bitmap strike equal to or just larger than the requested size.
  */
 static FT_Int ChooseBitmapStrike(FT_Face face, FT_F26Dot6 scaleY) {
@@ -450,7 +574,7 @@ static FT_Stroker_LineJoin ToFreetypeJoin(Paint::Join join) {
   }
 }
 
-void ScalerContextFreetype::GenerateImage(PackedGlyphID, GlyphData* glyph,
+void ScalerContextFreetype::GenerateImage(PackedGlyphID id, GlyphData* glyph,
                                           const StrokeDesc& stroke_desc) {
   SKITY_TRACE_EVENT(ScalerContextFreetype_GenerateImage);
   std::lock_guard<std::mutex> locker(FreetypeFace::f_t_mutex());
@@ -490,6 +614,8 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID, GlyphData* glyph,
     return;
   }
   EmboldenIfNeeded(glyph->Id());
+  const GlyphSubpixelOffset subpixel_offset = GetGlyphSubpixelOffset(desc_, id);
+  ApplyGlyphSubpixelOffset(face_->glyph, subpixel_offset);
 
   FT_Bitmap bitmap;
   GlyphBitmapData& info = glyph->image_;
@@ -514,52 +640,36 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID, GlyphData* glyph,
       glyph->hori_bearing_x_ = bitmapGlyph->left;
       glyph->hori_bearing_y_ = bitmapGlyph->top;
       bitmap = bitmapGlyph->bitmap;
-      // won't stroke bitmap glyph
-      uint8_t* copy_data =
-          reinterpret_cast<uint8_t*>(std::malloc(bitmap.rows * bitmap.pitch));
-      std::memcpy(copy_data, bitmap.buffer, bitmap.rows * bitmap.pitch);
-      info.buffer = copy_data;
-      info.need_free = true;
-      info.width = bitmap.width;
-      info.height = bitmap.rows;
-      info.origin_x = bitmapGlyph->left / desc_.context_scale;
-      info.origin_y = bitmapGlyph->top / desc_.context_scale;
-      info.format =
-          ft_pixel_mode_to_fmt(static_cast<FT_Pixel_Mode>(bitmap.pixel_mode));
+      // Won't stroke bitmap glyph. Copy before releasing ft_glyph.
+      if (!internal::CopyFreetypeBitmap(bitmap, &info)) {
+        FT_Done_Glyph(ft_glyph);
+        return;
+      }
+      SetGlyphBitmapOrigin(&info, bitmapGlyph->left, bitmapGlyph->top,
+                           subpixel_offset, desc_.context_scale);
       FT_Done_Glyph(ft_glyph);
     } else {
       if (FT_Render_Glyph(face_->glyph, FT_RENDER_MODE_NORMAL)) {
         return;
       }
       bitmap = face_->glyph->bitmap;
-      uint8_t* copy_data =
-          reinterpret_cast<uint8_t*>(std::malloc(bitmap.rows * bitmap.pitch));
-      std::memcpy(copy_data, bitmap.buffer, bitmap.rows * bitmap.pitch);
-      info.buffer = copy_data;
-      info.need_free = true;
-      info.width = bitmap.width;
-      info.height = bitmap.rows;
-      info.origin_x = face_->glyph->bitmap_left / desc_.context_scale;
-      info.origin_y = face_->glyph->bitmap_top / desc_.context_scale;
-      info.format =
-          ft_pixel_mode_to_fmt(static_cast<FT_Pixel_Mode>(bitmap.pixel_mode));
+      if (!internal::CopyFreetypeBitmap(bitmap, &info)) {
+        return;
+      }
+      SetGlyphBitmapOrigin(&info, face_->glyph->bitmap_left,
+                           face_->glyph->bitmap_top, subpixel_offset,
+                           desc_.context_scale);
     }
   } else {
     if (transform_matrix_.IsIdentity()) {
       bitmap = face_->glyph->bitmap;
       // Not use slot memory directly as slot in ft is temporary before next
       // loading.
-      uint32_t bytes_count = bitmap.rows * bitmap.pitch;
-      uint8_t* copy_data = reinterpret_cast<uint8_t*>(std::malloc(bytes_count));
-      std::memcpy(copy_data, bitmap.buffer, bytes_count);
-      info.buffer = copy_data;
-      info.need_free = true;
-      info.width = bitmap.width;
-      info.height = bitmap.rows;
+      if (!internal::CopyFreetypeBitmap(bitmap, &info)) {
+        return;
+      }
       info.origin_x = glyph->GetHoriBearingX() / desc_.context_scale;
       info.origin_y = glyph->GetHoriBearingY() / desc_.context_scale;
-      info.format =
-          ft_pixel_mode_to_fmt(static_cast<FT_Pixel_Mode>(bitmap.pixel_mode));
     } else {
       // transform bitmap
       bitmap = face_->glyph->bitmap;
@@ -597,8 +707,8 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID, GlyphData* glyph,
         info.height = dst_height;
         info.origin_x = glyph->GetHoriBearingX() / desc_.context_scale;
         info.origin_y = glyph->GetHoriBearingY() / desc_.context_scale;
-        info.format =
-            ft_pixel_mode_to_fmt(static_cast<FT_Pixel_Mode>(bitmap.pixel_mode));
+        info.row_bytes = static_cast<size_t>(dst_width) * sizeof(uint32_t);
+        info.format = BitmapFormat::kRGBA8;
       } else {
         // transformed bitmap is invisible
         info.buffer = nullptr;

--- a/src/text/ports/scaler_context_freetype.hpp
+++ b/src/text/ports/scaler_context_freetype.hpp
@@ -18,6 +18,13 @@
 #include "src/text/ports/typeface_freetype.hpp"
 #include "src/text/scaler_context.hpp"
 namespace skity {
+
+namespace internal {
+
+bool CopyFreetypeBitmap(const FT_Bitmap &source, GlyphBitmapData *target);
+
+}  // namespace internal
+
 class ScalerContextFreetype : public ScalerContext {
  public:
   ScalerContextFreetype(std::shared_ptr<TypefaceFreeType> typeface,

--- a/src/text/scaler_context_desc.cc
+++ b/src/text/scaler_context_desc.cc
@@ -21,6 +21,20 @@ Color GetPaintTextColor(const Paint& paint) {
                             : paint.GetFillColor());
 }
 
+uint8_t GetScalerFlags(const Font& font) {
+  uint8_t flags = 0;
+  if (font.IsForceAutoHinting()) {
+    flags |= ScalerContextDesc::kForceAutoHintingFlag;
+  }
+  if (font.IsEmbeddedBitmaps()) {
+    flags |= ScalerContextDesc::kEmbeddedBitmapsFlag;
+  }
+  if (font.IsLinearMetrics()) {
+    flags |= ScalerContextDesc::kLinearMetricsFlag;
+  }
+  return flags;
+}
+
 }  // namespace
 
 size_t ScalerContextDesc::hash() const {
@@ -59,6 +73,7 @@ ScalerContextDesc ScalerContextDesc::MakeCanonicalized(const Font& font,
   desc.subpixel_positioning = font.IsSubpixel() ? 1 : 0;
   desc.baseline_snap = font.IsBaselineSnap() ? 1 : 0;
   desc.edging = static_cast<uint8_t>(font.GetEdging());
+  desc.scaler_flags = GetScalerFlags(font);
 
   return desc;
 }
@@ -89,6 +104,7 @@ ScalerContextDesc ScalerContextDesc::MakeTransformed(
   desc.subpixel_positioning = font.IsSubpixel() ? 1 : 0;
   desc.baseline_snap = font.IsBaselineSnap() ? 1 : 0;
   desc.edging = static_cast<uint8_t>(font.GetEdging());
+  desc.scaler_flags = GetScalerFlags(font);
 
   return desc;
 }

--- a/src/text/scaler_context_desc.hpp
+++ b/src/text/scaler_context_desc.hpp
@@ -43,10 +43,14 @@ struct ScalerContextDesc {
   uint8_t subpixel_positioning{};
   uint8_t baseline_snap{};
   uint8_t edging{};
+  // Font options that affect scaler output but fit in one byte. Keeping these
+  // bits in the descriptor makes both scaler lookup and atlas lookup observe
+  // the same raster-policy identity without introducing structure padding.
+  uint8_t scaler_flags{};
 
-  // Keep the complete object representation initialized and free of implicit
-  // tail padding so it can be used directly as cache identity.
-  uint8_t reserved_padding{};
+  static constexpr uint8_t kForceAutoHintingFlag = 1u << 0;
+  static constexpr uint8_t kEmbeddedBitmapsFlag = 1u << 1;
+  static constexpr uint8_t kLinearMetricsFlag = 1u << 2;
 
   friend inline bool operator==(const ScalerContextDesc& lhs,
                                 const ScalerContextDesc& rhs) {
@@ -80,6 +84,18 @@ struct ScalerContextDesc {
   }
 
   Font::Edging GetEdging() const { return static_cast<Font::Edging>(edging); }
+
+  bool IsForceAutoHinting() const {
+    return (scaler_flags & kForceAutoHintingFlag) != 0;
+  }
+
+  bool IsEmbeddedBitmaps() const {
+    return (scaler_flags & kEmbeddedBitmapsFlag) != 0;
+  }
+
+  bool IsLinearMetrics() const {
+    return (scaler_flags & kLinearMetricsFlag) != 0;
+  }
 };
 
 static_assert(sizeof(Matrix22) == sizeof(float) * 4,
@@ -104,7 +120,7 @@ static_assert(sizeof(ScalerContextDesc) ==
                       sizeof(ScalerContextDesc::subpixel_positioning) +
                       sizeof(ScalerContextDesc::baseline_snap) +
                       sizeof(ScalerContextDesc::edging) +
-                      sizeof(ScalerContextDesc::reserved_padding),
+                      sizeof(ScalerContextDesc::scaler_flags),
               "ScalerContextDesc must have no padding");
 static_assert(std::is_trivially_copyable_v<ScalerContextDesc>,
               "ScalerContextDesc must be trivially copyable");

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -68,7 +68,11 @@ endif()
 
 # Place the cases that depend on specific fonts here.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT SKITY_CT_FONT))
-  target_compile_definitions(skity_unit_test PRIVATE -DSKITY_FONT_DIR="${CMAKE_SOURCE_DIR}/test/")
+  target_compile_definitions(skity_unit_test PRIVATE
+      -DFREETYPE_STATIC_LIB=1
+      -DSKITY_FONT_DIR="${CMAKE_SOURCE_DIR}/test/")
+  target_include_directories(skity_unit_test PRIVATE
+      ${CMAKE_SOURCE_DIR}/third_party/freetype2/include)
 
   target_sources(skity_unit_test PRIVATE text/typeface_test.cc)
 endif()

--- a/test/ut/text/atlas_glyph_test.cc
+++ b/test/ut/text/atlas_glyph_test.cc
@@ -334,16 +334,11 @@ TEST(AtlasGlyphTest, EdgingParticipatesInGlyphKey) {
 }
 
 TEST(AtlasGlyphTest, ScalerPolicyFlagsParticipateInGlyphKey) {
-  Font base_font(Typeface::GetDefaultTypeface(), 16.f);
-  Font configured_font = base_font;
-  configured_font.SetForceAutoHinting(true);
-  configured_font.SetEmbeddedBitmaps(true);
-  configured_font.SetLinearMetrics(true);
-
-  const ScalerContextDesc base_desc =
-      ScalerContextDesc::MakeTransformed(base_font, Paint(), 1.f, Matrix22{});
-  const ScalerContextDesc configured_desc = ScalerContextDesc::MakeTransformed(
-      configured_font, Paint(), 1.f, Matrix22{});
+  ScalerContextDesc base_desc{};
+  ScalerContextDesc configured_desc{};
+  configured_desc.scaler_flags = ScalerContextDesc::kForceAutoHintingFlag |
+                                 ScalerContextDesc::kEmbeddedBitmapsFlag |
+                                 ScalerContextDesc::kLinearMetricsFlag;
 
   EXPECT_FALSE(
       GlyphKey::Equal{}(GlyphKey(7, base_desc), GlyphKey(7, configured_desc)));

--- a/test/ut/text/atlas_glyph_test.cc
+++ b/test/ut/text/atlas_glyph_test.cc
@@ -333,6 +333,28 @@ TEST(AtlasGlyphTest, EdgingParticipatesInGlyphKey) {
       GlyphKey::Equal{}(GlyphKey(7, alias_desc), GlyphKey(7, antialias_desc)));
 }
 
+TEST(AtlasGlyphTest, ScalerPolicyFlagsParticipateInGlyphKey) {
+  Font base_font(Typeface::GetDefaultTypeface(), 16.f);
+  Font configured_font = base_font;
+  configured_font.SetForceAutoHinting(true);
+  configured_font.SetEmbeddedBitmaps(true);
+  configured_font.SetLinearMetrics(true);
+
+  const ScalerContextDesc base_desc =
+      ScalerContextDesc::MakeTransformed(base_font, Paint(), 1.f, Matrix22{});
+  const ScalerContextDesc configured_desc = ScalerContextDesc::MakeTransformed(
+      configured_font, Paint(), 1.f, Matrix22{});
+
+  EXPECT_FALSE(
+      GlyphKey::Equal{}(GlyphKey(7, base_desc), GlyphKey(7, configured_desc)));
+  EXPECT_FALSE(base_desc.IsForceAutoHinting());
+  EXPECT_FALSE(base_desc.IsEmbeddedBitmaps());
+  EXPECT_FALSE(base_desc.IsLinearMetrics());
+  EXPECT_TRUE(configured_desc.IsForceAutoHinting());
+  EXPECT_TRUE(configured_desc.IsEmbeddedBitmaps());
+  EXPECT_TRUE(configured_desc.IsLinearMetrics());
+}
+
 TEST(AtlasBitmapTest, CopiesGlyphWithPaddedRows) {
   constexpr uint32_t kAtlasWidth = 16;
   constexpr uint32_t kGlyphWidth = 3;

--- a/test/ut/text/typeface_test.cc
+++ b/test/ut/text/typeface_test.cc
@@ -32,14 +32,17 @@ struct RasterizedGlyph {
   std::vector<uint8_t> pixels;
 };
 
-RasterizedGlyph RasterizeGlyph(std::shared_ptr<Typeface> typeface,
-                               GlyphID glyph_id, uint8_t x_phase,
-                               uint8_t y_phase, float context_scale = 1.f) {
+RasterizedGlyph RasterizeGlyph(
+    std::shared_ptr<Typeface> typeface, GlyphID glyph_id, uint8_t x_phase,
+    uint8_t y_phase, float context_scale = 1.f,
+    const Matrix22& transform = Matrix22{},
+    Font::FontHinting hinting = Font::FontHinting::kNormal) {
   Font font(typeface, 48.f);
   font.SetSubpixel(true);
+  font.SetHinting(hinting);
   Paint paint;
-  ScalerContextDesc desc = ScalerContextDesc::MakeTransformed(
-      font, paint, context_scale, Matrix22{});
+  ScalerContextDesc desc =
+      ScalerContextDesc::MakeTransformed(font, paint, context_scale, transform);
   auto context = typeface->CreateScalerContext(&desc);
   EXPECT_NE(context, nullptr);
   if (!context) {
@@ -362,6 +365,25 @@ TEST(FreeTypeScalerContextTest, AppliesPackedPhaseInPhysicalPixelSpace) {
   ASSERT_FALSE(phase.pixels.empty());
   const float physical_origin = phase.origin_x * kContentScale + 0.25f;
   EXPECT_NEAR(physical_origin, std::round(physical_origin), 1e-6f);
+}
+
+TEST(FreeTypeScalerContextTest, DisablesHintingForNonAxisAlignedTransform) {
+  auto typeface = Typeface::MakeFromFile(kRobotoRegular);
+  ASSERT_NE(typeface, nullptr);
+  const GlyphID glyph_id = typeface->UnicharToGlyph('H');
+  ASSERT_NE(glyph_id, 0);
+
+  const Matrix22 y_skew{1.f, 0.f, 0.25f, 1.f};
+  const RasterizedGlyph requested_hinted = RasterizeGlyph(
+      typeface, glyph_id, 1, 1, 1.f, y_skew, Font::FontHinting::kNormal);
+  const RasterizedGlyph explicitly_unhinted = RasterizeGlyph(
+      typeface, glyph_id, 1, 1, 1.f, y_skew, Font::FontHinting::kNone);
+
+  EXPECT_FLOAT_EQ(requested_hinted.origin_x, explicitly_unhinted.origin_x);
+  EXPECT_FLOAT_EQ(requested_hinted.origin_y, explicitly_unhinted.origin_y);
+  EXPECT_EQ(requested_hinted.width, explicitly_unhinted.width);
+  EXPECT_EQ(requested_hinted.height, explicitly_unhinted.height);
+  EXPECT_EQ(requested_hinted.pixels, explicitly_unhinted.pixels);
 }
 
 TEST(FreeTypeScalerContextTest, ExpandsMonochromeBitmapToGray8) {

--- a/test/ut/text/typeface_test.cc
+++ b/test/ut/text/typeface_test.cc
@@ -4,10 +4,16 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <skity/text/font.hpp>
 #include <skity/text/font_manager.hpp>
 #include <skity/text/typeface.hpp>
+#include <vector>
 
 #include "concurrent_runner.h"
+#include "src/text/ports/scaler_context_freetype.hpp"
 #include "src/text/scaler_context.hpp"
 #include "src/text/scaler_context_desc.hpp"
 
@@ -15,6 +21,62 @@ using namespace skity;
 
 constexpr int kThreadCount = 8;
 constexpr int kIterations = 500;
+constexpr const char* kRobotoRegular =
+    SKITY_FONT_DIR "fonts/resources/Roboto-Regular.ttf";
+
+struct RasterizedGlyph {
+  float origin_x = 0.f;
+  float origin_y = 0.f;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  std::vector<uint8_t> pixels;
+};
+
+RasterizedGlyph RasterizeGlyph(std::shared_ptr<Typeface> typeface,
+                               GlyphID glyph_id, uint8_t x_phase,
+                               uint8_t y_phase, float context_scale = 1.f) {
+  Font font(typeface, 48.f);
+  font.SetSubpixel(true);
+  Paint paint;
+  ScalerContextDesc desc = ScalerContextDesc::MakeTransformed(
+      font, paint, context_scale, Matrix22{});
+  auto context = typeface->CreateScalerContext(&desc);
+  EXPECT_NE(context, nullptr);
+  if (!context) {
+    return {};
+  }
+
+  GlyphData glyph(glyph_id);
+  context->MakeGlyph(&glyph);
+  const StrokeDesc stroke_desc{false, paint.GetStrokeWidth(),
+                               paint.GetStrokeCap(), paint.GetStrokeJoin(),
+                               paint.GetStrokeMiter()};
+  context->GetImage(PackedGlyphID(glyph_id, x_phase, y_phase), &glyph,
+                    stroke_desc);
+
+  const GlyphBitmapData& image = glyph.Image();
+  RasterizedGlyph result{image.origin_x,
+                         image.origin_y,
+                         static_cast<uint32_t>(image.width),
+                         static_cast<uint32_t>(image.height),
+                         {}};
+  EXPECT_EQ(image.format, BitmapFormat::kGray8);
+  EXPECT_NE(image.buffer, nullptr);
+
+  const size_t tight_row_bytes = result.width;
+  EXPECT_GE(image.RowBytes(), tight_row_bytes);
+  if (image.buffer && image.RowBytes() >= tight_row_bytes) {
+    result.pixels.resize(tight_row_bytes * result.height);
+    for (size_t y = 0; y < result.height; ++y) {
+      std::memcpy(result.pixels.data() + y * tight_row_bytes,
+                  image.buffer + y * image.RowBytes(), tight_row_bytes);
+    }
+  }
+  if (image.need_free) {
+    std::free(image.buffer);
+  }
+  return result;
+}
 
 class TypefaceTest : public ::testing::Test {
  protected:
@@ -258,6 +320,93 @@ TEST_F(TypefaceTest, CreateScalerContextThreadSafe) {
     auto ctx = default_typeface->CreateScalerContext(&desc);
     EXPECT_NE(ctx, nullptr);
   });
+}
+
+TEST(FreeTypeScalerContextTest, RasterizesPackedSubpixelPhases) {
+  auto typeface = Typeface::MakeFromFile(kRobotoRegular);
+  ASSERT_NE(typeface, nullptr);
+  const GlyphID glyph_id = typeface->UnicharToGlyph('H');
+  ASSERT_NE(glyph_id, 0);
+
+  const RasterizedGlyph phase_0 = RasterizeGlyph(typeface, glyph_id, 0, 0);
+  const RasterizedGlyph x_phase_1 = RasterizeGlyph(typeface, glyph_id, 1, 0);
+  const RasterizedGlyph y_phase_1 = RasterizeGlyph(typeface, glyph_id, 0, 1);
+
+  ASSERT_FALSE(phase_0.pixels.empty());
+  ASSERT_FALSE(x_phase_1.pixels.empty());
+  ASSERT_FALSE(y_phase_1.pixels.empty());
+  EXPECT_TRUE(phase_0.width != x_phase_1.width ||
+              phase_0.height != x_phase_1.height ||
+              phase_0.pixels != x_phase_1.pixels);
+  EXPECT_TRUE(phase_0.width != y_phase_1.width ||
+              phase_0.height != y_phase_1.height ||
+              phase_0.pixels != y_phase_1.pixels);
+
+  EXPECT_NEAR(phase_0.origin_x, std::round(phase_0.origin_x), 1e-6f);
+  EXPECT_NEAR(x_phase_1.origin_x + 0.25f,
+              std::round(x_phase_1.origin_x + 0.25f), 1e-6f);
+  EXPECT_NEAR(y_phase_1.origin_y - 0.25f,
+              std::round(y_phase_1.origin_y - 0.25f), 1e-6f);
+}
+
+TEST(FreeTypeScalerContextTest, AppliesPackedPhaseInPhysicalPixelSpace) {
+  auto typeface = Typeface::MakeFromFile(kRobotoRegular);
+  ASSERT_NE(typeface, nullptr);
+  const GlyphID glyph_id = typeface->UnicharToGlyph('H');
+  ASSERT_NE(glyph_id, 0);
+
+  constexpr float kContentScale = 2.f;
+  const RasterizedGlyph phase =
+      RasterizeGlyph(typeface, glyph_id, 1, 0, kContentScale);
+
+  ASSERT_FALSE(phase.pixels.empty());
+  const float physical_origin = phase.origin_x * kContentScale + 0.25f;
+  EXPECT_NEAR(physical_origin, std::round(physical_origin), 1e-6f);
+}
+
+TEST(FreeTypeScalerContextTest, ExpandsMonochromeBitmapToGray8) {
+  uint8_t source_pixels[] = {0xA8u, 0x50u};
+  FT_Bitmap source{};
+  source.rows = 2;
+  source.width = 5;
+  source.pitch = 1;
+  source.buffer = source_pixels;
+  source.num_grays = 2;
+  source.pixel_mode = FT_PIXEL_MODE_MONO;
+
+  GlyphBitmapData target;
+  ASSERT_TRUE(internal::CopyFreetypeBitmap(source, &target));
+  ASSERT_NE(target.buffer, nullptr);
+  EXPECT_EQ(target.format, BitmapFormat::kGray8);
+  EXPECT_EQ(target.width, 5.f);
+  EXPECT_EQ(target.height, 2.f);
+  EXPECT_EQ(target.RowBytes(), 5u);
+  EXPECT_TRUE(target.need_free);
+
+  constexpr uint8_t kExpected[] = {0xFFu, 0u,    0xFFu, 0u,    0xFFu,
+                                   0u,    0xFFu, 0u,    0xFFu, 0u};
+  EXPECT_EQ(std::memcmp(target.buffer, kExpected, sizeof(kExpected)), 0);
+  std::free(target.buffer);
+}
+
+TEST(FreeTypeScalerContextTest, CopiesNegativePitchFromLogicalTopRow) {
+  uint8_t source_pixels[] = {0x50u, 0xA8u};
+  FT_Bitmap source{};
+  source.rows = 2;
+  source.width = 5;
+  source.pitch = -1;
+  source.buffer = source_pixels + 1;
+  source.num_grays = 2;
+  source.pixel_mode = FT_PIXEL_MODE_MONO;
+
+  GlyphBitmapData target;
+  ASSERT_TRUE(internal::CopyFreetypeBitmap(source, &target));
+  ASSERT_NE(target.buffer, nullptr);
+
+  constexpr uint8_t kExpected[] = {0xFFu, 0u,    0xFFu, 0u,    0xFFu,
+                                   0u,    0xFFu, 0u,    0xFFu, 0u};
+  EXPECT_EQ(std::memcmp(target.buffer, kExpected, sizeof(kExpected)), 0);
+  std::free(target.buffer);
 }
 
 TEST_F(TypefaceTest, GetFontDescriptorBasic) {


### PR DESCRIPTION
## Summary

- Add FreeType packed X/Y subpixel phase rasterization.
- Include scaler policy flags in glyph cache identity.
- Align outline, bitmap, and color glyph rasterization with Skia.
- Add unit coverage for subpixel phases, transforms, and bitmap handling.