### PR TITLE
feat(text): apply A8 mask gamma correction on Windows

### DIFF
--- a/src/render/text/atlas/atlas_manager.cc
+++ b/src/render/text/atlas/atlas_manager.cc
@@ -118,6 +118,11 @@ GlyphRegion Atlas::GetGlyphRegion(const Font& font,
   ScalerContextDesc scaler_context_desc = ScalerContextDesc::MakeTransformed(
       raster_font, raster_paint, load_sdf ? 1.f : context_scale,
       raster_transform);
+  if (load_sdf) {
+    scaler_context_desc.scaler_flags |=
+        ScalerContextDesc::kGenerateRawA8MaskFlag;
+    scaler_context_desc.foreground_color = Color_TRANSPARENT;
+  }
   GlyphKey key(
       load_sdf ? PackedGlyphID(packed_glyph_id.GetGlyphID()) : packed_glyph_id,
       scaler_context_desc);

--- a/src/text/ports/scaler_context_freetype.cc
+++ b/src/text/ports/scaler_context_freetype.cc
@@ -11,6 +11,12 @@
 
 #include "src/text/ports/scaler_context_freetype.hpp"
 
+#include <skity/macros.hpp>
+
+#if defined(SKITY_WIN)
+#include "src/text/ports/win/scaler_context_win.hpp"
+#endif
+
 #include <freetype/ftbitmap.h>
 #include <freetype/ftcolor.h>
 #include <freetype/ftoutln.h>
@@ -906,6 +912,10 @@ void ScalerContextFreetype::GenerateImage(PackedGlyphID id, GlyphData* glyph,
       info = {};
     }
   }
