### PR TITLE
feat(capi): add Vulkan C API binding and typed handle refactor

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -43,6 +43,9 @@ add_subdirectory(case/text)
 
 if (${SKITY_CAPI_MODULE})
   add_subdirectory(case/c_api)
+  if (${SKITY_VK_BACKEND})
+    add_subdirectory(case/c_api_vk)
+  endif()
 endif()
 
 if (${SKITY_IO_MODULE})

--- a/example/case/c_api_vk/CMakeLists.txt
+++ b/example/case/c_api_vk/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+add_executable(skity-c-api-vk main.cc)
+
+if (NOT TARGET volk::volk)
+  set(VULKAN_HEADERS_INSTALL_DIR
+      ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers
+      CACHE PATH "Use bundled Vulkan headers for examples" FORCE)
+  set(VOLK_PULL_IN_VULKAN OFF CACHE BOOL "Disable Volk Vulkan lookup" FORCE)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/volk third_party/volk)
+  target_include_directories(volk PUBLIC
+    ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include)
+endif()
+
+if (APPLE)
+  target_sources(skity-c-api-vk PRIVATE native_window_macos.mm)
+  target_compile_options(skity-c-api-vk PRIVATE -fobjc-arc)
+  target_link_libraries(skity-c-api-vk PRIVATE "-framework QuartzCore")
+endif()
+
+target_include_directories(skity-c-api-vk PRIVATE
+  ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
+)
+
+target_link_libraries(skity-c-api-vk PRIVATE skity::capi glfw volk::volk)
+set_target_properties(skity-c-api-vk PROPERTIES CXX_STANDARD 17)

