### PR TITLE
fix(recorder): initialize RecordingCanvas dp_builder_ to nullptr

### DIFF
--- a/include/skity/recorder/recording_canvas.hpp
+++ b/include/skity/recorder/recording_canvas.hpp
@@ -67,7 +67,7 @@ class SKITY_API RecordingCanvas : public Canvas {
   void AccumulateOpBounds(const Rect& raw_bounds, const Paint* paint);
   void UpdateProperties(const Paint& paint);
 
-  DisplayListBuilder* dp_builder_;
+  DisplayListBuilder* dp_builder_ = nullptr;
 };
 
 }  // namespace skity


### PR DESCRIPTION
The `dp_builder_` member was left uninitialized, so calling `GetLastOpOffset()` before `BeginRecording()` compared a garbage pointer against `nullptr`, passed the check, and dereferenced it — a crash any C++ consumer can hit, surfaced by the new C API tests.

One-line fix: default-initialize the pointer so the existing null guard actually holds.