### PR TITLE
fix(gpu): fall back gracefully when GPU texture creation fails

### DIFF
--- a/src/gpu/gl/gpu_context_impl_gl.cc
+++ b/src/gpu/gl/gpu_context_impl_gl.cc
@@ -126,7 +126,16 @@ std::unique_ptr<GPUSurface> GPUContextImplGL::CreateSurface(
 
 std::unique_ptr<GPURenderTarget> GPUContextImplGL::OnCreateRenderTarget(
     const GPURenderTargetDescriptor& desc, std::shared_ptr<Texture> texture) {
-  auto gl_texture = static_cast<GPUTextureGL*>(texture->GetGPUTexture().get());
+  if (texture == nullptr) {
+    return nullptr;
+  }
+
+  auto gpu_texture = texture->GetGPUTexture();
+  if (gpu_texture == nullptr) {
+    return nullptr;
+  }
+
+  auto gl_texture = static_cast<GPUTextureGL*>(gpu_texture.get());
 
   GPUSurfaceDescriptorGL surface_desc{};
   surface_desc.backend = GetBackendType();

--- a/src/gpu/gpu_context_impl.cc
+++ b/src/gpu/gpu_context_impl.cc
@@ -96,6 +96,10 @@ std::unique_ptr<GPURenderTarget> GPUContextImpl::CreateRenderTarget(
 
 std::shared_ptr<Image> GPUContextImpl::MakeSnapshot(
     std::unique_ptr<GPURenderTarget> render_target) {
+  if (render_target == nullptr) {
+    return nullptr;
+  }
+
   auto dl = render_target->recorder_.FinishRecording();
 
   if (dl == nullptr) {

--- a/src/gpu/mtl/gpu_context_impl_mtl.mm
+++ b/src/gpu/mtl/gpu_context_impl_mtl.mm
@@ -94,7 +94,12 @@ std::unique_ptr<GPURenderTarget> GPUContextImplMTL::OnCreateRenderTarget(
     return {};
   }
 
-  auto mtl_texture = static_cast<GPUTextureMTL *>(texture->GetGPUTexture().get());
+  auto gpu_texture = texture->GetGPUTexture();
+  if (gpu_texture == nullptr) {
+    return {};
+  }
+
+  auto mtl_texture = static_cast<GPUTextureMTL *>(gpu_texture.get());
 
   GPUSurfaceDescriptorMTL surface_desc{};
   surface_desc.backend = GetBackendType();

--- a/src/gpu/texture_impl.cc
+++ b/src/gpu/texture_impl.cc
@@ -60,9 +60,18 @@ void TextureImpl::DeferredUploadImage(std::shared_ptr<Pixmap> pixmap) {
 }
 
 void TextureImpl::CommitDeferredImageUpload() {
-  CHECK(pending_pixmap_);
-  UploadImage(pending_pixmap_);
-  pending_pixmap_.reset();
+  if (!pending_pixmap_) {
+    return;
+  }
+  auto delegate = delegate_.lock();
+  if (!delegate) {
+    return;
+  }
+  if (delegate->UploadTextureImage(*this, pending_pixmap_)) {
+    // Keep the pending pixmap when the upload fails (e.g. GPU memory
+    // exhaustion) so the upload can be retried on a later frame.
+    pending_pixmap_.reset();
+  }
 }
 
 void TextureImpl::UploadImage(std::shared_ptr<Pixmap> pixmap) {

--- a/src/gpu/texture_impl.hpp
+++ b/src/gpu/texture_impl.hpp
@@ -65,7 +65,9 @@ class TextureImplDelegate {
  public:
   virtual ~TextureImplDelegate() = default;
 
-  virtual void UploadTextureImage(const TextureImpl& texture,
+  // Returns whether the GPU texture was created (and the image uploaded)
+  // successfully. A false return means the upload can be retried later.
+  virtual bool UploadTextureImage(const TextureImpl& texture,
                                   std::shared_ptr<Pixmap> pixmap) = 0;
   virtual std::shared_ptr<GPUTexture> GetGPUTexture(TextureImpl* texture) = 0;
   virtual void DropTexture(const UniqueID& handler) = 0;

--- a/src/gpu/texture_manager.cc
+++ b/src/gpu/texture_manager.cc
@@ -94,7 +94,7 @@ TextureState TextureManager::QueryState(const UniqueID& handler) {
   return TextureState::Uploaded;
 }
 
-void TextureManager::SaveGPUTexture(const UniqueID& handler,
+bool TextureManager::SaveGPUTexture(const UniqueID& handler,
                                     CreateGPUTextureCallback callback) {
   UniqueLock lock(shared_mutex_);
   if (handler_to_texture_.find(handler) == handler_to_texture_.end() ||
@@ -102,6 +102,7 @@ void TextureManager::SaveGPUTexture(const UniqueID& handler,
     auto hw_texture = callback();
     handler_to_texture_.insert_or_assign(handler, std::move(hw_texture));
   }
+  return handler_to_texture_[handler] != nullptr;
 }
 
 std::shared_ptr<GPUTexture> TextureManager::QueryGPUTexture(
@@ -113,7 +114,7 @@ std::shared_ptr<GPUTexture> TextureManager::QueryGPUTexture(
   return handler_to_texture_[handler] ? handler_to_texture_[handler] : nullptr;
 }
 
-void TextureManager::UploadTextureImage(const TextureImpl& texture,
+bool TextureManager::UploadTextureImage(const TextureImpl& texture,
                                         std::shared_ptr<Pixmap> pixmap) {
   auto device = gpu_device_;
 
@@ -127,7 +128,7 @@ void TextureManager::UploadTextureImage(const TextureImpl& texture,
                              : std::min(requested_level_count, max_level_count);
   }
 
-  SaveGPUTexture(
+  return SaveGPUTexture(
       texture.GetHandler(),
       [device, pixmap = std::move(pixmap), format = texture.GetFormat(),
        mipmap_level_count]() -> std::shared_ptr<GPUTexture> {
@@ -170,7 +171,16 @@ std::shared_ptr<GPUTexture> TextureManager::GetGPUTexture(
   if (QueryState(texture->GetHandler()) == TextureState::Created) {
     texture->CommitDeferredImageUpload();
   }
-  CHECK(QueryState(texture->GetHandler()) == TextureState::Uploaded);
+  if (QueryState(texture->GetHandler()) != TextureState::Uploaded) {
+    // GPU texture creation may fail (e.g. out of GPU memory). Callers already
+    // handle a null texture by falling back to a solid color, so return null
+    // instead of killing the process. A pending pixmap, if any, is kept for a
+    // retry on a later frame.
+    LOGE("Failed to upload texture {} , texture state = {}",
+         texture->GetHandler().id,
+         static_cast<uint32_t>(QueryState(texture->GetHandler())));
+    return nullptr;
+  }
   return QueryGPUTexture(texture->GetHandler());
 }
 

--- a/src/gpu/texture_manager.hpp
+++ b/src/gpu/texture_manager.hpp
@@ -98,7 +98,7 @@ class TextureManager : public TextureImplDelegate,
                                                std::shared_ptr<Pixmap> pixmap);
 
   // TextureImplDelegate
-  void UploadTextureImage(const TextureImpl& texture,
+  bool UploadTextureImage(const TextureImpl& texture,
                           std::shared_ptr<Pixmap> pixmap) override;
   std::shared_ptr<GPUTexture> GetGPUTexture(TextureImpl* texture) override;
   void DropTexture(const UniqueID& handler) override;
@@ -112,7 +112,9 @@ class TextureManager : public TextureImplDelegate,
 
   TextureState QueryState(const UniqueID& handler);
 
-  void SaveGPUTexture(const UniqueID& handler,
+  // Returns whether the handler is associated with a valid GPU texture after
+  // this call.
+  bool SaveGPUTexture(const UniqueID& handler,
                       CreateGPUTextureCallback callback);
 
   std::shared_ptr<GPUTexture> QueryGPUTexture(const UniqueID& handler);

--- a/src/graphic/image.cc
+++ b/src/graphic/image.cc
@@ -69,6 +69,9 @@ bool ScalePixelsForTexture(std::shared_ptr<Pixmap> dst, GPUContext* context,
   desc.height = dst->Height();
   desc.sample_count = 1;
   auto render_target = context->CreateRenderTarget(desc);
+  if (!render_target) {
+    return false;
+  }
   auto canvas = render_target->GetCanvas();
   canvas->DrawImageRect(Image::MakeHWImage(texture),
                         Rect::MakeWH(texture->Width(), texture->Height()),
@@ -76,6 +79,9 @@ bool ScalePixelsForTexture(std::shared_ptr<Pixmap> dst, GPUContext* context,
                         sampling_options);
   std::shared_ptr<Image> snapshot =
       context->MakeSnapshot(std::move(render_target));
+  if (!snapshot) {
+    return false;
+  }
   auto snapshot_pixels = snapshot->ReadPixels(context);
   if (!snapshot_pixels) {
     return false;
@@ -116,8 +122,14 @@ class TextureImage : public Image {
     }
     const auto& texture_image = *GetTexture();
     auto gpu_texture = texture_image->GetGPUTexture();
+    if (gpu_texture == nullptr) {
+      return nullptr;
+    }
     auto* gpu_context_impl = static_cast<GPUContextImpl*>(context);
     auto data = gpu_context_impl->ReadPixels(gpu_texture);
+    if (data == nullptr) {
+      return nullptr;
+    }
 
     return std::make_shared<Pixmap>(
         data, Width(), Height(), AlphaType::kPremul_AlphaType,

--- a/src/graphic/image.cc
+++ b/src/graphic/image.cc
@@ -16,6 +16,7 @@
 #include "src/gpu/texture_manager.hpp"
 #include "src/graphic/bitmap_sampler.hpp"
 #include "src/graphic/color_priv.hpp"
+#include "src/logging.hpp"
 
 namespace skity {
 namespace {
@@ -222,6 +223,13 @@ std::shared_ptr<Texture> PromiseTextureImage::GetTextureByContext(
     }
 
     auto gpu_texture = texture_->GetGPUTexture();
+    if (!gpu_texture) {
+      // The promised texture has no GPU texture (e.g. creation failed).
+      // Drop the cache so the promise can be resolved again later.
+      LOGE("PromiseTextureImage: promise texture is not ready");
+      texture_.reset();
+      return nullptr;
+    }
 
     gpu_texture->SetRelease(release_callback_, promise_texture_context_);
   }
@@ -240,6 +248,13 @@ const std::shared_ptr<Texture>* PromiseTextureImage::GetTexture() const {
       return nullptr;
     }
     auto gpu_texture = texture_->GetGPUTexture();
+    if (!gpu_texture) {
+      // The promised texture has no GPU texture (e.g. creation failed).
+      // Drop the cache so the promise can be resolved again later.
+      LOGE("PromiseTextureImage: promise texture is not ready");
+      texture_.reset();
+      return nullptr;
+    }
     gpu_texture->SetRelease(release_callback_, promise_texture_context_);
   }
   return &texture_;


### PR DESCRIPTION
## Background

Online crash in `TextureManager::GetGPUTexture` (texture_manager.cc:173):

```
Check Failed: QueryState(texture->GetHandler()) == TextureState::Uploaded
```

## Root cause

Rendering is single threaded, so the only way to hit this CHECK is a failed `CreateTexture` inside `CommitDeferredImageUpload` (e.g. `vmaAllocateMemory` failure under GPU memory pressure): `SaveGPUTexture` wrote the null result back into the map, so the state stayed `Created`. The pending pixmap was also dropped after the failed upload, so the same texture would hit `CHECK(pending_pixmap_)` again on every following frame.

## Changes

- `TextureManager::GetGPUTexture` returns nullptr (with LOGE) instead of killing the process when the texture cannot be uploaded; callers fall back to solid color shading. The `Unknowing`-state CHECK is kept since it signals a real logic error.
- `TextureImpl::CommitDeferredImageUpload` keeps the pending pixmap on failure so the upload is retried on a later frame, and no longer CHECKs on an empty pixmap.
- Null guards for callers that dereferenced the result directly: `PromiseTextureImage` (drops the cached promise texture so it can be re-resolved later), and the GL/MTL `OnCreateRenderTarget` overrides (now match the VK one).
- Review follow-up: `TextureImage::ReadPixels` returns nullptr when the GPU texture or readback data is null (instead of building a Pixmap with null `Addr()`); `ScalePixelsForTexture` handles a failed render target / snapshot; `MakeSnapshot` guards a null render target.

## Verification

- `skity` builds; `skity_unit_test` passes (2 Arena failures are pre-existing on main, reproduced on a clean tree)
- `skity_vulkan_unit_test`: pass set identical to clean main (segfault in `CreatesGraphicsPipelineForRepositoryStyleTextureShaders` is pre-existing)
- golden (Metal): `ImageGolden.*` and `*ImageShader*` pass