### PR TITLE
fix(vk): reject presenting surfaces from a retired swapchain

### DIFF
--- a/src/gpu/vk/gpu_presenter_vk.cc
+++ b/src/gpu/vk/gpu_presenter_vk.cc
@@ -339,6 +339,7 @@ GPUSurfaceAcquireResult GPUPresenterVK::AcquireNextSurface(
   GPUSurfaceVK::PresentInfo present_info = {};
   present_info.owner = this;
   present_info.image_index = image_index;
+  present_info.generation = swapchain_generation_;
   surface->SetPresentInfo(present_info);
   has_outstanding_surface_ = true;
   result.status = GPUPresenterStatus::kSuccess;
@@ -367,6 +368,16 @@ GPUPresenterStatus GPUPresenterVK::Present(
       present_info->image_index >= image_present_semaphores_.size() ||
       present_info->image_index >= swapchain_images_.size()) {
     LOGE("Failed to present Vulkan surface: presenter state is invalid");
+    return GPUPresenterStatus::kError;
+  }
+  if (present_info->generation != swapchain_generation_) {
+    // The swapchain was recreated (e.g. resize / rotation) after this surface
+    // was acquired. Its image belongs to a retired swapchain; presenting it
+    // against the new one is UB and faults some Android drivers.
+    LOGE(
+        "Failed to present Vulkan surface: acquired from a retired swapchain "
+        "(generation {} vs {})",
+        present_info->generation, swapchain_generation_);
     return GPUPresenterStatus::kError;
   }
 
@@ -630,6 +641,10 @@ bool GPUPresenterVK::CreateSwapchain() {
   }
   swapchain_images_.resize(swapchain_image_count);
   image_in_flight_fences_.assign(swapchain_image_count, VK_NULL_HANDLE);
+  // Bump the swapchain generation so surfaces acquired from a previous,
+  // retired swapchain can be rejected at Present instead of feeding a stale
+  // image index into the driver.
+  ++swapchain_generation_;
   return true;
 }
 
@@ -747,9 +762,13 @@ void GPUPresenterVK::DestroySwapchain() {
 void GPUPresenterVK::Reset() {
   std::lock_guard<std::mutex> lock(mutex_);
   if (has_outstanding_surface_) {
-    LOGE(
-        "Resetting Vulkan presenter with an outstanding surface: its "
-        "swapchain image will leak from the presentation queue");
+    // The caller still holds a surface acquired from the to-be-destroyed
+    // swapchain. Destroying the swapchain below returns that image to the
+    // BufferQueue, so this is not a leak; the surface merely becomes stale and
+    // must not be presented (Present() rejects it via the generation check).
+    LOGW(
+        "Resetting Vulkan presenter with an outstanding surface from a "
+        "retired swapchain; it will be rejected at Present");
   }
   if (state_ != nullptr && state_->GetLogicalDevice() != VK_NULL_HANDLE &&
       state_->DeviceFns().vkDeviceWaitIdle != nullptr) {
@@ -762,6 +781,9 @@ void GPUPresenterVK::Reset() {
   DestroySwapchainImageViews();
   DestroySwapchain();
   current_frame_ = 0;
+  // Outstanding surfaces were acquired from the old swapchain; their images
+  // are returned to the BufferQueue by the swapchain destruction above and
+  // any later Present is rejected by the generation check.
   has_outstanding_surface_ = false;
   broken_ = false;
 }

--- a/src/gpu/vk/gpu_presenter_vk.hpp
+++ b/src/gpu/vk/gpu_presenter_vk.hpp
@@ -67,6 +67,7 @@ class GPUPresenterVK : public GPUPresenter {
   struct SurfacePresentInfo {
     const GPUPresenterVK* owner = nullptr;
     uint32_t image_index = 0;
+    uint64_t generation = 0;
   };
 
   bool LoadPresenterFns();
@@ -86,6 +87,7 @@ class GPUPresenterVK : public GPUPresenter {
   VkQueue present_queue_ = VK_NULL_HANDLE;
   int32_t present_queue_family_index_ = -1;
   VkSwapchainKHR swapchain_ = VK_NULL_HANDLE;
+  uint64_t swapchain_generation_ = 0;
   VkExtent2D swapchain_extent_ = {};
   VkFormat swapchain_format_ = VK_FORMAT_UNDEFINED;
   VkImageUsageFlags swapchain_image_usage_ =

--- a/src/gpu/vk/gpu_surface_vk.hpp
+++ b/src/gpu/vk/gpu_surface_vk.hpp
@@ -22,6 +22,11 @@ class GPUSurfaceVK : public GPUSurfaceImpl {
   struct PresentInfo {
     const void* owner = nullptr;
     uint32_t image_index = 0;
+    // Generation of the swapchain the image was acquired from. Used to reject
+    // surfaces that outlive a swapchain recreation (e.g. on resize / rotation):
+    // presenting a retired image against the new swapchain is UB and faults
+    // some Android drivers inside vkQueueSignalReleaseImageANDROID.
+    uint64_t generation = 0;
   };
 
   GPUSurfaceVK(const GPUSurfaceDescriptor& desc, GPUContextImpl* ctx,


### PR DESCRIPTION
When the presenter swapchain is recreated (e.g. resize / rotation on Android), a surface acquired from the old swapchain can still be presented by a caller that held it across the recreation. Because the old image was already returned to the BufferQueue when the swapchain was destroyed, presenting that stale index makes the driver double-release a buffer and faults inside vkQueueSignalReleaseImageANDROID (Mali SIGSEGV +0x8).

Tag every swapchain with a generation counter, record the generation on each acquired surface, and reject it at Present when it no longer matches the current swapchain. Also clarify the Reset comment: destroying the swapchain returns the outstanding buffer, so the stale surface is not a leak and simply gets rejected.