### PR TITLE
fix(gl): avoid glClear on PowerVR GPUs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -453,6 +453,8 @@ if(${SKITY_HW_RENDERER})
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_command_buffer_gl.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_device_gl.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_device_gl.hpp
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_driver_info_gl.cc
+      ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_driver_info_gl.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_context_impl_gl.cc
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_context_impl_gl.hpp
       ${CMAKE_CURRENT_LIST_DIR}/gpu/gl/gpu_render_pass_gl.cc

--- a/src/gpu/gl/gpu_command_buffer_gl.cc
+++ b/src/gpu/gl/gpu_command_buffer_gl.cc
@@ -6,6 +6,7 @@
 
 #include "src/gpu/gl/gl_interface.hpp"
 #include "src/gpu/gl/gpu_blit_pass_gl.hpp"
+#include "src/gpu/gl/gpu_device_gl.hpp"
 #include "src/gpu/gl/gpu_render_pass_gl.hpp"
 #include "src/gpu/gl/gpu_texture_gl.hpp"
 
@@ -14,7 +15,7 @@ namespace skity {
 std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginRenderPass(
     const GPURenderPassDescriptor& desc) {
   // this render pass needs msaa resolve
-  if (desc.color_attachment.resolve_texture && context_support_msaa_) {
+  if (desc.color_attachment.resolve_texture && device_->CanUseMSAA()) {
 #ifdef SKITY_ANDROID
     if (GLInterface::GlobalInterface()->ext_multisampled_render_to_texture !=
         0) {
@@ -37,6 +38,11 @@ std::shared_ptr<GPUBlitPass> GPUCommandBufferGL::BeginBlitPass() {
 bool GPUCommandBufferGL::Submit(const GPUSubmitInfo* submit_info) {
   (void)submit_info;
   return true;
+}
+
+std::shared_ptr<GPURenderPass> GPUCommandBufferGL::CreateRenderPassForFBO(
+    const GPURenderPassDescriptor& desc, uint32_t fbo_id) const {
+  return std::make_shared<GPURenderPassGL>(desc, fbo_id, device_);
 }
 
 std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginDirectRenderPass(
@@ -85,7 +91,7 @@ std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginDirectRenderPass(
 
   GL_CALL(BindFramebuffer, GL_FRAMEBUFFER, 0);
 
-  return std::make_shared<GPURenderPassGL>(desc, fbo_id);
+  return CreateRenderPassForFBO(desc, fbo_id);
 }
 
 std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginMSAAResolveRenderPass(
@@ -157,7 +163,7 @@ std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginMSAAResolveRenderPass(
   }
 
   return std::make_shared<GLMSAAResolveRenderPass>(desc, render_fbo,
-                                                   resolve_fbo);
+                                                   resolve_fbo, device_);
 }
 
 #ifdef SKITY_ANDROID
@@ -218,7 +224,7 @@ std::shared_ptr<GPURenderPass> GPUCommandBufferGL::BeginTileMSAARenderPass(
 
   GL_CALL(BindFramebuffer, GL_FRAMEBUFFER, 0);
 
-  return std::make_shared<GPURenderPassGL>(desc, fbo_id);
+  return CreateRenderPassForFBO(desc, fbo_id);
 }
 
 #endif

--- a/src/gpu/gl/gpu_command_buffer_gl.hpp
+++ b/src/gpu/gl/gpu_command_buffer_gl.hpp
@@ -9,10 +9,11 @@
 
 namespace skity {
 
+class GPUDeviceGL;
+
 class GPUCommandBufferGL : public GPUCommandBuffer {
  public:
-  explicit GPUCommandBufferGL(bool support_msaa)
-      : context_support_msaa_(support_msaa) {}
+  explicit GPUCommandBufferGL(GPUDeviceGL* device) : device_(device) {}
 
   ~GPUCommandBufferGL() override = default;
 
@@ -22,6 +23,9 @@ class GPUCommandBufferGL : public GPUCommandBuffer {
   std::shared_ptr<GPUBlitPass> BeginBlitPass() override;
 
   bool Submit(const GPUSubmitInfo* submit_info = nullptr) override;
+
+  std::shared_ptr<GPURenderPass> CreateRenderPassForFBO(
+      const GPURenderPassDescriptor& desc, uint32_t fbo_id) const;
 
  private:
   std::shared_ptr<GPURenderPass> BeginDirectRenderPass(
@@ -36,7 +40,7 @@ class GPUCommandBufferGL : public GPUCommandBuffer {
 #endif
 
  private:
-  bool context_support_msaa_;
+  GPUDeviceGL* device_;
 };
 
 }  // namespace skity

--- a/src/gpu/gl/gpu_device_gl.cc
+++ b/src/gpu/gl/gpu_device_gl.cc
@@ -5,6 +5,7 @@
 #include "src/gpu/gl/gpu_device_gl.hpp"
 
 #include <cstring>
+#include <string>
 
 #include "src/gpu/gl/gl_interface.hpp"
 #include "src/gpu/gl/gpu_buffer_gl.hpp"
@@ -16,6 +17,54 @@
 #include "src/tracing.hpp"
 
 namespace skity {
+namespace {
+
+std::string GetGLString(GLenum name) {
+  const auto* value = GL_CALL(GetString, name);
+  return value ? reinterpret_cast<const char*>(value) : "";
+}
+
+constexpr char kClearDrawVertexShader[] = R"(
+void main() {
+  vec2 position = vec2(-1.0, -1.0);
+  if (gl_VertexID == 1) {
+    position = vec2(3.0, -1.0);
+  } else if (gl_VertexID == 2) {
+    position = vec2(-1.0, 3.0);
+  }
+  gl_Position = vec4(position, -1.0, 1.0);
+}
+)";
+
+constexpr char kClearDrawFragmentShader[] = R"(
+layout(location = 0) out vec4 frag_color;
+void main() {
+  frag_color = vec4(0.0);
+}
+)";
+
+GLuint CreateClearDrawProgram(bool is_gles) {
+  const char* version = is_gles ? "#version 300 es\n" : "#version 330 core\n";
+  const char* fragment_precision = is_gles ? "precision mediump float;\n" : "";
+  const std::string vertex_source =
+      std::string(version) + kClearDrawVertexShader;
+  const std::string fragment_source =
+      std::string(version) + fragment_precision + kClearDrawFragmentShader;
+
+  GPUShaderFunctionGL vertex(GPULabel{std::string("GLClearDrawVertex")},
+                             GPUShaderStage::kVertex, vertex_source.c_str(),
+                             {});
+  GPUShaderFunctionGL fragment(GPULabel{std::string("GLClearDrawFragment")},
+                               GPUShaderStage::kFragment,
+                               fragment_source.c_str(), {});
+  if (!vertex.IsValid() || !fragment.IsValid()) {
+    return 0;
+  }
+
+  return CreateGLProgram(vertex.GetShader(), fragment.GetShader());
+}
+
+}  // namespace
 
 GPUDeviceGL::GPUDeviceGL() {
   auto gpu_caps = std::make_unique<GPUCaps>();
@@ -31,10 +80,26 @@ GPUDeviceGL::GPUDeviceGL() {
       gl_interface->ext_khr_blend_equation_advanced;
   gpu_caps->supports_dual_source_blending =
       !is_gles_ || gl_interface->ext_blend_func_extended;
+
+  driver_info_ = GLDriverInfo::FromStrings(GetGLString(GL_VENDOR),
+                                           GetGLString(GL_RENDERER),
+                                           GetGLString(GL_VERSION));
+  driver_workarounds_ = ResolveGLDriverWorkarounds(driver_info_);
   InitCaps(std::move(gpu_caps));
+
+  if (driver_workarounds_.use_draw_for_clear) {
+    clear_draw_program_ = CreateClearDrawProgram(is_gles_);
+    if (clear_draw_program_ == 0) {
+      LOGE("Failed to initialize GL clear-as-draw workaround");
+    }
+  }
 }
 
-GPUDeviceGL::~GPUDeviceGL() = default;
+GPUDeviceGL::~GPUDeviceGL() {
+  if (clear_draw_program_ != 0) {
+    GL_CALL(DeleteProgram, clear_draw_program_);
+  }
+}
 
 std::unique_ptr<GPUBuffer> GPUDeviceGL::CreateBuffer(
     const GPUBufferDescriptor& desc) {
@@ -91,7 +156,7 @@ std::unique_ptr<GPURenderPipeline> GPUDeviceGL::ClonePipeline(
 }
 
 std::shared_ptr<GPUCommandBuffer> GPUDeviceGL::CreateCommandBuffer() {
-  return std::make_shared<GPUCommandBufferGL>(CanUseMSAA());
+  return std::make_shared<GPUCommandBufferGL>(this);
 }
 
 std::shared_ptr<GPUSampler> GPUDeviceGL::CreateSampler(
@@ -233,8 +298,8 @@ void GPUDeviceGL::InitGLVersion() {
 
   auto version = GL_CALL(GetString, GL_VERSION);
 
-  if (std::strstr(reinterpret_cast<const char*>(version), "OpenGL ES") !=
-      nullptr) {
+  if (version != nullptr && std::strstr(reinterpret_cast<const char*>(version),
+                                        "OpenGL ES") != nullptr) {
     is_gles_ = true;
   }
 }

--- a/src/gpu/gl/gpu_device_gl.hpp
+++ b/src/gpu/gl/gpu_device_gl.hpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "src/gpu/gl/gpu_driver_info_gl.hpp"
 #include "src/gpu/gpu_device.hpp"
 
 namespace skity {
@@ -44,6 +45,14 @@ class GPUDeviceGL : public GPUDevice {
 
   uint32_t GetMaxTextureSize() override;
 
+  uint32_t GetClearDrawProgram() const { return clear_draw_program_; }
+
+  const GLDriverInfo& GetDriverInfo() const { return driver_info_; }
+
+  const GLDriverWorkarounds& GetDriverWorkarounds() const {
+    return driver_workarounds_;
+  }
+
   std::shared_ptr<GPUShaderFunction> CreateShaderFunctionFromModule(
       const GPUShaderFunctionDescriptor& desc);
 
@@ -57,6 +66,9 @@ class GPUDeviceGL : public GPUDevice {
   int32_t gl_version_major_ = 0;
   int32_t gl_version_minor_ = 0;
   bool is_gles_ = false;
+  uint32_t clear_draw_program_ = 0;
+  GLDriverInfo driver_info_ = {};
+  GLDriverWorkarounds driver_workarounds_ = {};
 };
 
 }  // namespace skity

--- a/src/gpu/gl/gpu_driver_info_gl.cc
+++ b/src/gpu/gl/gpu_driver_info_gl.cc
@@ -1,0 +1,40 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/gl/gpu_driver_info_gl.hpp"
+
+#include <utility>
+
+namespace skity {
+namespace {
+
+GLVendor DetectGLVendor(const std::string& renderer) {
+  constexpr char kPowerVRPrefix[] = "PowerVR";
+  if (renderer.compare(0, sizeof(kPowerVRPrefix) - 1, kPowerVRPrefix) == 0) {
+    return GLVendor::kPowerVR;
+  }
+
+  return GLVendor::kUnknown;
+}
+
+}  // namespace
+
+GLDriverInfo GLDriverInfo::FromStrings(std::string vendor, std::string renderer,
+                                       std::string version) {
+  GLDriverInfo info;
+  info.vendor = DetectGLVendor(renderer);
+  info.vendor_name = std::move(vendor);
+  info.renderer = std::move(renderer);
+  info.version = std::move(version);
+  return info;
+}
+
+GLDriverWorkarounds ResolveGLDriverWorkarounds(
+    const GLDriverInfo& driver_info) {
+  GLDriverWorkarounds workarounds;
+  workarounds.use_draw_for_clear = driver_info.vendor == GLVendor::kPowerVR;
+  return workarounds;
+}
+
+}  // namespace skity

--- a/src/gpu/gl/gpu_driver_info_gl.hpp
+++ b/src/gpu/gl/gpu_driver_info_gl.hpp
@@ -1,0 +1,35 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_GPU_GL_GPU_DRIVER_INFO_GL_HPP
+#define SRC_GPU_GL_GPU_DRIVER_INFO_GL_HPP
+
+#include <string>
+
+namespace skity {
+
+enum class GLVendor {
+  kUnknown,
+  kPowerVR,
+};
+
+struct GLDriverInfo {
+  static GLDriverInfo FromStrings(std::string vendor, std::string renderer,
+                                  std::string version);
+
+  GLVendor vendor = GLVendor::kUnknown;
+  std::string vendor_name;
+  std::string renderer;
+  std::string version;
+};
+
+struct GLDriverWorkarounds {
+  bool use_draw_for_clear = false;
+};
+
+GLDriverWorkarounds ResolveGLDriverWorkarounds(const GLDriverInfo& driver_info);
+
+}  // namespace skity
+
+#endif  // SRC_GPU_GL_GPU_DRIVER_INFO_GL_HPP

--- a/src/gpu/gl/gpu_render_pass_gl.cc
+++ b/src/gpu/gl/gpu_render_pass_gl.cc
@@ -8,6 +8,7 @@
 
 #include "src/gpu/gl/formats_gl.h"
 #include "src/gpu/gl/gpu_buffer_gl.hpp"
+#include "src/gpu/gl/gpu_device_gl.hpp"
 #include "src/gpu/gl/gpu_render_pipeline_gl.hpp"
 #include "src/gpu/gl/gpu_sampler_gl.hpp"
 #include "src/gpu/gl/gpu_texture_gl.hpp"
@@ -51,25 +52,14 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
       target_height,
   });
 
+  SetScissorBox(s.x, target_height - s.y - s.height, s.width, s.height);
+
+  ResetState();
+  Clear();
   GL_CALL(Viewport, v.x,                   // x
           target_height - v.y - v.height,  // y
           v.width,                         // width
           v.height);                       // height
-
-  SetScissorBox(s.x, target_height - s.y - s.height, s.width, s.height);
-
-  // sync state to default
-  GL_CALL(Disable, GL_STENCIL_TEST);
-  GL_CALL(StencilFunc, GL_ALWAYS, 0, 0xFF);
-  GL_CALL(StencilOp, GL_KEEP, GL_KEEP, GL_KEEP);
-  GL_CALL(StencilMask, 0xFF);
-  GL_CALL(ColorMask, 1, 1, 1, 1);
-  GL_CALL(Enable, GL_BLEND);
-  GL_CALL(BlendFunc, GL_ZERO, GL_ZERO);
-
-  SetDepthState(true, true, GPUCompareFunction::kAlways);
-
-  Clear();
   if (after_cleanup_action_) {
     after_cleanup_action_();
   }
@@ -107,7 +97,7 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
                   depth_stencil.depth_state.compare);
 
     // Set program
-    GL_CALL(UseProgram, pipeline->GetProgramId());
+    UseProgram(pipeline->GetProgramId());
 
     BindBuffer(GL_ARRAY_BUFFER,
                static_cast<GPUBufferGL*>(command->vertex_buffer.buffer)
@@ -262,8 +252,12 @@ void GPURenderPassGL::EncodeCommands(std::optional<GPUViewport> viewport,
 }
 
 void GPURenderPassGL::Clear() {
-  const auto& desc = GetDescriptor();
+  if (device_->GetDriverWorkarounds().use_draw_for_clear) {
+    ClearWithDraw();
+    return;
+  }
 
+  const auto& desc = GetDescriptor();
   GLuint clear_mask = 0;
 
   if (desc.color_attachment.load_op == GPULoadOp::kClear) {
@@ -287,6 +281,71 @@ void GPURenderPassGL::Clear() {
   if (clear_mask) {
     GL_CALL(Clear, clear_mask);
   }
+}
+
+void GPURenderPassGL::ClearWithDraw() {
+  const auto& desc = GetDescriptor();
+  const bool clear_color = desc.color_attachment.texture &&
+                           desc.color_attachment.load_op == GPULoadOp::kClear;
+  const bool clear_depth = desc.depth_attachment.texture &&
+                           desc.depth_attachment.load_op == GPULoadOp::kClear;
+  const bool clear_stencil =
+      desc.stencil_attachment.texture &&
+      desc.stencil_attachment.load_op == GPULoadOp::kClear;
+  if (!clear_color && !clear_depth && !clear_stencil) {
+    return;
+  }
+
+  DEBUG_CHECK(!clear_color || (desc.color_attachment.clear_value.r == 0.0 &&
+                               desc.color_attachment.clear_value.g == 0.0 &&
+                               desc.color_attachment.clear_value.b == 0.0 &&
+                               desc.color_attachment.clear_value.a == 0.0));
+  DEBUG_CHECK(!clear_depth || desc.depth_attachment.clear_value == 0.f);
+  DEBUG_CHECK(!clear_stencil || desc.stencil_attachment.clear_value == 0u);
+
+  const GLuint program = device_->GetClearDrawProgram();
+  DEBUG_CHECK(program != 0);
+  if (program == 0) {
+    LOGE("GL clear-as-draw is unavailable; skipping attachment clear");
+    return;
+  }
+
+  GL_CALL(Disable, GL_BLEND);
+  SetColorWriteMask(clear_color);
+  SetDepthState(clear_depth, true, GPUCompareFunction::kAlways);
+  if (clear_stencil) {
+    GL_CALL(Enable, GL_STENCIL_TEST);
+    GL_CALL(StencilFunc, GL_ALWAYS, 0, 0xFF);
+    GL_CALL(StencilOp, GL_REPLACE, GL_REPLACE, GL_REPLACE);
+    GL_CALL(StencilMask, 0xFF);
+  } else {
+    GL_CALL(Disable, GL_STENCIL_TEST);
+  }
+  UseProgram(program);
+  GL_CALL(Viewport, 0, 0, desc.GetTargetWidth(), desc.GetTargetHeight());
+  GL_CALL(DrawArrays, GL_TRIANGLES, 0, 3);
+
+  // The synthetic clear bypasses the render-pass state cache.
+  ResetState();
+}
+
+void GPURenderPassGL::ResetState() {
+  GL_CALL(Disable, GL_STENCIL_TEST);
+  GL_CALL(StencilFunc, GL_ALWAYS, 0, 0xFF);
+  GL_CALL(StencilOp, GL_KEEP, GL_KEEP, GL_KEEP);
+  GL_CALL(StencilMask, 0xFF);
+  GL_CALL(ColorMask, 1, 1, 1, 1);
+  GL_CALL(Enable, GL_BLEND);
+  GL_CALL(BlendFunc, GL_ZERO, GL_ZERO);
+  SetDepthState(true, true, GPUCompareFunction::kAlways);
+
+  enable_color_write_ = true;
+  enable_stencil_test_ = false;
+  stencil_reference_ = 0;
+  stencil_state_ = {};
+  blend_src_ = GL_ZERO;
+  blend_dst_ = GL_ZERO;
+  disable_blend_ = false;
 }
 
 void GPURenderPassGL::SetScissorBox(uint32_t x, uint32_t y, uint32_t width,
@@ -447,8 +506,8 @@ void GPURenderPassGL::BlitFramebuffer(uint32_t src_fbo, uint32_t dst_fbo,
 
 GLMSAAResolveRenderPass::GLMSAAResolveRenderPass(
     const skity::GPURenderPassDescriptor& desc, uint32_t target_fbo,
-    uint32_t resolve_fbo)
-    : GPURenderPassGL(desc, target_fbo), resolve_fbo_(resolve_fbo) {}
+    uint32_t resolve_fbo, GPUDeviceGL* device)
+    : GPURenderPassGL(desc, target_fbo, device), resolve_fbo_(resolve_fbo) {}
 
 void GLMSAAResolveRenderPass::EncodeCommands(
     std::optional<GPUViewport> viewport,

--- a/src/gpu/gl/gpu_render_pass_gl.hpp
+++ b/src/gpu/gl/gpu_render_pass_gl.hpp
@@ -7,15 +7,19 @@
 
 #include <functional>
 #include <unordered_map>
+#include <utility>
 
 #include "src/gpu/gpu_render_pass.hpp"
 
 namespace skity {
 
+class GPUDeviceGL;
+
 class GPURenderPassGL : public GPURenderPass {
  public:
-  GPURenderPassGL(const GPURenderPassDescriptor& desc, uint32_t target_fbo)
-      : GPURenderPass(desc), target_fbo_(target_fbo) {}
+  GPURenderPassGL(const GPURenderPassDescriptor& desc, uint32_t target_fbo,
+                  GPUDeviceGL* device)
+      : GPURenderPass(desc), target_fbo_(target_fbo), device_(device) {}
 
   ~GPURenderPassGL() override = default;
 
@@ -34,6 +38,10 @@ class GPURenderPassGL : public GPURenderPass {
 
  private:
   void Clear();
+
+  void ClearWithDraw();
+
+  void ResetState();
 
   void SetScissorBox(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
 
@@ -66,12 +74,14 @@ class GPURenderPassGL : public GPURenderPass {
   GPUScissorRect scissor_box_ = {};
   std::unordered_map<uint32_t, uint32_t> bound_buffer_ = {};
   std::function<void()> after_cleanup_action_ = nullptr;
+  GPUDeviceGL* device_;
 };
 
 class GLMSAAResolveRenderPass : public GPURenderPassGL {
  public:
   GLMSAAResolveRenderPass(const GPURenderPassDescriptor& desc,
-                          uint32_t target_fbo, uint32_t resolve_fbo);
+                          uint32_t target_fbo, uint32_t resolve_fbo,
+                          GPUDeviceGL* device);
 
   ~GLMSAAResolveRenderPass() override = default;
 

--- a/src/gpu/gl/gpu_render_pipeline_gl.cc
+++ b/src/gpu/gl/gpu_render_pipeline_gl.cc
@@ -8,6 +8,38 @@
 
 namespace skity {
 
+GLuint CreateGLProgram(GLuint vertex_shader, GLuint fragment_shader,
+                       GPUShaderFunctionErrorCallback error_callback) {
+  GLuint program = GL_CALL(CreateProgram);
+  if (program == 0) {
+    constexpr char kError[] = "OpenGL CreateProgram failed.";
+    LOGE("{}", kError);
+    if (error_callback) {
+      error_callback(kError);
+    }
+    return 0;
+  }
+
+  GL_CALL(AttachShader, program, vertex_shader);
+  GL_CALL(AttachShader, program, fragment_shader);
+  GL_CALL(LinkProgram, program);
+
+  GLint linked = GL_FALSE;
+  GL_CALL(GetProgramiv, program, GL_LINK_STATUS, &linked);
+  if (linked == GL_TRUE) {
+    return program;
+  }
+
+  GLchar info_log[1024] = {};
+  GL_CALL(GetProgramInfoLog, program, sizeof(info_log), nullptr, info_log);
+  LOGE("OpenGL program link error: {}", info_log);
+  if (error_callback) {
+    error_callback(info_log);
+  }
+  GL_CALL(DeleteProgram, program);
+  return 0;
+}
+
 GLProgram::~GLProgram() {
   if (program_ != 0) {
     GL_CALL(DeleteProgram, program_);
@@ -37,28 +69,11 @@ GLuint GLProgram::GetUniformBlockIndex(const std::string name) {
 GPURenderPipelineGL::GPURenderPipelineGL(
     const GPURenderPipelineDescriptor& desc)
     : GPURenderPipeline(desc) {
-  GLuint program = GL_CALL(CreateProgram);
-  GLint success;
   auto vs = static_cast<GPUShaderFunctionGL*>(desc.vertex_function.get())
                 ->GetShader();
   auto fs = static_cast<GPUShaderFunctionGL*>(desc.fragment_function.get())
                 ->GetShader();
-
-  GL_CALL(AttachShader, program, vs);
-  GL_CALL(AttachShader, program, fs);
-  GL_CALL(LinkProgram, program);
-  GL_CALL(GetProgramiv, program, GL_LINK_STATUS, &success);
-
-  if (!success) {
-    GLchar info_log[1024];
-    GL_CALL(GetProgramInfoLog, program, 1024, nullptr, info_log);
-    LOGE("OpenGL program link error : {}", info_log);
-    GL_CALL(DeleteProgram, program);
-    if (desc.error_callback) {
-      desc.error_callback(info_log);
-    }
-    program = 0;
-  }
+  GLuint program = CreateGLProgram(vs, fs, desc.error_callback);
 
   bool is_gles =
       static_cast<GPUShaderFunctionGL*>(desc.vertex_function.get())->IsGLES();

--- a/src/gpu/gl/gpu_render_pipeline_gl.hpp
+++ b/src/gpu/gl/gpu_render_pipeline_gl.hpp
@@ -13,6 +13,9 @@
 
 namespace skity {
 
+GLuint CreateGLProgram(GLuint vertex_shader, GLuint fragment_shader,
+                       GPUShaderFunctionErrorCallback error_callback = {});
+
 class GLProgram {
  public:
   explicit GLProgram(GLuint program, bool ubo_slot_in_shader)

--- a/src/render/hw/gl/gl_root_layer.cc
+++ b/src/render/hw/gl/gl_root_layer.cc
@@ -10,6 +10,7 @@
 
 #include "src/geometry/glm_helper.hpp"
 #include "src/gpu/gl/gpu_buffer_gl.hpp"
+#include "src/gpu/gl/gpu_command_buffer_gl.hpp"
 #include "src/gpu/gl/gpu_render_pass_gl.hpp"
 #include "src/gpu/gl/gpu_texture_gl.hpp"
 #include "src/gpu/gpu_context_impl.hpp"
@@ -90,7 +91,8 @@ std::shared_ptr<GPURenderPass> GLDirectRootLayer::OnBeginRenderPass(
   render_pass_desc.depth_attachment.store_op = GPUStoreOp::kDiscard;
   render_pass_desc.depth_attachment.clear_value = 0.f;
 
-  return std::make_shared<GPURenderPassGL>(render_pass_desc, fbo_id_);
+  return static_cast<GPUCommandBufferGL *>(cmd)->CreateRenderPassForFBO(
+      render_pass_desc, fbo_id_);
 }
 
 bool GLDirectRootLayer::OnCopyToDstTexture(
@@ -285,11 +287,13 @@ void GLDrawTextureLayer::OnPostDraw(GPURenderPass *, GPUCommandBuffer *cmd) {
   fake_desc.depth_attachment.store_op = GPUStoreOp::kDiscard;
   fake_desc.depth_attachment.clear_value = 0.f;
 
-  GPURenderPassGL fake_render_pass(fake_desc, resolve_fbo_);
+  auto fake_render_pass =
+      static_cast<GPUCommandBufferGL *>(cmd)->CreateRenderPassForFBO(
+          fake_desc, resolve_fbo_);
 
-  layer_back_draw_->Draw(&fake_render_pass, cmd);
+  layer_back_draw_->Draw(fake_render_pass.get(), cmd);
 
-  fake_render_pass.EncodeCommands(
+  fake_render_pass->EncodeCommands(
       GetViewport(), GPUScissorRect{0, 0, GetWidth(), GetHeight()});
 }
 
@@ -383,9 +387,11 @@ void GLPartialDrawTextureLayer::OnPostDraw(GPURenderPass *render_pass,
   fake_desc.depth_attachment.store_op = GPUStoreOp::kStore;
   fake_desc.depth_attachment.clear_value = 0.f;
 
-  GPURenderPassGL fake_render_pass(fake_desc, resolve_fbo_);
+  auto fake_render_pass =
+      static_cast<GPUCommandBufferGL *>(cmd)->CreateRenderPassForFBO(
+          fake_desc, resolve_fbo_);
 
-  layer_back_draw_->Draw(&fake_render_pass, cmd);
+  layer_back_draw_->Draw(fake_render_pass.get(), cmd);
 
   GPUViewport viewport{0.f,
                        0.f,
@@ -401,7 +407,7 @@ void GLPartialDrawTextureLayer::OnPostDraw(GPURenderPass *render_pass,
       target_height_,
   };
 
-  fake_render_pass.EncodeCommands(viewport, scissor);
+  fake_render_pass->EncodeCommands(viewport, scissor);
 }
 
 }  // namespace skity

--- a/test/golden/CMakeLists.txt
+++ b/test/golden/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SKITY_GOLDEN_TEST_SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_test_env_gl.hpp
   ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_test_env_gl.cc
   ${CMAKE_CURRENT_LIST_DIR}/common/gl/golden_texture_gl.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/common/gl/gpu_clear_draw_gl_test.cc
 )
 
 # Vulkan backend code
@@ -57,6 +58,7 @@ target_include_directories(skity_golden_test
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/module/wgx/include
   ${CMAKE_SOURCE_DIR}/third_party/glm
+  ${CMAKE_SOURCE_DIR}/third_party/glad/include
   ${CMAKE_SOURCE_DIR}/third_party/libSwAngle/include
 )
 

--- a/test/golden/common/gl/gpu_clear_draw_gl_test.cc
+++ b/test/golden/common/gl/gpu_clear_draw_gl_test.cc
@@ -1,0 +1,330 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <EGL/egl.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <memory>
+
+#include "common/golden_test_env.hpp"
+#include "src/gpu/gl/gl_interface.hpp"
+#include "src/gpu/gl/gpu_device_gl.hpp"
+#include "src/gpu/gl/gpu_render_pass_gl.hpp"
+#include "src/gpu/gl/gpu_texture_gl.hpp"
+#include "src/gpu/gpu_context_impl.hpp"
+
+namespace skity {
+namespace testing {
+namespace {
+
+PFNGLGETSTRINGPROC g_real_get_string = nullptr;
+PFNGLDRAWARRAYSPROC g_real_draw_arrays = nullptr;
+uint32_t g_gl_clear_call_count = 0;
+uint32_t g_gl_draw_arrays_call_count = 0;
+
+const GLubyte* GLAD_API_PTR ForcedPowerVRGetString(GLenum name) {
+  if (name == GL_RENDERER) {
+    return reinterpret_cast<const GLubyte*>("PowerVR GE8320");
+  }
+  return g_real_get_string(name);
+}
+
+void GLAD_API_PTR CountGLClear(GLbitfield) { ++g_gl_clear_call_count; }
+
+void GLAD_API_PTR CountGLDrawArrays(GLenum mode, GLint first, GLsizei count) {
+  ++g_gl_draw_arrays_call_count;
+  g_real_draw_arrays(mode, first, count);
+}
+
+class ScopedPowerVRWorkaround final {
+ public:
+  explicit ScopedPowerVRWorkaround(GLInterface* gl)
+      : gl_(gl),
+        get_string_(gl->fGetString),
+        clear_(gl->fClear),
+        draw_arrays_(gl->fDrawArrays) {
+    g_real_get_string = get_string_;
+    g_real_draw_arrays = draw_arrays_;
+    g_gl_clear_call_count = 0;
+    g_gl_draw_arrays_call_count = 0;
+    gl_->fGetString = ForcedPowerVRGetString;
+    gl_->fClear = CountGLClear;
+    gl_->fDrawArrays = CountGLDrawArrays;
+  }
+
+  ~ScopedPowerVRWorkaround() {
+    gl_->fGetString = get_string_;
+    gl_->fClear = clear_;
+    gl_->fDrawArrays = draw_arrays_;
+  }
+
+  uint32_t GetClearCallCount() const { return g_gl_clear_call_count; }
+
+  uint32_t GetDrawArraysCallCount() const {
+    return g_gl_draw_arrays_call_count;
+  }
+
+  void Clear(GLbitfield mask) const { clear_(mask); }
+
+ private:
+  GLInterface* gl_;
+  PFNGLGETSTRINGPROC get_string_;
+  PFNGLCLEARPROC clear_;
+  PFNGLDRAWARRAYSPROC draw_arrays_;
+};
+
+float UnpackDepth(uint32_t value) {
+  return static_cast<float>(value >> 8) / 0xFFFFFF;
+}
+
+TEST(GLClearDrawGLIntegrationTest,
+     ForcedWorkaroundClearsColorDepthStencilAndHonorsScissor) {
+  auto* env = GoldenTestEnv::GetInstance();
+  if (!env || env->GetBackend() != Backend::kGL) {
+    GTEST_SKIP() << "Requires the GL golden environment";
+  }
+
+  auto* gl = GLInterface::GlobalInterface();
+  ASSERT_NE(gl, nullptr);
+  ScopedPowerVRWorkaround workaround(gl);
+
+  auto gpu_context =
+      GLContextCreate(reinterpret_cast<void*>(eglGetProcAddress));
+  auto* context = static_cast<GPUContextImpl*>(gpu_context.get());
+  auto* device = static_cast<GPUDeviceGL*>(context->GetGPUDevice());
+  ASSERT_TRUE(device->GetDriverWorkarounds().use_draw_for_clear);
+  ASSERT_NE(device->GetClearDrawProgram(), 0u);
+  ASSERT_TRUE(device->CanUseMSAA());
+
+  constexpr uint32_t kSize = 8;
+  GLuint fbo = 0;
+  GLuint color_texture = 0;
+  GLuint depth_stencil_buffer = 0;
+  GLuint vao = 0;
+  gl->fGenFramebuffers(1, &fbo);
+  gl->fGenTextures(1, &color_texture);
+  gl->fGenRenderbuffers(1, &depth_stencil_buffer);
+  gl->fGenVertexArrays(1, &vao);
+  ASSERT_NE(fbo, 0u);
+  ASSERT_NE(color_texture, 0u);
+  ASSERT_NE(depth_stencil_buffer, 0u);
+  ASSERT_NE(vao, 0u);
+
+  gl->fBindTexture(GL_TEXTURE_2D, color_texture);
+  gl->fTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kSize, kSize, 0, GL_RGBA,
+                  GL_UNSIGNED_BYTE, nullptr);
+  gl->fBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_buffer);
+  gl->fRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, kSize, kSize);
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                            color_texture, 0);
+  gl->fFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                               GL_RENDERBUFFER, depth_stencil_buffer);
+  ASSERT_EQ(gl->fCheckFramebufferStatus(GL_FRAMEBUFFER),
+            GL_FRAMEBUFFER_COMPLETE);
+
+  gl->fDisable(GL_SCISSOR_TEST);
+  gl->fColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  gl->fDepthMask(GL_TRUE);
+  gl->fStencilMask(0xFF);
+  gl->fClearColor(1.f, 0.f, 1.f, 1.f);
+  gl->fClearDepthf(1.f);
+  gl->fClearStencil(0x7F);
+  workaround.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT |
+                   GL_STENCIL_BUFFER_BIT);
+
+  GPUTextureDescriptor color_desc;
+  color_desc.width = kSize;
+  color_desc.height = kSize;
+  color_desc.format = GPUTextureFormat::kRGBA8Unorm;
+  auto color = std::make_shared<GPUTexturePlaceholderGL>(color_desc);
+
+  GPUTextureDescriptor depth_stencil_desc = color_desc;
+  depth_stencil_desc.format = GPUTextureFormat::kDepth24Stencil8;
+  auto depth_stencil = std::make_shared<GPUTextureRenderBufferGL>(
+      depth_stencil_desc, depth_stencil_buffer);
+
+  GPURenderPassDescriptor pass_desc;
+  pass_desc.color_attachment.texture = color;
+  pass_desc.color_attachment.load_op = GPULoadOp::kClear;
+  pass_desc.color_attachment.clear_value = {};
+  pass_desc.depth_attachment.texture = depth_stencil;
+  pass_desc.depth_attachment.load_op = GPULoadOp::kClear;
+  pass_desc.depth_attachment.store_op = GPUStoreOp::kStore;
+  pass_desc.depth_attachment.clear_value = 0.f;
+  pass_desc.stencil_attachment.texture = depth_stencil;
+  pass_desc.stencil_attachment.load_op = GPULoadOp::kClear;
+  pass_desc.stencil_attachment.store_op = GPUStoreOp::kStore;
+  pass_desc.stencil_attachment.clear_value = 0;
+
+  gl->fBindVertexArray(vao);
+  gl->fEnable(GL_SCISSOR_TEST);
+  {
+    GPURenderPassGL pass(pass_desc, fbo, device);
+    pass.EncodeCommands(std::nullopt, GPUScissorRect{2, 2, 4, 4});
+  }
+  EXPECT_EQ(workaround.GetClearCallCount(), 0u);
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  std::array<uint8_t, 4> inside_color = {};
+  std::array<uint8_t, 4> outside_color = {};
+  gl->fReadPixels(3, 3, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, inside_color.data());
+  gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, outside_color.data());
+  EXPECT_EQ(inside_color, (std::array<uint8_t, 4>{0, 0, 0, 0}));
+  EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{255, 0, 255, 255}));
+
+  uint32_t inside_depth_stencil = 0;
+  uint32_t outside_depth_stencil = 0;
+  gl->fReadPixels(3, 3, 1, 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8,
+                  &inside_depth_stencil);
+  gl->fReadPixels(0, 0, 1, 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8,
+                  &outside_depth_stencil);
+  EXPECT_FLOAT_EQ(UnpackDepth(inside_depth_stencil), 0.f);
+  EXPECT_EQ(inside_depth_stencil & 0xFF, 0u);
+  EXPECT_FLOAT_EQ(UnpackDepth(outside_depth_stencil), 1.f);
+  EXPECT_EQ(outside_depth_stencil & 0xFF, 0x7Fu);
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+
+  pass_desc.color_attachment.load_op = GPULoadOp::kLoad;
+  const auto preserve_color_draw_count = workaround.GetDrawArraysCallCount();
+  {
+    GPURenderPassGL pass(pass_desc, fbo, device);
+    pass.EncodeCommands(std::nullopt, GPUScissorRect{0, 0, kSize, kSize});
+  }
+  EXPECT_EQ(workaround.GetDrawArraysCallCount(), preserve_color_draw_count + 1);
+
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fReadPixels(3, 3, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, inside_color.data());
+  gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, outside_color.data());
+  EXPECT_EQ(inside_color, (std::array<uint8_t, 4>{0, 0, 0, 0}));
+  EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{255, 0, 255, 255}));
+
+  gl->fReadPixels(0, 0, 1, 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8,
+                  &outside_depth_stencil);
+  EXPECT_FLOAT_EQ(UnpackDepth(outside_depth_stencil), 0.f);
+  EXPECT_EQ(outside_depth_stencil & 0xFF, 0u);
+  EXPECT_EQ(workaround.GetClearCallCount(), 0u);
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+  pass_desc.color_attachment.load_op = GPULoadOp::kClear;
+
+  gl->fDisable(GL_SCISSOR_TEST);
+  gl->fColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  gl->fDepthMask(GL_TRUE);
+  gl->fStencilMask(0xFF);
+  gl->fClearColor(1.f, 0.f, 1.f, 1.f);
+  gl->fClearDepthf(1.f);
+  gl->fClearStencil(0x7F);
+  workaround.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT |
+                   GL_STENCIL_BUFFER_BIT);
+
+  gl->fEnable(GL_SCISSOR_TEST);
+  {
+    GPURenderPassGL pass(pass_desc, fbo, device);
+    pass.EncodeCommands(GPUViewport{2.f, 2.f, 2.f, 2.f, 0.f, 1.f},
+                        GPUScissorRect{0, 0, kSize, kSize});
+  }
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, outside_color.data());
+  EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{0, 0, 0, 0}));
+  EXPECT_EQ(workaround.GetClearCallCount(), 0u);
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                               GL_RENDERBUFFER, 0);
+  ASSERT_EQ(gl->fCheckFramebufferStatus(GL_FRAMEBUFFER),
+            GL_FRAMEBUFFER_COMPLETE);
+  pass_desc.depth_attachment.texture.reset();
+  pass_desc.stencil_attachment.texture.reset();
+
+  auto draw_arrays_count = workaround.GetDrawArraysCallCount();
+  {
+    GPURenderPassGL pass(pass_desc, fbo, device);
+    pass.EncodeCommands(std::nullopt, GPUScissorRect{0, 0, kSize, kSize});
+  }
+  EXPECT_EQ(workaround.GetDrawArraysCallCount(), draw_arrays_count + 1);
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, outside_color.data());
+  EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{0, 0, 0, 0}));
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+
+  gl->fClearColor(1.f, 0.f, 1.f, 1.f);
+  workaround.Clear(GL_COLOR_BUFFER_BIT);
+  pass_desc.color_attachment.load_op = GPULoadOp::kLoad;
+  draw_arrays_count = workaround.GetDrawArraysCallCount();
+  {
+    GPURenderPassGL pass(pass_desc, fbo, device);
+    pass.EncodeCommands(std::nullopt, GPUScissorRect{0, 0, kSize, kSize});
+  }
+  EXPECT_EQ(workaround.GetDrawArraysCallCount(), draw_arrays_count);
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, outside_color.data());
+  EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{255, 0, 255, 255}));
+  EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+
+  gl->fFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                               GL_RENDERBUFFER, depth_stencil_buffer);
+  pass_desc.color_attachment.load_op = GPULoadOp::kClear;
+  pass_desc.depth_attachment.texture = depth_stencil;
+  pass_desc.stencil_attachment.texture = depth_stencil;
+
+  // Exercise the normal HWLayer pass, DrawTexture's final fake pass, and the
+  // desktop MSAA resolve path.
+  GPUSurfaceDescriptorGL surface_desc;
+  surface_desc.backend = GPUBackendType::kOpenGL;
+  surface_desc.width = kSize;
+  surface_desc.height = kSize;
+  surface_desc.surface_type = GLSurfaceType::kFramebuffer;
+  surface_desc.gl_id = fbo;
+  surface_desc.has_stencil_attachment = true;
+  for (auto mode : {GLSurfaceMode::kDirect, GLSurfaceMode::kDrawTexture,
+                    GLSurfaceMode::kBlit}) {
+    surface_desc.sample_count = mode == GLSurfaceMode::kBlit ? 4 : 1;
+    gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    gl->fDisable(GL_SCISSOR_TEST);
+    gl->fColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    gl->fDepthMask(GL_TRUE);
+    gl->fStencilMask(0xFF);
+    gl->fClearColor(1.f, 0.f, 1.f, 1.f);
+    gl->fClearDepthf(1.f);
+    gl->fClearStencil(0x7F);
+    workaround.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT |
+                     GL_STENCIL_BUFFER_BIT);
+
+    surface_desc.surface_mode = mode;
+    const auto clear_draw_count = workaround.GetDrawArraysCallCount();
+    auto surface = gpu_context->CreateSurface(&surface_desc);
+    ASSERT_NE(surface, nullptr);
+    auto* canvas = surface->LockCanvas();
+    ASSERT_NE(canvas, nullptr);
+    Paint paint;
+    paint.SetColor(Color_RED);
+    canvas->DrawRect(Rect::MakeXYWH(2.f, 2.f, 4.f, 4.f), paint);
+    canvas->Flush();
+    surface->Flush();
+
+    gl->fBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    gl->fReadPixels(3, 3, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, inside_color.data());
+    gl->fReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE,
+                    outside_color.data());
+    EXPECT_EQ(inside_color, (std::array<uint8_t, 4>{255, 0, 0, 255}));
+    EXPECT_EQ(outside_color, (std::array<uint8_t, 4>{0, 0, 0, 0}));
+    EXPECT_GT(workaround.GetDrawArraysCallCount(), clear_draw_count);
+    EXPECT_EQ(workaround.GetClearCallCount(), 0u);
+    EXPECT_EQ(gl->fGetError(), GL_NO_ERROR);
+  }
+
+  gl->fBindFramebuffer(GL_FRAMEBUFFER, 0);
+  gl->fBindVertexArray(0);
+  gl->fDisable(GL_SCISSOR_TEST);
+  gl->fDeleteFramebuffers(1, &fbo);
+  gl->fDeleteTextures(1, &color_texture);
+  gl->fDeleteVertexArrays(1, &vao);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace skity

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -59,6 +59,12 @@ add_executable(skity_unit_test
     utils/array_list_test.cc
 )
 
+if(${SKITY_GL_BACKEND})
+    target_sources(skity_unit_test PRIVATE
+        gpu/gl/gpu_driver_info_gl_test.cc
+    )
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     target_sources(skity_unit_test PRIVATE
         base/platform/win/str_conversion_test.cc

--- a/test/ut/gpu/gl/gpu_driver_info_gl_test.cc
+++ b/test/ut/gpu/gl/gpu_driver_info_gl_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/gpu/gl/gpu_driver_info_gl.hpp"
+
+#include <gtest/gtest.h>
+
+namespace skity {
+namespace {
+
+TEST(GLDriverInfoTest, DetectsAffectedPowerVRRenderers) {
+  constexpr const char* kRenderers[] = {
+      "PowerVR GE8320",
+      "PowerVR GE8100",
+      "PowerVR GM9446",
+      "PowerVR 7XTP-MT4",
+  };
+
+  for (const auto* renderer : kRenderers) {
+    auto info = GLDriverInfo::FromStrings("Imagination Technologies", renderer,
+                                          "OpenGL ES 3.2");
+    EXPECT_EQ(info.vendor, GLVendor::kPowerVR);
+    EXPECT_TRUE(ResolveGLDriverWorkarounds(info).use_draw_for_clear);
+  }
+}
+
+TEST(GLDriverInfoTest, DoesNotMatchOtherRenderers) {
+  auto mali = GLDriverInfo::FromStrings("ARM", "Mali-G78", "OpenGL ES 3.2");
+  auto angle = GLDriverInfo::FromStrings(
+      "Google Inc.", "ANGLE (PowerVR GE8320)", "OpenGL ES 3.0");
+
+  EXPECT_EQ(mali.vendor, GLVendor::kUnknown);
+  EXPECT_EQ(angle.vendor, GLVendor::kUnknown);
+  EXPECT_FALSE(ResolveGLDriverWorkarounds(mali).use_draw_for_clear);
+  EXPECT_FALSE(ResolveGLDriverWorkarounds(angle).use_draw_for_clear);
+}
+
+}  // namespace
+}  // namespace skity


### PR DESCRIPTION
PowerVR drivers observed in production can crash while executing glClear. Detect the renderer through generic GPU driver workarounds stored on GPUCaps and replace zero color, depth, and stencil clears with a fullscreen draw.

Keep the helper device-owned, reuse the GL render-pass pipeline state path, and generate the triangle from vertex_index so the workaround needs no vertex or index buffers. Add unit coverage for driver detection, clear planning, and shader generation, plus GL integration coverage that verifies scissored clears without calling glClear.