### PR TITLE
feat(capi): fill Canvas and Path C API gaps

### DIFF
--- a/module/capi/C_API_DESIGN.md
+++ b/module/capi/C_API_DESIGN.md
@@ -396,12 +396,12 @@ Priority tags: **P3** is deferred / low-value.
 | `Paint` | all setters + getters, fill/stroke split colors, effect/typeface attach | **P3**: `get_color4f`, `get_alpha_f`, SDF / font-threshold |
 | `Shader` | gradient factories (linear/radial/sweep/conical) + image shader + `set/get_local_matrix` | **P3**: `is_opaque`, `as_gradient` introspection |
 | `GPUSurface` | create, `lock_canvas`, `flush`, `read_pixels`, size getters, GL `surface_mode` + `can_blit_from_target_fbo`, Vulkan image/swapchain-image wrapping, external wait semaphore | **P3**: per-surface CoverageAAMode |
-| `Path` | construction, arc family (tangent / oval / SVG), `add_*` (incl. per-corner radii), boolean ops, `PathMeasure`, `transform`, last-pt get/set, `copy_with_matrix/scale`, counts / `get_point` / `is_rect` | **P3**: convexity / segment-masks introspection, verb iteration (`get_verb` / `Iter`), `add_path` extend mode (`AddMode`) |
+| `Path` | construction, arc family (tangent / oval / SVG), `add_*` (incl. per-corner radii), boolean ops, `PathMeasure`, `transform`, last-pt get/set, `copy_with_matrix/scale`, counts / `get_point` / `get_verb` / `get_conic_weight` / `is_rect` / `is_line` / `is_empty` / `is_finite`, convexity get/set, `get_segment_masks`, `add_path` append/extend modes, `clone`, `is_equal`, `get_last_move_pt` | `GetLastMovePt` has no failure signal on the C++ side (empty path result unspecified, mirrored here) |
 | `Image` | 5 factories (incl. the `GPUContext` variant) + `read_pixels` + `scale_pixels` + size getters | **P3**: alpha/type/backend introspection |
 | `Font` | create (incl. scale/skew ctor), typeface/size get/set, rendering-quality switch get/set, `get_metrics`, `make_with_size`, `get_widths` | **P3**: `get_widths` bounds overload, `LoadGlyph*` (needs GlyphData) |
 | `Typeface` | `make_from_file`, `make_from_data`, `get_default`, `unichars_to_glyphs`/`unichar_to_glyph` | **P3**: `get_font_style`/`is_bold`/`is_italic`, `contain_glyph`, `units_per_em`/`contains_color_table`, table / variation / descriptor |
 | `TextBlob` | build (UTF-8) + draw, `get_bounds`, `compute_bounds`, `TypefaceDelegate` fallback (ordered-list + custom-fallback-callback) | **P3**: `get_text_run`; fully custom `BreakTextRun` delegate (caller-driven segmentation) |
-| `Canvas` | full draw + state + clip + text/glyphs | **P3**: per-corner RRect draw/clip/drrect, `get_global_clip_bounds`, `draw_image` sampling overloads |
+| `Canvas` | full draw + state + clip + text/glyphs, `draw_image` sampling overloads, `draw_color4f`, per-corner-radii `draw_rrect`, `make_software_canvas` | **P3**: per-corner RRect clip/drrect, `get_global_clip_bounds` |
 | `DisplayList` | draw / cull-rect draw / bounds / op_count / properties / rtree search (+ non-overlapping rects) / per-op paint lookup, `begin_recording` with build options | `RecordedOpOffset` is exposed as a plain `int32_t` (round-trips through the public `RecordedOpOffset::Make`) — no opaque set type |
 | `GPUContext` | (see Fully covered) | **P3**: `create_texture_with_desc` (mipmap), `is_gpu_backend_supported`, `get_backend_type` |
 | `GPUNativeWindowVK` / `GPUPresenter` | Vulkan native-window creation, swapchain resize, surface acquire/present | complete |
@@ -452,9 +452,10 @@ module:
   `BreakTextRun` delegate (caller-driven run segmentation — the current
   `skity_typeface_delegate_create_fallback` keeps the built-in policy and only
   overrides the typeface choice).
