### PR TITLE
chore: improve Linux builds and handle OpenGL framebuffer changes

### DIFF
--- a/example/case/bicubic/CMakeLists.txt
+++ b/example/case/bicubic/CMakeLists.txt
@@ -10,5 +10,7 @@ add_executable(bicubic_example
 
 target_compile_definitions(bicubic_example PRIVATE -DEXAMPLE_IMAGE_ROOT="${CMAKE_SOURCE_DIR}/example/images/")
 
-target_compile_options(bicubic_example PRIVATE "-fobjc-arc")
+if (APPLE)
+  target_compile_options(bicubic_example PRIVATE "-fobjc-arc")
+endif()
 target_link_libraries(bicubic_example PUBLIC skity::example_common)

--- a/example/case/image/CMakeLists.txt
+++ b/example/case/image/CMakeLists.txt
@@ -26,5 +26,7 @@ if (${SKITY_MTL_BACKEND})
   )
 endif()
 
-target_compile_options(image_example PRIVATE "-fobjc-arc")
+if (APPLE)
+  target_compile_options(image_example PRIVATE "-fobjc-arc")
+endif()
 target_link_libraries(image_example PUBLIC skity::example_common)

--- a/example/common/CMakeLists.txt
+++ b/example/common/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 # glfw
 set(GLFW_INSTALL OFF CACHE BOOL "disable GLFW_INSTALL")
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/glfw third_party/glfw)
@@ -80,5 +78,7 @@ target_include_directories(skity_example_common PUBLIC ${CMAKE_SOURCE_DIR}/third
 target_link_libraries(skity_example_common PUBLIC glfw skity::skity)
 target_link_libraries(skity_example_common PUBLIC skity::codec)
 
-target_compile_options(skity_example_common PRIVATE "-fobjc-arc")
+if (APPLE)
+  target_compile_options(skity_example_common PRIVATE "-fobjc-arc")
+endif()
 target_compile_definitions(skity_example_common PRIVATE -DEXAMPLE_DEFAULT_FONT="${CMAKE_SOURCE_DIR}/example/images/RobotoMonoNerdFont-Regular.ttf")

--- a/example/common/gl/window_gl.cc
+++ b/example/common/gl/window_gl.cc
@@ -18,9 +18,7 @@ bool WindowGL::OnInit() {
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
   if (UseDebugAAPresent()) {
     glfwWindowHint(GLFW_SAMPLES, 0);
-#ifdef __APPLE__
-    glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
-#endif
+    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
   }
 
   return true;
@@ -43,35 +41,55 @@ std::unique_ptr<skity::GPUContext> WindowGL::CreateGPUContext() {
   return skity::GLContextCreate((void*)glfwGetProcAddress);
 }
 
-void WindowGL::OnShow() {
-  auto window = GetNativeWindow();
-
-  int32_t pp_width, pp_height;
-  glfwGetFramebufferSize(window, &pp_width, &pp_height);
-
-  int32_t logical_width, logical_height;
-  glfwGetWindowSize(window, &logical_width, &logical_height);
-
-  float density =
-      (float)(pp_width * pp_width + pp_height * pp_height) /
-      (float)(logical_width * logical_width + logical_height * logical_height);
-  auto screen_scale = std::sqrt(density);
-
-  skity::GPUSurfaceDescriptorGL desc{};
-  desc.backend = skity::GPUBackendType::kOpenGL;
-  desc.width = logical_width;
-  desc.height = logical_height;
-  desc.sample_count = UseDebugAAPresent() ? GetAASampleCount() : 4;
-  desc.content_scale = UseDebugAAPresent() ? 1.f : screen_scale;
-
-  desc.surface_type = skity::GLSurfaceType::kFramebuffer;
-  desc.gl_id = 0;
-  desc.has_stencil_attachment = true;
-
-  surface_ = GetGPUContext()->CreateSurface(&desc);
-}
+void WindowGL::OnShow() {}
 
 skity::Canvas* WindowGL::AquireCanvas() {
+  auto window = GetNativeWindow();
+
+  int32_t pp_width = 0;
+  int32_t pp_height = 0;
+  int32_t logical_width = 0;
+  int32_t logical_height = 0;
+  for (;;) {
+    glfwGetFramebufferSize(window, &pp_width, &pp_height);
+    glfwGetWindowSize(window, &logical_width, &logical_height);
+    if (pp_width > 0 && pp_height > 0 && logical_width > 0 &&
+        logical_height > 0) {
+      break;
+    }
+    if (glfwWindowShouldClose(window)) {
+      return nullptr;
+    }
+    glfwWaitEvents();
+  }
+
+  const float screen_scale =
+      static_cast<float>(std::hypot(pp_width, pp_height) /
+                         std::hypot(logical_width, logical_height));
+  const float content_scale = UseDebugAAPresent() ? 1.f : screen_scale;
+
+  // The framebuffer scale may change after the window is first displayed.
+  if (surface_ == nullptr || surface_->GetWidth() != logical_width ||
+      surface_->GetHeight() != logical_height ||
+      surface_->ContentScale() != content_scale) {
+    skity::GPUSurfaceDescriptorGL desc{};
+    desc.backend = skity::GPUBackendType::kOpenGL;
+    desc.width = logical_width;
+    desc.height = logical_height;
+    desc.sample_count = UseDebugAAPresent() ? GetAASampleCount() : 4;
+    desc.content_scale = content_scale;
+    desc.surface_type = skity::GLSurfaceType::kFramebuffer;
+    desc.gl_id = 0;
+    desc.has_stencil_attachment = true;
+
+    surface_.reset();
+    surface_ = GetGPUContext()->CreateSurface(&desc);
+  }
+
+  if (surface_ == nullptr) {
+    return nullptr;
+  }
+
   canvas_ = surface_->LockCanvas();
   return canvas_;
 }

--- a/module/codec/include/skity/codec/codec.hpp
+++ b/module/codec/include/skity/codec/codec.hpp
@@ -5,6 +5,7 @@
 #ifndef MODULE_CODEC_INCLUDE_SKITY_CODEC_CODEC_HPP
 #define MODULE_CODEC_INCLUDE_SKITY_CODEC_CODEC_HPP
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <skity/graphic/alpha_type.hpp>

--- a/module/io/include/skity/io/picture.hpp
+++ b/module/io/include/skity/io/picture.hpp
@@ -86,7 +86,7 @@ class SKITY_API Picture final {
 
  private:
   std::unique_ptr<RecordPlayback> playback_;
-  std::unique_ptr<MemoryWriter32> writer_ = {};
+  std::unique_ptr<MemoryWriter32> writer_;
 
   Rect cull_rect_;
 };

--- a/module/io/src/io/memory_read.cc
+++ b/module/io/src/io/memory_read.cc
@@ -4,6 +4,7 @@
 
 #include "src/io/memory_read.hpp"
 
+#include <cstring>
 #include <skity/codec/codec.hpp>
 #include <skity/io/picture.hpp>
 

--- a/module/io/src/picture.cc
+++ b/module/io/src/picture.cc
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <array>
+#include <cstring>
 #include <skity/io/picture.hpp>
 
 #include "src/io/memory_read.hpp"

--- a/module/wgx/include/wgsl_cross.h
+++ b/module/wgx/include/wgsl_cross.h
@@ -14,6 +14,7 @@
 #define WGX_API
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/module/wgx/msl/msl_attribute.h
+++ b/module/wgx/msl/msl_attribute.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <ostream>
 #include <string>

--- a/module/wgx/wgsl/ast/expression.h
+++ b/module/wgx/wgsl/ast/expression.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "wgsl/ast/identifier.h"
 #include "wgsl/ast/node.h"
 

--- a/module/wgx/wgsl/scanner.h
+++ b/module/wgx/wgsl/scanner.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/module/wgx/wgsl/token.h
+++ b/module/wgx/wgsl/token.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <variant>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,13 +167,6 @@ if (NOT ${SKITY_CT_FONT})
 
   target_link_libraries(skity PRIVATE freetype2)
 
-  if (NOT USE_THIRD_PARTY_ZLIB)
-    # link system zlib
-    target_link_libraries(skity PRIVATE z)
-  else()
-    target_link_libraries(skity PRIVATE ${SKITY_ZLIB_NAME})
-  endif()
-
   target_include_directories(skity SYSTEM BEFORE PRIVATE ${FREETYPE_DIR}/include)
 
   if (NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "OHOS" AND NOT EMSCRIPTEN)
@@ -188,6 +181,14 @@ if (NOT ${SKITY_CT_FONT})
     # use nanopng in android
     target_include_directories(skity PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../third_party/nanopng/include)
     target_sources(skity PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../third_party/nanopng/src/nanopng16.cc)
+  endif()
+
+  # Keep zlib after its dependents for linkers that process libraries in order.
+  if (NOT USE_THIRD_PARTY_ZLIB)
+    # link system zlib
+    target_link_libraries(skity PRIVATE z)
+  else()
+    target_link_libraries(skity PRIVATE ${SKITY_ZLIB_NAME})
   endif()
 
   target_sources(

--- a/src/base/mapping.hpp
+++ b/src/base/mapping.hpp
@@ -8,6 +8,7 @@
 #ifndef SRC_BASE_MAPPING_HPP
 #define SRC_BASE_MAPPING_HPP
 
+#include <cstdint>
 #include <initializer_list>
 #include <memory>
 #include <string>

--- a/src/render/text/sdf_gen.hpp
+++ b/src/render/text/sdf_gen.hpp
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/src/utils/xml/xml_parser.cc
+++ b/src/utils/xml/xml_parser.cc
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <cstdint>
 #include <cstring>
 #include <pugixml.hpp>
 #include <skity/utils/xml/xml_parser.hpp>


### PR DESCRIPTION
- Add missing standard headers for GCC 15 compatibility.
- Restrict Objective-C ARC flags to Apple builds.
- Link zlib after FreeType and libpng.
- Remove redundant initialization of Picture::writer_.
- Recreate OpenGL surfaces when window size or DPI scale changes.
- Apply the cross-platform framebuffer scaling hint for debug AA modes.