### PR TITLE
fix(render): cap curve tessellation segment counts

### DIFF
--- a/src/graphic/path_visitor.cc
+++ b/src/graphic/path_visitor.cc
@@ -125,11 +125,12 @@ void PathVisitor::HandleQuadTo(Vec2 const& p1, Vec2 const& p2, Vec2 const& p3,
     num = std::ceil(wangs_formula::Quadratic(
         kPrecision, arc.data(), wangs_formula::VectorXform(matrix_)));
   }
+  num = ClampCurveSegments(num);
   if (num <= 1.0f) {
     HandleLineTo(p1, p3);
     return;
   }
-  DEBUG_CHECK(num < (1 << 10));
+  DEBUG_CHECK(num <= kMaxCurveSegments);
 
   int segment_count = static_cast<int>(num);
   QuadCoeff coeff(arc);
@@ -188,11 +189,12 @@ void PathVisitor::HandleCubicTo(Vec2 const& p1, Vec2 const& p2, Vec2 const& p3,
     num = std::ceil(wangs_formula::Cubic(kPrecision, arc.data(),
                                          wangs_formula::VectorXform(matrix_)));
   }
+  num = ClampCurveSegments(num);
   if (num <= 1.0f) {
     HandleLineTo(p1, p4);
     return;
   }
-  DEBUG_CHECK(num < (1 << 10));
+  DEBUG_CHECK(num <= kMaxCurveSegments);
 
   int segment_count = static_cast<int>(num);
   CubicCoeff coeff(arc);

--- a/src/graphic/path_visitor.hpp
+++ b/src/graphic/path_visitor.hpp
@@ -5,10 +5,25 @@
 #ifndef SRC_GRAPHIC_PATH_VISITOR_HPP
 #define SRC_GRAPHIC_PATH_VISITOR_HPP
 