-- **Canvas**: per-corner RRect `draw_rrect` / `clip_rrect` / `draw_drrect`
-  (+RRect projection or 8-radii); `get_global_clip_bounds`; `draw_image`
-  sampling/paint overloads; `draw_color(color4f, blend)`.
+- **Canvas**: per-corner RRect `clip_rrect` / `draw_drrect`
+  (+RRect projection or 8-radii); `get_global_clip_bounds`. (`draw_rrect`
+  with per-corner radii, the `draw_image` sampling/paint overloads, and
+  `draw_color(color4f, blend)` are covered since the Canvas gap fill.)
 - **GPUContext**: `create_texture_with_desc` (mipmap, +`TextureDescriptor`
   mirror); `is_gpu_backend_supported`; `get_backend_type`.
 

--- a/module/capi/include/skity_c/skity_canvas.h
+++ b/module/capi/include/skity_c/skity_canvas.h
@@ -142,6 +142,16 @@ SKITY_C_API void skity_canvas_draw_color(skity_canvas canvas, skity_color color,
                                          skity_blend_mode mode);
 
 /**
+ * @brief Fill the entire clip with @p color using @p mode.
+ * @param color  unpremultiplied RGBA, one float per channel
+ * @param mode   blend mode used to combine the source color with the
+ * destination
+ */
+SKITY_C_API void skity_canvas_draw_color4f(skity_canvas canvas,
+                                           skity_color4f color,
+                                           skity_blend_mode mode);
+
+/**
  * @brief Fill the entire clip using @p paint. The paint's color, shader,
  *        color filter, image filter, and blend mode all apply.
  * @param paint  graphics state used to fill the canvas
@@ -215,6 +225,20 @@ SKITY_C_API void skity_canvas_draw_round_rect(skity_canvas canvas,
                                               float ry, skity_paint paint);
 
 /**
+ * @brief Draw the rounded rectangle bounded by @p rect with per-corner radii
+ *        @p radii using @p paint. Unlike skity_canvas_draw_round_rect, each
+ *        corner can have independent x-axis and y-axis radii.
+ * @param rect   bounds of the rounded rectangle to draw
+ * @param radii  corner radii as (x, y) pairs in the order top-left,
+ *               top-right, bottom-right, bottom-left; four entries
+ * @param paint  stroke or fill, blend, color, and so on, used to draw
+ */
+SKITY_C_API void skity_canvas_draw_rrect(skity_canvas canvas,
+                                         const skity_rect* rect,
+                                         const skity_vec2* radii,
+                                         skity_paint paint);
+
+/**
  * @brief Draw @p path using @p paint.
  * @param path   path to draw
  * @param paint  stroke or fill, blend, color, and so on, used to draw
@@ -231,6 +255,35 @@ SKITY_C_API void skity_canvas_draw_path(skity_canvas canvas, skity_path path,
  */
 SKITY_C_API void skity_canvas_draw_image(skity_canvas canvas, skity_image image,
                                          float x, float y);
