### PR TITLE
fix(vk): break GPU resource state reference cycle

### DIFF
--- a/src/gpu/vk/gpu_buffer_vk.cc
+++ b/src/gpu/vk/gpu_buffer_vk.cc
@@ -34,7 +34,9 @@ VkBufferUsageFlags ConvertGPUBufferUsageMask(GPUBufferUsageMask usage) {
 GPUBufferVK::GPUBufferVK(const GPUBufferDescriptor& desc,
                          std::shared_ptr<const VulkanContextState> state,
                          GPUBufferVKMemoryType memory_type)
-    : GPUBuffer(desc), state_(std::move(state)), memory_type_(memory_type) {}
+    : GPUBuffer(desc),
+      GPUObjectVK(std::move(state)),
+      memory_type_(memory_type) {}
 
 GPUBufferVK::~GPUBufferVK() { DestroyBuffer(); }
 
@@ -60,7 +62,8 @@ bool GPUBufferVK::UploadData(const void* data, size_t size) {
     return false;
   }
 
-  if (state_ == nullptr || state_->GetAllocator() == nullptr ||
+  const auto state = LockState();
+  if (state == nullptr || state->GetAllocator() == nullptr ||
       allocation_ == nullptr) {
     LOGE("Failed to upload Vulkan buffer data: allocator is unavailable");
     return false;
@@ -73,8 +76,8 @@ bool GPUBufferVK::UploadData(const void* data, size_t size) {
     return false;
   }
 
-  const VkResult result = vmaCopyMemoryToAllocation(state_->GetAllocator(),
-                                                    data, allocation_, 0, size);
+  const VkResult result = vmaCopyMemoryToAllocation(state->GetAllocator(), data,
+                                                    allocation_, 0, size);
   if (result != VK_SUCCESS) {
     LOGE("Failed to upload {} bytes to Vulkan buffer: {}", size,
          static_cast<int32_t>(result));
@@ -87,8 +90,9 @@ bool GPUBufferVK::UploadData(const void* data, size_t size) {
 bool GPUBufferVK::CreateBuffer(VkDeviceSize size) {
   DestroyBuffer();
 
-  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
-      state_->GetAllocator() == nullptr) {
+  const auto state = LockState();
+  if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE ||
+      state->GetAllocator() == nullptr) {
     LOGE("Failed to create Vulkan buffer: device or allocator is unavailable");
     return false;
   }
@@ -117,7 +121,7 @@ bool GPUBufferVK::CreateBuffer(VkDeviceSize size) {
 
   VmaAllocationInfo vma_info = {};
   const VkResult result =
-      vmaCreateBuffer(state_->GetAllocator(), &buffer_info, &allocation_info,
+      vmaCreateBuffer(state->GetAllocator(), &buffer_info, &allocation_info,
                       &buffer_, &allocation_, &vma_info);
   if (result != VK_SUCCESS || buffer_ == VK_NULL_HANDLE ||
       allocation_ == nullptr) {
@@ -133,9 +137,10 @@ bool GPUBufferVK::CreateBuffer(VkDeviceSize size) {
 }
 
 void GPUBufferVK::DestroyBuffer() {
-  if (state_ != nullptr && state_->GetAllocator() != nullptr &&
+  const auto state = LockState();
+  if (state != nullptr && state->GetAllocator() != nullptr &&
       buffer_ != VK_NULL_HANDLE && allocation_ != nullptr) {
-    vmaDestroyBuffer(state_->GetAllocator(), buffer_, allocation_);
+    vmaDestroyBuffer(state->GetAllocator(), buffer_, allocation_);
   }
 
   buffer_ = VK_NULL_HANDLE;

--- a/src/gpu/vk/gpu_buffer_vk.hpp
+++ b/src/gpu/vk/gpu_buffer_vk.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "src/gpu/gpu_buffer.hpp"
+#include "src/gpu/vk/gpu_object_vk.hpp"
 
 namespace skity {
 
@@ -20,7 +21,7 @@ enum class GPUBufferVKMemoryType {
   kHostVisible,
 };
 
-class GPUBufferVK : public GPUBuffer {
+class GPUBufferVK : public GPUBuffer, public GPUObjectVK {
  public:
   GPUBufferVK(
       const GPUBufferDescriptor& desc,
@@ -51,7 +52,6 @@ class GPUBufferVK : public GPUBuffer {
   bool CreateBuffer(VkDeviceSize size);
   void DestroyBuffer();
 
-  std::shared_ptr<const VulkanContextState> state_ = {};
   GPUBufferVKMemoryType memory_type_ = GPUBufferVKMemoryType::kDeviceLocal;
   VkBuffer buffer_ = VK_NULL_HANDLE;
   VmaAllocation allocation_ = nullptr;

--- a/src/gpu/vk/gpu_context_impl_vk.cc
+++ b/src/gpu/vk/gpu_context_impl_vk.cc
@@ -1137,8 +1137,13 @@ std::shared_ptr<Data> GPUContextVK::OnReadPixels(
 
   // Keep the command buffer alive through the cleanup action so the staging
   // buffer remains valid after CollectPendingSubmissions destroys the pending
-  // submission objects. The shared_ptr prevents early destruction.
-  command_buffer->RecordCleanupAction([command_buffer] {});
+  // submission objects. A weak_ptr is used on purpose: a strong capture
+  // would create a state -> pending submission -> cleanup lambda ->
+  // command buffer -> state reference cycle, which leads to re-entrant
+  // destruction of the VulkanContextState.
+  command_buffer->RecordCleanupAction(
+      [weak_command_buffer =
+           std::weak_ptr<GPUCommandBufferVK>(command_buffer)] {});
 
   if (!command_buffer->Submit()) {
     LOGE("GPUContextVK::OnReadPixels: failed to submit command buffer");

--- a/src/gpu/vk/gpu_external_texture_ahb.cc
+++ b/src/gpu/vk/gpu_external_texture_ahb.cc
@@ -20,18 +20,18 @@ GPUExternalTextureAHB::GPUExternalTextureAHB(
     : GPUTextureVK(state, descriptor, image,
                    /*allocation=*/nullptr, image_view, preferred_layout, format,
                    /*owns_image=*/false, /*owns_image_view=*/false),
-      state_(std::move(state)),
       memory_(memory) {
   SetCurrentLayout(initial_layout);
 }
 
 GPUExternalTextureAHB::~GPUExternalTextureAHB() {
-  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+  const auto state = LockState();
+  if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE) {
     return;
   }
 
-  VkDevice device = state_->GetLogicalDevice();
-  const auto& fns = state_->DeviceFns();
+  VkDevice device = state->GetLogicalDevice();
+  const auto& fns = state->DeviceFns();
 
   if (GetImageView() != VK_NULL_HANDLE && fns.vkDestroyImageView != nullptr) {
     fns.vkDestroyImageView(device, GetImageView(), nullptr);

--- a/src/gpu/vk/gpu_external_texture_ahb.hpp
+++ b/src/gpu/vk/gpu_external_texture_ahb.hpp
@@ -40,7 +40,6 @@ class GPUExternalTextureAHB : public GPUTextureVK {
                         VkImageLayout initial_layout,
                         VkImageLayout preferred_layout, VkFormat format);
 
-  std::shared_ptr<const VulkanContextState> state_;
   VkDeviceMemory memory_ = VK_NULL_HANDLE;
 };
 

--- a/src/gpu/vk/gpu_object_vk.hpp
+++ b/src/gpu/vk/gpu_object_vk.hpp
@@ -1,0 +1,48 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_VK_GPU_OBJECT_VK_HPP
+#define SRC_GPU_VK_GPU_OBJECT_VK_HPP
+
+#include <memory>
+
+namespace skity {
+
+class VulkanContextState;
+
+/**
+ * Base class for Vulkan GPU objects that need access to the
+ * VulkanContextState to destroy their Vulkan handles.
+ *
+ * The state is held weakly on purpose: pending submissions retain GPU
+ * objects (textures, samplers, buffers, ...) until GPU completion via
+ * cleanup actions. A strong reference would create a reference cycle:
+ * state -> pending submission -> cleanup action -> GPU object -> state,
+ * which prevents the state from being destroyed and leads to re-entrant
+ * destruction of the VulkanContextState when the cycle is torn down.
+ */
+class GPUObjectVK {
+ public:
+  explicit GPUObjectVK(std::shared_ptr<const VulkanContextState> state)
+      : state_(std::move(state)) {}
+
+  virtual ~GPUObjectVK() = default;
+
+ protected:
+  /**
+   * Returns the shared state if it is still alive, nullptr otherwise.
+   * When nullptr is returned (e.g. during context teardown), Vulkan handle
+   * destruction must be skipped since the device/allocator are gone.
+   */
+  std::shared_ptr<const VulkanContextState> LockState() const {
+    return state_.lock();
+  }
+
+ private:
+  std::weak_ptr<const VulkanContextState> state_;
+};
+
+}  // namespace skity
+
+#endif  // SRC_GPU_VK_GPU_OBJECT_VK_HPP

--- a/src/gpu/vk/gpu_sampler_vk.cc
+++ b/src/gpu/vk/gpu_sampler_vk.cc
@@ -10,17 +10,18 @@ namespace skity {
 
 GPUSamplerVK::GPUSamplerVK(std::shared_ptr<const VulkanContextState> state,
                            const GPUSamplerDescriptor& desc, VkSampler sampler)
-    : GPUSampler(desc), state_(std::move(state)), sampler_(sampler) {}
+    : GPUSampler(desc), GPUObjectVK(std::move(state)), sampler_(sampler) {}
 
 GPUSamplerVK::~GPUSamplerVK() {
-  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE ||
+  const auto state = LockState();
+  if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE ||
       sampler_ == VK_NULL_HANDLE) {
     return;
   }
 
-  if (state_->DeviceFns().vkDestroySampler != nullptr) {
-    state_->DeviceFns().vkDestroySampler(state_->GetLogicalDevice(), sampler_,
-                                         nullptr);
+  if (state->DeviceFns().vkDestroySampler != nullptr) {
+    state->DeviceFns().vkDestroySampler(state->GetLogicalDevice(), sampler_,
+                                        nullptr);
   }
   sampler_ = VK_NULL_HANDLE;
 }

--- a/src/gpu/vk/gpu_sampler_vk.hpp
+++ b/src/gpu/vk/gpu_sampler_vk.hpp
@@ -9,12 +9,13 @@
 
 #include "src/gpu/backend_cast.hpp"
 #include "src/gpu/gpu_sampler.hpp"
+#include "src/gpu/vk/gpu_object_vk.hpp"
 
 namespace skity {
 
 class VulkanContextState;
 
-class GPUSamplerVK : public GPUSampler {
+class GPUSamplerVK : public GPUSampler, public GPUObjectVK {
  public:
   GPUSamplerVK(std::shared_ptr<const VulkanContextState> state,
                const GPUSamplerDescriptor& desc, VkSampler sampler);
@@ -28,7 +29,6 @@ class GPUSamplerVK : public GPUSampler {
   SKT_BACKEND_CAST(GPUSamplerVK, GPUSampler)
 
  private:
-  std::shared_ptr<const VulkanContextState> state_ = {};
   VkSampler sampler_ = VK_NULL_HANDLE;
 };
 

--- a/src/gpu/vk/gpu_texture_vk.cc
+++ b/src/gpu/vk/gpu_texture_vk.cc
@@ -292,7 +292,7 @@ GPUTextureVK::GPUTextureVK(std::shared_ptr<const VulkanContextState> state,
                            VkImageLayout preferred_layout, VkFormat format,
                            bool owns_image, bool owns_image_view)
     : GPUTexture(descriptor),
-      state_(std::move(state)),
+      GPUObjectVK(std::move(state)),
       image_(image),
       allocation_(allocation),
       image_view_(image_view),
@@ -302,16 +302,17 @@ GPUTextureVK::GPUTextureVK(std::shared_ptr<const VulkanContextState> state,
       owns_image_view_(owns_image_view) {}
 
 GPUTextureVK::~GPUTextureVK() {
-  if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+  const auto state = LockState();
+  if (state != nullptr && state->GetLogicalDevice() != VK_NULL_HANDLE &&
       owns_image_view_ && image_view_ != VK_NULL_HANDLE &&
-      state_->DeviceFns().vkDestroyImageView != nullptr) {
-    state_->DeviceFns().vkDestroyImageView(state_->GetLogicalDevice(),
-                                           image_view_, nullptr);
+      state->DeviceFns().vkDestroyImageView != nullptr) {
+    state->DeviceFns().vkDestroyImageView(state->GetLogicalDevice(),
+                                          image_view_, nullptr);
   }
 
-  if (state_ != nullptr && state_->GetAllocator() != nullptr && owns_image_ &&
+  if (state != nullptr && state->GetAllocator() != nullptr && owns_image_ &&
       image_ != VK_NULL_HANDLE && allocation_ != nullptr) {
-    vmaDestroyImage(state_->GetAllocator(), image_, allocation_);
+    vmaDestroyImage(state->GetAllocator(), image_, allocation_);
   }
 }
 
@@ -462,19 +463,19 @@ size_t GPUTextureVK::GetBytes() const {
 
 void GPUTextureVK::UploadData(uint32_t offset_x, uint32_t offset_y,
                               uint32_t width, uint32_t height, void* data) {
-  if (state_ == nullptr || data == nullptr || width == 0 || height == 0) {
+  const auto state = LockState();
+  if (state == nullptr || data == nullptr || width == 0 || height == 0) {
     return;
   }
 
-  auto command_buffer = std::make_shared<GPUCommandBufferVK>(state_);
+  auto command_buffer = std::make_shared<GPUCommandBufferVK>(state);
   if (!command_buffer->Init()) {
     return;
   }
 
   command_buffer->SetLabel("VkUploadTextureData");
 
-  auto blit_pass =
-      std::make_shared<GPUBlitPassVK>(state_, command_buffer.get());
+  auto blit_pass = std::make_shared<GPUBlitPassVK>(state, command_buffer.get());
   blit_pass->UploadTextureData(shared_from_this(), offset_x, offset_y, width,
                                height, data);
   blit_pass->End();

--- a/src/gpu/vk/gpu_texture_vk.hpp
+++ b/src/gpu/vk/gpu_texture_vk.hpp
@@ -11,6 +11,7 @@
 
 #include "src/gpu/backend_cast.hpp"
 #include "src/gpu/gpu_texture.hpp"
+#include "src/gpu/vk/gpu_object_vk.hpp"
 
 namespace skity {
 
@@ -40,6 +41,7 @@ inline VkImageAspectFlags VkFormatAspectMaskForBarrier(VkFormat format) {
 }
 
 class GPUTextureVK : public GPUTexture,
+                     public GPUObjectVK,
                      public std::enable_shared_from_this<GPUTextureVK> {
  public:
   GPUTextureVK(std::shared_ptr<const VulkanContextState> state,
@@ -87,7 +89,6 @@ class GPUTextureVK : public GPUTexture,
   SKT_BACKEND_CAST(GPUTextureVK, GPUTexture)
 
  private:
-  std::shared_ptr<const VulkanContextState> state_ = {};
   VkImage image_ = VK_NULL_HANDLE;
   VmaAllocation allocation_ = nullptr;
   VkImageView image_view_ = VK_NULL_HANDLE;


### PR DESCRIPTION
Pending submissions retain GPU resources (textures, samplers, buffers) via cleanup actions until GPU completion. Holding the VulkanContextState strongly in those resources created a cycle
state -> submission -> cleanup action -> resource -> state, preventing the state from being destroyed and causing re-entrant destruction of VulkanContextState (repeated ~lambda frames and a crash on teardown).

Add GPUObjectVK base that holds the state weakly and exposes LockState(). GPUTextureVK, GPUSamplerVK, GPUBufferVK and GPUExternalTextureAHB now derive from it and skip Vulkan handle destruction when the state is gone. Also switch the readpixels command-buffer self-capture to a weak_ptr.