--- a/example/case/c_api_vk/main.cc
+++ b/example/case/c_api_vk/main.cc
@@ -1,0 +1,274 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef VK_NO_PROTOTYPES
+#define VK_NO_PROTOTYPES
+#endif
+
+#include <GLFW/glfw3.h>
+#include <skity_c/skity.h>
+#include <skity_c/skity_context_vk.h>
+#include <skity_c/skity_native_window_vk.h>
+#include <volk.h>
+#include <vulkan/vulkan.h>
+
+#include <skity/macros.hpp>
+
+#if defined(SKITY_MACOS)
+#include <vulkan/vulkan_macos.h>
+#include <vulkan/vulkan_metal.h>
+#endif
+
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#if defined(SKITY_MACOS)
+bool SetupCocoaVulkanWindow(GLFWwindow* window);
+void* GetCocoaVulkanLayer(GLFWwindow* window);
+void* GetCocoaVulkanView(GLFWwindow* window);
+#elif defined(SKITY_WIN)
+#define GLFW_EXPOSE_NATIVE_WIN32
+#include <GLFW/glfw3native.h>
+#elif defined(SKITY_LINUX)
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#define GLFW_EXPOSE_NATIVE_X11
+#include <GLFW/glfw3native.h>
+#endif
+
+namespace {
+
+bool HasExtension(const char* const* names, uint32_t count,
+                  const char* target) {
+  for (uint32_t i = 0; i < count; ++i) {
+    if (names[i] != nullptr && std::strcmp(names[i], target) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool BuildInstanceExtensions(GLFWwindow* window,
+                             std::vector<const char*>* extensions) {
+  uint32_t count = 0;
+  const char** required = glfwGetRequiredInstanceExtensions(&count);
+  if (required == nullptr || count == 0) {
+    return false;
+  }
+  extensions->assign(required, required + count);
+
+#if defined(SKITY_MACOS)
+  if (!HasExtension(extensions->data(),
+                    static_cast<uint32_t>(extensions->size()),
+                    VK_EXT_METAL_SURFACE_EXTENSION_NAME)) {
+    extensions->push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+  }
+  if (!HasExtension(extensions->data(),
+                    static_cast<uint32_t>(extensions->size()),
+                    VK_MVK_MACOS_SURFACE_EXTENSION_NAME)) {
+    extensions->push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+  }
+#else
+  (void)window;
+#endif
+  return true;
+}
+
+bool BuildNativeWindowInfo(GLFWwindow* window,
+                           skity_vk_native_window_info* info) {
+  *info = {};
+#if defined(SKITY_WIN)
+  info->type = SKITY_VK_NATIVE_WINDOW_TYPE_WIN32;
+  info->handle = glfwGetWin32Window(window);
+  info->secondary_handle = GetModuleHandle(nullptr);
+  return info->handle != nullptr;
+#elif defined(SKITY_MACOS)
+  info->type = SKITY_VK_NATIVE_WINDOW_TYPE_METAL_LAYER;
+  info->handle = GetCocoaVulkanLayer(window);
+  info->secondary_handle = GetCocoaVulkanView(window);
+  return info->handle != nullptr || info->secondary_handle != nullptr;
+#elif defined(SKITY_LINUX)
+  uint32_t count = 0;
+  const char** extensions = glfwGetRequiredInstanceExtensions(&count);
+  if (HasExtension(extensions, count, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+    info->type = SKITY_VK_NATIVE_WINDOW_TYPE_WAYLAND;
+    info->handle = glfwGetWaylandDisplay();
+    info->secondary_handle = glfwGetWaylandWindow(window);
+    return info->handle != nullptr && info->secondary_handle != nullptr;
+  }
+  info->type = SKITY_VK_NATIVE_WINDOW_TYPE_XLIB;
+  info->handle = glfwGetX11Display();
+  info->window_id = static_cast<uint64_t>(glfwGetX11Window(window));
+  return info->handle != nullptr && info->window_id != 0;
+#else
+  (void)window;
+  return false;
+#endif
+}
+
+float ContentScale(GLFWwindow* window) {
+  int framebuffer_width = 0;
+  int framebuffer_height = 0;
+  int window_width = 0;
+  int window_height = 0;
+  glfwGetFramebufferSize(window, &framebuffer_width, &framebuffer_height);
+  glfwGetWindowSize(window, &window_width, &window_height);
+  if (framebuffer_width <= 0 || framebuffer_height <= 0 || window_width <= 0 ||
+      window_height <= 0) {
+    return 1.f;
+  }
+  return std::sqrt(static_cast<float>(framebuffer_width * framebuffer_width +
+                                      framebuffer_height * framebuffer_height) /
+                   static_cast<float>(window_width * window_width +
+                                      window_height * window_height));
+}
+
+void DrawFrame(skity_canvas canvas, float time, skity_paint fill,
+               skity_paint gradient, skity_path star) {
+  skity_canvas_draw_color(canvas, 0xFF20232A, SKITY_BLEND_MODE_SRC);
+  skity_canvas_draw_path(canvas, star, gradient);
+
+  float radius = 24.f + 5.f * std::sin(time * 2.f);
+  skity_canvas_draw_circle(canvas, 400.f + 110.f * std::cos(time),
+                           330.f + 60.f * std::sin(time * 1.25f), radius, fill);
+}
+
+}  // namespace
+
+int main() {
+  if (volkInitialize() != VK_SUCCESS) {
+    fprintf(stderr, "failed to load the Vulkan loader\n");
+    return 1;
+  }
+  if (glfwInit() == GLFW_FALSE) {
+    return 1;
+  }
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  GLFWwindow* window =
+      glfwCreateWindow(800, 600, "skity-capi-vk", nullptr, nullptr);
+  if (window == nullptr) {
+    glfwTerminate();
+    return 1;
+  }
+#if defined(SKITY_MACOS)
+  if (!SetupCocoaVulkanWindow(window)) {
+    fprintf(stderr, "failed to attach a CAMetalLayer\n");
+    return 1;
+  }
+#endif
+
+  std::vector<const char*> extensions;
+  if (!BuildInstanceExtensions(window, &extensions)) {
+    fprintf(stderr, "failed to query Vulkan instance extensions\n");
+    return 1;
+  }
+
+  skity_context_create_info_vk context_info = {};
+  context_info.get_instance_proc_addr = vkGetInstanceProcAddr;
+  context_info.enabled_instance_extensions = extensions.data();
+  context_info.enabled_instance_extension_count =
+      static_cast<uint32_t>(extensions.size());
+  context_info.enabled_instance_extensions_known = 1;
+
+  skity_context context = nullptr;
+  if (skity_context_create_vk_ex(&context_info, &context) != SKITY_SUCCESS) {
+    fprintf(stderr, "skity_context_create_vk_ex failed\n");
+    return 1;
+  }
+
+  skity_vk_native_window_info native_info = {};
+  if (!BuildNativeWindowInfo(window, &native_info)) {
+    fprintf(stderr, "unsupported Vulkan window platform\n");
+    return 1;
+  }
+  int framebuffer_width = 0;
+  int framebuffer_height = 0;
+  glfwGetFramebufferSize(window, &framebuffer_width, &framebuffer_height);
+  skity_native_window_create_info_vk window_info = {};
+  window_info.native_window = native_info;
+  window_info.width = static_cast<uint32_t>(framebuffer_width);
+  window_info.height = static_cast<uint32_t>(framebuffer_height);
+  window_info.min_image_count = 2;
+  window_info.present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+
+  skity_native_window_vk native_window =
+      skity_native_window_create_vk(context, &window_info);
+  if (native_window == nullptr) {
+    fprintf(stderr, "skity_native_window_create_vk failed\n");
+    return 1;
+  }
+
+  skity_paint fill = skity_paint_create();
+  skity_paint_set_anti_alias(fill, 1);
+  skity_paint_set_color(fill, 0xFFFFFFFF);
+
+  skity_color4f colors[] = {{1.f, 0.25f, 0.3f, 1.f}, {0.25f, 0.75f, 1.f, 1.f}};
+  float positions[] = {0.f, 1.f};
+  skity_point points[] = {{180.f, 180.f, 0.f, 0.f}, {620.f, 500.f, 0.f, 0.f}};
+  skity_shader shader = skity_shader_create_linear(points, colors, positions, 2,
+                                                   SKITY_TILE_MODE_CLAMP, 0);
+  skity_paint gradient = skity_paint_create();
+  skity_paint_set_anti_alias(gradient, 1);
+  skity_paint_set_shader(gradient, shader);
+
+  skity_path star = skity_path_create();
+  skity_path_move_to(star, 400.f, 140.f);
+  skity_path_line_to(star, 470.f, 320.f);
+  skity_path_line_to(star, 660.f, 320.f);
+  skity_path_line_to(star, 510.f, 430.f);
+  skity_path_line_to(star, 560.f, 610.f);
+  skity_path_line_to(star, 400.f, 500.f);
+  skity_path_line_to(star, 240.f, 610.f);
+  skity_path_line_to(star, 290.f, 430.f);
+  skity_path_line_to(star, 140.f, 320.f);
+  skity_path_line_to(star, 330.f, 320.f);
+  skity_path_close(star);
+
+  while (glfwWindowShouldClose(window) == GLFW_FALSE) {
+    skity_surface surface = nullptr;
+    skity_result result = skity_native_window_acquire_next_surface_vk(
+        native_window, 4, ContentScale(window), &surface);
+    if (result == SKITY_ERROR_NEED_RECREATE) {
+      glfwGetFramebufferSize(window, &framebuffer_width, &framebuffer_height);
+      skity_native_window_resize_vk(native_window,
+                                    static_cast<uint32_t>(framebuffer_width),
+                                    static_cast<uint32_t>(framebuffer_height));
+      continue;
+    }
+    if (result != SKITY_SUCCESS) {
+      break;
+    }
+
+    skity_canvas canvas = skity_surface_lock_canvas(surface, 1);
+    if (canvas == nullptr) {
+      skity_surface_destroy(surface);
+      break;
+    }
+    DrawFrame(canvas, static_cast<float>(glfwGetTime()), fill, gradient, star);
+    skity_canvas_flush(canvas);
+    skity_canvas_destroy(canvas);
+
+    result = skity_native_window_present_vk(native_window, &surface);
+    if (result == SKITY_ERROR_NEED_RECREATE) {
+      glfwGetFramebufferSize(window, &framebuffer_width, &framebuffer_height);
+      skity_native_window_resize_vk(native_window,
+                                    static_cast<uint32_t>(framebuffer_width),
+                                    static_cast<uint32_t>(framebuffer_height));
+    } else if (result != SKITY_SUCCESS) {
+      break;
+    }
+    glfwPollEvents();
+  }
+
+  skity_path_destroy(star);
+  skity_paint_destroy(gradient);
+  skity_shader_destroy(shader);
+  skity_paint_destroy(fill);
+  skity_native_window_destroy_vk(native_window);
+  skity_context_destroy(context);
+  glfwDestroyWindow(window);
+  glfwTerminate();
+  return 0;
+}

--- a/example/case/c_api_vk/native_window_macos.mm
+++ b/example/case/c_api_vk/native_window_macos.mm
@@ -1,0 +1,40 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <GLFW/glfw3.h>
+
+#define GLFW_EXPOSE_NATIVE_COCOA
+#include <GLFW/glfw3native.h>
+
+#include <QuartzCore/CAMetalLayer.h>
+
+bool SetupCocoaVulkanWindow(GLFWwindow* window) {
+  if (window == nullptr) {
+    return false;
+  }
+  NSWindow* cocoa_window = glfwGetCocoaWindow(window);
+  if (cocoa_window == nil) {
+    return false;
+  }
+
+  CAMetalLayer* metal_layer = [CAMetalLayer layer];
+  metal_layer.opaque = YES;
+  metal_layer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+  metal_layer.framebufferOnly = NO;
+  metal_layer.frame = cocoa_window.contentView.bounds;
+  metal_layer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+  cocoa_window.contentView.layer = metal_layer;
+  cocoa_window.contentView.wantsLayer = YES;
+  return true;
+}
+
+void* GetCocoaVulkanLayer(GLFWwindow* window) {
+  NSWindow* cocoa_window = window != nullptr ? glfwGetCocoaWindow(window) : nullptr;
+  return cocoa_window == nullptr ? nullptr : (__bridge void*)cocoa_window.contentView.layer;
+}
+
+void* GetCocoaVulkanView(GLFWwindow* window) {
+  NSWindow* cocoa_window = window != nullptr ? glfwGetCocoaWindow(window) : nullptr;
+  return cocoa_window == nullptr ? nullptr : (__bridge void*)cocoa_window.contentView;
+}

--- a/module/capi/CMakeLists.txt
+++ b/module/capi/CMakeLists.txt
@@ -43,12 +43,19 @@ if (${SKITY_GL_BACKEND})
   target_compile_definitions(skity-capi PRIVATE -DSKITY_OPENGL)
 endif()
 
+# Vulkan-only wrapper sources depend on the vendored Vulkan headers, so they
+# are only compiled when the Vulkan backend is enabled.
+set(SKITY_CAPI_VULKAN_SOURCES)
 if (${SKITY_VK_BACKEND})
   target_compile_definitions(skity-capi PRIVATE -DSKITY_VULKAN)
   # skity keeps this include path private, so its C API target must add the
   # vendored Vulkan headers for its own wrapper sources.
   target_include_directories(skity-capi PRIVATE
     ${SKITY_ROOT}/third_party/Vulkan-Headers/include
+  )
+  list(APPEND SKITY_CAPI_VULKAN_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/src/semaphore_vk.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/native_window_vk.cpp
   )
 endif()
 
@@ -84,8 +91,7 @@ target_sources(
     ${CMAKE_CURRENT_LIST_DIR}/src/handle.hpp
     ${CMAKE_CURRENT_LIST_DIR}/src/context_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/surface_c.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/semaphore_vk.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/native_window_vk.cpp
+    ${SKITY_CAPI_VULKAN_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/src/canvas_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/paint_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/path_c.cpp

--- a/module/capi/CMakeLists.txt
+++ b/module/capi/CMakeLists.txt
@@ -84,6 +84,8 @@ target_sources(
     ${CMAKE_CURRENT_LIST_DIR}/src/handle.hpp
     ${CMAKE_CURRENT_LIST_DIR}/src/context_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/surface_c.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/semaphore_vk.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/native_window_vk.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/canvas_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/paint_c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/path_c.cpp

--- a/module/capi/C_API_DESIGN.md
+++ b/module/capi/C_API_DESIGN.md
@@ -272,13 +272,20 @@ skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
 
 Vulkan types (`PFN_vkGetInstanceProcAddr`, `VkInstance`, …) are already C and
 ABI-stable, so the C API reuses them directly rather than redefining wrappers.
-The two overloads mirror
+The simple constructor mirrors the engine-created overload of
 [`CreateGPUContextVK`](../../include/skity/gpu/gpu_context_vk.hpp):
 
 ```c
 skity_result skity_context_create_vk(PFN_vkGetInstanceProcAddr get_proc,
                                      skity_context* out_context);
 ```
+
+For applications that need to share their Vulkan instance, device, queues, and
+extension sets with skity, `skity_context_vk.h` also declares
+`skity_context_create_vk_ex` and `skity_context_create_info_vk`. Vulkan-only
+surface, texture, and semaphore wrappers are declared in `skity_surface_vk.h`,
+`skity_texture_vk.h`, and `skity_semaphore_vk.h` so non-Vulkan consumers do not
+need to include `<vulkan/vulkan.h>`.
 
 ### Metal (Stage 2)
 
@@ -388,7 +395,7 @@ Priority tags: **P3** is deferred / low-value.
 |---|---|---|
 | `Paint` | all setters + getters, fill/stroke split colors, effect/typeface attach | **P3**: `get_color4f`, `get_alpha_f`, SDF / font-threshold |
 | `Shader` | gradient factories (linear/radial/sweep/conical) + image shader + `set/get_local_matrix` | **P3**: `is_opaque`, `as_gradient` introspection |
-| `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters, GL `surface_mode` + `can_blit_from_target_fbo` | **P3**: per-surface CoverageAAMode, `add_external_wait_semaphore` (needs semaphore) |
+| `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters, GL `surface_mode` + `can_blit_from_target_fbo`, Vulkan image/swapchain-image wrapping, external wait semaphore | **P3**: per-surface CoverageAAMode |
 | `Path` | construction, arc family (tangent / oval / SVG), `add_*` (incl. per-corner radii), boolean ops, `PathMeasure`, `transform`, last-pt get/set, `copy_with_matrix/scale`, counts / `get_point` / `is_rect` | **P3**: convexity / segment-masks introspection, verb iteration (`get_verb` / `Iter`), `add_path` extend mode (`AddMode`) |
 | `Image` | 5 factories (incl. the `GPUContext` variant) + `read_pixels` + `scale_pixels` + size getters | **P3**: alpha/type/backend introspection |
 | `Font` | create (incl. scale/skew ctor), typeface/size get/set, rendering-quality switch get/set, `get_metrics`, `make_with_size`, `get_widths` | **P3**: `get_widths` bounds overload, `LoadGlyph*` (needs GlyphData) |
@@ -397,13 +404,13 @@ Priority tags: **P3** is deferred / low-value.
 | `Canvas` | full draw + state + clip + text/glyphs | **P3**: per-corner RRect draw/clip/drrect, `get_global_clip_bounds`, `draw_image` sampling overloads |
 | `DisplayList` | draw / cull-rect draw / bounds / op_count / properties / rtree search (+ non-overlapping rects) / per-op paint lookup, `begin_recording` with build options | `RecordedOpOffset` is exposed as a plain `int32_t` (round-trips through the public `RecordedOpOffset::Make`) — no opaque set type |
 | `GPUContext` | (see Fully covered) | **P3**: `create_texture_with_desc` (mipmap), `is_gpu_backend_supported`, `get_backend_type` |
+| `GPUNativeWindowVK` / `GPUPresenter` | Vulkan native-window creation, swapchain resize, surface acquire/present | complete |
 
 ### Not yet covered (whole module missing)
 
 | Module | Purpose | Why deferred |
 |---|---|---|
-| `GPUPresenter` | Vulkan swapchain present (`acquire_next_surface` / `present` / `resize`) | `Present()` consumes a `unique_ptr<GPUSurface>`, incompatible with the shared_ptr handle model (same blocker as `MakeSnapshot`). Vulkan-only; revisit alongside a transfer-ownership path. |
-| `GPUSemaphore` | cross-GPU / cross-process texture sync | `ImportSemaphore` takes a backend-specific derived struct (`GPUSemaphoreImportInfoVK`); the import path is Vulkan-only and unverified on the GL build. Will land together with `GPUPresenter`. |
+| `GPUPresenter` | Vulkan swapchain present (`acquire_next_surface` / `present` / `resize`) through `skity_native_window_vk` | C wrappers consume the acquired `unique_ptr` and explicitly invalidate the surface handle. |
 | `GlyphData` | glyph bitmap / path query (used by `Font::LoadGlyph*`) | exposing it cleanly needs a richer query surface |
 | `gpu_context_mtl` / `gpu_context_web` | Metal / WebGPU context | platform backends (Stage 2) |
 | `utils` (settings / trace) | config / tracing | minor |
@@ -451,7 +458,6 @@ module:
 - **GPUContext**: `create_texture_with_desc` (mipmap, +`TextureDescriptor`
   mirror); `is_gpu_backend_supported`; `get_backend_type`.
 
-> `GPUPresenter` / `GPUSemaphore` / `MakeSnapshot` remain blocked on the
-> `unique_ptr`-ownership / Vulkan-only constraints (see "Not yet covered").
+> `MakeSnapshot` remains blocked on the `unique_ptr`-ownership constraint.
 > The CPU raster backend (`Canvas::MakeSoftwareCanvas`) is intentionally
 > deferred — GPU paths are the current priority.

--- a/module/capi/README.md
+++ b/module/capi/README.md
@@ -30,10 +30,23 @@ cmake -DSKITY_EXAMPLE=ON -DSKITY_CAPI_MODULE=ON ...
 cmake --build . --target skity-c-api
 ```
 
+The Vulkan counterpart is
+[`../../example/case/c_api_vk/main.cc`](../../example/case/c_api_vk/main.cc).
+Build it with `SKITY_CAPI_MODULE=ON`, `SKITY_VK_BACKEND=ON`, and
+`SKITY_EXAMPLE=ON`, then target `skity-c-api-vk`.
+
 ## Usage
 
 ```c
 #include <skity_c/skity.h>
+
+/* For Vulkan-specific entry points:
+#include <skity_c/skity_context_vk.h>
+#include <skity_c/skity_surface_vk.h>
+#include <skity_c/skity_texture_vk.h>
+#include <skity_c/skity_semaphore_vk.h>
+#include <skity_c/skity_native_window_vk.h>
+*/
 
 skity_context ctx;
 skity_context_create_gl(my_gl_get_proc, &ctx);

--- a/module/capi/include/skity_c/skity_base.h
+++ b/module/capi/include/skity_c/skity_base.h
@@ -53,6 +53,7 @@ typedef enum {
   SKITY_ERROR_OUT_OF_HOST_MEMORY = -4, /**< host memory allocation failed */
   SKITY_ERROR_NOT_SUPPORTED =
       -5, /**< the operation is not supported on this build/backend */
+  SKITY_ERROR_NEED_RECREATE = -6, /**< a swapchain/resize retry is required */
 } skity_result;
 
 #ifdef __cplusplus

--- a/module/capi/include/skity_c/skity_context_vk.h
+++ b/module/capi/include/skity_c/skity_context_vk.h
@@ -33,6 +33,151 @@ SKITY_C_API skity_result
 skity_context_create_vk(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
                         skity_context* out_context);
 
+/**
+ * @brief Descriptor for creating a Vulkan context from caller-provided Vulkan
+ * state.
+ *
+ * Each native Vulkan handle is optional: passing NULL lets skity create and own
+ * that object. Caller-provided handles must stay valid for the lifetime of the
+ * resulting context and remain owned by the caller.
+ */
+typedef struct skity_context_create_info_vk {
+  /**
+   * Vulkan instance. If NULL, skity creates and owns one.
+   *
+   * @note The caller is responsible for enabling required instance extensions
+   * (for example VK_KHR_surface) and for destroying the instance.
+   */
+  VkInstance instance;
+
+  /**
+   * Loader for instance-level Vulkan procedures.
+   *
+   * @note Must not be NULL.
+   */
+  PFN_vkGetInstanceProcAddr get_instance_proc_addr;
+
+  /**
+   * Instance extensions enabled on `instance`.
+   *
+   * For a caller-provided instance this should list the extensions actually
+   * enabled. For an engine-created instance these entries are treated as
+   * additional requested extensions and are merged with skity's defaults.
+   */
+  const char* const* enabled_instance_extensions;
+
+  /** Number of entries in `enabled_instance_extensions`. */
+  uint32_t enabled_instance_extension_count;
+
+  /**
+   * Nonzero when `enabled_instance_extensions` fully describes the enabled
+   * instance extensions.
+   *
+   * Only meaningful for caller-provided instances.
+   */
+  uint32_t enabled_instance_extensions_known;
+
+  /**
+   * Vulkan physical device. If NULL, skity picks the first available device.
+   */
+  VkPhysicalDevice physical_device;
+
+  /**
+   * Vulkan logical device. If NULL, skity creates and owns one.
+   *
+   * When supplied, the device must have been created with the extensions skity
+   * needs (for example VK_KHR_timeline_semaphore or VK_KHR_external_memory).
+   *
+   * @note The caller remains responsible for destroying the device.
+   */
+  VkDevice logical_device;
+
+  /**
+   * Loader for device-level Vulkan procedures.
+   *
+   * @note Must not be NULL when `logical_device` is supplied.
+   */
+  PFN_vkGetDeviceProcAddr get_device_proc_addr;
+
+  /**
+   * Device extensions enabled on `logical_device`.
+   *
+   * For a caller-provided device this should list the extensions actually
+   * enabled. For an engine-created device these entries are treated as
+   * additional requested extensions.
+   */
+  const char* const* enabled_device_extensions;
+
+  /** Number of entries in `enabled_device_extensions`. */
+  uint32_t enabled_device_extension_count;
+
+  /**
+   * Nonzero when `enabled_device_extensions` fully describes the enabled
+   * device extensions.
+   *
+   * Only meaningful for caller-provided devices.
+   */
+  uint32_t enabled_device_extensions_known;
+
+  /**
+   * Nonzero when `logical_device` was created with the core `dualSrcBlend`
+   * feature enabled.
+   *
+   * Vulkan cannot query enabled core features from an existing device, so this
+   * must be declared explicitly. Ignored when skity creates the device.
+   */
+  uint32_t dual_source_blending_enabled;
+
+  /** Graphics queue. If NULL, skity picks the first graphics queue. */
+  VkQueue graphics_queue;
+
+  /**
+   * Graphics queue family index. If -1, skity picks the first graphics queue
+   * family index.
+   */
+  int32_t graphics_queue_family_index;
+
+  /** Compute queue. If NULL, skity picks the first compute queue. */
+  VkQueue compute_queue;
+
+  /**
+   * Compute queue family index. If -1, skity picks the first compute queue
+   * family index.
+   */
+  int32_t compute_queue_family_index;
+
+  /** Transfer queue. If NULL, skity picks the first transfer queue. */
+  VkQueue transfer_queue;
+
+  /**
+   * Transfer queue family index. If -1, skity picks the first transfer queue
+   * family index.
+   */
+  int32_t transfer_queue_family_index;
+
+  /**
+   * Nonzero to enable Vulkan debug runtime (for example VK_EXT_debug_utils and
+   * the Khronos validation layer) for engine-created instances.
+   *
+   * Ignored for caller-provided instances and in non-Debug builds.
+   */
+  uint32_t enable_debug_runtime;
+} skity_context_create_info_vk;
+
+/**
+ * @brief Create a GPUContext using caller-provided Vulkan state where
+ * available.
+ *
+ * Passing NULL for instance/device lets skity create those objects. When a
+ * logical device is supplied, its proc-address loader must also be supplied;
+ * the caller remains responsible for destroying instance, device, and queues.
+ *
+ * @param info  creation descriptor
+ * @param out_context receives the new context handle on success
+ */
+SKITY_C_API skity_result skity_context_create_vk_ex(
+    const skity_context_create_info_vk* info, skity_context* out_context);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/module/capi/include/skity_c/skity_native_window_vk.h
+++ b/module/capi/include/skity_c/skity_native_window_vk.h
@@ -1,0 +1,98 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_NATIVE_WINDOW_VK_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_NATIVE_WINDOW_VK_H
+
+#include <skity_c/skity_base.h>
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_context_vk.h>
+#include <skity_c/skity_surface.h>
+#include <vulkan/vulkan.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Vulkan native window kind. Values align with VKNativeWindowType. */
+typedef enum {
+  SKITY_VK_NATIVE_WINDOW_TYPE_INVALID = 0,
+  SKITY_VK_NATIVE_WINDOW_TYPE_WIN32,
+  SKITY_VK_NATIVE_WINDOW_TYPE_ANDROID,
+  SKITY_VK_NATIVE_WINDOW_TYPE_METAL_LAYER,
+  SKITY_VK_NATIVE_WINDOW_TYPE_WAYLAND,
+  SKITY_VK_NATIVE_WINDOW_TYPE_XCB,
+  SKITY_VK_NATIVE_WINDOW_TYPE_XLIB,
+} skity_vk_native_window_type;
+
+/** @brief Platform-neutral native window description for Vulkan surfaces. */
+typedef struct skity_vk_native_window_info {
+  skity_vk_native_window_type type;
+  void* handle;
+  void* secondary_handle;
+  uint64_t window_id;
+} skity_vk_native_window_info;
+
+/** @brief Vulkan native window and swapchain creation descriptor. */
+typedef struct skity_native_window_create_info_vk {
+  skity_vk_native_window_info native_window;
+  uint32_t width;
+  uint32_t height;
+  VkQueue present_queue;
+  int32_t present_queue_family_index;
+  uint32_t min_image_count;
+  VkFormat format;
+  VkColorSpaceKHR color_space;
+  VkPresentModeKHR present_mode;
+  VkCompositeAlphaFlagBitsKHR composite_alpha;
+  VkSurfaceTransformFlagBitsKHR pre_transform;
+  uint32_t clipped;
+} skity_native_window_create_info_vk;
+
+/** @brief Opaque handle to a Vulkan native window presenter. */
+typedef struct skity_native_window_vk_s* skity_native_window_vk;
+
+/** @brief Create a Vulkan native window and its initial swapchain. */
+SKITY_C_API skity_native_window_vk skity_native_window_create_vk(
+    skity_context context, const skity_native_window_create_info_vk* info);
+
+/** @brief Destroy the native window presenter and its swapchain. */
+SKITY_C_API void skity_native_window_destroy_vk(skity_native_window_vk window);
+
+/** @brief Return the current physical presentation width in pixels. */
+SKITY_C_API uint32_t
+skity_native_window_get_width_vk(skity_native_window_vk window);
+
+/** @brief Return the current physical presentation height in pixels. */
+SKITY_C_API uint32_t
+skity_native_window_get_height_vk(skity_native_window_vk window);
+
+/**
+ * @brief Recreate the presenter and swapchain for a new physical size.
+ * @return SKITY_SUCCESS on success, or a SKITY_ERROR_* code on failure
+ */
+SKITY_C_API skity_result skity_native_window_resize_vk(
+    skity_native_window_vk window, uint32_t width, uint32_t height);
+
+/**
+ * @brief Acquire the next one-shot render surface. It must be passed to
+ *        skity_native_window_present_vk before acquiring another surface.
+ */
+SKITY_C_API skity_result skity_native_window_acquire_next_surface_vk(
+    skity_native_window_vk window, uint32_t sample_count, float content_scale,
+    skity_surface* out_surface);
+
+/**
+ * @brief Present a surface acquired from this window. On success or
+ *        SKITY_ERROR_NEED_RECREATE the surface handle is consumed and must not
+ *        be used or destroyed again.
+ */
+SKITY_C_API skity_result skity_native_window_present_vk(
+    skity_native_window_vk window, skity_surface* surface);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_NATIVE_WINDOW_VK_H

--- a/module/capi/include/skity_c/skity_semaphore_vk.h
+++ b/module/capi/include/skity_c/skity_semaphore_vk.h
@@ -1,0 +1,38 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SEMAPHORE_VK_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SEMAPHORE_VK_H
+
+#include <skity_c/skity_context.h>
+#include <skity_c/skity_surface_vk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create an engine-owned Vulkan semaphore for external synchronization.
+ * @return new semaphore handle, or NULL on failure
+ */
+SKITY_C_API skity_semaphore skity_semaphore_create_vk(skity_context context);
+
+/**
+ * @brief Import a POSIX sync file descriptor into a Vulkan semaphore. The fd
+ *        ownership is transferred to the Vulkan driver on success.
+ * @return SKITY_SUCCESS on success, or a SKITY_ERROR_* code on failure
+ */
+SKITY_C_API skity_result skity_semaphore_import_vk(skity_context context,
+                                                   skity_semaphore semaphore,
+                                                   int sync_fd);
+
+/** @brief Release a semaphore previously created by
+ *         skity_semaphore_create_vk. Safe to call with NULL. */
+SKITY_C_API void skity_semaphore_destroy_vk(skity_semaphore semaphore);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SEMAPHORE_VK_H

--- a/module/capi/include/skity_c/skity_surface_vk.h
+++ b/module/capi/include/skity_c/skity_surface_vk.h
@@ -1,0 +1,70 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_VK_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_VK_H
+
+#include <skity_c/skity_surface.h>
+#include <vulkan/vulkan.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Vulkan render target kind. */
+typedef enum {
+  SKITY_VK_SURFACE_TYPE_INVALID = 0,
+  SKITY_VK_SURFACE_TYPE_TEXTURE,
+  SKITY_VK_SURFACE_TYPE_SWAPCHAIN_IMAGE,
+} skity_vk_surface_type;
+
+/**
+ * @brief External synchronization for a one-shot Vulkan surface.
+ *
+ * The semaphore and fence handles remain owned by the caller and must outlive
+ * the surface create/flush sequence.
+ */
+typedef struct skity_surface_sync_info_vk {
+  VkSemaphore wait_semaphore;
+  VkPipelineStageFlags wait_dst_stage_mask;
+  VkSemaphore signal_semaphore;
+  VkFence signal_fence;
+} skity_surface_sync_info_vk;
+
+/**
+ * @brief Vulkan backend extension for surface creation. Chain it through
+ *        skity_surface_create_info::p_next with s_type =
+ *        SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_VK.
+ */
+typedef struct skity_surface_create_info_vk {
+  skity_structure_type s_type;
+  const void* p_next;
+  skity_vk_surface_type surface_type;
+  VkImage image;
+  VkImageView image_view;
+  VkFormat format;
+  VkImageUsageFlags image_usage;
+  VkSurfaceTransformFlagBitsKHR pre_transform;
+  VkImageLayout initial_layout;
+  VkImageLayout final_layout;
+  uint32_t owns_image;
+  uint32_t owns_image_view;
+  const skity_surface_sync_info_vk* sync_info;
+} skity_surface_create_info_vk;
+
+/** @brief Opaque handle to a skity::GPUSemaphore. */
+typedef struct skity_semaphore_s* skity_semaphore;
+
+/**
+ * @brief Add an external wait semaphore to the next frame. Must be called
+ *        between skity_surface_lock_canvas and skity_surface_flush.
+ */
+SKITY_C_API void skity_surface_add_external_wait_semaphore_vk(
+    skity_surface surface, skity_semaphore semaphore);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_SURFACE_VK_H

--- a/module/capi/include/skity_c/skity_texture_vk.h
+++ b/module/capi/include/skity_c/skity_texture_vk.h
@@ -1,0 +1,37 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_VK_H
+#define MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_VK_H
+
+#include <skity_c/skity_texture.h>
+#include <vulkan/vulkan.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Vulkan backend extension for wrapping an existing VkImage. Chain it
+ *        through skity_backend_texture_info::p_next with s_type =
+ *        SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_VK.
+ */
+typedef struct skity_backend_texture_info_vk {
+  skity_structure_type s_type;
+  const void* p_next;
+  VkImage image;
+  VkImageView image_view;
+  VkFormat vk_format;
+  VkImageUsageFlags image_usage;
+  VkImageLayout initial_layout;
+  VkImageLayout final_layout;
+  uint32_t owns_image;
+  uint32_t owns_image_view;
+} skity_backend_texture_info_vk;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MODULE_CAPI_INCLUDE_SKITY_C_SKITY_TEXTURE_VK_H

--- a/module/capi/include/skity_c/skity_types.h
+++ b/module/capi/include/skity_c/skity_types.h
@@ -191,6 +191,10 @@ typedef enum {
   SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO,   /**< base backend texture info */
   SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL, /**< OpenGL-specific backend
                                                    texture info */
+  SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_VK,  /**< Vulkan-specific surface
+                                                   creation info */
+  SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_VK, /**< Vulkan-specific backend
+                                                   texture info */
 } skity_structure_type;
 
 /**

--- a/module/capi/src/bridge_c.cpp
+++ b/module/capi/src/bridge_c.cpp
@@ -28,7 +28,8 @@ SKITY_C_API skity_canvas skity_canvas_from_native(void* native) {
   }
   // Non-owning: the no-op deleter means skity_canvas_destroy only reclaims the
   // wrapper struct and never touches the caller's Canvas.
-  std::shared_ptr<void> impl(native, [](void*) {});
+  std::shared_ptr<skity::Canvas> impl(static_cast<skity::Canvas*>(native),
+                                      [](skity::Canvas*) {});
   return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0u,
                                                    std::move(impl));
 }

--- a/module/capi/src/context_c.cpp
+++ b/module/capi/src/context_c.cpp
@@ -45,7 +45,7 @@ skity_result skity_context_create_gl(skity_gl_get_proc get_proc,
   if (ctx == nullptr) {
     return SKITY_ERROR_INITIALIZATION_FAILED;
   }
-  std::shared_ptr<void> impl(ctx.release());
+  std::shared_ptr<skity::GPUContext> impl(ctx.release());
   skity_context_s* w = skity::capi::alloc_handle<skity_context_s>(
       SKITY_OBJECT_TYPE_CONTEXT, SKITY_HANDLE_OWNING, std::move(impl));
   if (w == nullptr) {
@@ -131,7 +131,7 @@ skity_precompile_context skity_context_create_precompile_context(
   if (pc == nullptr) {
     return nullptr;
   }
-  std::shared_ptr<void> impl(pc.release());
+  std::shared_ptr<skity::PrecompileContext> impl(pc.release());
   return skity::capi::alloc_handle<skity_precompile_context_s>(
       SKITY_OBJECT_TYPE_PRECOMPILE_CONTEXT, SKITY_HANDLE_OWNING,
       std::move(impl));
@@ -149,7 +149,57 @@ skity_result skity_context_create_vk(
   if (ctx == nullptr) {
     return SKITY_ERROR_INITIALIZATION_FAILED;
   }
-  std::shared_ptr<void> impl(ctx.release());
+  std::shared_ptr<skity::GPUContext> impl(ctx.release());
+  skity_context_s* w = skity::capi::alloc_handle<skity_context_s>(
+      SKITY_OBJECT_TYPE_CONTEXT, SKITY_HANDLE_OWNING, std::move(impl));
+  if (w == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out_context = w;
+  return SKITY_SUCCESS;
+}
+
+skity_result skity_context_create_vk_ex(
+    const skity_context_create_info_vk* info, skity_context* out_context) {
+  if (info == nullptr || out_context == nullptr ||
+      info->get_instance_proc_addr == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  if (info->logical_device != VK_NULL_HANDLE &&
+      info->get_device_proc_addr == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+
+  skity::GPUContextInfoVK vk_info{};
+  vk_info.instance = info->instance;
+  vk_info.get_instance_proc_addr = info->get_instance_proc_addr;
+  vk_info.enabled_instance_extensions = info->enabled_instance_extensions;
+  vk_info.enabled_instance_extension_count =
+      info->enabled_instance_extension_count;
+  vk_info.enabled_instance_extensions_known =
+      info->enabled_instance_extensions_known != 0;
+  vk_info.physical_device = info->physical_device;
+  vk_info.logical_device = info->logical_device;
+  vk_info.get_device_proc_addr = info->get_device_proc_addr;
+  vk_info.enabled_device_extensions = info->enabled_device_extensions;
+  vk_info.enabled_device_extension_count = info->enabled_device_extension_count;
+  vk_info.enabled_device_extensions_known =
+      info->enabled_device_extensions_known != 0;
+  vk_info.dual_source_blending_enabled =
+      info->dual_source_blending_enabled != 0;
+  vk_info.graphics_queue = info->graphics_queue;
+  vk_info.graphics_queue_family_index = info->graphics_queue_family_index;
+  vk_info.compute_queue = info->compute_queue;
+  vk_info.compute_queue_family_index = info->compute_queue_family_index;
+  vk_info.transfer_queue = info->transfer_queue;
+  vk_info.transfer_queue_family_index = info->transfer_queue_family_index;
+  vk_info.enable_debug_runtime = info->enable_debug_runtime != 0;
+
+  std::unique_ptr<skity::GPUContext> ctx = skity::CreateGPUContextVK(&vk_info);
+  if (ctx == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+  std::shared_ptr<skity::GPUContext> impl(ctx.release());
   skity_context_s* w = skity::capi::alloc_handle<skity_context_s>(
       SKITY_OBJECT_TYPE_CONTEXT, SKITY_HANDLE_OWNING, std::move(impl));
   if (w == nullptr) {

--- a/module/capi/src/handle.hpp
+++ b/module/capi/src/handle.hpp
@@ -9,6 +9,39 @@
 #include <memory>
 #include <new>
 
+namespace skity {
+
+class Bitmap;
+class Camera;
+class Canvas;
+class ColorFilter;
+class Data;
+class DisplayList;
+class Font;
+class FontManager;
+class FontStyleSet;
+class GPUContext;
+class GPUNativeWindowVK;
+class GPUSemaphore;
+class GPUSurface;
+class Image;
+class ImageFilter;
+class MaskFilter;
+class Paint;
+class Path;
+class PathEffect;
+class PathMeasure;
+class PictureRecorder;
+class Pixmap;
+class PrecompileContext;
+class Shader;
+class TextBlob;
+class Texture;
+class Typeface;
+class TypefaceDelegate;
+
+}  // namespace skity
+
 /*
  * Object type tag + handle header. These are implementation details of the
  * wrapper and are intentionally NOT exposed in the public C headers — handles
@@ -43,6 +76,8 @@ typedef enum {
   SKITY_OBJECT_TYPE_CAMERA,
   SKITY_OBJECT_TYPE_DATA,
   SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE,
+  SKITY_OBJECT_TYPE_SEMAPHORE,
+  SKITY_OBJECT_TYPE_NATIVE_WINDOW_VK,
 } skity_object_type;
 
 /* When set, the wrapper owns the underlying object and releases it on destroy.
@@ -56,8 +91,8 @@ typedef struct skity_object_header {
 } skity_object_header;
 
 /*
- * Wrapper-internal struct definitions. Each is `header + impl` where impl is a
- * type-erased shared_ptr:
+ * Wrapper-internal struct definitions. Each derives from `skity_handle_base<T>`
+ * and therefore carries `header + impl` where impl is a typed shared_ptr<T>:
  *   - owning handles store a shared_ptr with the default deleter (or the
  *     factory's original shared_ptr), so destroying the wrapper releases the
  *     object;
@@ -68,109 +103,46 @@ typedef struct skity_object_header {
  * These structs live at global scope so they match the C-side typedefs
  * produced by SKITY_C_DEFINE_HANDLE.
  */
-struct skity_context_s {
+template <typename T>
+struct skity_handle_base {
   skity_object_header header;
-  std::shared_ptr<void> impl;
+  std::shared_ptr<T> impl;
+
+  using value_type = T;
 };
-struct skity_surface_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
+
+struct skity_context_s : skity_handle_base<skity::GPUContext> {};
+struct skity_surface_s : skity_handle_base<skity::GPUSurface> {
+  std::unique_ptr<skity::GPUSurface> owned_surface;
 };
-struct skity_canvas_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
+struct skity_canvas_s : skity_handle_base<skity::Canvas> {};
+struct skity_paint_s : skity_handle_base<skity::Paint> {};
+struct skity_path_s : skity_handle_base<skity::Path> {};
+struct skity_shader_s : skity_handle_base<skity::Shader> {};
+struct skity_color_filter_s : skity_handle_base<skity::ColorFilter> {};
+struct skity_image_filter_s : skity_handle_base<skity::ImageFilter> {};
+struct skity_mask_filter_s : skity_handle_base<skity::MaskFilter> {};
+struct skity_path_effect_s : skity_handle_base<skity::PathEffect> {};
+struct skity_typeface_s : skity_handle_base<skity::Typeface> {};
+struct skity_font_manager_s : skity_handle_base<skity::FontManager> {};
+struct skity_picture_recorder_s : skity_handle_base<skity::PictureRecorder> {};
+struct skity_display_list_s : skity_handle_base<skity::DisplayList> {};
+struct skity_image_s : skity_handle_base<skity::Image> {};
+struct skity_text_blob_s : skity_handle_base<skity::TextBlob> {};
+struct skity_texture_s : skity_handle_base<skity::Texture> {};
+struct skity_font_style_set_s : skity_handle_base<skity::FontStyleSet> {};
+struct skity_precompile_context_s
+    : skity_handle_base<skity::PrecompileContext> {};
+struct skity_font_s : skity_handle_base<skity::Font> {};
+struct skity_bitmap_s : skity_handle_base<skity::Bitmap> {};
+struct skity_pixmap_s : skity_handle_base<skity::Pixmap> {};
+struct skity_path_measure_s : skity_handle_base<skity::PathMeasure> {};
+struct skity_camera_s : skity_handle_base<skity::Camera> {};
+struct skity_data_s : skity_handle_base<skity::Data> {};
+struct skity_typeface_delegate_s : skity_handle_base<skity::TypefaceDelegate> {
 };
-struct skity_paint_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_path_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_shader_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_color_filter_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_image_filter_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_mask_filter_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_path_effect_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_typeface_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_font_manager_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_picture_recorder_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_display_list_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_image_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_text_blob_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_texture_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_font_style_set_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_precompile_context_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_font_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_bitmap_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_pixmap_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_path_measure_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_camera_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_data_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
-};
-struct skity_typeface_delegate_s {
-  skity_object_header header;
-  std::shared_ptr<void> impl;
+struct skity_semaphore_s : skity_handle_base<skity::GPUSemaphore> {};
+struct skity_native_window_vk_s : skity_handle_base<skity::GPUNativeWindowVK> {
 };
 
 namespace skity {
@@ -181,9 +153,9 @@ namespace capi {
  * failed allocation returns nullptr (the wrapper is built with -fno-exceptions,
  * matching the core skity library).
  */
-template <typename Wrapper>
+template <typename Wrapper, typename T = typename Wrapper::value_type>
 inline Wrapper* alloc_handle(skity_object_type type, uint32_t flags,
-                             std::shared_ptr<void> impl) {
+                             std::shared_ptr<T> impl) {
   Wrapper* w = new (std::nothrow) Wrapper{};
   if (w == nullptr) return nullptr;
   w->header.type = type;
@@ -220,7 +192,7 @@ inline void destroy_handle(void* handle, skity_object_type expected) {
  * Resolve a handle and return its impl re-typed to T. Returns an empty
  * shared_ptr on null / wrong type.
  */
-template <typename Wrapper, typename T>
+template <typename Wrapper, typename T = typename Wrapper::value_type>
 inline std::shared_ptr<T> get_impl(void* handle, skity_object_type expected) {
   Wrapper* w = resolve<Wrapper>(handle, expected);
   if (w == nullptr) return nullptr;

--- a/module/capi/src/image_c.cpp
+++ b/module/capi/src/image_c.cpp
@@ -116,7 +116,8 @@ std::shared_ptr<skity::Texture> promise_get_thunk2(
   // Wrap the GPUContext as a non-owning handle for the duration of the call.
   skity_context ch = nullptr;
   if (gpu_ctx != nullptr) {
-    std::shared_ptr<void> non_owning(gpu_ctx, [](void*) {});
+    std::shared_ptr<skity::GPUContext> non_owning(gpu_ctx,
+                                                  [](skity::GPUContext*) {});
     ch = skity::capi::alloc_handle<skity_context_s>(SKITY_OBJECT_TYPE_CONTEXT,
                                                     0, std::move(non_owning));
   }
@@ -189,13 +190,12 @@ void skity_image_destroy(skity_image image) {
 
 uint32_t skity_image_get_width(skity_image image) {
   auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
-  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Width() : 0u;
+  return w ? (uint32_t)static_cast<skity::Image*>(w->impl.get())->Width() : 0u;
 }
 
 uint32_t skity_image_get_height(skity_image image) {
   auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
-  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Height()
-           : 0u;
+  return w ? (uint32_t)static_cast<skity::Image*>(w->impl.get())->Height() : 0u;
 }
 
 skity_image skity_image_create_from_texture(skity_texture texture) {

--- a/module/capi/src/image_c.cpp
+++ b/module/capi/src/image_c.cpp
@@ -190,12 +190,13 @@ void skity_image_destroy(skity_image image) {
 
 uint32_t skity_image_get_width(skity_image image) {
   auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
-  return w ? (uint32_t)static_cast<skity::Image*>(w->impl.get())->Width() : 0u;
+  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Width() : 0u;
 }
 
 uint32_t skity_image_get_height(skity_image image) {
   auto* w = skity::capi::resolve<skity_image_s>(image, SKITY_OBJECT_TYPE_IMAGE);
-  return w ? (uint32_t)static_cast<skity::Image*>(w->impl.get())->Height() : 0u;
+  return w ? (uint32_t) static_cast<skity::Image*>(w->impl.get())->Height()
+           : 0u;
 }
 
 skity_image skity_image_create_from_texture(skity_texture texture) {

--- a/module/capi/src/native_window_vk.cpp
+++ b/module/capi/src/native_window_vk.cpp
@@ -1,0 +1,171 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_native_window_vk.h>
+
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <skity/gpu/gpu_presenter.hpp>
+#include <skity/gpu/gpu_surface.hpp>
+#include <utility>
+
+#include "handle.hpp"
+
+namespace {
+
+skity::GPUNativeWindowVK* NativeWindowOf(skity_native_window_vk handle) {
+  auto window =
+      skity::capi::get_impl<skity_native_window_vk_s, skity::GPUNativeWindowVK>(
+          handle, SKITY_OBJECT_TYPE_NATIVE_WINDOW_VK);
+  return window.get();
+}
+
+}  // namespace
+
+extern "C" {
+
+skity_native_window_vk skity_native_window_create_vk(
+    skity_context context, const skity_native_window_create_info_vk* info) {
+  if (info == nullptr) {
+    return nullptr;
+  }
+  auto context_impl = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  if (context_impl == nullptr) {
+    return nullptr;
+  }
+
+  skity::GPUNativeWindowInfoVK descriptor{};
+  descriptor.native_window.type =
+      static_cast<skity::VKNativeWindowType>(info->native_window.type);
+  descriptor.native_window.handle = info->native_window.handle;
+  descriptor.native_window.secondary_handle =
+      info->native_window.secondary_handle;
+  descriptor.native_window.window_id = info->native_window.window_id;
+  descriptor.width = info->width;
+  descriptor.height = info->height;
+  descriptor.present_queue = info->present_queue;
+  descriptor.present_queue_family_index = info->present_queue_family_index;
+  descriptor.min_image_count = info->min_image_count;
+  descriptor.format = info->format;
+  descriptor.color_space = info->color_space;
+  descriptor.present_mode = info->present_mode;
+  descriptor.composite_alpha = info->composite_alpha;
+  descriptor.pre_transform = info->pre_transform;
+  descriptor.clipped = info->clipped != 0;
+
+  auto window = skity::CreateGPUNativeWindowVK(context_impl.get(), &descriptor);
+  if (window == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<skity::GPUNativeWindowVK> impl(window.release());
+  return skity::capi::alloc_handle<skity_native_window_vk_s>(
+      SKITY_OBJECT_TYPE_NATIVE_WINDOW_VK, SKITY_HANDLE_OWNING, std::move(impl));
+}
+
+void skity_native_window_destroy_vk(skity_native_window_vk window) {
+  skity::capi::destroy_handle<skity_native_window_vk_s>(
+      window, SKITY_OBJECT_TYPE_NATIVE_WINDOW_VK);
+}
+
+uint32_t skity_native_window_get_width_vk(skity_native_window_vk window) {
+  auto* native_window = NativeWindowOf(window);
+  return native_window != nullptr ? native_window->GetWidth() : 0u;
+}
+
+uint32_t skity_native_window_get_height_vk(skity_native_window_vk window) {
+  auto* native_window = NativeWindowOf(window);
+  return native_window != nullptr ? native_window->GetHeight() : 0u;
+}
+
+skity_result skity_native_window_resize_vk(skity_native_window_vk window,
+                                           uint32_t width, uint32_t height) {
+  auto* native_window = NativeWindowOf(window);
+  if (native_window == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+  return native_window->Resize(width, height)
+             ? SKITY_SUCCESS
+             : SKITY_ERROR_INITIALIZATION_FAILED;
+}
+
+skity_result skity_native_window_acquire_next_surface_vk(
+    skity_native_window_vk window, uint32_t sample_count, float content_scale,
+    skity_surface* out_surface) {
+  if (out_surface == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  auto* native_window = NativeWindowOf(window);
+  if (native_window == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+  auto* presenter = native_window->GetPresenter();
+  if (presenter == nullptr) {
+    return SKITY_ERROR_NOT_SUPPORTED;
+  }
+
+  skity::GPUSurfaceAcquireDescriptor descriptor{};
+  descriptor.sample_count = sample_count ? sample_count : 1;
+  descriptor.content_scale = content_scale != 0.f ? content_scale : 1.f;
+  auto result = presenter->AcquireNextSurface(descriptor);
+  if (result.status == skity::GPUPresenterStatus::kNeedRecreate) {
+    return SKITY_ERROR_NEED_RECREATE;
+  }
+  if (result.status != skity::GPUPresenterStatus::kSuccess ||
+      result.surface == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+
+  auto* handle = new (std::nothrow) skity_surface_s{};
+  if (handle == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  handle->header.type = SKITY_OBJECT_TYPE_SURFACE;
+  handle->header.flags = SKITY_HANDLE_OWNING;
+  handle->owned_surface = std::move(result.surface);
+  handle->impl = std::shared_ptr<skity::GPUSurface>(handle->owned_surface.get(),
+                                                    [](skity::GPUSurface*) {});
+  *out_surface = handle;
+  return SKITY_SUCCESS;
+}
+
+skity_result skity_native_window_present_vk(skity_native_window_vk window,
+                                            skity_surface* surface) {
+  if (surface == nullptr) {
+    return SKITY_ERROR_INVALID_ARGUMENT;
+  }
+  auto* native_window = NativeWindowOf(window);
+  if (native_window == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+  auto* presenter = native_window->GetPresenter();
+  auto* wrapper = skity::capi::resolve<skity_surface_s>(
+      *surface, SKITY_OBJECT_TYPE_SURFACE);
+  if (presenter == nullptr || wrapper == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+
+  auto* raw_surface = wrapper->owned_surface.release();
+  if (raw_surface == nullptr) {
+    skity::capi::destroy_handle<skity_surface_s>(*surface,
+                                                 SKITY_OBJECT_TYPE_SURFACE);
+    *surface = nullptr;
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+
+  skity::capi::destroy_handle<skity_surface_s>(*surface,
+                                               SKITY_OBJECT_TYPE_SURFACE);
+  *surface = nullptr;
+
+  auto status =
+      presenter->Present(std::unique_ptr<skity::GPUSurface>(raw_surface));
+  if (status == skity::GPUPresenterStatus::kSuccess) {
+    return SKITY_SUCCESS;
+  }
+  return status == skity::GPUPresenterStatus::kNeedRecreate
+             ? SKITY_ERROR_NEED_RECREATE
+             : SKITY_ERROR_INITIALIZATION_FAILED;
+}
+
+}  // extern "C"

--- a/module/capi/src/path_measure_c.cpp
+++ b/module/capi/src/path_measure_c.cpp
@@ -31,7 +31,7 @@ skity_path_measure skity_path_measure_create(skity_path path,
                                              uint32_t force_closed,
                                              float res_scale) {
   auto p = path_shared(path);
-  std::shared_ptr<void> impl;
+  std::shared_ptr<skity::PathMeasure> impl;
   if (p != nullptr) {
     impl =
         std::make_shared<skity::PathMeasure>(*p, force_closed != 0, res_scale);

--- a/module/capi/src/recorder_c.cpp
+++ b/module/capi/src/recorder_c.cpp
@@ -90,7 +90,7 @@ skity_canvas skity_picture_recorder_get_canvas(
   // The RecordingCanvas is owned by the recorder; wrap it non-owning.
   skity::Canvas* raw = r->GetRecordingCanvas();
   if (raw == nullptr) return nullptr;
-  std::shared_ptr<void> impl(raw, [](void*) {});
+  std::shared_ptr<skity::Canvas> impl(raw, [](skity::Canvas*) {});
   return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0,
                                                    std::move(impl));
 }
@@ -105,7 +105,7 @@ skity_result skity_picture_recorder_finish(skity_picture_recorder recorder,
   if (dl == nullptr) {
     return SKITY_ERROR_INVALID_ARGUMENT;
   }
-  std::shared_ptr<void> impl(dl.release());
+  std::shared_ptr<skity::DisplayList> impl(dl.release());
   skity_display_list_s* w = skity::capi::alloc_handle<skity_display_list_s>(
       SKITY_OBJECT_TYPE_DISPLAY_LIST, SKITY_HANDLE_OWNING, std::move(impl));
   if (w == nullptr) {
@@ -222,7 +222,7 @@ skity_paint skity_display_list_get_op_paint_by_offset(skity_display_list list,
   // The paint lives inside the display list's storage; wrap it non-owning so
   // the handle stays valid for the list's lifetime and in-place edits are
   // visible to later replays.
-  std::shared_ptr<void> impl(paint, [](void*) {});
+  std::shared_ptr<skity::Paint> impl(paint, [](skity::Paint*) {});
   return skity::capi::alloc_handle<skity_paint_s>(SKITY_OBJECT_TYPE_PAINT, 0,
                                                   std::move(impl));
 }

--- a/module/capi/src/semaphore_vk.cpp
+++ b/module/capi/src/semaphore_vk.cpp
@@ -1,0 +1,50 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_semaphore_vk.h>
+
+#include <skity/gpu/gpu_context.hpp>
+#include <skity/gpu/gpu_context_vk.hpp>
+#include <skity/gpu/gpu_semaphore.hpp>
+#include <utility>
+
+#include "handle.hpp"
+
+extern "C" {
+
+skity_semaphore skity_semaphore_create_vk(skity_context context) {
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  auto semaphore = ctx->CreateSemaphore();
+  if (semaphore == nullptr) {
+    return nullptr;
+  }
+  return skity::capi::alloc_handle<skity_semaphore_s>(
+      SKITY_OBJECT_TYPE_SEMAPHORE, SKITY_HANDLE_OWNING, std::move(semaphore));
+}
+
+skity_result skity_semaphore_import_vk(skity_context context,
+                                       skity_semaphore semaphore, int sync_fd) {
+  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+      context, SKITY_OBJECT_TYPE_CONTEXT);
+  auto sem = skity::capi::get_impl<skity_semaphore_s, skity::GPUSemaphore>(
+      semaphore, SKITY_OBJECT_TYPE_SEMAPHORE);
+  if (sem == nullptr || ctx == nullptr) {
+    return SKITY_ERROR_INVALID_HANDLE;
+  }
+  skity::GPUSemaphoreImportInfoVK info{};
+  info.sync_fd = sync_fd;
+  ctx->ImportSemaphore(sem.get(), info);
+  return SKITY_SUCCESS;
+}
+
+void skity_semaphore_destroy_vk(skity_semaphore semaphore) {
+  skity::capi::destroy_handle<skity_semaphore_s>(semaphore,
+                                                 SKITY_OBJECT_TYPE_SEMAPHORE);
+}
+
+}  // extern "C"

--- a/module/capi/src/surface_c.cpp
+++ b/module/capi/src/surface_c.cpp
@@ -15,6 +15,95 @@
 #include <skity/gpu/gpu_context_gl.hpp>
 #endif
 
+#if defined(SKITY_VULKAN)
+#include <skity_c/skity_surface_vk.h>
+
+#include <skity/gpu/gpu_context_vk.hpp>
+#endif
+
+namespace {
+
+skity_result CreateSurfaceHandle(std::unique_ptr<skity::GPUSurface> surface,
+                                 skity_surface* out_surface) {
+  if (surface == nullptr) {
+    return SKITY_ERROR_INITIALIZATION_FAILED;
+  }
+  std::shared_ptr<skity::GPUSurface> impl(surface.release());
+  skity_surface_s* handle = skity::capi::alloc_handle<skity_surface_s>(
+      SKITY_OBJECT_TYPE_SURFACE, SKITY_HANDLE_OWNING, std::move(impl));
+  if (handle == nullptr) {
+    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
+  }
+  *out_surface = handle;
+  return SKITY_SUCCESS;
+}
+
+#if defined(SKITY_OPENGL)
+skity_result CreateSurfaceGL(skity::GPUContext* context,
+                             const skity_surface_create_info* info,
+                             const skity_surface_create_info_gl* extension,
+                             skity_surface* out_surface) {
+  skity::GPUSurfaceDescriptorGL descriptor{};
+  descriptor.backend = skity::GPUBackendType::kOpenGL;
+  descriptor.width = info->width;
+  descriptor.height = info->height;
+  descriptor.sample_count = info->sample_count ? info->sample_count : 1;
+  descriptor.content_scale =
+      info->content_scale != 0.f ? info->content_scale : 1.f;
+  descriptor.surface_type =
+      extension->surface_type == SKITY_GL_SURFACE_TYPE_TEXTURE
+          ? skity::GLSurfaceType::kTexture
+          : skity::GLSurfaceType::kFramebuffer;
+  descriptor.gl_id = extension->gl_id;
+  descriptor.has_stencil_attachment = extension->has_stencil != 0;
+  descriptor.surface_mode =
+      static_cast<skity::GLSurfaceMode>(extension->surface_mode);
+  descriptor.can_blit_from_target_fbo =
+      extension->can_blit_from_target_fbo != 0;
+  return CreateSurfaceHandle(context->CreateSurface(&descriptor), out_surface);
+}
+#endif
+
+#if defined(SKITY_VULKAN)
+skity_result CreateSurfaceVK(skity::GPUContext* context,
+                             const skity_surface_create_info* info,
+                             const skity_surface_create_info_vk* extension,
+                             skity_surface* out_surface) {
+  skity::GPUSurfaceDescriptorVK descriptor{};
+  descriptor.backend = skity::GPUBackendType::kVulkan;
+  descriptor.width = info->width;
+  descriptor.height = info->height;
+  descriptor.sample_count = info->sample_count ? info->sample_count : 1;
+  descriptor.content_scale =
+      info->content_scale != 0.f ? info->content_scale : 1.f;
+  descriptor.surface_type =
+      extension->surface_type == SKITY_VK_SURFACE_TYPE_TEXTURE
+          ? skity::VKSurfaceType::kTexture
+          : skity::VKSurfaceType::kSwapchainImage;
+  descriptor.image = extension->image;
+  descriptor.image_view = extension->image_view;
+  descriptor.format = extension->format;
+  descriptor.image_usage = extension->image_usage;
+  descriptor.pre_transform = extension->pre_transform;
+  descriptor.initial_layout = extension->initial_layout;
+  descriptor.final_layout = extension->final_layout;
+  descriptor.owns_image = extension->owns_image != 0;
+  descriptor.owns_image_view = extension->owns_image_view != 0;
+
+  skity::GPUSurfaceSyncInfoVK sync_info{};
+  if (extension->sync_info != nullptr) {
+    sync_info.wait_semaphore = extension->sync_info->wait_semaphore;
+    sync_info.wait_dst_stage_mask = extension->sync_info->wait_dst_stage_mask;
+    sync_info.signal_semaphore = extension->sync_info->signal_semaphore;
+    sync_info.signal_fence = extension->sync_info->signal_fence;
+    descriptor.sync_info = &sync_info;
+  }
+  return CreateSurfaceHandle(context->CreateSurface(&descriptor), out_surface);
+}
+#endif
+
+}  // namespace
+
 extern "C" {
 
 skity_result skity_surface_create(skity_context context,
@@ -23,54 +112,35 @@ skity_result skity_surface_create(skity_context context,
   if (info == nullptr || out_surface == nullptr) {
     return SKITY_ERROR_INVALID_ARGUMENT;
   }
-  auto ctx = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
+  auto context_impl = skity::capi::get_impl<skity_context_s, skity::GPUContext>(
       context, SKITY_OBJECT_TYPE_CONTEXT);
-  if (ctx == nullptr) {
+  if (context_impl == nullptr) {
     return SKITY_ERROR_INVALID_HANDLE;
   }
 
-#if defined(SKITY_OPENGL)
-  // Locate the GL backend extension in the p_next chain.
-  const skity_surface_create_info_gl* gl_ext = nullptr;
+  skity_structure_type structure_type =
+      SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO;
   if (info->p_next != nullptr) {
-    auto s_type = *static_cast<const skity_structure_type*>(info->p_next);
-    if (s_type == SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL) {
-      gl_ext = static_cast<const skity_surface_create_info_gl*>(info->p_next);
-    }
-  }
-  if (gl_ext == nullptr) {
-    return SKITY_ERROR_INVALID_ARGUMENT;
+    structure_type = *static_cast<const skity_structure_type*>(info->p_next);
   }
 
-  skity::GPUSurfaceDescriptorGL desc{};
-  desc.backend = skity::GPUBackendType::kOpenGL;
-  desc.width = info->width;
-  desc.height = info->height;
-  desc.sample_count = info->sample_count ? info->sample_count : 1;
-  desc.content_scale = info->content_scale != 0.f ? info->content_scale : 1.f;
-  desc.surface_type = (gl_ext->surface_type == SKITY_GL_SURFACE_TYPE_TEXTURE)
-                          ? skity::GLSurfaceType::kTexture
-                          : skity::GLSurfaceType::kFramebuffer;
-  desc.gl_id = gl_ext->gl_id;
-  desc.has_stencil_attachment = gl_ext->has_stencil != 0;
-  desc.surface_mode = static_cast<skity::GLSurfaceMode>(gl_ext->surface_mode);
-  desc.can_blit_from_target_fbo = gl_ext->can_blit_from_target_fbo != 0;
-
-  std::unique_ptr<skity::GPUSurface> surf = ctx->CreateSurface(&desc);
-  if (surf == nullptr) {
-    return SKITY_ERROR_INITIALIZATION_FAILED;
+#if defined(SKITY_OPENGL)
+  if (structure_type == SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_GL) {
+    return CreateSurfaceGL(
+        context_impl.get(), info,
+        static_cast<const skity_surface_create_info_gl*>(info->p_next),
+        out_surface);
   }
-  std::shared_ptr<void> impl(surf.release());
-  skity_surface_s* w = skity::capi::alloc_handle<skity_surface_s>(
-      SKITY_OBJECT_TYPE_SURFACE, SKITY_HANDLE_OWNING, std::move(impl));
-  if (w == nullptr) {
-    return SKITY_ERROR_OUT_OF_HOST_MEMORY;
-  }
-  *out_surface = w;
-  return SKITY_SUCCESS;
-#else
-  return SKITY_ERROR_NOT_SUPPORTED;
 #endif
+#if defined(SKITY_VULKAN)
+  if (structure_type == SKITY_STRUCTURE_TYPE_SURFACE_CREATE_INFO_VK) {
+    return CreateSurfaceVK(
+        context_impl.get(), info,
+        static_cast<const skity_surface_create_info_vk*>(info->p_next),
+        out_surface);
+  }
+#endif
+  return SKITY_ERROR_INVALID_ARGUMENT;
 }
 
 void skity_surface_destroy(skity_surface surface) {
@@ -79,68 +149,81 @@ void skity_surface_destroy(skity_surface surface) {
 }
 
 skity_canvas skity_surface_lock_canvas(skity_surface surface, uint32_t clear) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  if (surf == nullptr) {
+  if (surface_impl == nullptr) {
     return nullptr;
   }
-  // The Canvas is owned by the surface; wrap it with a no-op deleter.
-  skity::Canvas* raw = surf->LockCanvas(clear != 0);
+  skity::Canvas* raw = surface_impl->LockCanvas(clear != 0);
   if (raw == nullptr) {
     return nullptr;
   }
-  std::shared_ptr<void> impl(raw, [](void*) {});
+  std::shared_ptr<skity::Canvas> impl(raw, [](skity::Canvas*) {});
   return skity::capi::alloc_handle<skity_canvas_s>(SKITY_OBJECT_TYPE_CANVAS, 0,
                                                    std::move(impl));
 }
 
 void skity_surface_flush(skity_surface surface) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  if (surf != nullptr) {
-    surf->Flush();
+  if (surface_impl != nullptr) {
+    surface_impl->Flush();
   }
 }
 
 skity_pixmap skity_surface_read_pixels(skity_surface surface,
                                        const skity_rect* rect) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  if (surf == nullptr) {
+  if (surface_impl == nullptr) {
     return nullptr;
   }
   skity::Rect region;
   if (rect != nullptr) {
     region = *reinterpret_cast<const skity::Rect*>(rect);
   } else {
-    region = skity::Rect::MakeXYWH(0.f, 0.f, (float)surf->GetWidth(),
-                                   (float)surf->GetHeight());
+    region = skity::Rect::MakeXYWH(
+        0.f, 0.f, static_cast<float>(surface_impl->GetWidth()),
+        static_cast<float>(surface_impl->GetHeight()));
   }
-  auto pm = surf->ReadPixels(region);
-  if (pm == nullptr) {
+  auto pixmap = surface_impl->ReadPixels(region);
+  if (pixmap == nullptr) {
     return nullptr;
   }
-  std::shared_ptr<void> impl(std::move(pm));
   return skity::capi::alloc_handle<skity_pixmap_s>(
-      SKITY_OBJECT_TYPE_PIXMAP, SKITY_HANDLE_OWNING, std::move(impl));
+      SKITY_OBJECT_TYPE_PIXMAP, SKITY_HANDLE_OWNING, std::move(pixmap));
 }
 
 uint32_t skity_surface_get_width(skity_surface surface) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  return surf ? surf->GetWidth() : 0u;
+  return surface_impl ? surface_impl->GetWidth() : 0u;
 }
 
 uint32_t skity_surface_get_height(skity_surface surface) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  return surf ? surf->GetHeight() : 0u;
+  return surface_impl ? surface_impl->GetHeight() : 0u;
 }
 
 float skity_surface_get_content_scale(skity_surface surface) {
-  auto surf = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
       surface, SKITY_OBJECT_TYPE_SURFACE);
-  return surf ? surf->ContentScale() : 1.f;
+  return surface_impl ? surface_impl->ContentScale() : 1.f;
 }
+
+#if defined(SKITY_VULKAN)
+void skity_surface_add_external_wait_semaphore_vk(skity_surface surface,
+                                                  skity_semaphore semaphore) {
+  auto surface_impl = skity::capi::get_impl<skity_surface_s, skity::GPUSurface>(
+      surface, SKITY_OBJECT_TYPE_SURFACE);
+  auto semaphore_impl =
+      skity::capi::get_impl<skity_semaphore_s, skity::GPUSemaphore>(
+          semaphore, SKITY_OBJECT_TYPE_SEMAPHORE);
+  if (surface_impl != nullptr && semaphore_impl != nullptr) {
+    surface_impl->AddExternalWaitSemaphore(semaphore_impl);
+  }
+}
+#endif
 
 }  // extern "C"

--- a/module/capi/src/text_c.cpp
+++ b/module/capi/src/text_c.cpp
@@ -177,9 +177,10 @@ skity_typeface_delegate skity_typeface_delegate_create_simple(
   if (delegate == nullptr) {
     return nullptr;
   }
+  std::shared_ptr<skity::TypefaceDelegate> impl(std::move(delegate));
   return skity::capi::alloc_handle<skity_typeface_delegate_s>(
       SKITY_OBJECT_TYPE_TYPEFACE_DELEGATE, SKITY_HANDLE_OWNING,
-      std::move(delegate));
+      std::move(impl));
 }
 
 skity_typeface_delegate skity_typeface_delegate_create_fallback(

--- a/module/capi/src/texture_c.cpp
+++ b/module/capi/src/texture_c.cpp
@@ -15,6 +15,12 @@
 #include <skity/gpu/gpu_context_gl.hpp>
 #endif
 
+#if defined(SKITY_VULKAN)
+#include <skity_c/skity_texture_vk.h>
+
+#include <skity/gpu/gpu_context_vk.hpp>
+#endif
+
 #include "handle.hpp"
 
 namespace {
@@ -160,34 +166,53 @@ skity_texture skity_texture_create_from_backend(
   if (ctx == nullptr) {
     return nullptr;
   }
+  auto st = info->p_next != nullptr
+                ? *static_cast<const skity_structure_type*>(info->p_next)
+                : SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO;
+  std::shared_ptr<skity::Texture> tex;
 #if defined(SKITY_OPENGL)
-  const skity_backend_texture_info_gl* gl = nullptr;
-  if (info->p_next != nullptr) {
-    auto st = *static_cast<const skity_structure_type*>(info->p_next);
-    if (st == SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL) {
-      gl = static_cast<const skity_backend_texture_info_gl*>(info->p_next);
-    }
+  if (st == SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_GL) {
+    const auto* gl =
+        static_cast<const skity_backend_texture_info_gl*>(info->p_next);
+    skity::GPUBackendTextureInfoGL bi{};
+    bi.backend = skity::GPUBackendType::kOpenGL;
+    bi.width = info->width;
+    bi.height = info->height;
+    bi.format = static_cast<skity::TextureFormat>(info->format);
+    bi.alpha_type = static_cast<skity::AlphaType>(info->alpha_type);
+    bi.tex_id = gl->texture_id;
+    bi.owned_by_engine = gl->owned_by_engine != 0;
+    tex = ctx->WrapTexture(&bi, release, userdata);
   }
-  if (gl == nullptr) {
-    return nullptr;
+#endif
+
+#if defined(SKITY_VULKAN)
+  if (st == SKITY_STRUCTURE_TYPE_BACKEND_TEXTURE_INFO_VK) {
+    const auto* vk =
+        static_cast<const skity_backend_texture_info_vk*>(info->p_next);
+    skity::GPUBackendTextureInfoVK bi{};
+    bi.backend = skity::GPUBackendType::kVulkan;
+    bi.width = info->width;
+    bi.height = info->height;
+    bi.format = static_cast<skity::TextureFormat>(info->format);
+    bi.alpha_type = static_cast<skity::AlphaType>(info->alpha_type);
+    bi.image = vk->image;
+    bi.image_view = vk->image_view;
+    bi.vk_format = vk->vk_format;
+    bi.image_usage = vk->image_usage;
+    bi.initial_layout = vk->initial_layout;
+    bi.final_layout = vk->final_layout;
+    bi.owns_image = vk->owns_image != 0;
+    bi.owns_image_view = vk->owns_image_view != 0;
+    tex = ctx->WrapTexture(&bi, release, userdata);
   }
-  skity::GPUBackendTextureInfoGL bi{};
-  bi.backend = skity::GPUBackendType::kOpenGL;
-  bi.width = info->width;
-  bi.height = info->height;
-  bi.format = static_cast<skity::TextureFormat>(info->format);
-  bi.alpha_type = static_cast<skity::AlphaType>(info->alpha_type);
-  bi.tex_id = gl->texture_id;
-  bi.owned_by_engine = gl->owned_by_engine != 0;
-  auto tex = ctx->WrapTexture(&bi, release, userdata);
+#endif
+
   if (tex == nullptr) {
     return nullptr;
   }
   return skity::capi::alloc_handle<skity_texture_s>(
       SKITY_OBJECT_TYPE_TEXTURE, SKITY_HANDLE_OWNING, std::move(tex));
-#else
-  return nullptr;
-#endif
 }
 
 }  // extern "C"

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -134,6 +134,14 @@ if (${SKITY_CAPI_MODULE})
         capi/recorder_c_test.cc
         capi/text_delegate_c_test.cc
     )
+    if (${SKITY_VK_BACKEND})
+        target_sources(skity_unit_test PRIVATE
+            capi/vulkan_c_test.cc
+        )
+        target_include_directories(skity_unit_test PRIVATE
+            ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
+        )
+    endif()
 
     target_include_directories(skity_unit_test PRIVATE
         ${CMAKE_SOURCE_DIR}/module/capi/include

--- a/test/ut/capi/vulkan_c_test.cc
+++ b/test/ut/capi/vulkan_c_test.cc
@@ -1,0 +1,41 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <skity_c/skity_context_vk.h>
+#include <skity_c/skity_native_window_vk.h>
+#include <skity_c/skity_semaphore_vk.h>
+#include <skity_c/skity_surface_vk.h>
+#include <skity_c/skity_texture_vk.h>
+#include <vulkan/vulkan.h>
+
+#include "gtest/gtest.h"
+
+TEST(VulkanCAPITest, ContextCreationValidatesArguments) {
+  skity_context context = nullptr;
+  EXPECT_EQ(skity_context_create_vk(nullptr, &context),
+            SKITY_ERROR_INVALID_ARGUMENT);
+  EXPECT_EQ(skity_context_create_vk_ex(nullptr, &context),
+            SKITY_ERROR_INVALID_ARGUMENT);
+  EXPECT_EQ(context, nullptr);
+
+  skity_context_create_info_vk info = {};
+  info.logical_device = reinterpret_cast<VkDevice>(0x1);
+  EXPECT_EQ(skity_context_create_vk_ex(&info, &context),
+            SKITY_ERROR_INVALID_ARGUMENT);
+  EXPECT_EQ(context, nullptr);
+}
+
+TEST(VulkanCAPITest, SemaphoreAndSurfaceValidateHandles) {
+  EXPECT_EQ(skity_semaphore_create_vk(nullptr), nullptr);
+  EXPECT_EQ(skity_semaphore_import_vk(nullptr, nullptr, -1),
+            SKITY_ERROR_INVALID_HANDLE);
+  skity_surface surface = nullptr;
+  skity_semaphore semaphore = nullptr;
+  skity_surface_add_external_wait_semaphore_vk(surface, semaphore);
+  EXPECT_EQ(
+      skity_native_window_acquire_next_surface_vk(nullptr, 1, 1.f, &surface),
+      SKITY_ERROR_INVALID_HANDLE);
+  EXPECT_EQ(skity_native_window_present_vk(nullptr, &surface),
+            SKITY_ERROR_INVALID_HANDLE);
+}


### PR DESCRIPTION
- Add Vulkan context/surface/texture/semaphore/native-window C APIs with macOS window support
- Add c_api_vk example linking volk / system libvulkan, plus Vulkan C API unit tests
- Refactor handle.hpp to a typed template base, replacing shared_ptr<void> impl
- Preserve native-window Present ownership via owned_surface unique_ptr