+
+/**
+ * @brief Draw @p image with its top-left corner at (@p x, @p y), filtered
+ *        with @p sampling and modulated by @p paint.
+ * @param image     image to draw
+ * @param x         position of the image's top-left corner on the x-axis
+ * @param y         position of the image's top-left corner on the y-axis
+ * @param sampling  sampling options used to filter the image; NULL to use the
+ * default
+ * @param paint     paint applied to modulate the image; NULL to draw without a
+ * paint
+ */
+SKITY_C_API void skity_canvas_draw_image_with_sampling(
+    skity_canvas canvas, skity_image image, float x, float y,
+    const skity_sampling_options* sampling, skity_paint paint);
+
+/**
+ * @brief Draw @p image scaled to fill @p dst, filtered with @p sampling and
+ *        modulated by @p paint.
+ * @param image     image to draw
+ * @param dst       destination rectangle to draw into
+ * @param sampling  sampling options used to filter the image; NULL to use the
+ * default
+ * @param paint     paint applied to modulate the image; NULL to draw without a
+ * paint
+ */
+SKITY_C_API void skity_canvas_draw_image_to_rect(
+    skity_canvas canvas, skity_image image, const skity_rect* dst,
+    const skity_sampling_options* sampling, skity_paint paint);
 
 /**
  * @brief Draw the sub-rectangle @p src of @p image into the destination
@@ -385,10 +438,22 @@ SKITY_C_API uint32_t skity_canvas_get_width(skity_canvas canvas);
 SKITY_C_API uint32_t skity_canvas_get_height(skity_canvas canvas);
 
 /**
- * @brief Release the non-owning canvas wrapper. The underlying Canvas object
- *        is owned by the surface and is not deleted here. Calling this is
- *        optional — the wrapper is small, but releasing it avoids leaking the
- *        wrapper struct across many frames.
+ * @brief Create a software (CPU-rasterized) canvas drawing into @p bitmap.
+ *
+ *        The returned canvas is owning: release it with skity_canvas_destroy,
+ *        which also deletes the underlying Canvas. The bitmap must outlive
+ *        the canvas.
+ *
+ * @param bitmap  bitmap that receives the drawing
+ * @return a canvas handle, or NULL on failure
+ */
+SKITY_C_API skity_canvas skity_canvas_make_software_canvas(skity_bitmap bitmap);
+
+/**
+ * @brief Release the canvas wrapper. For a canvas obtained from a surface or
+ *        recorder the underlying Canvas object is not deleted here; for a
+ *        canvas created with skity_canvas_make_software_canvas the underlying
+ *        object is deleted as well.
  */
 SKITY_C_API void skity_canvas_destroy(skity_canvas canvas);
 

--- a/module/capi/include/skity_c/skity_path.h
+++ b/module/capi/include/skity_c/skity_path.h
@@ -43,11 +43,47 @@ typedef enum {
   SKITY_ARC_SIZE_LARGE = 1, /**< sweep the larger of the two candidate arcs */
 } skity_arc_size;
 
+/** @brief Path verb kinds, in storage order. Values aligned with
+ *         skity::Path::Verb. */
+typedef enum {
+  SKITY_PATH_VERB_MOVE = 0, /**< begin a contour; 1 point */
+  SKITY_PATH_VERB_LINE,     /**< line segment; 2 points */
+  SKITY_PATH_VERB_QUAD,     /**< quadratic curve; 3 points */
+  SKITY_PATH_VERB_CONIC,    /**< conic curve; 3 points + weight */
+  SKITY_PATH_VERB_CUBIC,    /**< cubic curve; 4 points */
+  SKITY_PATH_VERB_CLOSE,    /**< close the contour; 1 point */
+  SKITY_PATH_VERB_DONE,     /**< no more verbs */
+} skity_path_verb;
+
+/** @brief Convexity classification. Values aligned with
+ *         skity::Path::ConvexityType. */
+typedef enum {
+  SKITY_CONVEXITY_UNKNOWN = 0, /**< not yet computed */
+  SKITY_CONVEXITY_CONVEX,      /**< all interior angles <= 180 degrees */
+  SKITY_CONVEXITY_CONCAVE,     /**< at least one interior angle > 180 degrees */
+} skity_convexity_type;
+
+/** @brief How an added path is appended to the existing contours. Values
+ *         aligned with skity::Path::AddMode. */
+typedef enum {
+  SKITY_PATH_ADD_MODE_APPEND =
+      0,                      /**< append src to the destination unaltered */
+  SKITY_PATH_ADD_MODE_EXTEND, /**< add a line to src if the prior contour is
+                                   not closed */
+} skity_path_add_mode;
+
 /** @brief Create an empty path. */
 SKITY_C_API skity_path skity_path_create(void);
 
 /** @brief Release the path handle and its underlying object. Safe on NULL. */
 SKITY_C_API void skity_path_destroy(skity_path path);
