### PR TITLE
fix(hw): discard layer and frame on GPU allocation failure

### DIFF
--- a/src/render/hw/hw_canvas.cc
+++ b/src/render/hw/hw_canvas.cc
@@ -713,19 +713,25 @@ void HWCanvas::OnFlush() {
 
     auto state = root_layer_->Prepare(&draw_context);
 
-    // currently root layer must contain stencil attachment
-    root_layer_->GenerateCommand(&draw_context, state);
+    if (state & HWDrawState::kDrawStateError) {
+      LOGE(
+          "HWCanvas::OnFlush: GPU resource allocation failed, discarding "
+          "frame");
+    } else {
+      // currently root layer must contain stencil attachment
+      root_layer_->GenerateCommand(&draw_context, state);
 
-    UploadMesh(cmd.get());
+      UploadMesh(cmd.get());
 
-    cmd->HoldResource(gpu_buffer_->GetGPUBufferOwner());
-    cmd->HoldResource(gpu_buffer_->GetGPUIndexBufferOwner());
-    cmd->HoldResource(static_buffer_->GetGPUBufferOwner());
-    cmd->HoldResource(static_buffer_->GetGPUIndexBufferOwner());
+      cmd->HoldResource(gpu_buffer_->GetGPUBufferOwner());
+      cmd->HoldResource(gpu_buffer_->GetGPUIndexBufferOwner());
+      cmd->HoldResource(static_buffer_->GetGPUBufferOwner());
+      cmd->HoldResource(static_buffer_->GetGPUIndexBufferOwner());
 
-    root_layer_->Draw(nullptr, cmd.get());
+      root_layer_->Draw(nullptr, cmd.get());
 
-    cmd->Submit(surface_->GetSubmitInfo());
+      cmd->Submit(surface_->GetSubmitInfo());
+    }
   }
 
   layer_stack_.clear();

