### PR TITLE
refactor(hw): centralize blend plan resolution

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,7 +326,8 @@ if(${SKITY_HW_RENDERER})
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/layer/hw_sub_layer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/dst_read_strategy.cc
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/dst_read_strategy.hpp
-    ${CMAKE_CURRENT_LIST_DIR}/render/hw/native_blend.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_blend_plan.cc
+    ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_blend_plan.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_buffer_layout_map.cc
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_buffer_layout_map.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_canvas.cc
@@ -358,6 +359,7 @@ if(${SKITY_HW_RENDERER})
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_stage_buffer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_static_buffer.cc
     ${CMAKE_CURRENT_LIST_DIR}/render/hw/hw_static_buffer.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/render/hw/native_blend.hpp
   )
 
   # Dynamic shader

--- a/src/render/hw/draw/hw_draw_step.cc
+++ b/src/render/hw/draw/hw_draw_step.cc
@@ -33,7 +33,7 @@ void HWDrawStep::GenerateCommand(const HWDrawStepContext& ctx, Command* cmd,
                        static_cast<uint32_t>(bottom - top)};
 
   cmd->pipeline = GetPipeline(ctx.context, ctx.state, ctx.color_format,
-                              ctx.sample_count, ctx.blend_mode);
+                              ctx.sample_count, ctx.blend_plan);
   if (RequireStencil()) {
     const auto stencil_state = GetStencilState();
     cmd->front_stencil_compare_mask = stencil_state.front.stencil_read_mask;
@@ -58,8 +58,8 @@ void HWDrawStep::GenerateCommand(const HWDrawStepContext& ctx, Command* cmd,
 bool HWDrawStep::PrecompilePipeline(HWDrawContext* context, HWDrawState state,
                                     GPUTextureFormat target_format,
                                     uint32_t sample_count,
-                                    BlendMode blend_mode) {
-  return GetPipeline(context, state, target_format, sample_count, blend_mode) !=
+                                    const HWBlendPlan& blend_plan) {
+  return GetPipeline(context, state, target_format, sample_count, blend_plan) !=
          nullptr;
 }
 
@@ -67,17 +67,16 @@ GPURenderPipeline* HWDrawStep::GetPipeline(HWDrawContext* context,
                                            HWDrawState state,
                                            GPUTextureFormat target_format,
                                            uint32_t sample_count,
-                                           BlendMode blend_mode) {
+                                           const HWBlendPlan& blend_plan) {
   SKITY_TRACE_EVENT(HWDrawStep_GetPipeline);
 
   HWPipelineDescriptor pipeline{};
 
   if (RequireColorWrite()) {
     pipeline.color_mask = 0xF;
-    pipeline.blend_mode = blend_mode;
+    pipeline.blend_plan = blend_plan;
   } else {
     pipeline.color_mask = 0x0;
-    pipeline.blend_mode = BlendMode::kDefault;
   }
 
   pipeline.color_format = target_format;

--- a/src/render/hw/draw/hw_draw_step.hpp
+++ b/src/render/hw/draw/hw_draw_step.hpp
@@ -5,12 +5,11 @@
 #ifndef SRC_RENDER_HW_DRAW_HW_DRAW_STEP_HPP
 #define SRC_RENDER_HW_DRAW_HW_DRAW_STEP_HPP
 
-#include <skity/graphic/blend_mode.hpp>
-
 #include "src/logging.hpp"
 #include "src/render/hw/draw/hw_wgsl_fragment.hpp"
 #include "src/render/hw/draw/hw_wgsl_geometry.hpp"
 #include "src/render/hw/draw/hw_wgsl_shader_writer.hpp"
+#include "src/render/hw/hw_blend_plan.hpp"
 #include "src/render/hw/hw_draw.hpp"
 #include "src/render/hw/hw_pipeline_key.hpp"
 #include "src/render/hw/hw_shader_generator.hpp"
@@ -25,7 +24,7 @@ struct HWDrawStepContext {
   Rect scissor = {};
   GPUTextureFormat color_format = GPUTextureFormat::kRGBA8Unorm;
   uint32_t sample_count = 1;
-  BlendMode blend_mode = BlendMode::kDefault;
+  HWBlendPlan blend_plan = {};
   Vec2 scale = {1.f, 1.f};
 };
 
@@ -50,7 +49,7 @@ class HWDrawStep : public HWShaderGenerator {
 
   bool PrecompilePipeline(HWDrawContext* context, HWDrawState state,
                           GPUTextureFormat target_format, uint32_t sample_count,
-                          BlendMode blend_mode);
+                          const HWBlendPlan& blend_plan);
 
   std::string GetVertexName() const override {
     if (geometry_->IsSnippet()) {
@@ -110,7 +109,8 @@ class HWDrawStep : public HWShaderGenerator {
  private:
   GPURenderPipeline* GetPipeline(HWDrawContext* context, HWDrawState state,
                                  GPUTextureFormat target_format,
-                                 uint32_t sample_count, BlendMode blend_mode);
+                                 uint32_t sample_count,
+                                 const HWBlendPlan& blend_plan);
 
  private:
   HWWGSLGeometry* geometry_;

--- a/src/render/hw/draw/hw_dynamic_coverage_path_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_coverage_path_draw.cc
@@ -50,7 +50,7 @@ void HWDynamicCoveragePathDraw::OnGenerateDrawStep(
       enable_conflation_correction_);
   const auto& paint = path_groups_.front().paint;
   auto* fragment = GenShadingFragment(context, paint, false);
-  ConfigureShadingFragment(context, paint, GetDstReadStrategy(), fragment);
+  ConfigureShadingFragment(context, paint, GetBlendPlan(), fragment);
 
   steps.emplace_back(context->arena_allocator->Make<ColorStep>(
       geometry, fragment, CoverageType::kNone));

--- a/src/render/hw/draw/hw_dynamic_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_draw.cc
@@ -36,7 +36,7 @@ void HWDynamicDraw::OnGenerateCommand(HWDrawContext* context,
   HWDrawStepContext ctx{
       context,          state,           GetTransform(),
       GetClipValue(),   GetScissorBox(), GetColorFormat(),
-      GetSampleCount(), blend_mode_,     context->scale,
+      GetSampleCount(), GetBlendPlan(),  context->scale,
   };
 
   for (auto& step : steps_) {
@@ -51,9 +51,7 @@ void HWDynamicDraw::OnGenerateCommand(HWDrawContext* context,
 }
 
 bool HWDynamicDraw::OnMergeIfPossible(HWDraw* draw) {
-  if (blend_mode_ != static_cast<HWDynamicDraw*>(draw)->blend_mode_) {
-    return false;
-  }
+  (void)draw;
   return true;
 }
 

--- a/src/render/hw/draw/hw_dynamic_draw.hpp
+++ b/src/render/hw/draw/hw_dynamic_draw.hpp
@@ -13,7 +13,7 @@ namespace skity {
 class HWDynamicDraw : public HWDraw {
  public:
   HWDynamicDraw(Matrix transform, BlendMode blend_mode)
-      : HWDraw(transform), blend_mode_(blend_mode), steps_(), commands_() {}
+      : HWDraw(transform, blend_mode), steps_(), commands_() {}
 
   ~HWDynamicDraw() override = default;
 
@@ -36,7 +36,6 @@ class HWDynamicDraw : public HWDraw {
                                   HWDrawContext* context) = 0;
 
  private:
-  BlendMode blend_mode_;
   ArrayList<HWDrawStep*, 2> steps_;
   ArrayList<Command*, 32> commands_;
 };

--- a/src/render/hw/draw/hw_dynamic_path_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_path_draw.cc
@@ -34,7 +34,7 @@ void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
   auto geom = GenGeometry(context, false);
 
   auto frag = GenShadingFragment(context, paint_, is_stroke_);
-  ConfigureShadingFragment(context, paint_, GetDstReadStrategy(), frag);
+  ConfigureShadingFragment(context, paint_, GetBlendPlan(), frag);
 
   CoverageType coverage = CoverageType::kNone;
 
@@ -60,7 +60,7 @@ void HWDynamicPathDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
     auto geometry = GenGeometry(context, true);
 
     auto fragment = GenShadingFragment(context, paint_, is_stroke_);
-    ConfigureShadingFragment(context, paint_, GetDstReadStrategy(), fragment);
+    ConfigureShadingFragment(context, paint_, GetBlendPlan(), fragment);
 
     steps.emplace_back(context->arena_allocator->Make<ColorAAStep>(
         std::move(geometry), std::move(fragment), coverage));

--- a/src/render/hw/draw/hw_dynamic_rrect_draw.cc
+++ b/src/render/hw/draw/hw_dynamic_rrect_draw.cc
@@ -56,7 +56,7 @@ void HWDynamicRRectDraw::OnGenerateDrawStep(ArrayList<HWDrawStep*, 2>& steps,
   auto geom = arena_allocator->Make<WGSLRRectGeometry>(batch_group_);
   auto frag = GenShadingFragment(
       context, paint, paint.GetStyle() == Paint::kStroke_Style, false);
-  ConfigureShadingFragment(context, paint, GetDstReadStrategy(), frag);
+  ConfigureShadingFragment(context, paint, GetBlendPlan(), frag);
 
   steps.emplace_back(context->arena_allocator->Make<ColorStep>(
       std::move(geom), std::move(frag), CoverageType::kNone));

--- a/src/render/hw/draw/wgx_utils.cc
+++ b/src/render/hw/draw/wgx_utils.cc
@@ -834,7 +834,7 @@ HWWGSLFragment* GenShadingFragment(HWDrawContext* context, const Paint& paint,
 }
 
 void ConfigureShadingFragment(HWDrawContext* context, const Paint& paint,
-                              DstReadStrategy dst_read_strategy,
+                              const HWBlendPlan& blend_plan,
                               HWWGSLFragment* fragment) {
   if (fragment == nullptr) {
     return;
@@ -848,9 +848,9 @@ void ConfigureShadingFragment(HWDrawContext* context, const Paint& paint,
     return;
   }
 
-  if (dst_read_strategy != DstReadStrategy::kNativeBlend) {
-    fragment->SetProgrammableBlending(
-        WGXProgrammableBlending::Make(paint.GetBlendMode(), dst_read_strategy));
+  if (blend_plan.dst_read_strategy != DstReadStrategy::kNativeBlend) {
+    fragment->SetProgrammableBlending(WGXProgrammableBlending::Make(
+        blend_plan.blend_mode, blend_plan.dst_read_strategy));
   } else if (context->gpuContext->GetGPUDevice()
                  ->GetCaps()
                  .native_blend_shader_variant) {

--- a/src/render/hw/draw/wgx_utils.hpp
+++ b/src/render/hw/draw/wgx_utils.hpp
@@ -18,9 +18,9 @@ namespace skity {
 
 struct Command;
 struct HWDrawContext;
+struct HWBlendPlan;
 class HWWGSLFragment;
 class Paint;
-enum class DstReadStrategy;
 
 void UploadBindGroup(uint32_t group, const wgx::BindGroupEntry* entry,
                      Command* cmd, HWDrawContext* ctx);
@@ -72,7 +72,7 @@ HWWGSLFragment* GenShadingFragment(HWDrawContext* context, const Paint& paint,
                                    bool is_stroke, bool has_color = true);
 
 void ConfigureShadingFragment(HWDrawContext* context, const Paint& paint,
-                              DstReadStrategy dst_read_strategy,
+                              const HWBlendPlan& blend_plan,
                               HWWGSLFragment* fragment);
 /**
  * Common code generator for Gradient Shader.

--- a/src/render/hw/filters/hw_blur_filter.cc
+++ b/src/render/hw/filters/hw_blur_filter.cc
@@ -75,7 +75,7 @@ void HWBlurFilter::PrepareWGXCMD(
       },
       output_texture->GetDescriptor().format,
       1,
-      BlendMode::kDefault,
+      {},
       context->scale,
   };
 

--- a/src/render/hw/filters/hw_color_filter.cc
+++ b/src/render/hw/filters/hw_color_filter.cc
@@ -71,7 +71,7 @@ void HWColorFilter::InternalPrepareCMDWGX(
       },
       input_texture->GetDescriptor().format,
       1,
-      BlendMode::kDefault,
+      {},
       context->scale,
   };
 

--- a/src/render/hw/filters/hw_down_sampler_filter.cc
+++ b/src/render/hw/filters/hw_down_sampler_filter.cc
@@ -79,7 +79,7 @@ void HWDownSamplerFilter::PrepareCMDWGX(
       },
       input_texture->GetDescriptor().format,
       1,
-      BlendMode::kDefault,
+      {},
       context->scale,
   };
 

--- a/src/render/hw/filters/hw_filter.cc
+++ b/src/render/hw/filters/hw_filter.cc
@@ -128,7 +128,7 @@ void HWFilter::InternalDrawChildrenOutpusWGX(
         },
         color_format,
         1,
-        BlendMode::kDefault,
+        {},
         context.scale,
     };
 

--- a/src/render/hw/hw_blend_plan.cc
+++ b/src/render/hw/hw_blend_plan.cc
@@ -1,0 +1,71 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/hw/hw_blend_plan.hpp"
+
+#include "src/graphic/blend_mode_priv.hpp"
+#include "src/render/hw/native_blend.hpp"
+
+namespace skity {
+namespace {
+
+HWBlendFormula ResolveLegacyFormula(BlendMode blend_mode) {
+  switch (blend_mode) {
+    case BlendMode::kClear:
+      return {GPUBlendFactor::kZero, GPUBlendFactor::kZero};
+    case BlendMode::kSrc:
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kZero};
+    case BlendMode::kDst:
+      return {GPUBlendFactor::kZero, GPUBlendFactor::kOne};
+    case BlendMode::kSrcOver:
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kOneMinusSrcAlpha};
+    case BlendMode::kDstOver:
+      return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kOne};
+    case BlendMode::kSrcIn:
+      return {GPUBlendFactor::kDstAlpha, GPUBlendFactor::kZero};
+    case BlendMode::kDstIn:
+      return {GPUBlendFactor::kZero, GPUBlendFactor::kSrcAlpha};
+    case BlendMode::kSrcOut:
+      return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kZero};
+    case BlendMode::kDstOut:
+      return {GPUBlendFactor::kZero, GPUBlendFactor::kOneMinusSrcAlpha};
+    case BlendMode::kSrcATop:
+      return {GPUBlendFactor::kDstAlpha, GPUBlendFactor::kOneMinusSrcAlpha};
+    case BlendMode::kDstATop:
+      return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kSrcAlpha};
+    case BlendMode::kXor:
+      return {GPUBlendFactor::kOneMinusDstAlpha,
+              GPUBlendFactor::kOneMinusSrcAlpha};
+    case BlendMode::kPlus:
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kOne};
+    default:
+      // Preserve the previous fallback for Modulate, Screen, and advanced
+      // modes. Correct coverage-aware routes are added in later commits.
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kZero};
+  }
+}
+
+}  // namespace
+
+HWBlendPlan ResolveHWBlendPlan(BlendMode blend_mode, const GPUCaps& caps,
+                               bool supports_texture_copy_dst_read) {
+  return {blend_mode, ResolveDstReadStrategy(blend_mode, caps,
+                                             supports_texture_copy_dst_read)};
+}
+
+HWBlendFormula ResolveHWBlendFormula(const HWBlendPlan& blend_plan,
+                                     const GPUCaps& caps,
+                                     bool shader_side_blending) {
+  if (!shader_side_blending && caps.supports_native_advanced_blend &&
+      IsAdvancedBlendMode(blend_plan.blend_mode)) {
+    if (auto operation = ToNativeBlendOp(blend_plan.blend_mode)) {
+      return {GPUBlendFactor::kOne, GPUBlendFactor::kOneMinusSrcAlpha,
+              *operation};
+    }
+  }
+
+  return ResolveLegacyFormula(blend_plan.blend_mode);
+}
+
+}  // namespace skity

--- a/src/render/hw/hw_blend_plan.hpp
+++ b/src/render/hw/hw_blend_plan.hpp
@@ -1,0 +1,49 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_RENDER_HW_HW_BLEND_PLAN_HPP
+#define SRC_RENDER_HW_HW_BLEND_PLAN_HPP
+
+#include <skity/graphic/blend_mode.hpp>
+
+#include "src/gpu/gpu_caps.hpp"
+#include "src/gpu/gpu_render_pipeline.hpp"
+#include "src/render/hw/dst_read_strategy.hpp"
+
+namespace skity {
+
+struct HWBlendFormula {
+  GPUBlendFactor src_factor = GPUBlendFactor::kOne;
+  GPUBlendFactor dst_factor = GPUBlendFactor::kOneMinusSrcAlpha;
+  GPUBlendOperation operation = GPUBlendOperation::kAdd;
+};
+
+struct HWBlendPlan {
+  BlendMode blend_mode = BlendMode::kSrcOver;
+  DstReadStrategy dst_read_strategy = DstReadStrategy::kNonRequired;
+
+  bool operator==(const HWBlendPlan& other) const {
+    return blend_mode == other.blend_mode &&
+           dst_read_strategy == other.dst_read_strategy;
+  }
+
+  bool operator!=(const HWBlendPlan& other) const { return !(*this == other); }
+};
+
+// Records the blend mode and resolves the same destination-read route used by
+// the existing rendering pipeline. This function only centralizes that
+// decision; it does not add coverage-aware blending behavior.
+HWBlendPlan ResolveHWBlendPlan(BlendMode blend_mode, const GPUCaps& caps,
+                               bool supports_texture_copy_dst_read);
+
+// Resolves the fixed-function state for the shader variant that will actually
+// be used. Keeping this distinction preserves the existing text path, whose
+// shader is currently created before its destination-read strategy is known.
+HWBlendFormula ResolveHWBlendFormula(const HWBlendPlan& blend_plan,
+                                     const GPUCaps& caps,
+                                     bool shader_side_blending);
+
+}  // namespace skity
+
+#endif  // SRC_RENDER_HW_HW_BLEND_PLAN_HPP

--- a/src/render/hw/hw_canvas.cc
+++ b/src/render/hw/hw_canvas.cc
@@ -21,8 +21,8 @@
 #include "src/render/hw/draw/hw_dynamic_path_clip.hpp"
 #include "src/render/hw/draw/hw_dynamic_path_draw.hpp"
 #include "src/render/hw/draw/hw_dynamic_rrect_draw.hpp"
-#include "src/render/hw/dst_read_strategy.hpp"
 #include "src/render/hw/filters/hw_filters.hpp"
+#include "src/render/hw/hw_blend_plan.hpp"
 #include "src/render/hw/layer/hw_filter_layer.hpp"
 #include "src/render/paint_order.hpp"
 #include "src/render/shape.hpp"
@@ -394,7 +394,7 @@ void HWCanvas::DrawGlyphsInternal(uint32_t count, const GlyphID* glyphs,
       // TODO(ColdPaleLight): create glyph draw fragments after the dst-read
       // strategy is known, or let glyph draws rebuild programmable blending
       // state here.
-      SetupDstReadStrategyForDraw(draw, paint.GetBlendMode());
+      SetupBlendPlanForDraw(draw, paint.GetBlendMode());
       CurrentLayer()->AddDraw(draw);
     }
   }
@@ -441,7 +441,7 @@ void HWCanvas::DrawPathInternal(const Path& path, const Paint& paint,
     auto bounds = is_stroke ? paint.ComputeFastBounds(path.GetBounds())
                             : path.GetBounds();
     SetupLayerSpaceBoundsForDraw(draw, bounds);
-    SetupDstReadStrategyForDraw(draw, paint.GetBlendMode());
+    SetupBlendPlanForDraw(draw, paint.GetBlendMode());
     CurrentLayer()->AddDraw(draw);
   };
 
@@ -577,7 +577,7 @@ void HWCanvas::DrawRRectInternal(const RRect& rrect, const Paint& paint,
     auto bounds = use_stroke ? paint.ComputeFastBounds(rrect.GetBounds())
                              : rrect.GetBounds();
     SetupLayerSpaceBoundsForDraw(draw, bounds);
-    SetupDstReadStrategyForDraw(draw, paint.GetBlendMode());
+    SetupBlendPlanForDraw(draw, paint.GetBlendMode());
     CurrentLayer()->AddDraw(draw);
   };
 
@@ -855,7 +855,6 @@ HWLayer* HWCanvas::GenLayer(const Paint& paint, Rect layer_bounds,
   layer->SetArenaAllocator(arena_allocator_);
   layer->SetColorFormat(surface_->GetGPUFormat());
   layer->SetAlpha(paint.GetAlphaF());
-  layer->SetBlendMode(paint.GetBlendMode());
 
   if (surface_->GetGPUContext()->GetGPUDevice()->CanUseMSAA()) {
     layer->SetSampleCount(GetCanvasSampleCount());
@@ -865,7 +864,7 @@ HWLayer* HWCanvas::GenLayer(const Paint& paint, Rect layer_bounds,
   layer->SetLayerSpaceBounds(transformed_bounds);
   layer->SetEnableMergingDrawCall(
       surface_->GetGPUContext()->IsEnableMergingDrawCall());
-  SetupDstReadStrategyForDraw(layer, paint.GetBlendMode());
+  SetupBlendPlanForDraw(layer, paint.GetBlendMode());
   layer->SetRTOrigin(
       ResolveLayerRTOrigin(surface_->GetGPUContext()->GetBackendType()));
 
@@ -890,9 +889,9 @@ bool HWCanvas::NeesOffScreenLayer(const Paint& paint) const {
   return false;
 }
 
-void HWCanvas::SetupDstReadStrategyForDraw(HWDraw* draw, BlendMode blend_mode) {
+void HWCanvas::SetupBlendPlanForDraw(HWDraw* draw, BlendMode blend_mode) {
   const auto& caps = surface_->GetGPUContext()->GetGPUDevice()->GetCaps();
-  draw->SetDstReadStrategy(ResolveDstReadStrategy(
+  draw->SetBlendPlan(ResolveHWBlendPlan(
       blend_mode, caps, CurrentLayer()->SupportsTextureCopyDstRead()));
 }
 

--- a/src/render/hw/hw_canvas.hpp
+++ b/src/render/hw/hw_canvas.hpp
@@ -125,7 +125,7 @@ class HWCanvas : public Canvas {
         CurrentLayer()->CalculateLayerSpaceBounds(bounds, transform));
   }
 
-  void SetupDstReadStrategyForDraw(HWDraw* draw, BlendMode blend_mode);
+  void SetupBlendPlanForDraw(HWDraw* draw, BlendMode blend_mode);
 
   bool NeesOffScreenLayer(const Paint& paint) const;
 

--- a/src/render/hw/hw_draw.hpp
+++ b/src/render/hw/hw_draw.hpp
@@ -13,6 +13,7 @@
 
 #include "skity/graphic/image.hpp"
 #include "src/render/hw/draw/wgx_programmable_blending.hpp"
+#include "src/render/hw/hw_blend_plan.hpp"
 #include "src/render/hw/hw_draw_pass.hpp"
 #include "src/render/hw/hw_render_target_cache.hpp"
 #include "src/render/hw/hw_static_buffer.hpp"
@@ -77,7 +78,8 @@ inline HWDrawState operator|=(HWDrawState& lhs, HWDrawState rhs) {
 
 class HWDraw {
  public:
-  explicit HWDraw(Matrix transform) : transform_(transform) {}
+  explicit HWDraw(Matrix transform, BlendMode blend_mode = BlendMode::kSrcOver)
+      : transform_(transform), blend_plan_{blend_mode} {}
 
   virtual ~HWDraw() = default;
 
@@ -130,6 +132,10 @@ class HWDraw {
       return false;
     }
 
+    if (blend_plan_ != draw->blend_plan_) {
+      return false;
+    }
+
     bool merged = OnMergeIfPossible(draw);
     if (merged) {
       layer_space_bounds_.Join(draw->layer_space_bounds_);
@@ -141,11 +147,13 @@ class HWDraw {
 
   void SetClipDepth(uint32_t clip_depth) { clip_depth_ = clip_depth; }
 
-  DstReadStrategy GetDstReadStrategy() const { return dst_read_strategy_; }
-
-  void SetDstReadStrategy(DstReadStrategy strategy) {
-    dst_read_strategy_ = strategy;
+  DstReadStrategy GetDstReadStrategy() const {
+    return blend_plan_.dst_read_strategy;
   }
+
+  const HWBlendPlan& GetBlendPlan() const { return blend_plan_; }
+
+  void SetBlendPlan(const HWBlendPlan& blend_plan) { blend_plan_ = blend_plan; }
 
  protected:
   virtual HWDrawState OnPrepare(HWDrawContext* context) = 0;
@@ -169,7 +177,7 @@ class HWDraw {
   Rect scissor_rect_ = {};
   Rect layer_space_bounds_ = Rect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
   HWDraw* clip_draw_ = nullptr;
-  DstReadStrategy dst_read_strategy_ = DstReadStrategy::kNonRequired;
+  HWBlendPlan blend_plan_ = {};
 };
 
 }  // namespace skity

--- a/src/render/hw/hw_pipeline_lib.cc
+++ b/src/render/hw/hw_pipeline_lib.cc
@@ -4,59 +4,16 @@
 
 #include "src/render/hw/hw_pipeline_lib.hpp"
 
-#include "src/gpu/gpu_caps.hpp"
 #include "src/gpu/gpu_device.hpp"
 #include "src/gpu/gpu_shader_function.hpp"
 #include "src/gpu/gpu_shader_module.hpp"
-#include "src/graphic/blend_mode_priv.hpp"
 #include "src/logging.hpp"
 #include "src/render/hw/draw/wgx_programmable_blending.hpp"
 #include "src/render/hw/hw_pipeline_key.hpp"
 #include "src/render/hw/hw_shader_generator.hpp"
-#include "src/render/hw/native_blend.hpp"
 #include "src/tracing.hpp"
 
 namespace skity {
-
-static std::pair<GPUBlendFactor, GPUBlendFactor> get_gpu_blending(
-    BlendMode blend_mode) {
-  if (blend_mode == BlendMode::kClear) {
-    return {GPUBlendFactor::kZero, GPUBlendFactor::kZero};
-  } else if (blend_mode == BlendMode::kSrc) {
-    return {GPUBlendFactor::kOne, GPUBlendFactor::kZero};
-  } else if (blend_mode == BlendMode::kSrcOver) {
-    return {GPUBlendFactor::kOne, GPUBlendFactor::kOneMinusSrcAlpha};
-  } else if (blend_mode == BlendMode::kDst) {
-    return {GPUBlendFactor::kZero, GPUBlendFactor::kOne};
-  } else if (blend_mode == BlendMode::kDstOver) {
-    return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kOne};
-  } else if (blend_mode == BlendMode::kSrcIn) {
-    return {GPUBlendFactor::kDstAlpha, GPUBlendFactor::kZero};
-  } else if (blend_mode == BlendMode::kDstIn) {
-    return {GPUBlendFactor::kZero, GPUBlendFactor::kSrcAlpha};
-  } else if (blend_mode == BlendMode::kSrcOut) {
-    return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kZero};
-  } else if (blend_mode == BlendMode::kDstOut) {
-    return {GPUBlendFactor::kZero, GPUBlendFactor::kOneMinusSrcAlpha};
-  } else if (blend_mode == BlendMode::kSrcATop) {
-    return {GPUBlendFactor::kDstAlpha, GPUBlendFactor::kOneMinusSrcAlpha};
-  } else if (blend_mode == BlendMode::kDstATop) {
-    return {GPUBlendFactor::kOneMinusDstAlpha, GPUBlendFactor::kSrcAlpha};
-  } else if (blend_mode == BlendMode::kXor) {
-    return {GPUBlendFactor::kOneMinusDstAlpha,
-            GPUBlendFactor::kOneMinusSrcAlpha};
-  } else if (blend_mode == BlendMode::kPlus) {
-    return {GPUBlendFactor::kOne, GPUBlendFactor::kOne};
-  } else {
-    return {GPUBlendFactor::kOne, GPUBlendFactor::kZero};
-  }
-}
-
-struct BlendState {
-  GPUBlendFactor src_factor;
-  GPUBlendFactor dst_factor;
-  GPUBlendOperation op;
-};
 
 // programmable_blending packs (blend_mode | dst_read_strategy<<8) when the draw
 // reads dst inside the shader (framebuffer-fetch / texture-copy). It is 0 for
@@ -76,30 +33,6 @@ static bool UsesFramebufferFetch(uint32_t programmable_blending) {
              static_cast<uint32_t>(DstReadStrategy::kFramebufferFetch);
 }
 
-// Unified blend-state resolution shared by pipeline creation and cache matching
-// so they cannot drift apart. Native advanced blend returns
-// {kOne, kOneMinusSrcAlpha, native_op}: the GL/Vulkan advanced equations ignore
-// the RGB blend factors, while the alpha channel (kept on ADD with those
-// factors) computes exactly source-over, matching every advanced shader branch.
-//
-// shader_side_blending is true for the framebuffer-fetch / texture-copy
-// pipeline (programmable_blending holds a packed key): those draws blend inside
-// the shader, so the fixed-function equation must stay on ADD regardless of
-// mode. For every other pipeline the native equation is selected purely from
-// blend_mode + caps — which is what lets the Vulkan native path share one
-// pipeline with ordinary blends and differ only by a blend-state variant.
-static BlendState resolve_blend_state(BlendMode blend_mode, const GPUCaps& caps,
-                                      bool shader_side_blending) {
-  if (!shader_side_blending && caps.supports_native_advanced_blend &&
-      IsAdvancedBlendMode(blend_mode)) {
-    if (auto op = ToNativeBlendOp(blend_mode)) {
-      return {GPUBlendFactor::kOne, GPUBlendFactor::kOneMinusSrcAlpha, *op};
-    }
-  }
-  auto factors = get_gpu_blending(blend_mode);
-  return {factors.first, factors.second, GPUBlendOperation::kAdd};
-}
-
 static void setup_blending_state(GPURenderPipelineDescriptor& gpu_desc,
                                  const HWPipelineDescriptor& hw_desc,
                                  const GPUCaps& caps,
@@ -107,11 +40,11 @@ static void setup_blending_state(GPURenderPipelineDescriptor& gpu_desc,
   gpu_desc.target.format = hw_desc.color_format;
   gpu_desc.target.write_mask = hw_desc.color_mask;
 
-  auto blend_state =
-      resolve_blend_state(hw_desc.blend_mode, caps, shader_side_blending);
-  gpu_desc.target.src_blend_factor = blend_state.src_factor;
-  gpu_desc.target.dst_blend_factor = blend_state.dst_factor;
-  gpu_desc.target.blend_op = blend_state.op;
+  auto formula =
+      ResolveHWBlendFormula(hw_desc.blend_plan, caps, shader_side_blending);
+  gpu_desc.target.src_blend_factor = formula.src_factor;
+  gpu_desc.target.dst_blend_factor = formula.dst_factor;
+  gpu_desc.target.blend_op = formula.operation;
 }
 
 HWPipeline::HWPipeline(GPUDevice* device, GPUBackendType backend,
@@ -159,13 +92,13 @@ bool HWPipeline::PipelineMatch(GPURenderPipeline* pipeline,
 
   const auto& gpu_desc = pipeline->GetDescriptor();
 
-  auto blend_state = resolve_blend_state(
-      desc.blend_mode, gpu_device_->GetCaps(), shader_side_blending_);
+  auto formula = ResolveHWBlendFormula(desc.blend_plan, gpu_device_->GetCaps(),
+                                       shader_side_blending_);
 
   return gpu_desc.target.write_mask == desc.color_mask &&
-         gpu_desc.target.src_blend_factor == blend_state.src_factor &&
-         gpu_desc.target.dst_blend_factor == blend_state.dst_factor &&
-         gpu_desc.target.blend_op == blend_state.op &&
+         gpu_desc.target.src_blend_factor == formula.src_factor &&
+         gpu_desc.target.dst_blend_factor == formula.dst_factor &&
+         gpu_desc.target.blend_op == formula.operation &&
          gpu_desc.sample_count == static_cast<int32_t>(desc.sample_count) &&
          gpu_desc.target.format == desc.color_format;
 }

--- a/src/render/hw/hw_pipeline_lib.hpp
+++ b/src/render/hw/hw_pipeline_lib.hpp
@@ -9,13 +9,13 @@
 
 #include <memory>
 #include <skity/gpu/gpu_context.hpp>
-#include <skity/graphic/blend_mode.hpp>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "src/gpu/gpu_render_pipeline.hpp"
+#include "src/render/hw/hw_blend_plan.hpp"
 #include "src/render/hw/hw_pipeline_key.hpp"
 
 namespace skity {
@@ -35,7 +35,7 @@ struct HWPipelineDescriptor {
   int32_t color_mask = 0xF;
   uint32_t sample_count = 1;
   const std::vector<GPUVertexBufferLayout>* buffers = nullptr;
-  BlendMode blend_mode = BlendMode::kDefault;
+  HWBlendPlan blend_plan = {};
   GPUTextureFormat color_format = GPUTextureFormat::kRGBA8Unorm;
   GPUDepthStencilState depth_stencil = {};
   HWShaderGenerator* shader_generator = nullptr;

--- a/src/render/hw/layer/hw_sub_layer.cc
+++ b/src/render/hw/layer/hw_sub_layer.cc
@@ -21,7 +21,7 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
     path.AddRect(bounds);
 
     Paint paint;
-    paint.SetBlendMode(blend_mode_);
+    paint.SetBlendMode(GetBlendPlan().blend_mode);
     paint.SetAlphaF(alpha_);
     paint.SetStyle(Paint::kFill_Style);
     paint.SetShader(CreateDrawLayerShader(context->gpuContext,
@@ -36,7 +36,7 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
   layer_back_draw_->SetColorFormat(GetColorFormat());
   layer_back_draw_->SetScissorBox(GetScissorBox());
 
-  layer_back_draw_->SetDstReadStrategy(GetDstReadStrategy());
+  layer_back_draw_->SetBlendPlan(GetBlendPlan());
 
   auto state = layer_back_draw_->Prepare(context);
 

--- a/src/render/hw/layer/hw_sub_layer.hpp
+++ b/src/render/hw/layer/hw_sub_layer.hpp
@@ -24,8 +24,6 @@ class HWSubLayer : public HWLayer {
 
   void SetAlpha(float alpha) { alpha_ = alpha; }
 
-  void SetBlendMode(BlendMode blend_mode) { blend_mode_ = blend_mode; }
-
   void ExpandTextureSizeToNextPow2() {
     texture_size_ = MakeApprox(texture_size_);
   }
@@ -86,7 +84,6 @@ class HWSubLayer : public HWLayer {
 
  private:
   float alpha_ = 1.0f;
-  BlendMode blend_mode_ = BlendMode::kSrcOver;
   HWDraw* layer_back_draw_ = {};
   std::shared_ptr<GPUTexture> color_texture_ = {};
   std::shared_ptr<GPUTexture> layer_back_draw_texture_ = {};

--- a/src/render/hw/precompile_context.cc
+++ b/src/render/hw/precompile_context.cc
@@ -19,7 +19,6 @@
 #include "src/effect/pixmap_shader.hpp"
 #include "src/gpu/gpu_context_impl.hpp"
 #include "src/gpu/gpu_sampler.hpp"
-#include "src/graphic/blend_mode_priv.hpp"
 #include "src/logging.hpp"
 #include "src/render/hw/draw/fragment/wgsl_gradient_fragment.hpp"
 #include "src/render/hw/draw/fragment/wgsl_solid_color.hpp"
@@ -37,9 +36,8 @@
 #include "src/render/hw/draw/step/clip_step.hpp"
 #include "src/render/hw/draw/step/color_step.hpp"
 #include "src/render/hw/draw/step/stencil_step.hpp"
-#include "src/render/hw/draw/wgx_filter.hpp"
-#include "src/render/hw/draw/wgx_programmable_blending.hpp"
-#include "src/render/hw/dst_read_strategy.hpp"
+#include "src/render/hw/draw/wgx_utils.hpp"
+#include "src/render/hw/hw_blend_plan.hpp"
 #include "src/render/hw/hw_draw.hpp"
 #include "src/tracing.hpp"
 #include "src/utils/arena_allocator.hpp"
@@ -85,14 +83,22 @@ GPUTextureFormat ResolvePrecompileColorFormat(PrecompileColorType color_type) {
   return GPUTextureFormat::kInvalid;
 }
 
+HWBlendPlan ResolvePrecompileBlendPlan(HWDrawContext* context,
+                                       BlendMode blend_mode) {
+  const auto& caps = context->gpuContext->GetGPUDevice()->GetCaps();
+  return ResolveHWBlendPlan(blend_mode, caps,
+                            /*supports_texture_copy_dst_read=*/true);
+}
+
 bool PrecompileStep(HWDrawStep* step, HWDrawStepContext* ctx,
                     BlendMode blend_mode) {
   DEBUG_CHECK(step != nullptr);
   DEBUG_CHECK(ctx != nullptr);
 
+  auto blend_plan = ResolvePrecompileBlendPlan(ctx->context, blend_mode);
   auto success =
       step->PrecompilePipeline(ctx->context, ctx->state, ctx->color_format,
-                               ctx->sample_count, blend_mode);
+                               ctx->sample_count, blend_plan);
   if (!success) {
     LOGE("Precompile shader failed: failed to create render pipeline");
   }
@@ -102,24 +108,9 @@ bool PrecompileStep(HWDrawStep* step, HWDrawStepContext* ctx,
 }
 
 HWWGSLFragment* ApplyPaintEffects(HWWGSLFragment* fragment, const Paint& paint,
-                                  GPUContextImpl* gpu_context) {
-  if (paint.GetColorFilter() != nullptr) {
-    fragment->SetFilter(WGXFilterFragment::Make(paint.GetColorFilter().get()));
-  }
-
-  if (IsAdvancedBlendMode(paint.GetBlendMode())) {
-    const auto& caps = gpu_context->GetGPUDevice()->GetCaps();
-    auto strategy = ResolveDstReadStrategy(paint.GetBlendMode(), caps);
-    if (strategy == DstReadStrategy::kNativeBlend) {
-      if (caps.native_blend_shader_variant) {
-        fragment->SetUsesNativeAdvancedBlend(true);
-      }
-    } else {
-      fragment->SetProgrammableBlending(
-          WGXProgrammableBlending::Make(paint.GetBlendMode(), strategy));
-    }
-  }
-
+                                  HWDrawContext* context) {
+  auto blend_plan = ResolvePrecompileBlendPlan(context, paint.GetBlendMode());
+  ConfigureShadingFragment(context, paint, blend_plan, fragment);
   return fragment;
 }
 
@@ -133,7 +124,7 @@ HWWGSLFragment* MakeColorFragment(HWDrawStepContext* ctx, const Paint& paint,
     if (type != Shader::GradientType::kNone) {
       fragment = arena->Make<WGSLGradientFragment>(
           info, type, paint.GetAlphaF(), paint.GetShader()->GetLocalMatrix());
-      return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+      return ApplyPaintEffects(fragment, paint, ctx->context);
     }
   }
 
@@ -143,7 +134,7 @@ HWWGSLFragment* MakeColorFragment(HWDrawStepContext* ctx, const Paint& paint,
     fragment = arena->Make<WGSLSolidColor>(paint.GetFillColor());
   }
 
-  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+  return ApplyPaintEffects(fragment, paint, ctx->context);
 }
 
 HWWGSLFragment* MakeTextureFragment(HWDrawStepContext* ctx, const Paint& paint,
@@ -151,7 +142,7 @@ HWWGSLFragment* MakeTextureFragment(HWDrawStepContext* ctx, const Paint& paint,
                                     const Matrix& matrix) {
   auto* fragment = ctx->context->arena_allocator->Make<WGSLTextureFragment>(
       std::move(shader), nullptr, nullptr, 1.f, matrix, 1.f, 1.f);
-  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+  return ApplyPaintEffects(fragment, paint, ctx->context);
 }
 
 void PrecompilePathStep(HWDrawStepContext* ctx, const Paint& paint,
@@ -292,7 +283,7 @@ HWWGSLFragment* MakeTextFragment(HWDrawStepContext* ctx, const Paint& paint,
                                                   std::move(sampler));
   }
 
-  return ApplyPaintEffects(fragment, paint, ctx->context->gpuContext);
+  return ApplyPaintEffects(fragment, paint, ctx->context);
 }
 
 void PrecompileTextStep(HWDrawStepContext* ctx, const Paint& paint, bool sdf,

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(skity_unit_test
     render/hw/hw_pipeline_key_test.cc
     render/hw/precompile_test.cc
     render/hw/dst_read_strategy_test.cc
+    render/hw/hw_blend_plan_test.cc
     render/hw/hw_texture_copy_info_test.cc
     render/hw/draw/hw_wgsl_shader_writer_test.cc
     render/hw/draw/wgsl_text_fragment_test.cc

--- a/test/ut/render/hw/hw_blend_plan_test.cc
+++ b/test/ut/render/hw/hw_blend_plan_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/render/hw/hw_blend_plan.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using skity::BlendMode;
+using skity::GPUBlendFactor;
+using skity::GPUBlendOperation;
+using skity::GPUCaps;
+
+TEST(HWBlendPlan, ResolvesLegacyFixedFunctionFormulas) {
+  struct TestCase {
+    BlendMode mode;
+    GPUBlendFactor src_factor;
+    GPUBlendFactor dst_factor;
+  };
+  constexpr TestCase kCases[] = {
+      {BlendMode::kClear, GPUBlendFactor::kZero, GPUBlendFactor::kZero},
+      {BlendMode::kSrc, GPUBlendFactor::kOne, GPUBlendFactor::kZero},
+      {BlendMode::kDst, GPUBlendFactor::kZero, GPUBlendFactor::kOne},
+      {BlendMode::kSrcOver, GPUBlendFactor::kOne,
+       GPUBlendFactor::kOneMinusSrcAlpha},
+      {BlendMode::kDstOver, GPUBlendFactor::kOneMinusDstAlpha,
+       GPUBlendFactor::kOne},
+      {BlendMode::kSrcIn, GPUBlendFactor::kDstAlpha, GPUBlendFactor::kZero},
+      {BlendMode::kDstIn, GPUBlendFactor::kZero, GPUBlendFactor::kSrcAlpha},
+      {BlendMode::kSrcOut, GPUBlendFactor::kOneMinusDstAlpha,
+       GPUBlendFactor::kZero},
+      {BlendMode::kDstOut, GPUBlendFactor::kZero,
+       GPUBlendFactor::kOneMinusSrcAlpha},
+      {BlendMode::kSrcATop, GPUBlendFactor::kDstAlpha,
+       GPUBlendFactor::kOneMinusSrcAlpha},
+      {BlendMode::kDstATop, GPUBlendFactor::kOneMinusDstAlpha,
+       GPUBlendFactor::kSrcAlpha},
+      {BlendMode::kXor, GPUBlendFactor::kOneMinusDstAlpha,
+       GPUBlendFactor::kOneMinusSrcAlpha},
+      {BlendMode::kPlus, GPUBlendFactor::kOne, GPUBlendFactor::kOne},
+      {BlendMode::kModulate, GPUBlendFactor::kOne, GPUBlendFactor::kZero},
+      {BlendMode::kScreen, GPUBlendFactor::kOne, GPUBlendFactor::kZero},
+  };
+
+  GPUCaps caps = {};
+  for (const auto& test : kCases) {
+    auto formula = skity::ResolveHWBlendFormula({test.mode}, caps,
+                                                /*shader_side_blending=*/false);
+    EXPECT_EQ(formula.src_factor, test.src_factor);
+    EXPECT_EQ(formula.dst_factor, test.dst_factor);
+    EXPECT_EQ(formula.operation, GPUBlendOperation::kAdd);
+  }
+}
+
+TEST(HWBlendPlan, UsesNativeAdvancedOperationOnlyOutsideShader) {
+  GPUCaps caps = {};
+  caps.supports_native_advanced_blend = true;
+  auto plan = skity::HWBlendPlan{BlendMode::kOverlay};
+
+  auto native =
+      skity::ResolveHWBlendFormula(plan, caps, /*shader_side_blending=*/false);
+  EXPECT_EQ(native.src_factor, GPUBlendFactor::kOne);
+  EXPECT_EQ(native.dst_factor, GPUBlendFactor::kOneMinusSrcAlpha);
+  EXPECT_EQ(native.operation, GPUBlendOperation::kOverlay);
+
+  auto programmable =
+      skity::ResolveHWBlendFormula(plan, caps, /*shader_side_blending=*/true);
+  EXPECT_EQ(programmable.src_factor, GPUBlendFactor::kOne);
+  EXPECT_EQ(programmable.dst_factor, GPUBlendFactor::kZero);
+  EXPECT_EQ(programmable.operation, GPUBlendOperation::kAdd);
+
+  auto modulate = skity::ResolveHWBlendFormula({BlendMode::kModulate}, caps,
+                                               /*shader_side_blending=*/false);
+  EXPECT_EQ(modulate.src_factor, GPUBlendFactor::kOne);
+  EXPECT_EQ(modulate.dst_factor, GPUBlendFactor::kZero);
+  EXPECT_EQ(modulate.operation, GPUBlendOperation::kAdd);
+}
+
+TEST(HWBlendPlan, CarriesResolvedDestinationReadStrategy) {
+  GPUCaps caps = {};
+  caps.supports_framebuffer_fetch = true;
+
+  auto plan =
+      skity::ResolveHWBlendPlan(BlendMode::kOverlay, caps,
+                                /*supports_texture_copy_dst_read=*/true);
+  EXPECT_EQ(plan.blend_mode, BlendMode::kOverlay);
+  EXPECT_EQ(plan.dst_read_strategy, skity::DstReadStrategy::kFramebufferFetch);
+}
+
+}  // namespace


### PR DESCRIPTION
Resolve blend modes, destination-read strategies, and fixed-function formulas through a shared HWBlendPlan flow. Carry the plan from canvas setup through draw steps, shader configuration, pipeline creation, and precompilation while removing duplicate blend state from dynamic draws and sublayers.\n\nPreserve the existing rendering behavior and add unit coverage for legacy formulas, native advanced operations, shader-side blending, and destination-read selection.