+
+/** @brief Create a new path that is a copy of @p src. */
+SKITY_C_API skity_path skity_path_clone(skity_path src);
+
+/** @brief Return whether the two paths hold equal verbs, points, and weights.
+ */
+SKITY_C_API uint32_t skity_path_is_equal(skity_path a, skity_path b);
 
 /** @brief Clear all verbs and points, leaving the path empty (fill type is
  *         retained). */
@@ -174,6 +210,22 @@ SKITY_C_API skity_path_fill_type skity_path_get_fill_type(skity_path path);
 SKITY_C_API void skity_path_add_path_matrix(skity_path path, skity_path src,
                                             const skity_matrix* matrix);
 
+/**
+ * @brief Append @p src to @p path under @p mode. With
+ *        SKITY_PATH_ADD_MODE_EXTEND, a line is added first when the prior
+ *        contour is not closed.
+ */
+SKITY_C_API void skity_path_add_path_with_mode(skity_path path, skity_path src,
+                                               skity_path_add_mode mode);
+
+/**
+ * @brief Append @p src to @p path under @p mode after transforming it by
+ *        @p matrix.
+ */
+SKITY_C_API void skity_path_add_path_matrix_with_mode(
+    skity_path path, skity_path src, const skity_matrix* matrix,
+    skity_path_add_mode mode);
+
 /** @brief Append the contours of @p src in reverse order to @p path. */
 SKITY_C_API void skity_path_reverse_add_path(skity_path path, skity_path src);
 
@@ -191,6 +243,26 @@ SKITY_C_API uint32_t skity_path_get_point(skity_path path, int32_t index,
                                           skity_vec4* out);
 
 /**
+ * @brief Return the verb kind at @p index. Pair with
+ *        skity_path_count_verbs / skity_path_count_points /
+ *        skity_path_get_point to walk the path by index.
+ *
+ *        Conic verbs carry a weight that the index-based walk cannot fetch;
+ *        it is only available through the C++ Path::Iter.
+ *
+ * @return the verb kind, or SKITY_PATH_VERB_DONE if @p index is out of range.
+ */
+SKITY_C_API skity_path_verb skity_path_get_verb(skity_path path, int32_t index);
+
+/**
+ * @brief Write the weight of the @p index -th conic segment into @p out.
+ *        The index counts conic verbs only, in storage order.
+ * @return 1 on success, 0 if @p index is out of range.
+ */
+SKITY_C_API uint32_t skity_path_get_conic_weight(skity_path path, int32_t index,
+                                                 float* out);
+
+/**
  * @brief Test whether the path is equivalent to a single rect when filled.
  * @param out_rect      if non-NULL and the test passes, receives the rect
  * @param out_is_closed if non-NULL and the test passes, set to 1 when the
@@ -199,6 +271,39 @@ SKITY_C_API uint32_t skity_path_get_point(skity_path path, int32_t index,
  */
 SKITY_C_API uint32_t skity_path_is_rect(skity_path path, skity_rect* out_rect,
                                         uint32_t* out_is_closed);