+
+#if defined(SKITY_WIN)
+  ApplyA8MaskGammaForWindows(&info, desc_);
+#endif
 }
 
 void ScalerContextFreetype::GenerateImageInfo(PackedGlyphID, GlyphData* glyph,

--- a/src/text/ports/win/scaler_context_win.cc
+++ b/src/text/ports/win/scaler_context_win.cc
@@ -52,7 +52,7 @@
 namespace skity {
 namespace {
 
-static constexpr float kSkiaMaskGammaContrast = 128.f / 255.f;
+static constexpr float kA8MaskGammaContrast = 128.f / 255.f;
 
 static float ComputeFakeBoldScale(float text_size) {
   if (text_size <= 9.0f) {
@@ -369,14 +369,14 @@ static uint8_t Expand3BitLuminance(uint8_t value) {
   return value | (value >> 3) | (value >> 6);
 }
 
-static uint8_t SkiaCanonicalColorChannel(uint8_t value) {
+static uint8_t CanonicalizeColorChannel(uint8_t value) {
   return Expand3BitLuminance(static_cast<uint8_t>(value >> 5));
 }
 
-static uint8_t SkiaA8LuminanceTableIndex(Color foreground_color) {
-  uint8_t r = SkiaCanonicalColorChannel(ColorGetR(foreground_color));
-  uint8_t g = SkiaCanonicalColorChannel(ColorGetG(foreground_color));
-  uint8_t b = SkiaCanonicalColorChannel(ColorGetB(foreground_color));
+static uint8_t A8LuminanceTableIndex(Color foreground_color) {
+  uint8_t r = CanonicalizeColorChannel(ColorGetR(foreground_color));
+  uint8_t g = CanonicalizeColorChannel(ColorGetG(foreground_color));
+  uint8_t b = CanonicalizeColorChannel(ColorGetB(foreground_color));
   uint8_t luminance = static_cast<uint8_t>((r * 54 + g * 183 + b * 19) >> 8);
   return static_cast<uint8_t>(luminance >> 5);
 }
@@ -558,7 +558,7 @@ static bool DecodePngGlyphImageToBGRA(const void* data, size_t size,
   return true;
 }
 
-static std::array<std::array<uint8_t, 256>, 8> BuildSkiaMaskGammaTables() {
+static std::array<std::array<uint8_t, 256>, 8> BuildA8MaskGammaTables() {
   std::array<std::array<uint8_t, 256>, 8> tables{};
 
   for (size_t table_index = 0; table_index < tables.size(); table_index++) {
@@ -566,7 +566,7 @@ static std::array<std::array<uint8_t, 256>, 8> BuildSkiaMaskGammaTables() {
     float lin_src = SrgbToLinear(src);
     float dst = 1.f - src;
     float lin_dst = SrgbToLinear(dst);
-    float adjusted_contrast = kSkiaMaskGammaContrast * lin_dst;
+    float adjusted_contrast = kA8MaskGammaContrast * lin_dst;
 
     for (size_t alpha = 0; alpha < tables[table_index].size(); alpha++) {
       float raw_src_alpha = static_cast<float>(alpha) / 255.f;
@@ -588,10 +588,9 @@ static std::array<std::array<uint8_t, 256>, 8> BuildSkiaMaskGammaTables() {
   return tables;
 }
 
-static uint8_t ApplySkiaMaskGammaToAlpha(uint8_t alpha,
-                                         Color foreground_color) {
-  static const auto tables = BuildSkiaMaskGammaTables();
-  uint8_t table_index = SkiaA8LuminanceTableIndex(foreground_color);
+static uint8_t ApplyA8MaskGammaToAlpha(uint8_t alpha, Color foreground_color) {
+  static const auto tables = BuildA8MaskGammaTables();
+  uint8_t table_index = A8LuminanceTableIndex(foreground_color);
   return tables[table_index][alpha];
 }
 
@@ -2298,12 +2297,9 @@ class ScalerContextDWrite : public ScalerContext {
       return false;
     }
 
-    for (size_t i = 0; i < byte_size; i++) {
-      buffer[i] = ApplySkiaMaskGammaToAlpha(buffer[i], desc_.foreground_color);
-    }
-
     image.buffer = buffer;
     image.need_free = true;
+    ApplyA8MaskGammaForWindows(&image, desc_);
     GlyphDataWinAccess::SetImage(glyph, image);
     return true;
   }
@@ -2588,6 +2584,29 @@ class ScalerContextDWrite : public ScalerContext {
 };
 
 }  // namespace
+
+void ApplyA8MaskGammaForWindows(GlyphBitmapData* image,
+                                const ScalerContextDesc& desc) {
+  if (desc.ShouldGenerateRawA8Mask() || !image ||
+      image->format != BitmapFormat::kGray8 || !image->buffer ||
+      image->width <= 0.f || image->height <= 0.f) {
+    return;
+  }
+
+  const size_t width = static_cast<size_t>(image->width);
+  const size_t height = static_cast<size_t>(image->height);
+  const size_t row_bytes = image->RowBytes();
+  if (row_bytes < width) {
+    return;
+  }
+
+  for (size_t y = 0; y < height; y++) {
+    uint8_t* row = image->buffer + y * row_bytes;
+    for (size_t x = 0; x < width; x++) {
+      row[x] = ApplyA8MaskGammaToAlpha(row[x], desc.foreground_color);
+    }
+  }
+}
 
 std::unique_ptr<ScalerContext> MakeScalerContextDWrite(
     std::shared_ptr<Typeface> typeface, IDWriteFactory* factory,

--- a/src/text/ports/win/scaler_context_win.hpp
+++ b/src/text/ports/win/scaler_context_win.hpp
@@ -17,6 +17,9 @@
 
 namespace skity {
 
+void ApplyA8MaskGammaForWindows(GlyphBitmapData* image,
+                                const ScalerContextDesc& desc);
+
 std::unique_ptr<ScalerContext> MakeScalerContextDWrite(
     std::shared_ptr<Typeface> typeface, IDWriteFactory* factory,
     IDWriteFontFace* font_face, const ScalerContextDesc* desc);

--- a/src/text/scaler_context_desc.hpp
+++ b/src/text/scaler_context_desc.hpp
@@ -43,14 +43,15 @@ struct ScalerContextDesc {
   uint8_t subpixel_positioning{};
   uint8_t baseline_snap{};
   uint8_t edging{};
-  // Font options that affect scaler output but fit in one byte. Keeping these
-  // bits in the descriptor makes both scaler lookup and atlas lookup observe
-  // the same raster-policy identity without introducing structure padding.
+  // Options that affect scaler output but fit in one byte. Keeping these bits
+  // in the descriptor makes both scaler lookup and atlas lookup observe the
+  // same raster-policy identity without introducing structure padding.
   uint8_t scaler_flags{};
 
   static constexpr uint8_t kForceAutoHintingFlag = 1u << 0;
   static constexpr uint8_t kEmbeddedBitmapsFlag = 1u << 1;
   static constexpr uint8_t kLinearMetricsFlag = 1u << 2;
+  static constexpr uint8_t kGenerateRawA8MaskFlag = 1u << 3;
 
   friend inline bool operator==(const ScalerContextDesc& lhs,
                                 const ScalerContextDesc& rhs) {
@@ -95,6 +96,10 @@ struct ScalerContextDesc {
 
   bool IsLinearMetrics() const {
     return (scaler_flags & kLinearMetricsFlag) != 0;
+  }
+
+  bool ShouldGenerateRawA8Mask() const {
+    return (scaler_flags & kGenerateRawA8MaskFlag) != 0;
   }
 };
 

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     target_sources(skity_unit_test PRIVATE
         base/platform/win/str_conversion_test.cc
+        text/a8_mask_gamma_test.cc
         text/dwrite_stability_test.cc
     )
     target_compile_definitions(skity_unit_test PRIVATE

--- a/test/ut/text/a8_mask_gamma_test.cc
+++ b/test/ut/text/a8_mask_gamma_test.cc
@@ -1,0 +1,52 @@
+// Copyright 2021 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <skity/graphic/color.hpp>
+
+#include "src/text/ports/win/scaler_context_win.hpp"
+
+namespace skity {
+namespace {
+
+TEST(A8MaskGammaTest, SrgbPreblendAdjustsCoverageAndPreservesPadding) {
+  std::array<uint8_t, 8> pixels = {0, 16, 32, 0xEE, 64, 128, 255, 0xDD};
+  GlyphBitmapData image;
+  image.width = 3.f;
+  image.height = 2.f;
+  image.buffer = pixels.data();
+  image.row_bytes = 4;
+  image.format = BitmapFormat::kGray8;
+
+  ScalerContextDesc desc{};
+  desc.foreground_color = ColorSetRGB(246, 246, 246);
+  ApplyA8MaskGammaForWindows(&image, desc);
+
+  const std::array<uint8_t, 8> expected = {0,   71,  99,  0xEE,
+                                           137, 188, 255, 0xDD};
+  EXPECT_EQ(pixels, expected);
+}
+
+TEST(A8MaskGammaTest, RawMaskPreservesCoverageAndPadding) {
+  const std::array<uint8_t, 8> expected = {0, 16, 32, 0xEE, 64, 128, 255, 0xDD};
+  std::array<uint8_t, 8> pixels = expected;
+  GlyphBitmapData image;
+  image.width = 3.f;
+  image.height = 2.f;
+  image.buffer = pixels.data();
+  image.row_bytes = 4;
+  image.format = BitmapFormat::kGray8;
+
+  ScalerContextDesc desc{};
+  desc.foreground_color = ColorSetRGB(246, 246, 246);
+  desc.scaler_flags |= ScalerContextDesc::kGenerateRawA8MaskFlag;
+  ApplyA8MaskGammaForWindows(&image, desc);
+
+  EXPECT_EQ(pixels, expected);
+}
+
+}  // namespace
+}  // namespace skity

--- a/test/ut/text/atlas_glyph_test.cc
+++ b/test/ut/text/atlas_glyph_test.cc
@@ -338,16 +338,19 @@ TEST(AtlasGlyphTest, ScalerPolicyFlagsParticipateInGlyphKey) {
   ScalerContextDesc configured_desc{};
   configured_desc.scaler_flags = ScalerContextDesc::kForceAutoHintingFlag |
                                  ScalerContextDesc::kEmbeddedBitmapsFlag |
-                                 ScalerContextDesc::kLinearMetricsFlag;
+                                 ScalerContextDesc::kLinearMetricsFlag |
+                                 ScalerContextDesc::kGenerateRawA8MaskFlag;
 
   EXPECT_FALSE(
       GlyphKey::Equal{}(GlyphKey(7, base_desc), GlyphKey(7, configured_desc)));
   EXPECT_FALSE(base_desc.IsForceAutoHinting());
   EXPECT_FALSE(base_desc.IsEmbeddedBitmaps());
   EXPECT_FALSE(base_desc.IsLinearMetrics());
+  EXPECT_FALSE(base_desc.ShouldGenerateRawA8Mask());
   EXPECT_TRUE(configured_desc.IsForceAutoHinting());
   EXPECT_TRUE(configured_desc.IsEmbeddedBitmaps());
   EXPECT_TRUE(configured_desc.IsLinearMetrics());
+  EXPECT_TRUE(configured_desc.ShouldGenerateRawA8Mask());
 }
 
 TEST(AtlasBitmapTest, CopiesGlyphWithPaddedRows) {


### PR DESCRIPTION
Apply A8 gamma correction to both DirectWrite and FreeType glyph masks. Preserve raw A8 coverage for SDF generation and add regression tests for gamma conversion, row padding, and scaler policy flags.