### PR TITLE
fix(vk): defer resource destruction on device loss

### DIFF
--- a/src/gpu/vk/gpu_command_buffer_vk.cc
+++ b/src/gpu/vk/gpu_command_buffer_vk.cc
@@ -267,7 +267,15 @@ bool GPUCommandBufferVK::Submit(const GPUSubmitInfo* submit_info) {
   if (result != VK_SUCCESS) {
     LOGE("Failed to submit Vulkan command buffer: {}",
          static_cast<int32_t>(result));
-    if (owns_fence) {
+    if (result == VK_ERROR_DEVICE_LOST) {
+      LOGE("Vulkan logical device lost during submission of command buffer");
+      // The logical device is gone. Destroying any Vulkan object created on
+      // it (command pool, VMA buffers, textures) faults some drivers (e.g.
+      // MediaTek mt6855), so mark the state lost and let all GPU resources
+      // skip their handle destruction while the context is recreated.
+      state_->MarkDeviceLost();
+    }
+    if (owns_fence && !state_->IsDeviceLost()) {
       device_fns.vkDestroyFence(state_->GetLogicalDevice(), fence, nullptr);
     }
     return false;
@@ -317,6 +325,18 @@ void GPUCommandBufferVK::ApplyDebugLabelsIfNeeded() {
 void GPUCommandBufferVK::Reset() {
   stage_buffers_.clear();
   cleanup_actions_.clear();
+
+  // stage_buffers_/cleanup_actions_ are destroyed above; on a lost device the
+  // GPUBufferVK/GPUTextureVK destructors already skip their driver calls via
+  // GPUObjectVK::LockState(). The command pool is owned here, so guard it
+  // explicitly: destroying it against a lost device is UB.
+  if (state_ != nullptr && state_->IsDeviceLost()) {
+    command_buffer_ = VK_NULL_HANDLE;
+    command_pool_ = VK_NULL_HANDLE;
+    recording_ = false;
+    submitted_ = false;
+    return;
+  }
 
   if (state_ != nullptr && command_pool_ != VK_NULL_HANDLE &&
       state_->GetLogicalDevice() != VK_NULL_HANDLE &&

--- a/src/gpu/vk/gpu_object_vk.hpp
+++ b/src/gpu/vk/gpu_object_vk.hpp
@@ -7,10 +7,9 @@
 
 #include <memory>
 
+#include "src/gpu/vk/vulkan_context_state.hpp"
+
 namespace skity {
-
-class VulkanContextState;
-
 /**
  * Base class for Vulkan GPU objects that need access to the
  * VulkanContextState to destroy their Vulkan handles.
@@ -36,7 +35,14 @@ class GPUObjectVK {
    * destruction must be skipped since the device/allocator are gone.
    */
   std::shared_ptr<const VulkanContextState> LockState() const {
-    return state_.lock();
+    const auto state = state_.lock();
+    if (state == nullptr || state->IsDeviceLost()) {
+      // A lost device invalidates every Vulkan object created on it.
+      // Destroying handles against it is UB and crashes some drivers, so
+      // treat the state as gone and skip destruction.
+      return {};
+    }
+    return state;
   }
 
  private:

--- a/src/gpu/vk/gpu_presenter_vk.cc
+++ b/src/gpu/vk/gpu_presenter_vk.cc
@@ -386,6 +386,12 @@ GPUPresenterStatus GPUPresenterVK::Present(
       fns_.vkQueuePresentKHR(present_queue_, &present_info_vk);
   has_outstanding_surface_ = false;
   current_frame_ = (current_frame_ + 1) % frame_slots_.size();
+  if (result == VK_ERROR_DEVICE_LOST) {
+    LOGE("Vulkan logical device lost during vkQueuePresentKHR");
+    state_->MarkDeviceLost();
+    broken_ = true;
+    return GPUPresenterStatus::kError;
+  }
   if (result == VK_SUCCESS) {
     return GPUPresenterStatus::kSuccess;
   }
@@ -681,7 +687,8 @@ bool GPUPresenterVK::CreateFrameSlots() {
 }
 
 void GPUPresenterVK::DestroyFrameSlots() {
-  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+  if (state_ == nullptr || state_->IsDeviceLost() ||
+      state_->GetLogicalDevice() == VK_NULL_HANDLE) {
     frame_slots_.clear();
     image_present_semaphores_.clear();
     return;
@@ -710,7 +717,8 @@ void GPUPresenterVK::DestroyFrameSlots() {
 }
 
 void GPUPresenterVK::DestroySwapchainImageViews() {
-  if (state_ == nullptr || state_->GetLogicalDevice() == VK_NULL_HANDLE) {
+  if (state_ == nullptr || state_->IsDeviceLost() ||
+      state_->GetLogicalDevice() == VK_NULL_HANDLE) {
     swapchain_image_views_.clear();
     return;
   }
@@ -726,7 +734,8 @@ void GPUPresenterVK::DestroySwapchainImageViews() {
 }
 
 void GPUPresenterVK::DestroySwapchain() {
-  if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
+  if (state_ != nullptr && !state_->IsDeviceLost() &&
+      state_->GetLogicalDevice() != VK_NULL_HANDLE &&
       swapchain_ != VK_NULL_HANDLE && fns_.vkDestroySwapchainKHR != nullptr) {
     fns_.vkDestroySwapchainKHR(state_->GetLogicalDevice(), swapchain_, nullptr);
   }

--- a/src/gpu/vk/gpu_render_pass_vk.cc
+++ b/src/gpu/vk/gpu_render_pass_vk.cc
@@ -610,7 +610,8 @@ bool RecordDrawCommands(const std::shared_ptr<const VulkanContextState>& state,
     std::weak_ptr<const VulkanContextState> weak_state = state;
     command_buffer.RecordCleanupAction([weak_state, descriptor_pool]() {
       auto state = weak_state.lock();
-      if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE ||
+      if (state == nullptr || state->IsDeviceLost() ||
+          state->GetLogicalDevice() == VK_NULL_HANDLE ||
           state->DeviceFns().vkDestroyDescriptorPool == nullptr) {
         return;
       }
@@ -1005,7 +1006,8 @@ bool RecordLegacyRenderPass(
   std::weak_ptr<const VulkanContextState> weak_state = state;
   command_buffer.RecordCleanupAction([weak_state, framebuffer]() {
     auto state = weak_state.lock();
-    if (state == nullptr || state->GetLogicalDevice() == VK_NULL_HANDLE) {
+    if (state == nullptr || state->IsDeviceLost() ||
+        state->GetLogicalDevice() == VK_NULL_HANDLE) {
       return;
     }
 

--- a/src/gpu/vk/vulkan_context_state.cc
+++ b/src/gpu/vk/vulkan_context_state.cc
@@ -613,6 +613,9 @@ const std::vector<std::string>& VulkanContextState::GetEnabledInstanceLayers()
 
 bool VulkanContextState::Initialize(const GPUContextInfoVK& info) {
   Reset();
+  // A fresh device is being created; re-arm the lost flag only after the old
+  // (possibly lost) device has been torn down safely.
+  device_lost_ = false;
   LOGD("Initializing VulkanContextState");
 
 #if defined(SKITY_ANDROID)
@@ -663,6 +666,12 @@ void VulkanContextState::CollectPendingSubmissions(bool wait_all) const {
       if (result != VK_SUCCESS) {
         LOGW("Failed to wait Vulkan pending submissions: {}",
              static_cast<int32_t>(result));
+        if (result == VK_ERROR_DEVICE_LOST) {
+          LOGE(
+              "Vulkan logical device lost while waiting for pending "
+              "submissions");
+          MarkDeviceLost();
+        }
       }
     }
 
@@ -682,13 +691,20 @@ void VulkanContextState::CollectPendingSubmissions(bool wait_all) const {
       if (result != VK_NOT_READY) {
         LOGW("Failed to query Vulkan fence status: {}",
              static_cast<int32_t>(result));
+        if (result == VK_ERROR_DEVICE_LOST) {
+          LOGE(
+              "Vulkan logical device lost: fence reported "
+              "VK_ERROR_DEVICE_LOST");
+          MarkDeviceLost();
+        }
       }
       ++it;
     }
   }
 
   for (auto& submission : completed_submissions) {
-    if (submission.owns_fence && submission.fence != VK_NULL_HANDLE) {
+    if (!IsDeviceLost() && submission.owns_fence &&
+        submission.fence != VK_NULL_HANDLE) {
       functions_.device.vkDestroyFence(logical_device_, submission.fence,
                                        nullptr);
       submission.fence = VK_NULL_HANDLE;
@@ -701,7 +717,7 @@ void VulkanContextState::CollectPendingSubmissions(bool wait_all) const {
     }
     submission.cleanup_actions.clear();
 
-    if (submission.command_pool != VK_NULL_HANDLE) {
+    if (!IsDeviceLost() && submission.command_pool != VK_NULL_HANDLE) {
       functions_.device.vkDestroyCommandPool(logical_device_,
                                              submission.command_pool, nullptr);
       submission.command_pool = VK_NULL_HANDLE;

--- a/src/gpu/vk/vulkan_context_state.hpp
+++ b/src/gpu/vk/vulkan_context_state.hpp
@@ -134,6 +134,18 @@ class VulkanContextState {
 
   void CollectPendingSubmissions(bool wait_all) const;
 
+  /**
+   * Returns true once the logical device has been reported lost (e.g. by
+   * vkQueueSubmit / vkQueuePresentKHR / fence query). After a device loss the
+   * only useful recovery is to tear the whole context down and recreate it;
+   * destroying individual Vulkan objects against the lost device is UB and
+   * faults some drivers (e.g. MediaTek mt6855). GPU resources must therefore
+   * skip their Vulkan-handle destruction while this returns true.
+   */
+  bool IsDeviceLost() const { return device_lost_; }
+
+  void MarkDeviceLost() const { device_lost_ = true; }
+
   VkRenderPass GetOrCreateLegacyRenderPass(
       const LegacyRenderPassKey& key) const;
 
@@ -183,6 +195,7 @@ class VulkanContextState {
   bool advanced_blend_coherent_ = false;
   bool dual_source_blending_enabled_ = false;
   VulkanDebugRuntimeState debug_runtime_ = {};
+  mutable bool device_lost_ = false;
 #if defined(SKITY_ANDROID)
   Fn_AHardwareBuffer_describe fn_ahb_describe_ = nullptr;
 #endif


### PR DESCRIPTION
When the logical device is lost (vkQueueSubmit / vkQueuePresentKHR / fence query returns VK_ERROR_DEVICE_LOST), destroying any Vulkan object created on it is UB and faults some drivers (e.g. MediaTek mt6855). The only recovery is to tear down and recreate the whole context.

Track device loss on VulkanContextState via IsDeviceLost()/MarkDeviceLost and make every teardown/cleanup path skip driver-handle destruction while it is set:
- GPUObjectVK::LockState() returns null, so texture/sampler/buffer destructors skip vkDestroy*/vmaDestroy*.
- GPUCommandBufferVK skips command-pool/fence destruction and marks the state when Submit hits VK_ERROR_DEVICE_LOST.
- CollectPendingSubmissions marks loss on a lost fence and skips fence/ command-pool destruction.
- GPUPresenterVK and render-pass cleanup lambdas (descriptor pool, framebuffer) skip destruction on a lost device.

The flag is only cleared when a fresh device initializes successfully. Device-lost detection is also logged so the failing stage (submit, present or fence wait) can be pinpointed on device.