+
+/**
+ * @brief Return the convexity classification. SKITY_CONVEXITY_UNKNOWN is
+ *        computed on demand, so the first call may take time.
+ */
+SKITY_C_API skity_convexity_type skity_path_get_convexity_type(skity_path path);
+
+/** @brief Override the cached convexity classification. */
+SKITY_C_API void skity_path_set_convexity_type(skity_path path,
+                                               skity_convexity_type type);
+
+/**
+ * @brief Return a bit mask of the segment kinds present in the path:
+ *        bit 0 line, bit 1 quad, bit 2 conic, bit 3 cubic. Cached, very fast.
+ */
+SKITY_C_API uint32_t skity_path_get_segment_masks(skity_path path);
+
+/** @brief Return whether all points of the path are finite. */
+SKITY_C_API uint32_t skity_path_is_finite(skity_path path);
+
+/** @brief Return whether the path holds no verbs. */
+SKITY_C_API uint32_t skity_path_is_empty(skity_path path);
+
+/**
+ * @brief Test whether the path is equivalent to a single line segment.
+ * @param out_pts  if non-NULL and the test passes, receives the two endpoints
+ * @return 1 if the path is a line, 0 otherwise.
+ */
+SKITY_C_API uint32_t skity_path_is_line(skity_path path, skity_vec4* out_pts);
+
+/** @brief Write the point of the most recent Move verb into @p out. The
+ *         result of an empty path is unspecified. */
+SKITY_C_API void skity_path_get_last_move_pt(skity_path path, skity_vec4* out);
 
 /**
  * @brief Append an elliptical arc that lies on the ellipse bounded by @p oval.

--- a/module/capi/src/canvas_c.cpp
+++ b/module/capi/src/canvas_c.cpp
@@ -7,6 +7,8 @@
 #include <skity/geometry/matrix.hpp>
 #include <skity/geometry/rect.hpp>
 #include <skity/geometry/rrect.hpp>
+#include <skity/geometry/vector.hpp>
+#include <skity/graphic/bitmap.hpp>
 #include <skity/graphic/image.hpp>
 #include <skity/graphic/paint.hpp>
 #include <skity/graphic/path.hpp>
@@ -39,6 +41,18 @@ skity::Path* path_of(skity_path handle) {
 skity::Canvas::ClipOp to_clip_op(skity_clip_op op) {
   return op == SKITY_CLIP_OP_DIFFERENCE ? skity::Canvas::ClipOp::kDifference
                                         : skity::Canvas::ClipOp::kIntersect;
+}
+
+skity::SamplingOptions to_sampling_options(
+    const skity_sampling_options* sampling) {
+  skity::SamplingOptions so{};
+  if (sampling != nullptr) {
+    so.filter = static_cast<skity::FilterMode>(sampling->filter);
+    so.mipmap = static_cast<skity::MipmapMode>(sampling->mipmap);
+    so.cubic.B = sampling->cubic_b;
+    so.cubic.C = sampling->cubic_c;
+  }
+  return so;
 }
 
 skity::TextBlob* text_blob_of(skity_text_blob handle) {
@@ -133,6 +147,14 @@ void skity_canvas_draw_color(skity_canvas canvas, skity_color color,
   }
 }
 
+void skity_canvas_draw_color4f(skity_canvas canvas, skity_color4f color,
+                               skity_blend_mode mode) {
+  if (auto* c = canvas_of(canvas)) {
+    c->DrawColor(*reinterpret_cast<const skity::Color4f*>(&color),
+                 static_cast<skity::BlendMode>(mode));
+  }
+}
+
 void skity_canvas_draw_paint(skity_canvas canvas, skity_paint paint) {
   auto* c = canvas_of(canvas);
   auto* p = paint_of(paint);
@@ -187,6 +209,19 @@ void skity_canvas_draw_round_rect(skity_canvas canvas, const skity_rect* rect,
   }
 }
 
+void skity_canvas_draw_rrect(skity_canvas canvas, const skity_rect* rect,
+                             const skity_vec2* radii, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto* p = paint_of(paint);
+  if (c == nullptr || rect == nullptr || radii == nullptr || p == nullptr) {
+    return;
+  }
+  skity::RRect rr;
+  rr.SetRectRadii(*reinterpret_cast<const skity::Rect*>(rect),
+                  reinterpret_cast<const skity::Vec2*>(radii));
+  c->DrawRRect(rr, *p);
+}
+
 void skity_canvas_draw_path(skity_canvas canvas, skity_path path,
                             skity_paint paint) {
   auto* c = canvas_of(canvas);
@@ -205,6 +240,32 @@ void skity_canvas_draw_image(skity_canvas canvas, skity_image image, float x,
   if (c != nullptr && img != nullptr) {
     c->DrawImage(img, x, y);
   }
+}
+
+void skity_canvas_draw_image_with_sampling(
+    skity_canvas canvas, skity_image image, float x, float y,
+    const skity_sampling_options* sampling, skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  if (c == nullptr || img == nullptr) {
+    return;
+  }
+  c->DrawImage(img, x, y, to_sampling_options(sampling), paint_of(paint));
+}
+
+void skity_canvas_draw_image_to_rect(skity_canvas canvas, skity_image image,
+                                     const skity_rect* dst,
+                                     const skity_sampling_options* sampling,
+                                     skity_paint paint) {
+  auto* c = canvas_of(canvas);
+  auto img = skity::capi::get_impl<skity_image_s, skity::Image>(
+      image, SKITY_OBJECT_TYPE_IMAGE);
+  if (c == nullptr || img == nullptr || dst == nullptr) {
+    return;
+  }
+  c->DrawImage(img, *reinterpret_cast<const skity::Rect*>(dst),
+               to_sampling_options(sampling), paint_of(paint));
 }
 
 void skity_canvas_draw_image_rect(skity_canvas canvas, skity_image image,
@@ -346,6 +407,22 @@ uint32_t skity_canvas_get_width(skity_canvas canvas) {
 uint32_t skity_canvas_get_height(skity_canvas canvas) {
   auto* c = canvas_of(canvas);
   return c ? c->Height() : 0;
+}
+
+skity_canvas skity_canvas_make_software_canvas(skity_bitmap bitmap) {
+  auto b = skity::capi::get_impl<skity_bitmap_s, skity::Bitmap>(
+      bitmap, SKITY_OBJECT_TYPE_BITMAP);
+  if (b == nullptr) {
+    return nullptr;
+  }
+  std::unique_ptr<skity::Canvas> canvas =
+      skity::Canvas::MakeSoftwareCanvas(b.get());
+  if (canvas == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<skity::Canvas> impl(canvas.release());
+  return skity::capi::alloc_handle<skity_canvas_s>(
+      SKITY_OBJECT_TYPE_CANVAS, SKITY_HANDLE_OWNING, std::move(impl));
 }
 
 void skity_canvas_destroy(skity_canvas canvas) {

--- a/module/capi/src/path_c.cpp
+++ b/module/capi/src/path_c.cpp
@@ -21,6 +21,10 @@ skity::Path::Direction to_dir(skity_path_direction d) {
   return static_cast<skity::Path::Direction>(d);
 }
 
+skity::Path::AddMode to_add_mode(skity_path_add_mode m) {
+  return static_cast<skity::Path::AddMode>(m);
+}
+
 }  // namespace
 
 extern "C" {
@@ -33,6 +37,21 @@ skity_path skity_path_create(void) {
 
 void skity_path_destroy(skity_path path) {
   skity::capi::destroy_handle<skity_path_s>(path, SKITY_OBJECT_TYPE_PATH);
+}
+
+skity_path skity_path_clone(skity_path src) {
+  auto* s = path_of(src);
+  if (s == nullptr) return nullptr;
+  return skity::capi::alloc_handle<skity_path_s>(
+      SKITY_OBJECT_TYPE_PATH, SKITY_HANDLE_OWNING,
+      std::make_shared<skity::Path>(*s));
+}
+
+uint32_t skity_path_is_equal(skity_path a, skity_path b) {
+  auto* pa = path_of(a);
+  auto* pb = path_of(b);
+  if (pa == nullptr || pb == nullptr) return 0u;
+  return *pa == *pb ? 1u : 0u;
 }
 
 void skity_path_reset(skity_path path) {
@@ -160,6 +179,26 @@ void skity_path_add_path_matrix(skity_path path, skity_path src,
   }
 }
 
+void skity_path_add_path_with_mode(skity_path path, skity_path src,
+                                   skity_path_add_mode mode) {
+  auto* p = path_of(path);
+  auto* s = path_of(src);
+  if (p != nullptr && s != nullptr) {
+    p->AddPath(*s, to_add_mode(mode));
+  }
+}
+
+void skity_path_add_path_matrix_with_mode(skity_path path, skity_path src,
+                                          const skity_matrix* matrix,
+                                          skity_path_add_mode mode) {
+  auto* p = path_of(path);
+  auto* s = path_of(src);
+  if (p != nullptr && s != nullptr && matrix != nullptr) {
+    p->AddPath(*s, *reinterpret_cast<const skity::Matrix*>(matrix),
+               to_add_mode(mode));
+  }
+}
+
 void skity_path_reverse_add_path(skity_path path, skity_path src) {
   auto* p = path_of(path);
   auto* s = path_of(src);
@@ -171,6 +210,35 @@ void skity_path_reverse_add_path(skity_path path, skity_path src) {
 uint32_t skity_path_count_verbs(skity_path path) {
   auto* p = path_of(path);
   return p ? (uint32_t)p->CountVerbs() : 0u;
+}
+
+skity_path_verb skity_path_get_verb(skity_path path, int32_t index) {
+  auto* p = path_of(path);
+  if (p == nullptr || index < 0) {
+    return SKITY_PATH_VERB_DONE;
+  }
+  // skity::Path::Verb and skity_path_verb are value-aligned enums; out of
+  // range yields kDone on the C++ side as well.
+  return static_cast<skity_path_verb>(p->GetVerb(index));
+}
+
+uint32_t skity_path_get_conic_weight(skity_path path, int32_t index,
+                                     float* out) {
+  auto* p = path_of(path);
+  if (p == nullptr || out == nullptr || index < 0) return 0u;
+  // The weight array is indexed by conic order, so the valid range is found
+  // by counting the conic verbs.
+  int32_t conic_count = 0;
+  int32_t verb_count = static_cast<int32_t>(p->CountVerbs());
+  for (int32_t i = 0; i < verb_count; i++) {
+    if (p->GetVerb(i) != skity::Path::Verb::kConic) continue;
+    if (conic_count == index) {
+      *out = p->ConicWeights()[conic_count];
+      return 1u;
+    }
+    conic_count++;
+  }
+  return 0u;
 }
 
 uint32_t skity_path_count_points(skity_path path) {
@@ -202,6 +270,52 @@ uint32_t skity_path_is_rect(skity_path path, skity_rect* out_rect,
   }
   if (out_is_closed != nullptr) *out_is_closed = is_closed ? 1u : 0u;
   return 1u;
+}
+
+skity_convexity_type skity_path_get_convexity_type(skity_path path) {
+  auto* p = path_of(path);
+  // skity::Path::ConvexityType and skity_convexity_type are value-aligned.
+  return p ? static_cast<skity_convexity_type>(p->GetConvexityType())
+           : SKITY_CONVEXITY_UNKNOWN;
+}
+
+void skity_path_set_convexity_type(skity_path path, skity_convexity_type type) {
+  if (auto* p = path_of(path)) {
+    p->SetConvexityType(static_cast<skity::Path::ConvexityType>(type));
+  }
+}
+
+uint32_t skity_path_get_segment_masks(skity_path path) {
+  auto* p = path_of(path);
+  return p ? p->GetSegmentMasks() : 0u;
+}
+
+uint32_t skity_path_is_finite(skity_path path) {
+  auto* p = path_of(path);
+  return p && p->IsFinite() ? 1u : 0u;
+}
+
+uint32_t skity_path_is_empty(skity_path path) {
+  auto* p = path_of(path);
+  return p && p->IsEmpty() ? 1u : 0u;
+}
+
+uint32_t skity_path_is_line(skity_path path, skity_vec4* out_pts) {
+  auto* p = path_of(path);
+  if (p == nullptr) return 0u;
+  skity::Point pts[2];
+  if (!p->IsLine(pts)) return 0u;
+  if (out_pts != nullptr) {
+    reinterpret_cast<skity::Vec4*>(out_pts)[0] = pts[0];
+    reinterpret_cast<skity::Vec4*>(out_pts)[1] = pts[1];
+  }
+  return 1u;
+}
+
+void skity_path_get_last_move_pt(skity_path path, skity_vec4* out) {
+  auto* p = path_of(path);
+  if (p == nullptr || out == nullptr) return;
+  *reinterpret_cast<skity::Vec4*>(out) = p->GetLastMovePt();
 }
 
 void skity_path_arc_to_oval(skity_path path, const skity_rect* oval,


### PR DESCRIPTION
Canvas +5: image sampling/to-rect overloads, draw_color4f, per-corner radii draw_rrect, make_software_canvas.
Path +13 (+3 enums): get_verb/get_conic_weight, convexity, segment masks, is_finite/empty/line, last_move_pt, clone, is_equal, and add_path append/extend modes.