--- a/src/render/hw/hw_draw.hpp
+++ b/src/render/hw/hw_draw.hpp
@@ -58,6 +58,8 @@ enum HWDrawState : uint32_t {
   kDrawStateNone = 0,
   kDrawStateStencil = 1 << 0,
   kDrawStateDepth = 1 << 1,
+  // A child draw/layer failed to prepare (e.g. GPU texture allocation failed).
+  kDrawStateError = 1 << 2,
 };
 
 inline HWDrawState operator|(HWDrawState lhs, HWDrawState rhs) {

--- a/src/render/hw/hw_layer.cc
+++ b/src/render/hw/hw_layer.cc
@@ -363,6 +363,12 @@ std::shared_ptr<Shader> HWLayer::CreateDrawLayerShader(
     GPUContext* gpu_context, std::shared_ptr<GPUTexture> gpu_texture,
     const Rect& bounds) const {
   (void)gpu_context;
+  if (!gpu_texture) {
+    LOGE(
+        "HWLayer::CreateDrawLayerShader: gpu_texture is null, skip layer back "
+        "draw");
+    return {};
+  }
   auto texture = std::make_shared<InternalTexture>(
       gpu_texture, AlphaType::kPremul_AlphaType);
 

--- a/src/render/hw/hw_layer.cc
+++ b/src/render/hw/hw_layer.cc
@@ -273,6 +273,14 @@ HWDrawState HWLayer::OnPrepare(HWDrawContext* context) {
           static_cast<GPUTextureUsageMask>(GPUTextureUsage::kTextureBinding);
       desc.storage_mode = GPUTextureStorageMode::kPrivate;
       copy_info.texture = gpu_device_->CreateTexture(desc);
+      if (!copy_info.texture) {
+        LOGE(
+            "HWLayer::OnPrepare: failed to allocate dst read copy texture "
+            "({}x{}), discarding frame",
+            desc.width, desc.height);
+        layer_state_ |= HWDrawState::kDrawStateError;
+        continue;
+      }
       GPUSamplerDescriptor sampler_desc;
       copy_info.sampler = gpu_device_->CreateSampler(sampler_desc);
     }

--- a/src/render/hw/hw_layer.cc
+++ b/src/render/hw/hw_layer.cc
@@ -282,8 +282,9 @@ HWDrawState HWLayer::OnPrepare(HWDrawContext* context) {
     layer_state_ |= kDrawStateDepth | kDrawStateStencil;
   }
 
-  // abstract layer no need stencil test and depth for itself
-  return HWDrawState::kDrawStateNone;
+  // abstract layer no need stencil test and depth for itself, but propagate
+  // an error from any child draw/layer to the root layer.
+  return layer_state_ & HWDrawState::kDrawStateError;
 }
 
 void HWLayer::OnGenerateCommand(HWDrawContext* context, HWDrawState state) {

--- a/src/render/hw/hw_render_target_cache.hpp
+++ b/src/render/hw/hw_render_target_cache.hpp
@@ -54,11 +54,16 @@ class HWRenderTarget
       : texture_(texture) {}
 
   const GPUTextureDescriptor& GetKey() const override {
-    return texture_->GetDescriptor();
+    // A texture allocation failure yields a null GPUTexture. Keep the cache
+    // operations (byte accounting, key comparison) safe in that case.
+    static const GPUTextureDescriptor kEmptyDescriptor{};
+    return texture_ ? texture_->GetDescriptor() : kEmptyDescriptor;
   }
   std::shared_ptr<GPUTexture> GetValue() const override { return texture_; }
 
-  size_t GetBytes() const override { return texture_->GetBytes(); }
+  size_t GetBytes() const override {
+    return texture_ ? texture_->GetBytes() : 0;
+  }
 
  private:
   std::shared_ptr<GPUTexture> texture_;

--- a/src/render/hw/layer/hw_filter_layer.cc
+++ b/src/render/hw/layer/hw_filter_layer.cc
@@ -19,6 +19,12 @@ HWDrawState HWFilterLayer::OnPrepare(HWDrawContext* context) {
   auto device = context->gpuContext->GetGPUDevice();
   auto input_texture = device->CreateTexture(desc);
 
+  // If the filter input texture cannot be created, discard this layer
+  // instead of running the filter against a null attachment.
+  if (!input_texture) {
+    return HWDrawState::kDrawStateNone;
+  }
+
   HWFilterOutput filter_result{
       input_texture,
       GetBounds(),

--- a/src/render/hw/layer/hw_filter_layer.cc
+++ b/src/render/hw/layer/hw_filter_layer.cc
@@ -5,6 +5,7 @@
 #include "src/render/hw/layer/hw_filter_layer.hpp"
 
 #include "src/gpu/gpu_context_impl.hpp"
+#include "src/logging.hpp"
 #include "src/render/hw/hw_render_pass_builder.hpp"
 
 namespace skity {
@@ -22,6 +23,9 @@ HWDrawState HWFilterLayer::OnPrepare(HWDrawContext* context) {
   // If the filter input texture cannot be created, discard this layer
   // instead of running the filter against a null attachment.
   if (!input_texture) {
+    LOGE(
+        "HWFilterLayer::OnPrepare: failed to allocate filter input texture, "
+        "discarding layer");
     return HWDrawState::kDrawStateNone;
   }
 

--- a/src/render/hw/layer/hw_filter_layer.cc
+++ b/src/render/hw/layer/hw_filter_layer.cc
@@ -26,7 +26,7 @@ HWDrawState HWFilterLayer::OnPrepare(HWDrawContext* context) {
     LOGE(
         "HWFilterLayer::OnPrepare: failed to allocate filter input texture, "
         "discarding layer");
-    return HWDrawState::kDrawStateNone;
+    return HWDrawState::kDrawStateError;
   }
 
   HWFilterOutput filter_result{

--- a/src/render/hw/layer/hw_sub_layer.cc
+++ b/src/render/hw/layer/hw_sub_layer.cc
@@ -14,6 +14,13 @@ namespace skity {
 HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
   InitTexture(context->gpuContext, context->pool);
 
+  // If either the color attachment or the layer back texture cannot be created
+  // (e.g. GPU texture allocation failure), there is nothing meaningful to
+  // render, so discard this layer entirely.
+  if (!color_texture_ || !layer_back_draw_texture_) {
+    return HWDrawState::kDrawStateNone;
+  }
+
   // prepare layer back draw
   {
     auto bounds = GetLayerBackDrawBounds();
@@ -50,9 +57,21 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
 }
 
 void HWSubLayer::OnGenerateCommand(HWDrawContext* context, HWDrawState state) {
+  if (!color_texture_ || !layer_back_draw_texture_) {
+    return;
+  }
+
   HWLayer::OnGenerateCommand(context, state);
 
   layer_back_draw_->GenerateCommand(context, state);
+}
+
+void HWSubLayer::Draw(GPURenderPass* render_pass, GPUCommandBuffer* cmd) {
+  if (!color_texture_ || !layer_back_draw_texture_) {
+    return;
+  }
+
+  HWLayer::Draw(render_pass, cmd);
 }
 
 std::shared_ptr<GPURenderPass> HWSubLayer::OnBeginRenderPass(

--- a/src/render/hw/layer/hw_sub_layer.cc
+++ b/src/render/hw/layer/hw_sub_layer.cc
@@ -5,6 +5,7 @@
 #include "src/render/hw/layer/hw_sub_layer.hpp"
 
 #include "src/gpu/gpu_context_impl.hpp"
+#include "src/logging.hpp"
 #include "src/render/hw/draw/fragment/wgsl_texture_fragment.hpp"
 #include "src/render/hw/draw/hw_dynamic_path_draw.hpp"
 #include "src/render/hw/hw_render_pass_builder.hpp"
@@ -18,6 +19,10 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
   // (e.g. GPU texture allocation failure), there is nothing meaningful to
   // render, so discard this layer entirely.
   if (!color_texture_ || !layer_back_draw_texture_) {
+    LOGE(
+        "HWSubLayer::OnPrepare: failed to allocate layer texture ({}, {}), "
+        "discarding layer",
+        GetWidth(), GetHeight());
     return HWDrawState::kDrawStateNone;
   }
 

--- a/src/render/hw/layer/hw_sub_layer.cc
+++ b/src/render/hw/layer/hw_sub_layer.cc
@@ -23,7 +23,7 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
         "HWSubLayer::OnPrepare: failed to allocate layer texture ({}, {}), "
         "discarding layer",
         GetWidth(), GetHeight());
-    return HWDrawState::kDrawStateNone;
+    return HWDrawState::kDrawStateError;
   }
 
   // prepare layer back draw
@@ -54,7 +54,7 @@ HWDrawState HWSubLayer::OnPrepare(HWDrawContext* context) {
 
   // need to prepare self before all children
   // so can make sure self layer texture is not used by children layer
-  HWLayer::OnPrepare(context);
+  state |= HWLayer::OnPrepare(context);
 
   PrepareRenderPassDesc(context);
 

--- a/src/render/hw/layer/hw_sub_layer.hpp
+++ b/src/render/hw/layer/hw_sub_layer.hpp
@@ -24,6 +24,8 @@ class HWSubLayer : public HWLayer {
 
   void SetAlpha(float alpha) { alpha_ = alpha; }
 
+  void Draw(GPURenderPass* render_pass, GPUCommandBuffer* cmd) override;
+
   void ExpandTextureSizeToNextPow2() {
     texture_size_ = MakeApprox(texture_size_);
   }

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(skity_unit_test
     render/hw/coverage_aa_line_encoder_test.cc
     render/hw/coverage_aa_path_tiler_test.cc
     render/hw/hw_pipeline_key_test.cc
+    render/hw/hw_sub_layer_discard_test.cc
     render/hw/precompile_test.cc
     render/hw/dst_read_strategy_test.cc
     render/hw/hw_blend_plan_test.cc

--- a/test/ut/render/hw/hw_sub_layer_discard_test.cc
+++ b/test/ut/render/hw/hw_sub_layer_discard_test.cc
@@ -1,0 +1,142 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <skity/geometry/rect.hpp>
+
+#include "src/gpu/gpu_context_impl.hpp"
+#include "src/gpu/gpu_device.hpp"
+#include "src/render/hw/layer/hw_sub_layer.hpp"
+
+namespace skity {
+namespace {
+
+// A GPU device whose texture creation always fails (e.g. GPU memory pressure
+// or device loss). Every other resource API returns a null placeholder, since
+// the layer discard path never reaches them.
+class FailingGPUDevice : public GPUDevice {
+ public:
+  std::unique_ptr<GPUBuffer> CreateBuffer(
+      const GPUBufferDescriptor&) override {
+    return {};
+  }
+
+  std::shared_ptr<GPUShaderFunction> CreateShaderFunction(
+      const GPUShaderFunctionDescriptor&) override {
+    return {};
+  }
+
+  std::unique_ptr<GPURenderPipeline> CreateRenderPipeline(
+      const GPURenderPipelineDescriptor&) override {
+    return {};
+  }
+
+  std::unique_ptr<GPURenderPipeline> ClonePipeline(
+      GPURenderPipeline*, const GPURenderPipelineDescriptor&) override {
+    return {};
+  }
+
+  std::shared_ptr<GPUCommandBuffer> CreateCommandBuffer() override {
+    return {};
+  }
+
+  std::shared_ptr<GPUSampler> CreateSampler(
+      const GPUSamplerDescriptor&) override {
+    return {};
+  }
+
+  std::shared_ptr<GPUTexture> CreateTexture(
+      const GPUTextureDescriptor&) override {
+    return {};
+  }
+
+  bool CanUseMSAA() override { return false; }
+
+  uint32_t GetBufferAlignment() override { return 0; }
+
+  uint32_t GetMaxTextureSize() override { return 4096; }
+};
+
+class FailingGPUContext : public GPUContextImpl {
+ public:
+  FailingGPUContext() : GPUContextImpl(GPUBackendType::kNone) {}
+
+  ~FailingGPUContext() override = default;
+
+ protected:
+  std::unique_ptr<GPUSurface> CreateSurface(
+      GPUSurfaceDescriptor*) override {
+    return {};
+  }
+
+  std::unique_ptr<GPUDevice> CreateGPUDevice() override {
+    return std::make_unique<FailingGPUDevice>();
+  }
+
+  std::shared_ptr<GPUTexture> OnWrapTexture(
+      GPUBackendTextureInfo*, ReleaseCallback, ReleaseUserData) override {
+    return {};
+  }
+
+  std::unique_ptr<GPURenderTarget> OnCreateRenderTarget(
+      const GPURenderTargetDescriptor&, std::shared_ptr<Texture>) override {
+    return {};
+  }
+
+  std::shared_ptr<Data> OnReadPixels(
+      const std::shared_ptr<GPUTexture>&) const override {
+    return {};
+  }
+};
+
+}  // namespace
+}  // namespace skity
+
+// Regression test for an online crash in
+// HWLayer::CreateDrawLayerShader (hw_layer.cc):
+// when the layer back texture cannot be created, HWSubLayer must discard the
+// whole layer instead of dereferencing a null texture while building the layer
+// back shader / render pass.
+TEST(HWSubLayerDiscard, SkipsLayerWhenBackTextureCreationFails) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::HWSubLayer layer(skity::Matrix{}, 1,
+                          skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f), 100,
+                          100);
+  layer.SetClipDepth(0);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+
+  // Prepare must not crash and must report that the layer is skipped.
+  auto state = layer.Prepare(&draw_context);
+  EXPECT_EQ(state, skity::HWDrawState::kDrawStateNone);
+
+  EXPECT_NO_FATAL_FAILURE(layer.GenerateCommand(&draw_context, state));
+  EXPECT_NO_FATAL_FAILURE(layer.Draw(nullptr, nullptr));
+}
+
+// The render target cache must survive a failed texture allocation even when
+// the cache is enabled: byte/key accounting must not dereference the null
+// texture (HWRenderTarget::GetBytes/GetKey).
+TEST(HWSubLayerDiscard, RenderTargetCacheHandlesAllocationFailure) {
+  skity::FailingGPUDevice device;
+  auto cache = skity::HWRenderTargetCache::Create(&device);
+
+  skity::GPUTextureDescriptor desc;
+  desc.width = 100;
+  desc.height = 100;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  desc.sample_count = 1;
+
+  auto resource = cache->ObtainResource(desc);
+  ASSERT_NE(resource, nullptr);
+  EXPECT_EQ(resource->GetValue(), nullptr);
+  EXPECT_EQ(resource->GetBytes(), static_cast<size_t>(0));
+}

--- a/test/ut/render/hw/hw_sub_layer_discard_test.cc
+++ b/test/ut/render/hw/hw_sub_layer_discard_test.cc
@@ -146,6 +146,24 @@ class TestSubLayer : public HWSubLayer {
   }
 };
 
+// A GPU device that hands out stub textures while every other resource API
+// keeps failing. Control group for the dst-copy failure test: prepare stays
+// error-free as long as the copy texture itself can be allocated.
+class SucceedingGPUDevice : public FailingGPUDevice {
+ public:
+  std::shared_ptr<GPUTexture> CreateTexture(
+      const GPUTextureDescriptor& desc) override {
+    return std::make_shared<TestGPUTexture>(desc);
+  }
+};
+
+class SucceedingGPUContext : public FailingGPUContext {
+ protected:
+  std::unique_ptr<GPUDevice> CreateGPUDevice() override {
+    return std::make_unique<SucceedingGPUDevice>();
+  }
+};
+
 }  // namespace
 }  // namespace skity
 
@@ -312,6 +330,65 @@ TEST(HWSubLayerDiscard, SubLayerHasNoErrorWhenChildrenPrepareFine) {
   draw_context.arena_allocator = &arena;
 
   auto state = layer.Prepare(&draw_context);
+  EXPECT_EQ(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
+}
+
+// The dst-read copy texture is allocated during prepare (hw_layer.cc). When
+// that allocation fails, the layer must report kDrawStateError instead of
+// leaving a null texture for the blit pass and dst-read sampling at draw time.
+TEST(HWSubLayerDiscard, DstCopyTextureFailurePropagatesError) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+  skity::TestParentLayer parent(skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f),
+                                100, 100);
+  parent.SetArenaAllocator(&arena);
+  parent.SetClipDepth(0);
+
+  skity::HWBlendPlan blend_plan;
+  blend_plan.dst_read_strategy = skity::DstReadStrategy::kTextureCopy;
+  skity::StubDraw dst_read_draw(skity::HWDrawState::kDrawStateNone);
+  dst_read_draw.SetBlendPlan(blend_plan);
+  dst_read_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  parent.AddDraw(&dst_read_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = parent.Prepare(&draw_context);
+  EXPECT_NE(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
+}
+
+// Control group for the test above: the same dst-read draw must not produce
+// an error when the copy texture can be allocated.
+TEST(HWSubLayerDiscard, DstCopyTextureSuccessHasNoError) {
+  skity::SucceedingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+  skity::TestParentLayer parent(skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f),
+                                100, 100);
+  parent.SetArenaAllocator(&arena);
+  parent.SetClipDepth(0);
+
+  skity::HWBlendPlan blend_plan;
+  blend_plan.dst_read_strategy = skity::DstReadStrategy::kTextureCopy;
+  skity::StubDraw dst_read_draw(skity::HWDrawState::kDrawStateNone);
+  dst_read_draw.SetBlendPlan(blend_plan);
+  dst_read_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  parent.AddDraw(&dst_read_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = parent.Prepare(&draw_context);
   EXPECT_EQ(state & skity::HWDrawState::kDrawStateError,
             skity::HWDrawState::kDrawStateNone);
 }

--- a/test/ut/render/hw/hw_sub_layer_discard_test.cc
+++ b/test/ut/render/hw/hw_sub_layer_discard_test.cc
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-
 #include <skity/geometry/rect.hpp>
 
 #include "src/gpu/gpu_context_impl.hpp"
@@ -20,8 +19,7 @@ namespace {
 // the layer discard path never reaches them.
 class FailingGPUDevice : public GPUDevice {
  public:
-  std::unique_ptr<GPUBuffer> CreateBuffer(
-      const GPUBufferDescriptor&) override {
+  std::unique_ptr<GPUBuffer> CreateBuffer(const GPUBufferDescriptor&) override {
     return {};
   }
 
@@ -68,8 +66,7 @@ class FailingGPUContext : public GPUContextImpl {
   ~FailingGPUContext() override = default;
 
  protected:
-  std::unique_ptr<GPUSurface> CreateSurface(
-      GPUSurfaceDescriptor*) override {
+  std::unique_ptr<GPUSurface> CreateSurface(GPUSurfaceDescriptor*) override {
     return {};
   }
 
@@ -77,8 +74,9 @@ class FailingGPUContext : public GPUContextImpl {
     return std::make_unique<FailingGPUDevice>();
   }
 
-  std::shared_ptr<GPUTexture> OnWrapTexture(
-      GPUBackendTextureInfo*, ReleaseCallback, ReleaseUserData) override {
+  std::shared_ptr<GPUTexture> OnWrapTexture(GPUBackendTextureInfo*,
+                                            ReleaseCallback,
+                                            ReleaseUserData) override {
     return {};
   }
 

--- a/test/ut/render/hw/hw_sub_layer_discard_test.cc
+++ b/test/ut/render/hw/hw_sub_layer_discard_test.cc
@@ -10,6 +10,7 @@
 #include "src/gpu/gpu_context_impl.hpp"
 #include "src/gpu/gpu_device.hpp"
 #include "src/render/hw/layer/hw_sub_layer.hpp"
+#include "src/utils/arena_allocator.hpp"
 
 namespace skity {
 namespace {
@@ -91,6 +92,60 @@ class FailingGPUContext : public GPUContextImpl {
   }
 };
 
+// Minimal HWLayer that hosts child draws without a texture backend, used to
+// verify that a child's prepare error is propagated to the parent.
+class TestParentLayer : public HWLayer {
+ public:
+  TestParentLayer(const Rect& bounds, uint32_t width, uint32_t height)
+      : HWLayer(Matrix{}, 0, bounds, width, height) {}
+
+ protected:
+  std::shared_ptr<GPURenderPass> OnBeginRenderPass(GPUCommandBuffer*,
+                                                   bool) override {
+    return {};
+  }
+
+  void OnPostDraw(GPURenderPass*, GPUCommandBuffer*) override {}
+};
+
+// Stub draw that always returns the given prepare state.
+class StubDraw : public HWDraw {
+ public:
+  explicit StubDraw(HWDrawState state) : HWDraw(Matrix{}), state_(state) {}
+
+  void Draw(GPURenderPass*, GPUCommandBuffer*) override {}
+
+ protected:
+  HWDrawState OnPrepare(HWDrawContext*) override { return state_; }
+
+  void OnGenerateCommand(HWDrawContext*, HWDrawState) override {}
+
+ private:
+  HWDrawState state_;
+};
+
+// Minimal GPUTexture that does not touch a real GPU, used to give a sub
+// layer a valid color/back texture so its own texture guard does not trigger.
+class TestGPUTexture : public GPUTexture {
+ public:
+  explicit TestGPUTexture(const GPUTextureDescriptor& desc)
+      : GPUTexture(desc) {}
+
+  size_t GetBytes() const override { return 0; }
+
+  void UploadData(uint32_t, uint32_t, uint32_t, uint32_t, void*) override {}
+};
+
+// HWSubLayer that lets tests inject a texture without a working device.
+class TestSubLayer : public HWSubLayer {
+ public:
+  using HWSubLayer::HWSubLayer;
+
+  void SetLayerTexture(const std::shared_ptr<GPUTexture>& texture) {
+    SetTextures(texture, texture);
+  }
+};
+
 }  // namespace
 }  // namespace skity
 
@@ -138,4 +193,125 @@ TEST(HWSubLayerDiscard, RenderTargetCacheHandlesAllocationFailure) {
   ASSERT_NE(resource, nullptr);
   EXPECT_EQ(resource->GetValue(), nullptr);
   EXPECT_EQ(resource->GetBytes(), static_cast<size_t>(0));
+}
+
+// A failing child must make its parent's prepare report kDrawStateError, so the
+// error can keep bubbling up to the root layer.
+TEST(HWSubLayerDiscard, PropagatesChildPrepareErrorToParent) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+  skity::TestParentLayer parent(skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f),
+                                100, 100);
+  parent.SetArenaAllocator(&arena);
+  parent.SetClipDepth(0);
+
+  skity::StubDraw failing_draw(skity::HWDrawState::kDrawStateError);
+  failing_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  parent.AddDraw(&failing_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = parent.Prepare(&draw_context);
+  EXPECT_NE(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
+}
+
+// A parent whose children all prepare successfully must NOT report an error.
+TEST(HWSubLayerDiscard, ParentHasNoErrorWhenChildrenPrepareFine) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+  skity::TestParentLayer parent(skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f),
+                                100, 100);
+  parent.SetArenaAllocator(&arena);
+  parent.SetClipDepth(0);
+
+  skity::StubDraw passing_draw(skity::HWDrawState::kDrawStateNone);
+  passing_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  parent.AddDraw(&passing_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = parent.Prepare(&draw_context);
+  EXPECT_EQ(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
+}
+
+// A sub layer with a valid texture that still aggregates a failing child's
+// prepare error and reports it upward.
+TEST(HWSubLayerDiscard, SubLayerPropagatesChildPrepareErrorUpward) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+
+  skity::GPUTextureDescriptor desc;
+  desc.width = 100;
+  desc.height = 100;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  auto texture = std::make_shared<skity::TestGPUTexture>(desc);
+
+  skity::TestSubLayer layer(skity::Matrix{}, 1,
+                            skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f), 100,
+                            100);
+  layer.SetArenaAllocator(&arena);
+  layer.SetClipDepth(0);
+  layer.SetLayerTexture(texture);
+
+  skity::StubDraw failing_draw(skity::HWDrawState::kDrawStateError);
+  failing_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  layer.AddDraw(&failing_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = layer.Prepare(&draw_context);
+  EXPECT_NE(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
+}
+
+// A sub layer with a valid texture and healthy children must not report an
+// error (proves the error above comes from the child, not the layer texture).
+TEST(HWSubLayerDiscard, SubLayerHasNoErrorWhenChildrenPrepareFine) {
+  skity::FailingGPUContext context;
+  ASSERT_TRUE(context.Init());
+
+  skity::ArenaAllocator arena;
+
+  skity::GPUTextureDescriptor desc;
+  desc.width = 100;
+  desc.height = 100;
+  desc.format = skity::GPUTextureFormat::kRGBA8Unorm;
+  auto texture = std::make_shared<skity::TestGPUTexture>(desc);
+
+  skity::TestSubLayer layer(skity::Matrix{}, 1,
+                            skity::Rect::MakeXYWH(0.f, 0.f, 100.f, 100.f), 100,
+                            100);
+  layer.SetArenaAllocator(&arena);
+  layer.SetClipDepth(0);
+  layer.SetLayerTexture(texture);
+
+  skity::StubDraw passing_draw(skity::HWDrawState::kDrawStateNone);
+  passing_draw.SetLayerSpaceBounds(skity::Rect::MakeWH(100.f, 100.f));
+  layer.AddDraw(&passing_draw);
+
+  skity::HWDrawContext draw_context;
+  draw_context.total_clip_depth = 1;
+  draw_context.gpuContext = &context;
+  draw_context.arena_allocator = &arena;
+
+  auto state = layer.Prepare(&draw_context);
+  EXPECT_EQ(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
 }

--- a/test/ut/render/hw/hw_sub_layer_discard_test.cc
+++ b/test/ut/render/hw/hw_sub_layer_discard_test.cc
@@ -114,7 +114,8 @@ TEST(HWSubLayerDiscard, SkipsLayerWhenBackTextureCreationFails) {
 
   // Prepare must not crash and must report that the layer is skipped.
   auto state = layer.Prepare(&draw_context);
-  EXPECT_EQ(state, skity::HWDrawState::kDrawStateNone);
+  EXPECT_NE(state & skity::HWDrawState::kDrawStateError,
+            skity::HWDrawState::kDrawStateNone);
 
   EXPECT_NO_FATAL_FAILURE(layer.GenerateCommand(&draw_context, state));
   EXPECT_NO_FATAL_FAILURE(layer.Draw(nullptr, nullptr));


### PR DESCRIPTION
A failed GPU texture allocation (e.g. memory pressure) could reach
HWLayer::CreateDrawLayerShader with a null texture and crash (online
arm64 report). Layers whose allocation fails are now discarded instead
of crashing or rendering partial output.

- HWSubLayer/HWFilterLayer return kDrawStateError and skip
  Prepare/GenerateCommand/Draw when their color or layer-back texture
  allocation fails
- Add kDrawStateError to HWDrawState and propagate it from child
  layers to the root; HWCanvas::OnFlush drops the whole frame instead
  of presenting stale/partial content
- Make render target cache getters null-safe for failed allocations
- Log whenever a layer or the whole frame is discarded
- Add unit tests for the skip path, cache null-safety, and error
  propagation up through parent/sub-layers