### PR TITLE
feat(text): Add a workaround for large emoji glyphs

### DIFF
--- a/include/skity/gpu/gpu_context.hpp
+++ b/include/skity/gpu/gpu_context.hpp
@@ -292,10 +292,11 @@ class SKITY_API GPUContext {
 
   /**
    * Use a larger atlas cache for better performance, but with that comes a
-   * larger memory overhead. There are 4 times more memory if the corresponding
-   * bit is set.
+   * larger memory overhead. The overhead depends on the selected format and
+   * atlas layout.
    * @param larger_atlas_mask  bit 0 represents the A8 format for normal texts,
-   * and bit 1 represents the RGBA32 format for emoji texts.
+   * bit 1 represents the RGBA32 format for emoji texts, bit 2 is reserved, and
+   * bit 3 enables the 2048x2048 large Emoji atlas.
    */
   void SetLargerAtlasMask(std::uint8_t larger_atlas_mask) {
     larger_atlas_mask_ = larger_atlas_mask;

--- a/src/render/text/atlas/atlas_glyph.hpp
+++ b/src/render/text/atlas/atlas_glyph.hpp
@@ -21,7 +21,20 @@ constexpr auto Atlas_Padding = 2;
 constexpr glm::ivec4 INVALID_LOC = glm::ivec4{-1, -1, 0, 0};
 
 struct AtlasConfig {
-  explicit AtlasConfig(AtlasFormat format, bool enable_larger_atlas) {
+  explicit AtlasConfig(AtlasFormat format, bool enable_larger_atlas,
+                       bool enable_large_emoji_atlas = false) {
+    if (format == AtlasFormat::RGBA32 && enable_large_emoji_atlas) {
+      is_large_emoji_atlas = true;
+      max_num_bitmap_per_texture = 1;
+      max_num_bitmap_per_atlas = MAX_NUM_TEXTURE_PER_ATLAS;
+      col_mask = 0;
+      row_mask = 0;
+      row_shift = 0;
+      max_bitmap_size = 2048;
+      max_texture_size = 2048;
+      return;
+    }
+
     // There are 4 or 16 bitmaps to be uploaded onto one texture, and 4 textures
     // to be used dynamiclly, regardless of format. We only config different
     // size of bitmap to match different formats.
@@ -50,6 +63,7 @@ struct AtlasConfig {
   std::uint16_t row_shift;
   std::uint16_t max_bitmap_size;
   std::uint16_t max_texture_size;
+  bool is_large_emoji_atlas = false;
   // Sync with the number of textures in fragment shader
   static constexpr std::uint16_t MAX_NUM_TEXTURE_PER_ATLAS = 4;
 };

--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -44,10 +44,17 @@ Atlas* AtlasManager::GetAtlas(AtlasFormat format) {
   if (!atlas_[index]) {
     bool enable_larger_atlas =
         gpu_context_->GetLargerAtlasMask() & (1 << index);
-    atlas_[index] =
-        std::make_unique<Atlas>(format, gpu_device_, enable_larger_atlas);
+    bool enable_large_emoji_atlas =
+        format == AtlasFormat::RGBA32 && IsLargeEmojiAtlasEnabled();
+    atlas_[index] = std::make_unique<Atlas>(
+        format, gpu_device_, enable_larger_atlas, enable_large_emoji_atlas);
   }
   return atlas_[index].get();
+}
+
+bool AtlasManager::IsLargeEmojiAtlasEnabled() const {
+  constexpr size_t kRGBA32Index = static_cast<size_t>(AtlasFormat::RGBA32);
+  return gpu_context_->GetLargerAtlasMask() & (1 << (kRGBA32Index + 2));
 }
 
 void AtlasManager::ClearExtraRes() {
@@ -60,10 +67,10 @@ void AtlasManager::ClearExtraRes() {
 
 /// Atlas
 Atlas::Atlas(AtlasFormat format, GPUDevice* gpu_device,
-             bool enable_larger_atlas)
+             bool enable_larger_atlas, bool enable_large_emoji_atlas)
     : format_(format),
       gpu_device_(gpu_device),
-      atlas_config_(format, enable_larger_atlas) {
+      atlas_config_(format, enable_larger_atlas, enable_large_emoji_atlas) {
   switch (format_) {
     case AtlasFormat::A8:
       bytes_per_pixel_ = 1;

--- a/src/render/text/atlas/atlas_manager.hpp
+++ b/src/render/text/atlas/atlas_manager.hpp
@@ -24,7 +24,8 @@ class GPUContextImpl;
 
 class Atlas {
  public:
-  Atlas(AtlasFormat format, GPUDevice* gpu_device, bool enable_larger_atlas);
+  Atlas(AtlasFormat format, GPUDevice* gpu_device, bool enable_larger_atlas,
+        bool enable_large_emoji_atlas);
 
   AtlasFormat GetFormat() { return format_; }
 
@@ -77,6 +78,8 @@ class AtlasManager {
   AtlasManager(GPUDevice* gpu_device, GPUContextImpl* gpu_context);
 
   Atlas* GetAtlas(AtlasFormat format);
+
+  bool IsLargeEmojiAtlasEnabled() const;
 
   void ClearExtraRes();
 

--- a/src/render/text/glyph_run.cc
+++ b/src/render/text/glyph_run.cc
@@ -650,6 +650,24 @@ GlyphRunList GlyphRun::MakeInternal(
   float sy = Vec2{transform.GetSkewX(), transform.GetScaleY()}.Length();
   float maximun_text_scale =
       std::abs(glm::max(sx * context_scale, sy * context_scale));
+  if (format == AtlasFormat::RGBA32 &&
+      atlas_manager->IsLargeEmojiAtlasEnabled() && !transform.HasPersp()) {
+    constexpr float kMaxLargeEmojiTextSize = 1024.f;
+    const float effective_text_size = font.GetSize() * maximun_text_scale;
+    if (effective_text_size >= paint.GetFontThreshold() &&
+        effective_text_size < kMaxLargeEmojiTextSize) {
+      Atlas* atlas = atlas_manager->GetAtlas(format);
+      if (atlas->GetConfig().is_large_emoji_atlas) {
+        Paint working_paint = paint;
+        working_paint.SetStyle(Paint::kFill_Style);
+        return DirectGlyphRun::SubRunListByTexture(
+            count, glyphs, origin, position_x, position_y, font, working_paint,
+            format, context_scale, transform, false, atlas_manager,
+            arena_allocator);
+      }
+    }
+  }
+
   if (control.CanUseDirect(font.GetSize() * maximun_text_scale, transform,
                            paint, font.GetTypeface())) {
     // texture


### PR DESCRIPTION
Gate the temporary large-glyph path behind an opt-in switch and route oversized color emoji through it while preserving the existing A8 text path.