### PR TITLE
fix(font): synchronize FreeType library lifetime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           - name: Compile Code
             run: |
                 export PATH=$PWD/buildtools/llvm/bin:$PATH
-                cmake -B out/cmake_host_build -DSKITY_TEST=ON -DSKITY_VK_BACKEND=ON -DSKITY_TEST_COVERAGE=OFF -DSKITY_CODEC_MODULE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
+                cmake -B out/cmake_host_build -DSKITY_TEST=ON -DSKITY_TEST_UT=ON -DSKITY_TEST_BENCH=OFF -DSKITY_TEST_GOLDEN=OFF -DSKITY_TEST_TSAN=ON -DSKITY_VK_BACKEND=ON -DSKITY_TEST_COVERAGE=OFF -DSKITY_CODEC_MODULE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-fPIC"
                 cmake --build out/cmake_host_build --target skity_unit_test skity_vulkan_unit_test
           - name: Unit Test
             run: |

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -81,6 +81,13 @@ cmake_dependent_option(
   OFF
 )
 
+cmake_dependent_option(
+  SKITY_TEST_TSAN "option for enabling ThreadSanitizer in unit tests"
+  OFF
+  [[SKITY_TEST AND SKITY_TEST_UT AND NOT SKITY_TEST_BENCH AND NOT SKITY_TEST_GOLDEN AND NOT SKITY_TEST_COVERAGE]]
+  OFF
+)
+
 option(SKITY_LOG "option for logging" OFF)
 option(SKITY_CT_FONT "option for open CoreText font backend on Darwin" OFF)
 