+#include <algorithm>
+#include <cmath>
 #include <skity/geometry/matrix.hpp>
 #include <skity/graphic/path.hpp>
 
 namespace skity {
+
+constexpr float kMaxCurveSegments = 256.f;
+
+// Apply after segment multipliers and before converting to an integer.
+inline float ClampCurveSegments(float segments) {
+  if (std::isnan(segments) || segments < 0.f) {
+    return 0.f;
+  }
+  // Bound tessellation work for extreme inputs. Capping can exceed
+  // the requested approximation error; subdivide curves before tessellation
+  // if that error bound must be preserved.
+  return std::min(segments, kMaxCurveSegments);
+}
 
 /**
  * A abstract class to do common path processing.

--- a/src/render/hw/draw/geometry/wgsl_tess_path_fill_geometry.cc
+++ b/src/render/hw/draw/geometry/wgsl_tess_path_fill_geometry.cc
@@ -137,7 +137,8 @@ struct TessPathFillVisitor {
     arc_[2] = p2;
     arc_[3] = p3;
 
-    uint32_t num = std::ceil(wangs_formula::Cubic(precision_, arc_, xform_));
+    uint32_t num = std::ceil(
+        ClampCurveSegments(wangs_formula::Cubic(precision_, arc_, xform_)));
     num = std::max(num, 1u);
 
     uint32_t count = DivCeil(num, kMaxNumSegmentsPerInstance);

--- a/src/render/hw/draw/geometry/wgsl_tess_path_stroke_geometry.cc
+++ b/src/render/hw/draw/geometry/wgsl_tess_path_stroke_geometry.cc
@@ -202,7 +202,8 @@ struct TessPathStrokeVisitor {
     arc_[1] = p1;
     arc_[2] = p2;
     arc_[3] = p3;
-    uint32_t num = std::ceil(wangs_formula::Cubic(precision_, arc_, xform_));
+    uint32_t num = std::ceil(
+        ClampCurveSegments(wangs_formula::Cubic(precision_, arc_, xform_)));
     num = std::max(num, 1u);
 
     uint32_t count = DivCeil(num, kMaxNumSegmentsPerInstance);
@@ -307,8 +308,8 @@ struct TessPathStrokeVisitor {
       arc_[0] = center + Vec2{stroke_radius_, 0};
       arc_[1] = center;
       arc_[2] = center + Vec2{0, stroke_radius_};
-      num = std::ceil(
-          2 * wangs_formula::Conic(precision_, arc_, FloatRoot2Over2, xform_));
+      num = std::ceil(ClampCurveSegments(
+          2 * wangs_formula::Conic(precision_, arc_, FloatRoot2Over2, xform_)));
       num = std::max(num, 1u);
       semicircle_segments_num_ = num;
     } else {

--- a/src/render/hw/hw_path_raster.cc
+++ b/src/render/hw/hw_path_raster.cc
@@ -5,6 +5,7 @@
 #include "src/render/hw/hw_path_raster.hpp"
 
 #include "src/geometry/conic.hpp"
+#include "src/graphic/path_visitor.hpp"
 #include "src/logging.hpp"
 
 namespace skity {
@@ -77,6 +78,7 @@ void HWPathStrokeRaster::OnQuadTo(const Vec2& p1, const Vec2& p2,
 
   auto num = glm::ceil(wangs_formula::Quadratic(4.f, arc.data(), xform_));
 
+  num = ClampCurveSegments(num);
   if (num <= 1.f) {
     OnLineTo(p1, p3);
     return;
@@ -131,6 +133,7 @@ void HWPathStrokeRaster::OnConicTo(const Vec2& p1, const Vec2& p2,
 
   float num = glm::ceil(wangs_formula::Conic(4.f, arc.data(), weight, xform_));
 
+  num = ClampCurveSegments(num);
   if (num <= 1.f) {
     OnLineTo(p1, p3);
     return;
@@ -189,6 +192,7 @@ void HWPathStrokeRaster::OnCubicTo(const Vec2& p1, const Vec2& p2,
 
   auto num = glm::ceil(wangs_formula::Cubic(4.f, arc.data(), xform_));
 
+  num = ClampCurveSegments(num);
   if (num <= 1.f) {
     OnLineTo(p1, p4);
     return;
@@ -460,9 +464,9 @@ void HWPathStrokeRaster::GenerateCircleMesh(Vec2 const& center) {
     Vec2 p1 = center + Vec2{stroke_radius_, 0};
     Vec2 p2 = center + Vec2{0, stroke_radius_};
     std::array<const Vec2, 3> arc{p1, center, p2};
-    uint32_t semicircle_segments_num =
-        std::ceil(2 * wangs_formula::Conic(kPrecision, arc.data(),
-                                           FloatRoot2Over2, xform_));
+    uint32_t semicircle_segments_num = std::ceil(
+        ClampCurveSegments(2 * wangs_formula::Conic(kPrecision, arc.data(),
+                                                    FloatRoot2Over2, xform_)));
     semicircle_segments_num = std::max(semicircle_segments_num, 2u);
     float angle = FloatPI / semicircle_segments_num;
     circle_mesh_points_.reserve(2 * semicircle_segments_num + 1);

--- a/test/ut/geometry/geometry_test.cc
+++ b/test/ut/geometry/geometry_test.cc
@@ -7,9 +7,12 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "src/geometry/math.hpp"
+#include "src/geometry/wangs_formula.hpp"
+#include "src/graphic/path_visitor.hpp"
 
 TEST(QUAD, tangents) {
   std::vector<std::array<skity::Point, 3>> pts = {
@@ -137,4 +140,90 @@ TEST(Geometry, CircleInterpolation) {
     EXPECT_TRUE(skity::FloatNearlyZero(cos01_prime - cos34_prime));
     EXPECT_TRUE(Vec2NearlyEqual(result[3], {1, 0}));
   }
+}
+
+TEST(CurveSegmentLimit, SegmentLimits) {
+  using skity::ClampCurveSegments;
+  for (float value : {0.f, 0.5f, 32.25f, 255.5f, 256.f}) {
+    EXPECT_FLOAT_EQ(ClampCurveSegments(value), value);
+  }
+  for (float value : {256.5f, 3.e9f, std::numeric_limits<float>::max(),
+                      std::numeric_limits<float>::infinity()}) {
+    EXPECT_FLOAT_EQ(ClampCurveSegments(value), 256.f);
+    EXPECT_EQ(static_cast<int>(std::ceil(ClampCurveSegments(value))) + 1, 257);
+  }
+  for (float value : {-1.f, -std::numeric_limits<float>::infinity(),
+                      std::numeric_limits<float>::quiet_NaN()}) {
+    EXPECT_FLOAT_EQ(ClampCurveSegments(value), 0.f);
+  }
+  EXPECT_FLOAT_EQ(ClampCurveSegments(2.f * ClampCurveSegments(200.f)), 256.f);
+}
+
+TEST(CurveSegmentLimit, RawCurveEstimates) {
+  using namespace skity::wangs_formula;
+  const skity::Vec2 normal[] = {{0, 0}, {20, 40}, {40, 0}, {60, 20}};
+  EXPECT_FLOAT_EQ(Quadratic(4.f, normal), Root4(QuadraticP4(4.f, normal)));
+  EXPECT_FLOAT_EQ(Cubic(4.f, normal), Root4(CubicP4(4.f, normal)));
+  EXPECT_FLOAT_EQ(Conic(4.f, normal, 0.7f),
+                  std::sqrt(ConicP2(4.f, normal, 0.7f)));
+  for (float scale : {1.e8f, 1.e20f}) {
+    const skity::Vec2 large[] = {
+        {0, 0}, {0, scale}, {scale, 0}, {scale, scale}};
+    EXPECT_GT(Quadratic(4.f, large), 256.f);
+    EXPECT_GT(Cubic(4.f, large), 256.f);
+    EXPECT_GT(Conic(4.f, large, 0.7f), 256.f);
+    EXPECT_GT(QuadraticP4(4.f, large), 256.f * 256.f * 256.f * 256.f);
+  }
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  const skity::Vec2 invalid[] = {
+      {nan, nan}, {nan, nan}, {nan, nan}, {nan, nan}};
+  EXPECT_TRUE(std::isnan(Quadratic(4.f, invalid)));
+  EXPECT_TRUE(std::isnan(Cubic(4.f, invalid)));
+  EXPECT_TRUE(std::isnan(Conic(4.f, invalid, 0.7f)));
+  const skity::Vec2 zero[4] = {};
+  EXPECT_FLOAT_EQ(Quadratic(4.f, zero), 0.f);
+  EXPECT_FLOAT_EQ(Cubic(4.f, zero), 0.f);
+  EXPECT_FLOAT_EQ(Conic(4.f, zero, 1.f), 0.f);
+}
+
+namespace {
+class CountingPathVisitor : public skity::PathVisitor {
+ public:
+  CountingPathVisitor() : PathVisitor(true, skity::Matrix{}) {}
+  int segments = 0;
+  skity::Vec2 end = {};
+
+ protected:
+  void OnBeginPath() override { segments = 0; }
+  void OnEndPath() override {}
+  void OnMoveTo(const skity::Vec2&) override {}
+  void OnLineTo(const skity::Vec2&, const skity::Vec2& p) override {
+    ++segments;
+    end = p;
+  }
+  void OnQuadTo(const skity::Vec2&, const skity::Vec2&,
+                const skity::Vec2&) override {}
+  void OnConicTo(const skity::Vec2&, const skity::Vec2&, const skity::Vec2&,
+                 float) override {}
+  void OnCubicTo(const skity::Vec2&, const skity::Vec2&, const skity::Vec2&,
+                 const skity::Vec2&) override {}
+  void OnClose() override {}
+};
+}  // namespace
+
+TEST(CurveSegmentLimit, PathVisitorBoundsLargeCurves) {
+  CountingPathVisitor visitor;
+  skity::Path quad;
+  quad.MoveTo(0, 0);
+  quad.QuadTo(0, 1.e20f, 10, 0);
+  visitor.VisitPath(quad, false);
+  EXPECT_EQ(visitor.segments, 256);
+  EXPECT_EQ(visitor.end, (skity::Vec2{10, 0}));
+
+  skity::Path cubic;
+  cubic.MoveTo(0, 0);
+  cubic.CubicTo(0, 1.e20f, 1.e20f, 0, 10, 0);
+  visitor.VisitPath(cubic, false);
+  EXPECT_EQ(visitor.segments, 256);
+  EXPECT_EQ(visitor.end, (skity::Vec2{10, 0}));
 }


### PR DESCRIPTION
Extreme inputs can produce excessive or non-finite segment estimates, leading to excessive work or unsafe integer conversions. Limit segment counts to 256 at rendering call sites while preserving the raw Wang formula and existing smaller buffer limits.

Add regression coverage and implementation documentation. Validation: 3 unit tests and 5 shape golden tests passed.