### PR TITLE
feat(capi): expose TypefaceDelegate fallback and DisplayList partial redraw

### DIFF
--- a/module/capi/C_API_DESIGN.md
+++ b/module/capi/C_API_DESIGN.md
@@ -362,8 +362,8 @@ These modules have complete (or near-complete) C coverage of their core:
 - Effects: `color_filter`, `mask_filter`, `path_effect`, `image_filter`
   (all factories)
 - `FontManager` + `FontStyleSet`
-- `PictureRecorder` + `DisplayList` (core record / replay; introspection is
-  not — see below)
+- `PictureRecorder` + `DisplayList` (record / replay / cull-rect replay /
+  rtree search / properties / per-op paint lookup)
 - `PrecompileContext`
 - `Texture` (create / wrap-external / upload / deferred-upload)
 - `GPUContext` (create, `set_error_callback`, all `set_enable_*` tuning,
@@ -382,20 +382,20 @@ gaps — they are listed in the next table.
 
 ### Partially covered (gaps remain)
 
-Priority tags: **P0/P1/P2** are planned for the next pass; **P3** is deferred.
+Priority tags: **P3** is deferred / low-value.
 
 | Module | Covered | Missing (priority) |
 |---|---|---|
-| `Paint` | all setters (style/stroke/color/alpha/blend/aa/text-size), attach shader/filter/effect/typeface | **P0**: fill/stroke split-color (`set/get_stroke_color`, `set/get_fill_color`); getters (`get_stroke_miter/cap/join`, `get_text_size`, `get_shader`/`get_color_filter`/…). **P3**: `get_color4f`, `get_alpha_f`, SDF / font-threshold |
-| `Shader` | gradient factories (linear/radial/sweep/conical) + image shader | **P0**: `set/get_local_matrix` (gradient transform). **P3**: `is_opaque`, `as_gradient` introspection |
-| `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters | **P0**: GL `surface_mode` + `can_blit_from_target_fbo` on `surface_create_info_gl`. **P3**: per-surface CoverageAAMode, `add_external_wait_semaphore` (needs semaphore) |
-| `Path` | construction, tangent `arc_to`, `add_*`, boolean ops, `PathMeasure`, `transform`, `count`/`get_point`/`is_rect` | **P1**: oval `arc_to(oval,start,sweep)` + SVG `arc_to(rx,ry,rot,ArcSize,sweep,x,y)` (+ `ArcSize` enum), per-corner `add_round_rect(radii[])`, `get/set_last_pt`, `AddMode` (extend), `copy_with_matrix/scale`. **P3**: convexity / segment-masks introspection |
-| `Image` | 5 factories + `read_pixels` + size getters | **P1**: `scale_pixels`; `make_from_pixels` variant taking a `GPUContext`. **P3**: alpha/type/backend introspection |
-| `Font` | create, set typeface/size, `get_metrics`, rendering-quality switches, `make_with_size`, `get_widths` | **P0**: rendering-switch getters (`is_subpixel`/…), `get_size`, `get_typeface`. **P1**: `scale_x/skew_x` (+ 4-arg ctor). **P3**: `get_widths` bounds overload, `LoadGlyph*` (needs GlyphData) |
-| `Typeface` | `make_from_file`, `get_default`, `unichars_to_glyphs`/`unichar_to_glyph` | **P1**: `make_from_data` (in-memory load, pairs with `skity_data`). **P3**: `get_font_style`/`is_bold`/`is_italic`, `contain_glyph`, `units_per_em`/`contains_color_table`, table / variation / descriptor |
-| `TextBlob` | build (UTF-8) + draw | **P2**: `get_bounds_rect`, `compute_bounds`. **P3**: `get_text_run`; multi-font fallback via `TypefaceDelegate` (large, separate increment) |
+| `Paint` | all setters + getters, fill/stroke split colors, effect/typeface attach | **P3**: `get_color4f`, `get_alpha_f`, SDF / font-threshold |
+| `Shader` | gradient factories (linear/radial/sweep/conical) + image shader + `set/get_local_matrix` | **P3**: `is_opaque`, `as_gradient` introspection |
+| `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters, GL `surface_mode` + `can_blit_from_target_fbo` | **P3**: per-surface CoverageAAMode, `add_external_wait_semaphore` (needs semaphore) |
+| `Path` | construction, arc family (tangent / oval / SVG), `add_*` (incl. per-corner radii), boolean ops, `PathMeasure`, `transform`, last-pt get/set, `copy_with_matrix/scale`, counts / `get_point` / `is_rect` | **P3**: convexity / segment-masks introspection, verb iteration (`get_verb` / `Iter`), `add_path` extend mode (`AddMode`) |
+| `Image` | 5 factories (incl. the `GPUContext` variant) + `read_pixels` + `scale_pixels` + size getters | **P3**: alpha/type/backend introspection |
+| `Font` | create (incl. scale/skew ctor), typeface/size get/set, rendering-quality switch get/set, `get_metrics`, `make_with_size`, `get_widths` | **P3**: `get_widths` bounds overload, `LoadGlyph*` (needs GlyphData) |
+| `Typeface` | `make_from_file`, `make_from_data`, `get_default`, `unichars_to_glyphs`/`unichar_to_glyph` | **P3**: `get_font_style`/`is_bold`/`is_italic`, `contain_glyph`, `units_per_em`/`contains_color_table`, table / variation / descriptor |
+| `TextBlob` | build (UTF-8) + draw, `get_bounds`, `compute_bounds`, `TypefaceDelegate` fallback (ordered-list + custom-fallback-callback) | **P3**: `get_text_run`; fully custom `BreakTextRun` delegate (caller-driven segmentation) |
 | `Canvas` | full draw + state + clip + text/glyphs | **P3**: per-corner RRect draw/clip/drrect, `get_global_clip_bounds`, `draw_image` sampling overloads |
-| `DisplayList` | draw / bounds / op_count | **P3**: `search` (RTree) + property getters (`has_shader`, …) — needs `build_rtree` option + `RecordedOpOffset` as a set |
+| `DisplayList` | draw / cull-rect draw / bounds / op_count / properties / rtree search (+ non-overlapping rects) / per-op paint lookup, `begin_recording` with build options | `RecordedOpOffset` is exposed as a plain `int32_t` (round-trips through the public `RecordedOpOffset::Make`) — no opaque set type |
 | `GPUContext` | (see Fully covered) | **P3**: `create_texture_with_desc` (mipmap), `is_gpu_backend_supported`, `get_backend_type` |
 
 ### Not yet covered (whole module missing)
@@ -414,25 +414,12 @@ Priority tags: **P0/P1/P2** are planned for the next pass; **P3** is deferred.
 
 ### Suggested priorities
 
-**P0** — high-value, low-cost (next pass):
-
-- ☐ `Paint` fill/stroke split-color setters + getters; remaining `Paint` getters
-- ☐ `Font` rendering-switch getters + `get_size` / `get_typeface`
-- ☐ `Shader::set/get_local_matrix` (gradient transforms)
-- ☐ GL `surface_mode` on `surface_create_info_gl` (only functional GL gap)
-
-**P1** — core capability:
-
-- ☐ `Path` arc family (oval arc, SVG arc + `ArcSize`) + per-corner round-rect
-- ☐ `Image::scale_pixels` + `make_from_pixels(context)`
-- ☐ `Typeface` / `FontManager::make_from_data` (in-memory font load)
-- ☐ `Font::scale_x/skew_x` (+ 4-arg ctor)
-
-**P2** — measurement:
-
-- ☐ `TextBlob::get_bounds_rect` / `compute_bounds`
-
-**P3** — deferred. Detailed backlog by module:
+The original **P0–P2** backlog (paint getters, shader local matrix, GL
+`surface_mode`, path arc family, image `scale_pixels`, typeface
+`make_from_data`, font `scale_x/skew_x`, text-blob bounds) plus the
+**TypefaceDelegate fallback** and **DisplayList partial-redraw** increments
+have all landed. What remains is **P3** — deferred. Detailed backlog by
+module:
 
 - **Paint**: `get_color4f`, `get_alpha_f`; SDF / font-threshold
   (`set/is_sdf_for_small_text`, `get/set_font_threshold`).
@@ -454,15 +441,13 @@ Priority tags: **P0/P1/P2** are planned for the next pass; **P3** is deferred.
   variable fonts (`get_variation_design_position` / `parameters`,
   `make_variation`, +`FontArguments`); cache keys (`typeface_id`,
   `get_font_descriptor`).
-- **TextBlob**: `get_text_run` (+`TextRun` projection); **`TypefaceDelegate`
-  multi-font fallback** — the largest text gap (CJK/emoji auto-fallback).
+- **TextBlob**: `get_text_run` (+`TextRun` projection); a fully custom
+  `BreakTextRun` delegate (caller-driven run segmentation — the current
+  `skity_typeface_delegate_create_fallback` keeps the built-in policy and only
+  overrides the typeface choice).
 - **Canvas**: per-corner RRect `draw_rrect` / `clip_rrect` / `draw_drrect`
   (+RRect projection or 8-radii); `get_global_clip_bounds`; `draw_image`
   sampling/paint overloads; `draw_color(color4f, blend)`.
-- **DisplayList**: `search` / `search_non_overlapping_drawn_rects` (RTree);
-  property getters (`has_save_layer` / `has_shader` / …); `get_op_paint_by_offset`
-  (+`RecordedOpOffset`); `draw(canvas, cull_rect)`; prerequisite
-  `begin_recording(rect, DisplayListBuildOptions)` (+`build_rtree` option).
 - **GPUContext**: `create_texture_with_desc` (mipmap, +`TextureDescriptor`
   mirror); `is_gpu_backend_supported`; `get_backend_type`.
 

--- a/module/capi/include/skity_c/skity_recorder.h
+++ b/module/capi/include/skity_c/skity_recorder.h
@@ -27,7 +27,7 @@ SKITY_C_DEFINE_HANDLE(skity_picture_recorder);
  */
 SKITY_C_DEFINE_HANDLE(skity_display_list);
 
-// ----- picture recorder: records draw commands into a display list -----
+// ----- picture recorder: records draw commands into a display list ------
 
 /** @brief Create a new picture recorder. */
 SKITY_C_API skity_picture_recorder skity_picture_recorder_create(void);
@@ -45,6 +45,51 @@ SKITY_C_API void skity_picture_recorder_destroy(
  */
 SKITY_C_API void skity_picture_recorder_begin(skity_picture_recorder recorder,
                                               const skity_rect* bounds);
+
+/**
+ * @brief Options controlling how the recorded display list is built. Mirrors
+ *        skity::DisplayListBuildOptions.
+ */
+typedef struct skity_display_list_build_options {
+  /**
+   * Non-zero to build an RTree of recorded op bounds. Required for
+   * skity_display_list_search and the cull-rect variant of
+   * skity_display_list_draw to do partial work; without it both fall back to
+   * whole-list behavior.
+   */
+  uint32_t build_rtree;
+} skity_display_list_build_options;
+
+/**
+ * @brief Begin recording with explicit build options.
+ *
+ * Same as skity_picture_recorder_begin, plus control over the display list
+ * build. Passing NULL @p options is equivalent to
+ * skity_picture_recorder_begin.
+ *
+ * @param recorder  the recorder handle
+ * @param bounds    cull rect of the recorded content, or NULL for an unbounded
+ *                  recording
+ * @param options   build options, or NULL for the defaults
+ */
+SKITY_C_API void skity_picture_recorder_begin_with_options(
+    skity_picture_recorder recorder, const skity_rect* bounds,
+    const skity_display_list_build_options* options);
+
+/**
+ * @brief Return the storage offset of the most recently recorded op, for use
+ *        with skity_display_list_get_op_paint_by_offset.
+ *
+ * Mirrors RecordingCanvas::GetLastOpOffset. Call it right after the draw call
+ * of interest, while still recording.
+ *
+ * @param recorder  the recorder handle
+ * @return          the op's byte offset into the finished display list, or -1
+ *                  when nothing has been recorded yet (or recording has not
+ *                  begun)
+ */
+SKITY_C_API int32_t skity_picture_recorder_get_last_op_offset(
+    skity_picture_recorder recorder);
 
 /**
  * @brief Return the recording canvas. It is owned by the recorder (a
@@ -81,6 +126,65 @@ SKITY_C_API void skity_display_list_draw(skity_display_list list,
                                          skity_canvas canvas);
 
 /**
+ * @brief Playback only the recorded commands that intersect @p cull_rect
+ *        (partial redraw), keeping the save / clip / matrix state those
+ *        commands depend on.
+ *
+ * Requires a display list recorded with build_rtree set; otherwise this falls
+ * back to replaying the whole list. An empty or NULL @p cull_rect draws
+ * nothing. Mirrors DisplayList::Draw(canvas, cull_rect).
+ *
+ * @param list       the display list to replay
+ * @param canvas     destination canvas receiving the draws
+ * @param cull_rect  damage region to redraw, or NULL to draw nothing
+ */
+SKITY_C_API void skity_display_list_draw_with_cull_rect(
+    skity_display_list list, skity_canvas canvas, const skity_rect* cull_rect);
+
+/**
+ * @brief Return the offsets of recorded ops whose (device-space) bounds
+ *        intersect @p rect, in recording order.
+ *
+ * Requires a display list recorded with build_rtree set; without it, 0 is
+ * always returned. Offsets are opaque values only meaningful to this display
+ * list — feed them to skity_display_list_get_op_paint_by_offset.
+ *
+ * Two-pass idiom: call with @p out_offsets NULL (or a small capacity) to learn
+ * the count, then call again with a sufficiently large buffer. When @p capacity
+ * is smaller than the result count, only @p capacity entries are written.
+ *
+ * @param list         the display list recorded with build_rtree
+ * @param rect         query rectangle; an empty rect matches nothing
+ * @param out_offsets  receives up to @p capacity op offsets, or NULL to only
+ *                     query the count
+ * @param capacity     number of entries @p out_offsets can hold
+ * @return             the total number of matching ops
+ */
+SKITY_C_API uint32_t skity_display_list_search(
+    skity_display_list list, const skity_rect* rect, int32_t* out_offsets,
+    uint32_t capacity);
+
+/**
+ * @brief Return the damage region covering the ops intersecting @p rect,
+ *        merged into mutually non-overlapping rectangles.
+ *
+ * Useful to compute the area that skity_display_list_draw_with_cull_rect will
+ * touch (e.g. to union with a surface damage region). Requires build_rtree;
+ * without it, 0 is always returned. Same two-pass idiom as
+ * skity_display_list_search.
+ *
+ * @param list       the display list recorded with build_rtree
+ * @param rect       query rectangle; an empty rect matches nothing
+ * @param out_rects  receives up to @p capacity rectangles, or NULL to only
+ *                   query the count
+ * @param capacity   number of entries @p out_rects can hold
+ * @return           the total number of result rectangles
+ */
+SKITY_C_API uint32_t skity_display_list_search_non_overlapping_drawn_rects(
+    skity_display_list list, const skity_rect* rect, skity_rect* out_rects,
+    uint32_t capacity);
+
+/**
  * @brief Write the display list's cull bounds into @p out_bounds.
  * @param list        the display list
  * @param out_bounds  receives the bounds rectangle
@@ -90,6 +194,48 @@ SKITY_C_API void skity_display_list_get_bounds(skity_display_list list,
 
 /** @brief Return the number of recorded draw ops in the list. */
 SKITY_C_API uint32_t skity_display_list_get_op_count(skity_display_list list);
+
+/** @brief Recorded-content property bits, aligned with
+ *         skity::DisplayList::Property. */
+typedef enum {
+  SKITY_DISPLAY_LIST_PROPERTY_NONE = 0,
+  SKITY_DISPLAY_LIST_PROPERTY_SAVE_LAYER = 1 << 0, /**< contains a save_layer */
+  SKITY_DISPLAY_LIST_PROPERTY_SHADER = 1 << 1,     /**< some paint has a shader */
+  SKITY_DISPLAY_LIST_PROPERTY_COLOR_FILTER = 1 << 2, /**< a paint has a color
+                                                        filter */
+  SKITY_DISPLAY_LIST_PROPERTY_MASK_FILTER = 1 << 3, /**< a paint has a mask
+                                                        filter */
+  SKITY_DISPLAY_LIST_PROPERTY_IMAGE_FILTER = 1 << 4, /**< a paint has an image
+                                                        filter */
+} skity_display_list_property;
+
+/**
+ * @brief Return the display list's property bitmask, a combination of
+ *        skity_display_list_property values. Mirrors the DisplayList::Has*()
+ *        getters.
+ * @param list  the display list
+ * @return     property bits; 0 for an empty list
+ */
+SKITY_C_API uint32_t skity_display_list_get_properties(skity_display_list list);
+
+/**
+ * @brief Return the paint of the op recorded at @p offset, for in-place
+ *        modification before replay.
+ *
+ * The returned handle is non-owning: the paint lives inside the display list's
+ * storage, so the handle stays valid until @p list is destroyed, and
+ * skity_paint_destroy on it only reclaims the wrapper. Mutations are seen by
+ * the next skity_display_list_draw / draw_with_cull_rect.
+ *
+ * @param list    the display list the offset came from
+ * @param offset  op offset from skity_display_list_search or
+ *                skity_picture_recorder_get_last_op_offset
+ * @return        a non-owning paint handle, or NULL when @p offset is invalid
+ *                for this list or the op carries no paint (e.g. clip / matrix
+ *                ops)
+ */
+SKITY_C_API skity_paint skity_display_list_get_op_paint_by_offset(
+    skity_display_list list, int32_t offset);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/module/capi/include/skity_c/skity_text.h
+++ b/module/capi/include/skity_c/skity_text.h
@@ -96,6 +96,85 @@ SKITY_C_DEFINE_HANDLE(skity_font);
  *         container of pre-laid-out text runs built from a UTF-8 string. */
 SKITY_C_DEFINE_HANDLE(skity_text_blob);
 
+/** @brief Opaque typeface delegate, the C handle for skity::TypefaceDelegate.
+ *         Decides which typeface renders a code point the paint's typeface
+ *         does not cover, enabling multi-font fallback (CJK / emoji mixing). */
+SKITY_C_DEFINE_HANDLE(skity_typeface_delegate);
+
+/**
+ * @brief Create a fallback delegate over an ordered typeface list.
+ *
+ * For a code point not covered by the paint's typeface, the first typeface in
+ * @p typefaces that contains a glyph for it is used; a code point covered by
+ * none of them is dropped. Mirrors
+ * skity::TypefaceDelegate::CreateSimpleFallbackDelegate.
+ *
+ * The delegate holds shared references to the typefaces, so the passed handles
+ * may be released immediately afterwards.
+ *
+ * @param typefaces  array of fallback typefaces, probed in order
+ * @param count      number of entries in @p typefaces
+ * @return           delegate handle, or NULL when @p typefaces is NULL or
+ *                   @p count is 0 (no fallback)
+ */
+SKITY_C_API skity_typeface_delegate skity_typeface_delegate_create_simple(
+    const skity_typeface* typefaces, uint32_t count);
+
+/**
+ * @brief Fallback probe invoked when the paint's typeface has no glyph for a
+ *        code point.
+ *
+ * The returned handle must stay valid across the delegate's lifetime (the
+ * wrapper only takes a shared reference and never releases the handle);
+ * returning NULL drops the code point from the layout.
+ *
+ * @param userdata   caller-supplied pointer passed back unchanged
+ * @param code_point Unicode code point needing a fallback typeface
+ * @return           a typeface handle, or NULL if no fallback applies
+ */
+typedef skity_typeface (*skity_typeface_fallback_fn)(void* userdata,
+                                                     uint32_t code_point);
+
+/**
+ * @brief Create a fallback delegate driven by a C callback.
+ *
+ * Text-run splitting follows the built-in policy (same as
+ * skity_typeface_delegate_create_simple); only the typeface choice is
+ * delegated to @p fallback.
+ *
+ * @param fallback  callback deciding the fallback typeface; must not be NULL
+ * @param userdata  caller-supplied pointer passed back to the callbacks
+ * @param release   callback invoked with @p userdata when the delegate is
+ *                  destroyed; may be NULL
+ * @return          delegate handle, or NULL on invalid arguments
+ */
+SKITY_C_API skity_typeface_delegate skity_typeface_delegate_create_fallback(
+    skity_typeface_fallback_fn fallback, void* userdata,
+    void (*release)(void* userdata));
+
+/** @brief Release the delegate handle and its underlying object. Safe on NULL.
+ *         Invokes the @p release callback given to
+ *         skity_typeface_delegate_create_fallback, if any. */
+SKITY_C_API void skity_typeface_delegate_destroy(
+    skity_typeface_delegate delegate);
+
+/**
+ * @brief Build an immutable text blob from a UTF-8 string using @p delegate
+ *        for per-code-point font fallback.
+ *
+ * The text size and base typeface are taken from @p paint; code points the
+ * paint's typeface does not cover are routed through the delegate. Passing a
+ * NULL @p delegate is equivalent to skity_text_blob_create (no fallback).
+ *
+ * @param text      NUL-terminated UTF-8 string to lay out
+ * @param paint     paint supplying the text size and base typeface
+ * @param delegate  fallback policy, or NULL for none
+ * @return          the new text blob, or NULL on invalid arguments (including
+ *                  a paint with no typeface set)
+ */
+SKITY_C_API skity_text_blob skity_text_blob_create_with_delegate(
+    const char* text, skity_paint paint, skity_typeface_delegate delegate);
+
 /**
  * @brief Build an immutable text blob from a UTF-8 string.
  *

--- a/module/capi/src/handle.hpp
+++ b/module/capi/src/handle.hpp
@@ -42,6 +42,7 @@ typedef enum {
   SKITY_OBJECT_TYPE_PATH_MEASURE,
   SKITY_OBJECT_TYPE_CAMERA,
   SKITY_OBJECT_TYPE_DATA,
+  SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE,
 } skity_object_type;
 
 /* When set, the wrapper owns the underlying object and releases it on destroy.
@@ -164,6 +165,10 @@ struct skity_camera_s {
   std::shared_ptr<void> impl;
 };
 struct skity_data_s {
+  skity_object_header header;
+  std::shared_ptr<void> impl;
+};
+struct skity_typeface_delegate_s {
   skity_object_header header;
   std::shared_ptr<void> impl;
 };

--- a/module/capi/src/recorder_c.cpp
+++ b/module/capi/src/recorder_c.cpp
@@ -4,10 +4,14 @@
 
 #include <skity_c/skity_recorder.h>
 
+#include <algorithm>
+
 #include <skity/recorder/display_list.hpp>
 #include <skity/recorder/picture_recorder.hpp>
+#include <skity/recorder/recording_canvas.hpp>
 #include <skity/render/canvas.hpp>
 #include <utility>
+#include <vector>
 
 #include "handle.hpp"
 
@@ -57,6 +61,29 @@ void skity_picture_recorder_begin(skity_picture_recorder recorder,
   }
 }
 
+void skity_picture_recorder_begin_with_options(
+    skity_picture_recorder recorder, const skity_rect* bounds,
+    const skity_display_list_build_options* options) {
+  auto* r = recorder_of(recorder);
+  if (r == nullptr) return;
+  skity::DisplayListBuildOptions opts;
+  if (options != nullptr) {
+    opts.build_rtree = options->build_rtree != 0;
+  }
+  if (bounds != nullptr) {
+    r->BeginRecording(*reinterpret_cast<const skity::Rect*>(bounds), opts);
+  } else {
+    r->BeginRecording(skity::Rect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F), opts);
+  }
+}
+
+int32_t skity_picture_recorder_get_last_op_offset(
+    skity_picture_recorder recorder) {
+  auto* r = recorder_of(recorder);
+  if (r == nullptr) return -1;
+  return r->GetRecordingCanvas()->GetLastOpOffset().GetValue();
+}
+
 skity_canvas skity_picture_recorder_get_canvas(
     skity_picture_recorder recorder) {
   auto* r = recorder_of(recorder);
@@ -102,6 +129,60 @@ void skity_display_list_draw(skity_display_list list, skity_canvas canvas) {
   }
 }
 
+void skity_display_list_draw_with_cull_rect(skity_display_list list,
+                                           skity_canvas canvas,
+                                           const skity_rect* cull_rect) {
+  auto* dl = display_list_of(list);
+  auto* c = canvas_of(canvas);
+  if (dl == nullptr || c == nullptr) {
+    return;
+  }
+  if (cull_rect == nullptr) {
+    return;
+  }
+  dl->Draw(c, *reinterpret_cast<const skity::Rect*>(cull_rect));
+}
+
+uint32_t skity_display_list_search(skity_display_list list,
+                                   const skity_rect* rect, int32_t* out_offsets,
+                                   uint32_t capacity) {
+  auto* dl = display_list_of(list);
+  if (dl == nullptr || rect == nullptr) {
+    return 0;
+  }
+  auto offsets = dl->Search(*reinterpret_cast<const skity::Rect*>(rect));
+  uint32_t count = (uint32_t)offsets.size();
+  if (out_offsets != nullptr && capacity > 0) {
+    uint32_t fill = std::min(count, capacity);
+    for (uint32_t i = 0; i < fill; i++) {
+      out_offsets[i] = offsets[i].GetValue();
+    }
+  }
+  return count;
+}
+
+uint32_t skity_display_list_search_non_overlapping_drawn_rects(
+    skity_display_list list, const skity_rect* rect, skity_rect* out_rects,
+    uint32_t capacity) {
+  auto* dl = display_list_of(list);
+  if (dl == nullptr || rect == nullptr) {
+    return 0;
+  }
+  auto rects =
+      dl->SearchNonOverlappingDrawnRects(*reinterpret_cast<const skity::Rect*>(rect));
+  uint32_t count = (uint32_t)rects.size();
+  if (out_rects != nullptr && capacity > 0) {
+    uint32_t fill = std::min(count, capacity);
+    for (uint32_t i = 0; i < fill; i++) {
+      out_rects[i].left = rects[i].Left();
+      out_rects[i].top = rects[i].Top();
+      out_rects[i].right = rects[i].Right();
+      out_rects[i].bottom = rects[i].Bottom();
+    }
+  }
+  return count;
+}
+
 void skity_display_list_get_bounds(skity_display_list list,
                                    skity_rect* out_bounds) {
   auto* dl = display_list_of(list);
@@ -116,6 +197,35 @@ void skity_display_list_get_bounds(skity_display_list list,
 uint32_t skity_display_list_get_op_count(skity_display_list list) {
   auto* dl = display_list_of(list);
   return dl != nullptr ? dl->OpCount() : 0u;
+}
+
+uint32_t skity_display_list_get_properties(skity_display_list list) {
+  uint32_t props = 0;
+  auto* dl = display_list_of(list);
+  if (dl == nullptr) return 0;
+  if (dl->HasSaveLayer()) props |= SKITY_DISPLAY_LIST_PROPERTY_SAVE_LAYER;
+  if (dl->HasShader()) props |= SKITY_DISPLAY_LIST_PROPERTY_SHADER;
+  if (dl->HasColorFilter()) props |= SKITY_DISPLAY_LIST_PROPERTY_COLOR_FILTER;
+  if (dl->HasMaskFilter()) props |= SKITY_DISPLAY_LIST_PROPERTY_MASK_FILTER;
+  if (dl->HasImageFilter()) props |= SKITY_DISPLAY_LIST_PROPERTY_IMAGE_FILTER;
+  return props;
+}
+
+skity_paint skity_display_list_get_op_paint_by_offset(skity_display_list list,
+                                                      int32_t offset) {
+  auto* dl = display_list_of(list);
+  if (dl == nullptr) return nullptr;
+  // RecordedOpOffset::Make is the public int round-trip factory; the value is
+  // only meaningful for the display list it came from.
+  skity::Paint* paint =
+      dl->GetOpPaintByOffset(skity::RecordedOpOffset::Make(offset));
+  if (paint == nullptr) return nullptr;
+  // The paint lives inside the display list's storage; wrap it non-owning so
+  // the handle stays valid for the list's lifetime and in-place edits are
+  // visible to later replays.
+  std::shared_ptr<void> impl(paint, [](void*) {});
+  return skity::capi::alloc_handle<skity_paint_s>(SKITY_OBJECT_TYPE_PAINT, 0,
+                                                  std::move(impl));
 }
 
 }  // extern "C"

--- a/module/capi/src/text_c.cpp
+++ b/module/capi/src/text_c.cpp
@@ -12,6 +12,8 @@
 #include <skity/text/font_style.hpp>
 #include <skity/text/text_blob.hpp>
 #include <skity/text/typeface.hpp>
+#include <utility>
+#include <vector>
 
 #include "handle.hpp"
 
@@ -45,6 +47,49 @@ skity::Font* font_of(skity_font handle) {
   auto* w = skity::capi::resolve<skity_font_s>(handle, SKITY_OBJECT_TYPE_FONT);
   return w ? static_cast<skity::Font*>(w->impl.get()) : nullptr;
 }
+
+skity::TypefaceDelegate* typeface_delegate_of(skity_typeface_delegate handle) {
+  auto* w = skity::capi::resolve<skity_typeface_delegate_s>(
+      handle, SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE);
+  return w ? static_cast<skity::TypefaceDelegate*>(w->impl.get()) : nullptr;
+}
+
+/*
+ * TypefaceDelegate adapter over a C fallback callback. BreakTextRun keeps the
+ * built-in empty policy (single run, per-code-point fallback), matching
+ * CreateSimpleFallbackDelegate.
+ */
+class CallbackDelegate : public skity::TypefaceDelegate {
+ public:
+  CallbackDelegate(skity_typeface_fallback_fn fallback, void* userdata,
+                   void (*release)(void*))
+      : fallback_(fallback), userdata_(userdata), release_(release) {}
+
+  ~CallbackDelegate() override {
+    if (release_ != nullptr) {
+      release_(userdata_);
+    }
+  }
+
+  std::shared_ptr<skity::Typeface> Fallback(
+      uint32_t code_point, skity::Paint const&) override {
+    if (fallback_ == nullptr) {
+      return nullptr;
+    }
+    // The handle stays owned by the C side; only a shared reference is taken.
+    return skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+        fallback_(userdata_, code_point), SKITY_OBJECT_TYPE_TYPEFACE);
+  }
+
+  std::vector<std::vector<uint32_t>> BreakTextRun(const char*) override {
+    return {};
+  }
+
+ private:
+  skity_typeface_fallback_fn fallback_;
+  void* userdata_;
+  void (*release_)(void*);
+};
 
 skity::FontStyle to_font_style(skity_font_style s) {
   return skity::FontStyle(s.weight, s.width,
@@ -111,6 +156,66 @@ uint16_t skity_typeface_unichar_to_glyph(skity_typeface typeface,
                                          uint32_t unichar) {
   auto* tf = typeface_of(typeface);
   return tf ? tf->UnicharToGlyph(unichar) : 0;
+}
+
+skity_typeface_delegate skity_typeface_delegate_create_simple(
+    const skity_typeface* typefaces, uint32_t count) {
+  if (typefaces == nullptr || count == 0) {
+    return nullptr;
+  }
+  std::vector<std::shared_ptr<skity::Typeface>> faces;
+  faces.reserve(count);
+  for (uint32_t i = 0; i < count; i++) {
+    auto tf = skity::capi::get_impl<skity_typeface_s, skity::Typeface>(
+        typefaces[i], SKITY_OBJECT_TYPE_TYPEFACE);
+    if (tf == nullptr) {
+      return nullptr;
+    }
+    faces.push_back(std::move(tf));
+  }
+  auto delegate = skity::TypefaceDelegate::CreateSimpleFallbackDelegate(faces);
+  if (delegate == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_delegate_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE, SKITY_HANDLE_OWNING,
+      std::move(delegate));
+}
+
+skity_typeface_delegate skity_typeface_delegate_create_fallback(
+    skity_typeface_fallback_fn fallback, void* userdata,
+    void (*release)(void* userdata)) {
+  if (fallback == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_typeface_delegate_s>(
+      SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE, SKITY_HANDLE_OWNING,
+      std::make_shared<CallbackDelegate>(fallback, userdata, release));
+}
+
+void skity_typeface_delegate_destroy(skity_typeface_delegate delegate) {
+  skity::capi::destroy_handle<skity_typeface_delegate_s>(
+      delegate, SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE);
+}
+
+skity_text_blob skity_text_blob_create_with_delegate(
+    const char* text, skity_paint paint, skity_typeface_delegate delegate) {
+  if (text == nullptr) {
+    return nullptr;
+  }
+  auto* pw =
+      skity::capi::resolve<skity_paint_s>(paint, SKITY_OBJECT_TYPE_PAINT);
+  if (pw == nullptr) {
+    return nullptr;
+  }
+  auto* p = static_cast<skity::Paint*>(pw->impl.get());
+  skity::TextBlobBuilder builder;
+  auto blob = builder.BuildTextBlob(text, *p, typeface_delegate_of(delegate));
+  if (blob == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_text_blob_s>(
+      SKITY_OBJECT_TYPE_TEXT_BLOB, SKITY_HANDLE_OWNING, std::move(blob));
 }
 
 skity_text_blob skity_text_blob_create(const char* text, skity_paint paint) {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -120,6 +120,20 @@ if (${SKITY_CODEC_MODULE})
     target_link_libraries(skity_unit_test PUBLIC skity::codec)
 endif()
 
+# C API wrapper tests (CPU-only; replay targets are recording canvases).
+if (${SKITY_CAPI_MODULE})
+    target_sources(skity_unit_test PRIVATE
+        capi/recorder_c_test.cc
+        capi/text_delegate_c_test.cc
+    )
+
+    target_include_directories(skity_unit_test PRIVATE
+        ${CMAKE_SOURCE_DIR}/module/capi/include
+    )
+
+    target_link_libraries(skity_unit_test PUBLIC skity::capi)
+endif()
+
 # no-rtti
 if (MSVC)
     target_compile_options(skity_unit_test PUBLIC /EHsc /GR-)

--- a/test/ut/capi/recorder_c_test.cc
+++ b/test/ut/capi/recorder_c_test.cc
@@ -1,0 +1,248 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Unit tests for the recorder / display-list surface of the C API
+// (module/capi). Everything here is CPU-only: display lists are replayed into
+// another PictureRecorder's canvas and inspected via op counts / offsets.
+
+#include <skity_c/skity_canvas.h>
+#include <skity_c/skity_paint.h>
+#include <skity_c/skity_recorder.h>
+#include <skity_c/skity_shader.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// RAII guards for the C handles used in these tests.
+struct RecorderGuard {
+  skity_picture_recorder r = skity_picture_recorder_create();
+  ~RecorderGuard() { skity_picture_recorder_destroy(r); }
+};
+
+struct PaintGuard {
+  skity_paint p = skity_paint_create();
+  ~PaintGuard() { skity_paint_destroy(p); }
+};
+
+struct DisplayListGuard {
+  skity_display_list l = nullptr;
+  ~DisplayListGuard() { skity_display_list_destroy(l); }
+  skity_display_list release() {
+    skity_display_list out = l;
+    l = nullptr;
+    return out;
+  }
+};
+
+struct ShaderGuard {
+  skity_shader s = nullptr;
+  ~ShaderGuard() { skity_shader_destroy(s); }
+};
+
+constexpr skity_rect kBounds = {0.f, 0.f, 1000.f, 1000.f};
+
+// Records `draws` separated rects (20x20 each, spaced 60 apart) into a
+// display list built with the requested rtree option.
+skity_display_list RecordSeparatedRects(uint32_t draws, uint32_t build_rtree,
+                                        int32_t* last_offset = nullptr) {
+  RecorderGuard recorder;
+  skity_display_list_build_options options;
+  options.build_rtree = build_rtree;
+  skity_picture_recorder_begin_with_options(recorder.r, &kBounds, &options);
+
+  skity_canvas canvas = skity_picture_recorder_get_canvas(recorder.r);
+  PaintGuard paint;
+  for (uint32_t i = 0; i < draws; i++) {
+    float x = 20.f + i * 60.f;
+    skity_rect rect = {x, 20.f, x + 20.f, 40.f};
+    skity_canvas_draw_rect(canvas, &rect, paint.p);
+  }
+  if (last_offset != nullptr) {
+    *last_offset = skity_picture_recorder_get_last_op_offset(recorder.r);
+  }
+
+  DisplayListGuard out;
+  EXPECT_EQ(skity_picture_recorder_finish(recorder.r, &out.l), SKITY_SUCCESS);
+  return out.release();
+}
+
+// Replays @p list into a fresh recording canvas and returns the target's
+// finished display list, whose op count is then comparable.
+skity_display_list ReplayIntoRecordingCanvas(skity_display_list list,
+                                             const skity_rect* cull_rect) {
+  RecorderGuard target;
+  skity_picture_recorder_begin(target.r, &kBounds);
+  skity_canvas canvas = skity_picture_recorder_get_canvas(target.r);
+  if (cull_rect != nullptr) {
+    skity_display_list_draw_with_cull_rect(list, canvas, cull_rect);
+  } else {
+    skity_display_list_draw(list, canvas);
+  }
+  DisplayListGuard out;
+  EXPECT_EQ(skity_picture_recorder_finish(target.r, &out.l), SKITY_SUCCESS);
+  return out.release();
+}
+
+}  // namespace
+
+TEST(CapiRecorder, GetLastOpOffsetBeforeBeginIsInvalid) {
+  RecorderGuard recorder;
+  EXPECT_EQ(skity_picture_recorder_get_last_op_offset(recorder.r), -1);
+}
+
+TEST(CapiRecorder, BeginWithOptionsBuildsSearchableList) {
+  int32_t last_offset = -1;
+  DisplayListGuard list{RecordSeparatedRects(3, 1, &last_offset)};
+  ASSERT_NE(list.l, nullptr);
+  EXPECT_GE(last_offset, 0);
+
+  // Covering only the last rect matches exactly one op.
+  skity_rect last = {140.f, 20.f, 160.f, 40.f};
+  int32_t offsets[4] = {-1, -1, -1, -1};
+  EXPECT_EQ(skity_display_list_search(list.l, &last, offsets, 4), 1u);
+  EXPECT_EQ(offsets[0], last_offset);
+
+  // The whole canvas matches all three, in recording order.
+  EXPECT_EQ(skity_display_list_search(list.l, &kBounds, offsets, 4), 3u);
+  EXPECT_TRUE(offsets[0] < offsets[1] && offsets[1] < offsets[2]);
+
+  // Capacity truncates the fill but not the reported count.
+  offsets[0] = offsets[1] = offsets[2] = offsets[3] = -1;
+  EXPECT_EQ(skity_display_list_search(list.l, &kBounds, offsets, 1), 3u);
+  EXPECT_EQ(offsets[1], -1);  // untouched beyond capacity
+
+  // A count-only query works without an output buffer.
+  EXPECT_EQ(skity_display_list_search(list.l, &kBounds, nullptr, 0), 3u);
+
+  // A region with no draws matches nothing.
+  skity_rect empty_region = {0.f, 500.f, 1000.f, 600.f};
+  EXPECT_EQ(skity_display_list_search(list.l, &empty_region, offsets, 4), 0u);
+}
+
+TEST(CapiRecorder, SearchWithoutRTreeReturnsNothing) {
+  DisplayListGuard list{RecordSeparatedRects(2, 0)};
+  ASSERT_NE(list.l, nullptr);
+  EXPECT_EQ(skity_display_list_search(list.l, &kBounds, nullptr, 0), 0u);
+  EXPECT_EQ(skity_display_list_search_non_overlapping_drawn_rects(
+                list.l, &kBounds, nullptr, 0),
+            0u);
+}
+
+TEST(CapiRecorder, SearchNonOverlappingDrawnRectsMergesAdjacent) {
+  RecorderGuard recorder;
+  skity_display_list_build_options options;
+  options.build_rtree = 1;
+  skity_picture_recorder_begin_with_options(recorder.r, &kBounds, &options);
+  skity_canvas canvas = skity_picture_recorder_get_canvas(recorder.r);
+  PaintGuard paint;
+  skity_rect left = {20.f, 20.f, 40.f, 40.f};
+  skity_rect right = {40.f, 20.f, 60.f, 40.f};  // shares the edge with left
+  skity_canvas_draw_rect(canvas, &left, paint.p);
+  skity_canvas_draw_rect(canvas, &right, paint.p);
+  DisplayListGuard list;
+  ASSERT_EQ(skity_picture_recorder_finish(recorder.r, &list.l), SKITY_SUCCESS);
+
+  skity_rect rects[2];
+  uint32_t count = skity_display_list_search_non_overlapping_drawn_rects(
+      list.l, &kBounds, rects, 2);
+  ASSERT_EQ(count, 1u);
+  EXPECT_FLOAT_EQ(rects[0].left, 20.f);
+  EXPECT_FLOAT_EQ(rects[0].top, 20.f);
+  EXPECT_FLOAT_EQ(rects[0].right, 60.f);
+  EXPECT_FLOAT_EQ(rects[0].bottom, 40.f);
+}
+
+TEST(CapiRecorder, DrawWithCullRectReplaysFewerOps) {
+  DisplayListGuard list{RecordSeparatedRects(3, 1)};
+  ASSERT_NE(list.l, nullptr);
+
+  skity_rect last_rect = {140.f, 20.f, 160.f, 40.f};
+  DisplayListGuard full{ReplayIntoRecordingCanvas(list.l, nullptr)};
+  DisplayListGuard partial{ReplayIntoRecordingCanvas(list.l, &last_rect)};
+  ASSERT_NE(full.l, nullptr);
+  ASSERT_NE(partial.l, nullptr);
+
+  EXPECT_EQ(skity_display_list_get_op_count(full.l), 3u);
+  EXPECT_EQ(skity_display_list_get_op_count(partial.l), 1u);
+
+  // A NULL cull rect draws nothing.
+  RecorderGuard null_target;
+  skity_picture_recorder_begin(null_target.r, &kBounds);
+  skity_canvas null_canvas = skity_picture_recorder_get_canvas(null_target.r);
+  skity_display_list_draw_with_cull_rect(list.l, null_canvas, nullptr);
+  DisplayListGuard null_list;
+  ASSERT_EQ(skity_picture_recorder_finish(null_target.r, &null_list.l),
+            SKITY_SUCCESS);
+  EXPECT_EQ(skity_display_list_get_op_count(null_list.l), 0u);
+}
+
+TEST(CapiRecorder, DrawWithCullRectWithoutRTreeReplaysAll) {
+  DisplayListGuard list{RecordSeparatedRects(3, 0)};
+  ASSERT_NE(list.l, nullptr);
+
+  skity_rect last_rect = {140.f, 20.f, 160.f, 40.f};
+  DisplayListGuard culled{ReplayIntoRecordingCanvas(list.l, &last_rect)};
+  DisplayListGuard full{ReplayIntoRecordingCanvas(list.l, nullptr)};
+  // Without an rtree the cull rect is ignored and everything is replayed.
+  EXPECT_EQ(skity_display_list_get_op_count(culled.l),
+            skity_display_list_get_op_count(full.l));
+}
+
+TEST(CapiRecorder, PropertiesReflectRecordedPaints) {
+  RecorderGuard recorder;
+  skity_display_list_build_options options;
+  options.build_rtree = 1;
+  skity_rect bounds = {0.f, 0.f, 100.f, 100.f};
+  skity_picture_recorder_begin_with_options(recorder.r, &bounds, &options);
+  skity_canvas canvas = skity_picture_recorder_get_canvas(recorder.r);
+
+  PaintGuard paint;
+  skity_color4f red = {{1.f, 0.f, 0.f, 1.f}};
+  skity_point pts[2] = {{{0.f, 0.f, 0.f, 1.f}}, {{100.f, 0.f, 0.f, 1.f}}};
+  ShaderGuard shader{skity_shader_create_linear(pts, &red, nullptr, 2,
+                                                SKITY_TILE_MODE_CLAMP, 0)};
+  ASSERT_NE(shader.s, nullptr);
+  skity_paint_set_shader(paint.p, shader.s);
+
+  skity_rect rect = {10.f, 10.f, 50.f, 50.f};
+  skity_canvas_draw_rect(canvas, &rect, paint.p);
+  skity_canvas_save_layer(canvas, &bounds, paint.p);
+
+  DisplayListGuard list;
+  ASSERT_EQ(skity_picture_recorder_finish(recorder.r, &list.l), SKITY_SUCCESS);
+
+  uint32_t props = skity_display_list_get_properties(list.l);
+  EXPECT_TRUE(props & SKITY_DISPLAY_LIST_PROPERTY_SHADER);
+  EXPECT_TRUE(props & SKITY_DISPLAY_LIST_PROPERTY_SAVE_LAYER);
+  EXPECT_FALSE(props & SKITY_DISPLAY_LIST_PROPERTY_COLOR_FILTER);
+  EXPECT_FALSE(props & SKITY_DISPLAY_LIST_PROPERTY_MASK_FILTER);
+  EXPECT_FALSE(props & SKITY_DISPLAY_LIST_PROPERTY_IMAGE_FILTER);
+}
+
+TEST(CapiRecorder, GetOpPaintByOffset) {
+  int32_t offset = -1;
+  DisplayListGuard list{RecordSeparatedRects(1, 1, &offset)};
+  ASSERT_NE(list.l, nullptr);
+  ASSERT_GE(offset, 0);
+
+  // Non-owning paint handle lives inside the display list and is mutable.
+  skity_paint paint = skity_display_list_get_op_paint_by_offset(list.l, offset);
+  ASSERT_NE(paint, nullptr);
+  EXPECT_EQ(skity_paint_get_color(paint), 0xFF000000u);
+  skity_paint_set_color(paint, 0xFFFF0000u);
+
+  // A second lookup observes the in-place edit (same underlying Paint).
+  skity_paint paint2 =
+      skity_display_list_get_op_paint_by_offset(list.l, offset);
+  ASSERT_NE(paint2, nullptr);
+  EXPECT_EQ(skity_paint_get_color(paint2), 0xFFFF0000u);
+  skity_paint_destroy(paint);
+  skity_paint_destroy(paint2);
+
+  // Invalid offsets return NULL.
+  EXPECT_EQ(skity_display_list_get_op_paint_by_offset(list.l, -1), nullptr);
+  EXPECT_EQ(skity_display_list_get_op_paint_by_offset(list.l, 1 << 30),
+            nullptr);
+}

--- a/test/ut/capi/text_delegate_c_test.cc
+++ b/test/ut/capi/text_delegate_c_test.cc
@@ -1,0 +1,171 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Unit tests for the TypefaceDelegate surface of the C API (module/capi):
+// multi-font fallback when building text blobs. Cases needing real font
+// files are guarded on SKITY_FONT_DIR (mirroring text/typeface_test.cc) and
+// skip when the fixture is unavailable.
+
+#include <skity_c/skity_paint.h>
+#include <skity_c/skity_text.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct TypefaceGuard {
+  skity_typeface t = nullptr;
+  ~TypefaceGuard() { skity_typeface_destroy(t); }
+};
+
+struct PaintGuard {
+  skity_paint p = skity_paint_create();
+  ~PaintGuard() { skity_paint_destroy(p); }
+};
+
+struct DelegateGuard {
+  skity_typeface_delegate d = nullptr;
+  ~DelegateGuard() { skity_typeface_delegate_destroy(d); }
+};
+
+struct BlobGuard {
+  skity_text_blob b = nullptr;
+  ~BlobGuard() { skity_text_blob_destroy(b); }
+};
+
+// Callback state shared between the test body and the C callbacks.
+struct FallbackState {
+  skity_typeface result = nullptr;  // returned to skity on every probe
+  int calls = 0;
+  int releases = 0;
+};
+
+skity_typeface CountingFallback(void* userdata, uint32_t code_point) {
+  auto* state = static_cast<FallbackState*>(userdata);
+  state->calls++;
+  // Only claim the pile-of-poo; anything else has no fallback.
+  return code_point == 0x1F4A9 ? state->result : nullptr;
+}
+
+void CountingRelease(void* userdata) {
+  static_cast<FallbackState*>(userdata)->releases++;
+}
+
+}  // namespace
+
+TEST(CapiTextDelegate, CreateSimpleRejectsEmptyList) {
+  EXPECT_EQ(skity_typeface_delegate_create_simple(nullptr, 0), nullptr);
+  TypefaceGuard tf{skity_typeface_get_default()};
+  ASSERT_NE(tf.t, nullptr);
+  EXPECT_EQ(skity_typeface_delegate_create_simple(nullptr, 1), nullptr);
+  EXPECT_EQ(skity_typeface_delegate_create_simple(&tf.t, 0), nullptr);
+}
+
+TEST(CapiTextDelegate, CreateFallbackRejectsNullCallback) {
+  EXPECT_EQ(skity_typeface_delegate_create_fallback(nullptr, nullptr, nullptr),
+            nullptr);
+}
+
+TEST(CapiTextDelegate, BlobRequiresPaintTypeface) {
+  PaintGuard paint;
+  BlobGuard blob{skity_text_blob_create("hi", paint.p)};
+  EXPECT_EQ(blob.b, nullptr);
+
+  // A missing typeface fails the delegate path too (NULL delegate or not).
+  BlobGuard with_delegate{
+      skity_text_blob_create_with_delegate("hi", paint.p, nullptr)};
+  EXPECT_EQ(with_delegate.b, nullptr);
+}
+
+TEST(CapiTextDelegate, NullDelegateBehavesLikePlainCreate) {
+  TypefaceGuard tf{skity_typeface_get_default()};
+  ASSERT_NE(tf.t, nullptr);
+  PaintGuard paint;
+  skity_paint_set_typeface(paint.p, tf.t);
+
+  BlobGuard plain{skity_text_blob_create("abc", paint.p)};
+  BlobGuard with_null{skity_text_blob_create_with_delegate("abc", paint.p, nullptr)};
+  ASSERT_NE(plain.b, nullptr);
+  ASSERT_NE(with_null.b, nullptr);
+  skity_rect plain_bounds = {}, null_bounds = {};
+  skity_text_blob_get_bounds(plain.b, &plain_bounds);
+  skity_text_blob_get_bounds(with_null.b, &null_bounds);
+  EXPECT_FLOAT_EQ(plain_bounds.right - plain_bounds.left,
+                  null_bounds.right - null_bounds.left);
+}
+
+TEST(CapiTextDelegate, FallbackCallbackDrivesLayoutAndRelease) {
+  TypefaceGuard tf{skity_typeface_get_default()};
+  ASSERT_NE(tf.t, nullptr);
+
+  FallbackState state;
+  state.result = tf.t;
+  {
+    DelegateGuard delegate{skity_typeface_delegate_create_fallback(
+        &CountingFallback, &state, &CountingRelease)};
+    ASSERT_NE(delegate.d, nullptr);
+
+    PaintGuard paint;
+    skity_paint_set_typeface(paint.p, tf.t);
+    BlobGuard blob{skity_text_blob_create_with_delegate(
+        "a\xF0\x9F\x92\xA9"  // U+1F4A9 PILE OF POO
+        "b",
+        paint.p, delegate.d)};
+    // The default typeface has no glyph for the emoji, so the callback ran.
+    EXPECT_GT(state.calls, 0);
+    if (blob.b != nullptr) {
+      skity_rect bounds = {};
+      skity_text_blob_get_bounds(blob.b, &bounds);
+      EXPECT_GT(bounds.right, bounds.left);
+    }
+  }
+  // The release callback fires exactly once when the delegate is destroyed.
+  EXPECT_EQ(state.releases, 1);
+}
+
+#ifdef SKITY_FONT_DIR
+
+namespace {
+constexpr const char* kRobotoRegular =
+    SKITY_FONT_DIR "fonts/resources/Roboto-Regular.ttf";
+constexpr const char* kNotoColorEmoji =
+    SKITY_FONT_DIR "fonts/resources/NotoColorEmoji.ttf";
+}  // namespace
+
+// Roboto covers the ASCII part of the text and the emoji font takes the
+// pile-of-poo, exercising the multi-font fallback path end to end.
+TEST(CapiTextDelegate, SimpleDelegateFallsBackAcrossFonts) {
+  TypefaceGuard roboto{skity_typeface_make_from_file(kRobotoRegular)};
+  TypefaceGuard emoji{skity_typeface_make_from_file(kNotoColorEmoji)};
+  ASSERT_NE(roboto.t, nullptr);
+#if defined(__APPLE__)
+  // NotoColorEmoji is a CBDT/CBLC bitmap font; the CoreText port may reject
+  // it, in which case the fallback list is unusable and there is nothing to
+  // assert beyond graceful failure.
+  if (emoji.t == nullptr) {
+    GTEST_SKIP() << "CoreText rejected NotoColorEmoji.ttf";
+  }
+#endif
+  if (emoji.t == nullptr) {
+    GTEST_SKIP() << "emoji font fixture unavailable";
+  }
+
+  skity_typeface faces[1] = {emoji.t};
+  DelegateGuard delegate{skity_typeface_delegate_create_simple(faces, 1)};
+  ASSERT_NE(delegate.d, nullptr);
+
+  PaintGuard paint;
+  skity_paint_set_typeface(paint.p, roboto.t);
+  BlobGuard blob{skity_text_blob_create_with_delegate(
+      "ok \xF0\x9F\x92\xA9"  // U+1F4A9 PILE OF POO
+      "!",
+      paint.p, delegate.d)};
+  ASSERT_NE(blob.b, nullptr);
+  skity_rect bounds = {};
+  skity_text_blob_get_bounds(blob.b, &bounds);
+  EXPECT_GT(bounds.right, bounds.left);
+  EXPECT_GT(bounds.bottom, bounds.top);
+}
+
+#endif  // SKITY_FONT_DIR


### PR DESCRIPTION
Close two drawing-capability gaps of the C wrapper (`module/capi`). **Stacked on #446** — merge that first; a test here depends on the `dp_builder_` initialization fix.

## Multi-font text fallback (TypefaceDelegate)

- `skity_typeface_delegate_create_simple(typefaces[], count)` — wraps `CreateSimpleFallbackDelegate`, handles share typeface reference counts
- `skity_typeface_delegate_create_fallback(fn, userdata, release)` — drives the typeface choice through a C callback (built-in run-splitting policy, optional release callback on destroy)
- `skity_text_blob_create_with_delegate` — builds blobs with per-code-point fallback (CJK / emoji mixing); NULL delegate is equivalent to the plain create

## DisplayList partial redraw

- `skity_picture_recorder_begin_with_options` — exposes `build_rtree`
- `skity_display_list_draw_with_cull_rect` — replays only ops intersecting the damage rect, restoring the save/clip/matrix state they depend on
- `skity_display_list_search` / `search_non_overlapping_drawn_rects` — rtree hits as plain `int32_t` offsets, two-pass buffers
- `skity_display_list_get_properties` — recorded-content property bits
- `skity_display_list_get_op_paint_by_offset` — non-owning, mutable paint handle (in-place edits visible to later replays)
- `skity_picture_recorder_get_last_op_offset` — latest op offset (on the recorder: `GetLastOpOffset` is a `RecordingCanvas` non-virtual method and the wrapper builds with `-fno-rtti`)

## Tests & docs

- `test/ut/capi/` — 14 CPU-only cases: replay targets are recording canvases (cull 3→1 ops, NULL cull → 0, no-rtree degradation, property bits, in-place paint mutation); font fixtures from `test/fonts/resources`
- `C_API_DESIGN.md` §11 coverage table synced — the P0–P2 backlog it still listed had already landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)