--- a/src/text/ports/freetype_face.cc
+++ b/src/text/ports/freetype_face.cc
@@ -30,19 +30,22 @@ static FreeTypeLibrary* global_freetype_library;
 FreetypeFace::FreetypeFace(const std::shared_ptr<Data>& stream,
                            const FontArguments& font_args)
     : data_(stream) {
-  RefFreeTypeLibrary();
-  const void* memoryBase = data_->RawData();
-  if (memoryBase) {
-    FT_Open_Args args;
-    memset(&args, 0, sizeof(args));
-    args.flags = FT_OPEN_MEMORY;
-    args.memory_base = (const FT_Byte*)memoryBase;
-    args.memory_size = data_->Size();
+  {
+    std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
+    RefFreeTypeLibrary();
+    const void* memoryBase = data_->RawData();
+    if (memoryBase) {
+      FT_Open_Args args;
+      memset(&args, 0, sizeof(args));
+      args.flags = FT_OPEN_MEMORY;
+      args.memory_base = (const FT_Byte*)memoryBase;
+      args.memory_size = data_->Size();
 
-    FT_Face face;
-    if (!FT_Open_Face(global_freetype_library->library(), &args,
-                      font_args.GetCollectionIndex(), &face)) {
-      ft_face_.reset(face);
+      FT_Face face;
+      if (!FT_Open_Face(global_freetype_library->library(), &args,
+                        font_args.GetCollectionIndex(), &face)) {
+        ft_face_.reset(face);
+      }
     }
   }
 
@@ -50,6 +53,7 @@ FreetypeFace::FreetypeFace(const std::shared_ptr<Data>& stream,
 }
 
 FreetypeFace::~FreetypeFace() {
+  std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
   if (Valid()) {
     ft_face_.reset();  // Must release face before the library, the library
                        // frees existing faces.
@@ -158,7 +162,10 @@ void FreetypeFace::UnrefFreeTypeLibrary() {
 }
 
 FontScanner::FontScanner() {
-  FreetypeFace::RefFreeTypeLibrary();
+  {
+    std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
+    FreetypeFace::RefFreeTypeLibrary();
+  }
   weight_map_.emplace("all", FontStyle::kNormal_Weight);
   weight_map_.emplace("black", FontStyle::kBlack_Weight);
   weight_map_.emplace("bold", FontStyle::kBold_Weight);
@@ -187,11 +194,14 @@ FontScanner::FontScanner() {
   weight_map_.emplace("ultralight", FontStyle::kExtraLight_Weight);
 }
 
-FontScanner::~FontScanner() { FreetypeFace::UnrefFreeTypeLibrary(); }
+FontScanner::~FontScanner() {
+  std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
+  FreetypeFace::UnrefFreeTypeLibrary();
+}
 
 bool FontScanner::RecognizedFont(std::shared_ptr<Data> stream,
                                  int* num_fonts) const {
-  std::lock_guard<std::mutex> lock(library_mutex_);
+  std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
 
   FT_StreamRec streamRec;
   UniqueFTFace face(this->OpenFace(std::move(stream), -1, &streamRec));
@@ -216,7 +226,7 @@ static std::string LowerString(std::string s) {
 bool FontScanner::ScanFont(std::shared_ptr<Data> stream, int ttcIndex,
                            std::string* name, FontStyle* style,
                            bool* is_fixed_pitch, AxisDefinitions* axes) const {
-  std::lock_guard<std::mutex> lock(library_mutex_);
+  std::lock_guard<std::mutex> lock(FreeTypeLibrary::Mutex());
 
   FT_StreamRec streamRec;
   UniqueFTFace face(OpenFace(stream, ttcIndex, &streamRec));

--- a/src/text/ports/freetype_face.hpp
+++ b/src/text/ports/freetype_face.hpp
@@ -39,6 +39,11 @@ class FreeTypeLibrary {
   FreeTypeLibrary();
   ~FreeTypeLibrary();
 
+  static std::mutex& Mutex() {
+    static NoDestructor<std::mutex> mutex;
+    return *mutex;
+  }
+
   FT_Library library() { return ft_library_; }
 
  private:
@@ -75,7 +80,9 @@ class FreetypeFace {
 
   // Private to ref_ft_library and unref_ft_library
   static int library_ref_count_;
+  // The caller must hold FreeTypeLibrary::Mutex().
   static bool RefFreeTypeLibrary();
+  // The caller must hold FreeTypeLibrary::Mutex().
   static void UnrefFreeTypeLibrary();
 
   friend class FontScanner;
@@ -87,6 +94,8 @@ class FontScanner {
  public:
   FontScanner();
   ~FontScanner();
+  FontScanner(const FontScanner&) = delete;
+  FontScanner& operator=(const FontScanner&) = delete;
   struct AxisDefinition {
     FourByteTag fTag;
     int32_t fMinimum;
@@ -105,11 +114,11 @@ class FontScanner {
       FT_Face face, FT_Library library);
 
  private:
+  // The caller must hold FreeTypeLibrary::Mutex().
   FT_Face OpenFace(std::shared_ptr<Data> stream, int ttcIndex,
                    FT_Stream ftStream) const;
 
   std::unordered_map<std::string, int> weight_map_;
-  mutable std::mutex library_mutex_;
 };
 
 }  // namespace skity

--- a/src/text/ports/typeface_freetype.cc
+++ b/src/text/ports/typeface_freetype.cc
@@ -108,6 +108,10 @@ TypefaceFreeType::TypefaceFreeType(const class FontStyle& style)
 
 TypefaceFreeType::~TypefaceFreeType() {
   ScalerContextCache::GlobalScalerContextCache()->PurgeByTypeface(typeface_id_);
+  if (freetype_face_holder_) {
+    std::lock_guard<std::mutex> lock(FreetypeFace::f_t_mutex());
+    freetype_face_holder_.reset();
+  }
 }
 
 int TypefaceFreeType::OnGetTableTags(FontTableTag tags[]) const {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -143,7 +143,16 @@ if (${SKITY_TEST_COVERAGE} AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
     target_compile_options(skity_unit_test PRIVATE --coverage -O0 -g)
     target_link_options(skity_unit_test PRIVATE --coverage)
-else()
+elseif (${SKITY_TEST_TSAN} AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(skity PRIVATE
+        -fsanitize=thread
+        -fno-omit-frame-pointer
+        -g
+    )
+    target_link_options(skity PRIVATE
+        -fsanitize=thread
+    )
+
     target_compile_options(skity_unit_test PRIVATE
         -fsanitize=thread
         -fno-omit-frame-pointer

--- a/test/ut/text/typeface_test.cc
+++ b/test/ut/text/typeface_test.cc
@@ -5,14 +5,20 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <skity/text/font.hpp>
 #include <skity/text/font_manager.hpp>
 #include <skity/text/typeface.hpp>
+#include <string>
+#include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "concurrent_runner.h"
+#include "src/text/ports/freetype_face.hpp"
 #include "src/text/ports/scaler_context_freetype.hpp"
 #include "src/text/scaler_context.hpp"
 #include "src/text/scaler_context_desc.hpp"
@@ -23,6 +29,64 @@ constexpr int kThreadCount = 8;
 constexpr int kIterations = 500;
 constexpr const char* kRobotoRegular =
     SKITY_FONT_DIR "fonts/resources/Roboto-Regular.ttf";
+
+class ReusableBarrier {
+ public:
+  explicit ReusableBarrier(int participant_count)
+      : participant_count_(participant_count) {}
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    const int generation = generation_;
+
+    if (++arrived_count_ == participant_count_) {
+      arrived_count_ = 0;
+      ++generation_;
+      condition_.notify_all();
+      return;
+    }
+
+    condition_.wait(lock, [&] { return generation_ != generation; });
+  }
+
+ private:
+  const int participant_count_;
+  int arrived_count_ = 0;
+  int generation_ = 0;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+};
+
+static_assert(!std::is_copy_constructible<FontScanner>::value,
+              "FontScanner must not duplicate its FreeType library reference");
+static_assert(!std::is_copy_assignable<FontScanner>::value,
+              "FontScanner must not duplicate its FreeType library reference");
+
+void ExpectRobotoScan(FontScanner* scanner, const std::shared_ptr<Data>& data) {
+  int num_fonts = 0;
+  const bool recognized = scanner->RecognizedFont(data, &num_fonts);
+  EXPECT_TRUE(recognized);
+  if (recognized) {
+    EXPECT_EQ(num_fonts, 1);
+  }
+
+  std::string family_name;
+  FontStyle style;
+  bool is_fixed_pitch = true;
+  FontScanner::AxisDefinitions axes{};
+  const bool scanned =
+      scanner->ScanFont(data, 0, &family_name, &style, &is_fixed_pitch, &axes);
+  EXPECT_TRUE(scanned);
+  if (!scanned) {
+    return;
+  }
+
+  EXPECT_EQ(family_name, "Roboto");
+  EXPECT_EQ(style.weight(), FontStyle::kNormal_Weight);
+  EXPECT_EQ(style.width(), FontStyle::kNormal_Width);
+  EXPECT_EQ(style.slant(), FontStyle::kUpright_Slant);
+  EXPECT_FALSE(is_fixed_pitch);
+}
 
 struct RasterizedGlyph {
   float origin_x = 0.f;
@@ -243,6 +307,83 @@ TEST_F(TypefaceTest, UnicharsToGlyphsThreadSafe) {
       EXPECT_NE(g, 0);
     }
   });
+}
+
+TEST(TypefaceFreeTypeTest, MakeFromDataThreadSafe) {
+  auto data = Data::MakeFromFileName(kRobotoRegular);
+  ASSERT_NE(data, nullptr);
+
+  // Warm up the default FontManager before exercising the target race.
+  ASSERT_NE(Typeface::MakeFromData(data), nullptr);
+
+  constexpr int kMakeFromDataThreadCount = 16;
+  ReusableBarrier iteration_start(kMakeFromDataThreadCount);
+  ConcurrentRunner runner(kMakeFromDataThreadCount, 5000);
+  runner.Run([&](int) {
+    // Re-synchronize every iteration so concurrent MakeFromData calls do not
+    // drift apart after the initial start barrier.
+    iteration_start.Wait();
+    auto typeface = Typeface::MakeFromData(data);
+    EXPECT_NE(typeface, nullptr);
+  });
+}
+
+TEST(FontScannerFreeTypeTest, ScansRobotoData) {
+  auto data = Data::MakeFromFileName(kRobotoRegular);
+  ASSERT_NE(data, nullptr);
+
+  FontScanner scanner;
+  ExpectRobotoScan(&scanner, data);
+}
+
+TEST(TypefaceFreeTypeTest, LazyFaceDestructionKeepsLibraryUsable) {
+  auto data = Data::MakeFromFileName(kRobotoRegular);
+  ASSERT_NE(data, nullptr);
+
+  auto typeface = Typeface::MakeFromData(data);
+  ASSERT_NE(typeface, nullptr);
+  EXPECT_GT(typeface->CountTables(), 0);
+  EXPECT_GT(typeface->GetUnitsPerEm(), 0u);
+
+  typeface.reset();
+
+  auto reloaded_typeface = Typeface::MakeFromData(data);
+  ASSERT_NE(reloaded_typeface, nullptr);
+  EXPECT_GT(reloaded_typeface->CountTables(), 0);
+}
+
+TEST(FreeTypeLibraryTest, ScannerAndLazyTypefaceLifetimesInterleave) {
+  auto data = Data::MakeFromFileName(kRobotoRegular);
+  ASSERT_NE(data, nullptr);
+
+  constexpr int kLibraryThreadCount = 8;
+  constexpr int kLibraryIterations = 500;
+  ReusableBarrier iteration_start(kLibraryThreadCount);
+  std::vector<std::thread> threads;
+  threads.reserve(kLibraryThreadCount);
+
+  for (int thread_index = 0; thread_index < kLibraryThreadCount;
+       ++thread_index) {
+    threads.emplace_back([&, thread_index] {
+      for (int iteration = 0; iteration < kLibraryIterations; ++iteration) {
+        iteration_start.Wait();
+        if ((thread_index & 1) == 0) {
+          FontScanner scanner;
+          ExpectRobotoScan(&scanner, data);
+        } else {
+          auto typeface = Typeface::MakeFromData(data);
+          EXPECT_NE(typeface, nullptr);
+          if (typeface) {
+            EXPECT_GT(typeface->CountTables(), 0);
+          }
+        }
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
 }
 
 TEST_F(TypefaceTest, TableCountAndTagsConsistent) {


### PR DESCRIPTION
Serialize shared FreeType library refcounting and face open/close operations across Typeface and FontScanner instances. Release lazy faces while holding the face mutex to keep teardown ordered.