### PR TITLE
ci: cache android build deps (cmake, gradle, habitat)

### DIFF
--- a/.github/actions/pack-android-aar/action.yml
+++ b/.github/actions/pack-android-aar/action.yml
@@ -5,6 +5,27 @@ description: build skity android aar
 runs:
   using: composite
   steps:
+    # actions/cache does not expand shell variables in `path`, so export the
+    # absolute ANDROID_HOME first
+    - name: Export ANDROID_HOME
+      shell: bash
+      run: echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+
+    - name: Cache Android SDK cmake
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.ANDROID_HOME }}/cmake/3.22.1
+        key: android-cmake-3.22.1-v1
+
+    - name: Cache Gradle
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches/modules-2
+          ~/.gradle/wrapper
+        key: gradle-${{ runner.os }}-${{ hashFiles('platform/android/**/*.gradle', 'platform/android/gradle/libs.versions.toml', 'platform/android/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: gradle-${{ runner.os }}-
+
     - name: build skity android aar
       shell: bash
       run: |

--- a/.github/actions/sync-deps/action.yml
+++ b/.github/actions/sync-deps/action.yml
@@ -26,17 +26,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: resolve cache target slug
+      # cache keys cannot contain commas, so slug the target (module,ci -> module-ci)
+      shell: bash
+      run: echo "HAB_TARGET_SLUG=$(echo '${{ inputs.target }}' | tr ',' '-')" >> "$GITHUB_ENV"
+
     - name: setup cache action
       if: ${{ inputs.cache-backend == 'lynx-infra' }}
       uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
         path: ~/.habitat_cache
-        key: hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.target }}-${{ hashFiles('./.habitat', './hab/DEPS', './hab/DEPS.ci', './hab/DEPS.dev', './hab/DEPS.module') }}
+        key: hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ env.HAB_TARGET_SLUG }}-${{ hashFiles('./.habitat', './hab/DEPS', './hab/DEPS.ci', './hab/DEPS.dev', './hab/DEPS.module') }}
         # the second restore key is the legacy prefix without the target
         # segment, kept so entries saved before the key change stay reachable;
         # drop it once main has rotated to the new key format
         restore-keys: |
-          hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.target }}-
+          hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ env.HAB_TARGET_SLUG }}-
           hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-
 
     - name: run habitat sync

--- a/.github/actions/sync-deps/action.yml
+++ b/.github/actions/sync-deps/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
   target:
     description: habitat target
-    default: ''
+    default: 'dev,module,ci'
     required: false
   # actions/cache stores files with relative directory, which causes inconsistency between self-hosted runner and
   # container runner. Therefore, add this temporary option to modify cache key prefix as a workaround. Delete this when
@@ -31,11 +31,15 @@ runs:
       uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
         path: ~/.habitat_cache
-        key: hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('./.habitat', './hab/DEPS', './hab/DEPS.ci', './hab/DEPS.dev', './hab/DEPS.module') }}
+        key: hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.target }}-${{ hashFiles('./.habitat', './hab/DEPS', './hab/DEPS.ci', './hab/DEPS.dev', './hab/DEPS.module') }}
+        # the second restore key is the legacy prefix without the target
+        # segment, kept so entries saved before the key change stay reachable;
+        # drop it once main has rotated to the new key format
         restore-keys: |
+          hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.target }}-
           hab${{ inputs.cache-key-prefix }}-${{ runner.os }}-
 
     - name: run habitat sync
       shell: bash
       run: |
-        tools/hab sync . --target dev,module,ci
+        tools/hab sync . --target ${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
             - main
         paths:
             - '.github/workflows/ci.yml'
+            - '.github/actions/**'
             - 'include/**'
             - 'src/**'
             - 'module/**'
@@ -20,6 +21,7 @@ on:
             - main
         paths:
             - '.github/workflows/ci.yml'
+            - '.github/actions/**'
             - 'include/**'
             - 'src/**'
             - 'module/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,9 @@ jobs:
           - name: Download Source
             uses: actions/checkout@v4.2.2
           - name: Sync Dependencies
-            run: |
-                ./tools/hab sync -f --target module,ci
+            uses: ./.github/actions/sync-deps
+            with:
+              target: module,ci
           - name: Android Build Check
             uses: ./.github/actions/pack-android-aar
     ios_build_check:

--- a/.github/workflows/publis_release.yml
+++ b/.github/workflows/publis_release.yml
@@ -23,8 +23,9 @@ jobs:
           - name: Download Source
             uses: actions/checkout@v4.2.2
           - name: Sync Dependencies
-            run: |
-                ./tools/hab sync -f --target module,ci
+            uses: ./.github/actions/sync-deps
+            with:
+              target: module,ci
           - name: Android Build Check
             uses: ./.github/actions/pack-android-aar
           - name: Build Android Release Artifact


### PR DESCRIPTION
## Summary

Cache the dependencies the android jobs re-download on every run: the
sdkmanager-installed cmake, gradle distributions/maven deps, and
habitat-managed dependencies.

## Changes

- **pack-android-aar**: cache `$ANDROID_HOME/cmake/3.22.1` and
  `~/.gradle/caches/modules-2` + `~/.gradle/wrapper`; `sdkmanager
  --install` is idempotent on cache hits. NDK is preinstalled on the
  runner image and is not cached.
- **ci.yml trigger paths**: add `.github/actions/**` so composite
  action changes trigger the workflow.
- **sync-deps**: honor the declared-but-unused `target` input (default
  `dev,module,ci` unchanged) and include the target in the cache key,
  slugged (`module,ci` -> `module-ci`) since cache keys cannot contain
  commas. A legacy restore key without the target segment keeps
  pre-change entries reachable during migration.
- **android jobs** (ci + publish release): replace the bare
  `hab sync -f --target module,ci` with sync-deps (`target: module,ci`);
  dropping `-f` matches every other caller and only affects the deploy
  step, not the download cache.
